### PR TITLE
feat: Support adding Clang USRs to the graph

### DIFF
--- a/kythe/cxx/common/indexing/KytheGraphRecorder.cc
+++ b/kythe/cxx/common/indexing/KytheGraphRecorder.cc
@@ -31,8 +31,7 @@ static const std::string* const kNodeKindSpellings[] = {
     new std::string("interface"),  new std::string("package"),
     new std::string("tsigma"),     new std::string("doc"),
     new std::string("tbuiltin"),   new std::string("meta"),
-    new std::string("diagnostic"),
-};
+    new std::string("diagnostic"), new std::string("clang/usr")};
 
 static const std::string* kEdgeKindSpellings[] = {
     new std::string("/kythe/edge/defines"),
@@ -77,6 +76,7 @@ static const std::string* kEdgeKindSpellings[] = {
     new std::string("/kythe/edge/ref/init/implicit"),
     new std::string("/kythe/edge/imputes"),
     new std::string("/kythe/edge/tagged"),
+    new std::string("/clang/usr"),
 };
 
 bool of_spelling(absl::string_view str, EdgeKindID* edge_id) {

--- a/kythe/cxx/common/indexing/KytheGraphRecorder.h
+++ b/kythe/cxx/common/indexing/KytheGraphRecorder.h
@@ -45,7 +45,8 @@ enum class NodeKindID {
   kDoc,
   kTBuiltin,
   kMeta,
-  kDiagnostic
+  kDiagnostic,
+  kUsr
 };
 
 /// \brief Known properties of nodes. See the schema for details.
@@ -115,7 +116,8 @@ enum class EdgeKindID {
   kRefInit,
   kRefInitImplicit,
   kImputes,
-  kTagged
+  kTagged,
+  kUsr
 };
 
 /// \brief Returns the Kythe spelling of `node_kind_id`

--- a/kythe/cxx/indexer/cxx/GraphObserver.h
+++ b/kythe/cxx/indexer/cxx/GraphObserver.h
@@ -537,6 +537,13 @@ class GraphObserver {
       FunctionSubkind Subkind,
       const absl::optional<MarkedSource>& MarkedSource) {}
 
+  /// \brief Assigns a USR to node.
+  /// \param Node The target node.
+  /// \param Usr The raw USR.
+  /// \param ByteSize Number of significant bytes to use.
+  virtual void assignUsr(const NodeId& Node, llvm::StringRef Usr,
+                         int ByteSize) {}
+
   /// \brief Describes whether an enum is scoped (`enum class`).
   enum class EnumKind {
     Scoped,   ///< This enum is scoped (an `enum class`).

--- a/kythe/cxx/indexer/cxx/IndexerASTHooks.cc
+++ b/kythe/cxx/indexer/cxx/IndexerASTHooks.cc
@@ -43,6 +43,7 @@
 #include "clang/AST/TemplateName.h"
 #include "clang/AST/Type.h"
 #include "clang/AST/TypeLoc.h"
+#include "clang/Index/USRGeneration.h"
 #include "clang/Lex/Lexer.h"
 #include "clang/Sema/Lookup.h"
 #include "gflags/gflags.h"
@@ -3006,6 +3007,7 @@ bool IndexerASTVisitor::VisitFunctionDecl(clang::FunctionDecl* Decl) {
                                 Subkind, absl::nullopt);
     Observer.recordMarkedSource(OuterNode,
                                 Marks.GenerateMarkedSource(OuterNode));
+    AssignUSR(OuterNode, Decl);
     return true;
   }
   if (NameRangeInContext) {
@@ -3034,6 +3036,7 @@ bool IndexerASTVisitor::VisitFunctionDecl(clang::FunctionDecl* Decl) {
                               GraphObserver::Completeness::Definition, Subkind,
                               absl::nullopt);
   Observer.recordMarkedSource(OuterNode, Marks.GenerateMarkedSource(OuterNode));
+  AssignUSR(OuterNode, Decl);
   return true;
 }
 
@@ -3257,6 +3260,16 @@ bool IndexerASTVisitor::AddNameToStream(llvm::raw_string_ostream& Ostream,
     }
   }
   return true;
+}
+
+void IndexerASTVisitor::AssignUSR(const GraphObserver::NodeId& TargetNode,
+                                  const clang::NamedDecl* ND) {
+  if (UsrByteSize <= 0 || Job->UnderneathImplicitTemplateInstantiation) return;
+  const auto* DC = ND->getDeclContext();
+  if (DC->isFunctionOrMethod()) return;
+  llvm::SmallString<128> Usr;
+  if (clang::index::generateUSRForDecl(ND, Usr)) return;
+  Observer.assignUsr(TargetNode, Usr, UsrByteSize);
 }
 
 GraphObserver::NameId IndexerASTVisitor::BuildNameIdForDecl(

--- a/kythe/cxx/indexer/cxx/IndexerFrontendAction.cc
+++ b/kythe/cxx/indexer/cxx/IndexerFrontendAction.cc
@@ -191,6 +191,7 @@ std::string IndexCompilationUnit(
   Action->setVerbosity(Options.Verbosity);
   Action->setObjCFwdDeclEmitDocs(Options.ObjCFwdDocs);
   Action->setCppFwdDeclEmitDocs(Options.CppFwdDocs);
+  Action->setUsrByteSize(Options.UsrByteSize);
   llvm::IntrusiveRefCntPtr<clang::FileManager> FileManager(
       new clang::FileManager(FSO, Options.AllowFSAccess ? nullptr : VFS));
   std::vector<std::string> Args(Unit.argument().begin(), Unit.argument().end());

--- a/kythe/cxx/indexer/cxx/IndexerFrontendAction.h
+++ b/kythe/cxx/indexer/cxx/IndexerFrontendAction.h
@@ -104,6 +104,9 @@ class IndexerFrontendAction : public clang::ASTFrontendAction {
   /// \param B Behavior to use.
   void setCppFwdDeclEmitDocs(BehaviorOnFwdDeclComments B) { CppFwdDocs = B; }
 
+  /// \brief Use this many raw bytes for USRs.
+  void setUsrByteSize(int S) { UsrByteSize = S; }
+
  private:
   std::unique_ptr<clang::ASTConsumer> CreateASTConsumer(
       clang::CompilerInstance& CI, llvm::StringRef Filename) override {
@@ -143,7 +146,7 @@ class IndexerFrontendAction : public clang::ASTFrontendAction {
     }
     return llvm::make_unique<IndexerASTConsumer>(
         Observer, IgnoreUnimplemented, TemplateMode, Verbosity, ObjCFwdDocs,
-        CppFwdDocs, Supports, ShouldStopIndexing, CreateWorklist);
+        CppFwdDocs, Supports, ShouldStopIndexing, CreateWorklist, UsrByteSize);
   }
 
   bool BeginSourceFileAction(clang::CompilerInstance& CI) override {
@@ -181,6 +184,9 @@ class IndexerFrontendAction : public clang::ASTFrontendAction {
   /// \return a new worklist for the given visitor.
   std::function<std::unique_ptr<IndexerWorklist>(IndexerASTVisitor*)>
       CreateWorklist;
+  /// \brief The number of (raw) bytes to use to represent a USR. If 0,
+  /// no USRs will be recorded.
+  int UsrByteSize = 0;
 };
 
 /// \brief Allows stdin to be replaced with a mapped file.
@@ -255,6 +261,9 @@ struct IndexerOptions {
   /// as possible.
   /// \return true if indexing should be cancelled.
   std::function<bool()> ShouldStopIndexing = [] { return false; };
+  /// \brief The number of (raw) bytes to use to represent a USR. If 0,
+  /// no USRs will be recorded.
+  int UsrByteSize = 0;
 };
 
 /// \brief Indexes `Unit`, reading from `Files` in the assumed and writing

--- a/kythe/cxx/indexer/cxx/KytheGraphObserver.h
+++ b/kythe/cxx/indexer/cxx/KytheGraphObserver.h
@@ -190,6 +190,9 @@ class KytheGraphObserver : public GraphObserver {
       FunctionSubkind subkind,
       const absl::optional<MarkedSource>& marked_source) override;
 
+  void assignUsr(const NodeId& node, llvm::StringRef usr,
+                 int byte_size) override;
+
   void recordAbsVarNode(
       const NodeId& node,
       const absl::optional<MarkedSource>& marked_source) override;

--- a/kythe/cxx/indexer/cxx/KytheIndexerMain.cc
+++ b/kythe/cxx/indexer/cxx/KytheIndexerMain.cc
@@ -46,6 +46,8 @@ DEFINE_bool(experimental_drop_objc_fwd_class_docs, false,
             "Drop comments for Objective-C forward class declarations.");
 DEFINE_bool(experimental_drop_cpp_fwd_decl_docs, false,
             "Drop comments for C++ forward declarations.");
+DEFINE_int32(experimental_usr_byte_size, 0,
+             "Use this many bytes to represent a USR (or don't at all if 0).");
 
 namespace kythe {
 
@@ -73,6 +75,9 @@ int main(int argc, char* argv[]) {
   options.CppFwdDocs = FLAGS_experimental_drop_cpp_fwd_decl_docs
                            ? kythe::BehaviorOnFwdDeclComments::Ignore
                            : kythe::BehaviorOnFwdDeclComments::Emit;
+  options.UsrByteSize = FLAGS_experimental_usr_byte_size <= 0
+                            ? 0
+                            : FLAGS_experimental_usr_byte_size;
   options.DropInstantiationIndependentData =
       FLAGS_experimental_drop_instantiation_independent_data;
   options.AllowFSAccess = context.allow_filesystem_access();

--- a/kythe/cxx/indexer/cxx/testdata/BUILD
+++ b/kythe/cxx/indexer/cxx/testdata/BUILD
@@ -686,6 +686,15 @@ cc_indexer_test(
 )
 
 cc_indexer_test(
+    name = "usr",
+    srcs = ["basic/usr.cc"],
+    check_for_singletons = True,
+    experimental_usr_byte_size = 20,
+    ignore_unimplemented = True,
+    tags = ["basic"],
+)
+
+cc_indexer_test(
     name = "vardecl_double_shadowed_local_anchor",
     srcs = ["basic/vardecl_double_shadowed_local_anchor.cc"],
     check_for_singletons = True,

--- a/kythe/cxx/indexer/cxx/testdata/basic/usr.cc
+++ b/kythe/cxx/indexer/cxx/testdata/basic/usr.cc
@@ -1,0 +1,6 @@
+// We index USRs.
+
+//- @foo defines/binding Foo
+//- FooUsr /clang/usr Foo
+//- FooUsr=vname(_,"","","","usr").node/kind clang/usr
+void foo() { }

--- a/third_party/llvm/BUILD
+++ b/third_party/llvm/BUILD
@@ -39,6 +39,7 @@ cc_library(
         "llvm/build/lib/libclangLex.a",
         "llvm/build/lib/libclangBasic.a",
         "llvm/build/lib/libclangAnalysis.a",
+        "llvm/build/lib/libclangIndex.a",
         "llvm/build/lib/libLLVMMipsInfo.a",
         "llvm/build/lib/libLLVMAArch64Info.a",
         "llvm/build/lib/libLLVMARMInfo.a",

--- a/tools/build_rules/verifier_test/cc_indexer_test.bzl
+++ b/tools/build_rules/verifier_test/cc_indexer_test.bzl
@@ -57,6 +57,7 @@ _INDEXER_FLAGS = {
     "experimental_drop_instantiation_independent_data": False,
     "experimental_drop_objc_fwd_class_docs": False,
     "experimental_drop_cpp_fwd_decl_docs": False,
+    "experimental_usr_byte_size": 0,
 }
 
 def _compiler_options(ctx, cpp, copts, includes):
@@ -586,6 +587,7 @@ def cc_indexer_test(
         template instantiations.
       experimental_drop_instantiation_independent_data: Whether the indexer should
         drop extraneous instantiation independent data.
+      experimental_usr_byte_size: How many bytes of a USR to use.
     """
     _indexer_test(
         name = name,
@@ -635,6 +637,7 @@ def objc_indexer_test(
         template instantiations.
       experimental_drop_instantiation_independent_data: Whether the indexer should
         drop extraneous instantiation independent data.
+      experimental_usr_byte_size: How many bytes of a USR to use.
     """
     _indexer_test(
         name = name,

--- a/tools/modules/update.sh
+++ b/tools/modules/update.sh
@@ -130,7 +130,7 @@ if [[ -z "$1" || "$1" == "--build_only" ]]; then
         clangFrontend clang-headers clangLex clangParse clangRewrite clangSema \
         clangSerialization clangTooling LLVMAArch64Info LLVMARMInfo \
         LLVMBitReader LLVMCore LLVMMC LLVMMCParser LLVMMipsInfo LLVMOption \
-        LLVMBinaryFormat \
+        LLVMBinaryFormat clangIndex \
         LLVMPowerPCInfo LLVMProfileData LLVMX86Info clangFormat clangToolingCore
     cd ..
   fi


### PR DESCRIPTION
Clang tools use USRs ("Unified Symbol Resolution") as ticket-equivalents
(but they're insufficiently specific for Kythe). This PR adds a new flag,
--experimental_usr_byte_size, which (if given a nonzero value) instructs
the indexer to take that many bytes off the SHA1 hash of USRs and
add them as clang/usr nodes with /clang/usr edges pointing at the
C++ nodes to which they refer:

    //- @foo defines/binding Foo
    //- FooUsr /clang/usr Foo
    //- FooUsr=vname(_,"","","","usr").node/kind clang/usr
    void foo() { }

Similar to the way we deal with JVM names, the corpus, path,
and root fields of a usr vname are cleared. Clients are permitted
to write their own USR tickets. The USR value itself is encoded
in capital hex (to match Clang's own internal USR stringification,
modulo the configurable size of the SHA1 prefix).

USRs are added only for NamedDecls that:
  * are FunctionDecls
  * are not under implicit template instantiations
  * are not in a DeclContext inside a function body
  * can actually be assigned USRs from Clang

Future PRs may allow various other NamedDecl subtypes to be granted
USRs, but it is unlikely that we will support assigning USRs to
decls that are not at TU/namespace scope.