### PR TITLE
Record @deprecated javadoc tags in the Java indexer

### DIFF
--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/BUILD
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/BUILD
@@ -83,6 +83,12 @@ java_verifier_test(
 )
 
 java_verifier_test(
+    name = "deprecation_tests",
+    size = "small",
+    srcs = ["Deprecation.java"],
+)
+
+java_verifier_test(
     name = "comments_tests",
     size = "small",
     srcs = ["Comments.java"],

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Deprecation.java
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Deprecation.java
@@ -1,0 +1,31 @@
+package pkg;
+
+//- @+8Deprecation defines/binding DeprecationClass
+
+/**
+ * This the javadoc summary fragment, not the {@code @deprecated} tag.
+ *
+ * @deprecated this class is obsolete; prefer {@link Comments}
+ * @author this is an author tag, not the {@code @deprecated} tag.
+ */
+public class Deprecation {
+  //- DeprecationClass.tag/deprecated "this class is obsolete; prefer {@link Comments}"
+
+  //- @+3deprecatedMethod defines/binding DeprecationMethod
+
+  /** @deprecated this method is obsolete */
+  void deprecatedMethod() {}
+  //- DeprecationMethod.tag/deprecated "this method is obsolete"
+
+  //- @+3deprecatedField defines/binding DeprecationField
+
+  /** @deprecated this field is obsolete */
+  int deprecatedField;
+  //- DeprecationField.tag/deprecated "this field is obsolete"
+
+  //- @+3deprecatedFieldEmpty defines/binding DeprecationFieldEmpty
+
+  /** @deprecated */
+  int deprecatedFieldEmpty;
+  //- DeprecationFieldEmpty.tag/deprecated ""
+}


### PR DESCRIPTION
Record the contents of `@deprecated` javadoc tags, and attach them to the
javadoc documentation node under `/kythe/java/deprecated`.