### PR TITLE
fix: specify revision to diff against when using arc

### DIFF
--- a/tools/git/pre-commit.sh
+++ b/tools/git/pre-commit.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # TODO(#3173): remove need for arcanist
-arc lint
+arc lint --rev HEAD
 
 # TODO(#3173): remove need for arcanist
-WAIT_FOR_BAZEL=1 USE_BAZELRC=1 arc unit
+WAIT_FOR_BAZEL=1 USE_BAZELRC=1 arc unit --rev HEAD


### PR DESCRIPTION
Without these changes, arc fails when I try to commit.

```{.sh}
$ arc --version
arcanist 83661809e532c3fe444a8bf7c7d6936e6377691b (26 Oct 2018)
libphutil cf96fd681e7d35ad21c7aaaa0bd1869124e377ef (1 Nov 2018)
```

Error message when trying to commit:

```
You're running a command which operates on a range of revisions (usually,
from some revision to HEAD) but have not specified the revision that should
determine the start of the range.

Previously, arc assumed you meant 'HEAD^' when you did not specify a start
revision, but this behavior does not make much sense in most workflows
outside of Facebook's historic git-svn workflow.

arc no longer assumes 'HEAD^'. You must specify a relative commit explicitly
when you invoke a command (e.g., `arc diff HEAD^`, not just `arc diff`) or
select a default for this working copy.

In most cases, the best default is 'origin/master'. You can also select
'HEAD^' to preserve the old behavior, or some other remote or branch. But you
almost certainly want to select 'origin/master'.

(Technically: the merge-base of the selected revision and HEAD is used to
determine the start of the commit range.)

    What default do you want to use? [origin/master]  Exception 
The program is attempting to read user input, but stdin is being piped from some other source (not a TTY).
(Run with `--trace` for a full exception trace.)
```

The message says that `HEAD^` used to be the default, but it seems like `HEAD` makes more sense because you want to look at changes *since* the last commit, but not those included in the last commit.