### PR TITLE
fix(cxx_extractor): segfault when given nonexistent file

### DIFF
--- a/kythe/cxx/extractor/cxx_extractor.cc
+++ b/kythe/cxx/extractor/cxx_extractor.cc
@@ -948,7 +948,7 @@ void KindexWriterSink::OpenIndex(const std::string& hash) {
 }
 
 KindexWriterSink::~KindexWriterSink() {
-  CHECK(!coded_stream_->HadError())
+  CHECK(!(coded_stream_ && coded_stream_->HadError()))
       << "Errors encountered writing to " << open_path_;
   coded_stream_.reset();
   gzip_stream_.reset();


### PR DESCRIPTION
When going through the examples, I mis-typed a file name parameter to the cxx_extractor and got a segfault. It did print a helpful error message about the missing file before crashing which was good :)

Stack trace:

~~~{.sh}
#0  google::protobuf::io::CodedOutputStream::HadError (this=0x0) at external/com_google_protobuf/src/google/protobuf/io/coded_stream.h:816
#1  0x000000000041ea6d in kythe::KindexWriterSink::~KindexWriterSink (this=0x22a0400) at kythe/cxx/extractor/cxx_extractor.cc:951
#2  0x000000000041ecb9 in kythe::KindexWriterSink::~KindexWriterSink (this=0x22a0400) at kythe/cxx/extractor/cxx_extractor.cc:950
#3  0x000000000044a65f in std::default_delete<kythe::CompilationWriterSink>::operator() (this=0x7fffffffd390, __ptr=0x22a0400) at /usr/bin/../lib/gcc/x86_64-linux-gnu/7.3.0/../../../../include/c++/7.3.0/bits/unique_ptr.h:78
#4  0x0000000000432e90 in std::unique_ptr<kythe::CompilationWriterSink, std::default_delete<kythe::CompilationWriterSink> >::~unique_ptr (this=0x7fffffffd390)
    at /usr/bin/../lib/gcc/x86_64-linux-gnu/7.3.0/../../../../include/c++/7.3.0/bits/unique_ptr.h:268
#5  0x0000000000424c05 in kythe::ExtractorConfiguration::Extract (this=0x7fffffffd488, lang=kythe::supported_language::Language::kCpp) at kythe/cxx/extractor/cxx_extractor.cc:1406
#6  0x000000000041b9a0 in main (argc=8, argv=0x7fffffffd8c8) at kythe/cxx/extractor/cxx_extractor_main.cc:53
~~~

One other thing I noticed is that the program exits with code 0 in this case (after the segfault fix) - it should probably exit with an error code.