### PR TITLE
fix(docs): fixed a few broken links

### DIFF
--- a/kythe/docs/exploring-kythe-sample-web-ui.txt
+++ b/kythe/docs/exploring-kythe-sample-web-ui.txt
@@ -107,6 +107,6 @@ http://www.kythe.io/docs/schema/#param[/kythe/edge/param]:: declared parameters
 
 These examples are just a taste of the data exposed in our sample web UI.  With
 other specialized interfaces such as the
-https://kythe.io/repo/kythe/go/serving/tools/kythe.go[Kythe command-line],
+https://kythe.io/repo/kythe/go/serving/tools/kythe/kythe.go[Kythe command-line],
 Kythe's data can lead to some very useful tools for viewing, editing, and
 grokking source code across multiple languages.

--- a/kythe/docs/kythe-configurable-extraction.txt
+++ b/kythe/docs/kythe-configurable-extraction.txt
@@ -57,9 +57,9 @@ configuration schema is defined within https://github.com/kythe/kythe/blob/maste
 
 Instances of this configuration schema can be placed in the root directory of
 the repository in a file named: ".kythe-extraction-config", formatted as a https://developers.google.com/protocol-buffers/docs/proto3#json[JSON encoded protobuf].
-An example of an existing extraction configuration can be found here: https://github.com/kythe/kythe/blob/master/kythe/go/extractors/config/testdata/mvn_config.json[mvn_config.json].
+An example of an existing extraction configuration can be found here: https://github.com/kythe/kythe/blob/master/kythe/go/extractors/config/base/testdata/mvn_config.json[mvn_config.json].
 The corresponding extraction image which gets generated from the mvn_config.json
-file can be found here: https://github.com/kythe/kythe/blob/master/kythe/go/extractors/config/testdata/expected_mvn_config.Dockerfile[expected_mvn_config.Dockerfile].
+file can be found here: https://github.com/kythe/kythe/blob/master/kythe/go/extractors/config/base/testdata/expected_mvn_config.Dockerfile[expected_mvn_config.Dockerfile].
 This configuration serves as an input to the https://github.com/kythe/kythe/blob/master/kythe/go/platform/tools/extraction/extractrepo.go[extractrepo]
 tool which executes the Kythe extraction process on a given repository.
 
@@ -175,7 +175,7 @@ here: https://github.com/kythe/kythe/blob/master/kythe/go/platform/tools/extract
 These tools require the following to programs to be locally installed and
 accessible on the $PATH: https://www.docker.com/get-docker[Docker], https://git-scm.com/downloads[Git].
 
-The https://github.com/kythe/kythe/blob/master/kythe/go/platform/tools/extraction/extractrepo.go[extractrepo]
+The https://github.com/kythe/kythe/blob/master/kythe/go/platform/tools/extraction/extractrepo/extractrepo.go[extractrepo]
 binary provides a tool for running an extraction manually. It consumes an extraction configuration file either specified as a command line argument, or else contained within the ".kythe-extraction-config" file in the root of the repository. The
 binary generates the extraction image, clones the repository, and then runs the
 extraction image's container to perform the Kythe extraction on its contents.
@@ -184,7 +184,7 @@ The usage for the binary is as follows:
 extractrepo -repo <repo_uri> -output <output_file_path> -config [config_file_path]
 ....
 
-The https://github.com/kythe/kythe/blob/master/kythe/go/platform/tools/extraction/repotester.go[repostester]
+The https://github.com/kythe/kythe/blob/master/kythe/go/platform/tools/extraction/repotester/repotester.go[repostester]
 binary provides a tool which runs an extraction on a given repository, and then
 runs a smoke test to verify adequate file coverage on the extraction's output.
 The usage for the binary is as follows:

--- a/kythe/docs/kythe-storage.txt
+++ b/kythe/docs/kythe-storage.txt
@@ -651,23 +651,23 @@ repository:
 write_entries::
   A tool that writes a stream of Kythe entries stored as protobuf messages to
   an arbitrary graph store service.
-  [link:/repo/kythe/go/storage/tools/write_entries.go[source]]
+  [link:/repo/kythe/go/storage/tools/write_entries/write_entries.go[source]]
 
 read_entries::
   A tool that scans a Kythe graph store, printing each entry to standard output.
-  [link:/repo/kythe/go/storage/tools/read_entries.go[source]]
+  [link:/repo/kythe/go/storage/tools/read_entries/read_entries.go[source]]
 
 triples::
   A tool to convert a stream of Kythe entries into
   link:http://en.wikipedia.org/wiki/N-Triples[triples].
-  [link:/repo/kythe/go/storage/tools/triples.go[source]]
+  [link:/repo/kythe/go/storage/tools/triples/triples.go[source]]
 
 directory_indexer::
   A tool to generate Kythe entries representing a directory tree.
-  [link:/repo/kythe/go/storage/tools/directory_indexer.go[source]]
+  [link:/repo/kythe/go/storage/tools/directory_indexer/directory_indexer.go[source]]
 
 leveldb::
   An implementation of a graph store using link:http://leveldb.org[LevelDB]
-  (via link:http://github.com/jmjodges/levigo[levigo]).
+  (via link:http://github.com/jmhodges/levigo[levigo]).
   [link:/repo/kythe/go/storage/leveldb/leveldb.go[source]]
 

--- a/kythe/web/site/examples.md
+++ b/kythe/web/site/examples.md
@@ -42,7 +42,7 @@ java -Xbootclasspath/p:third_party/javac/javac*.jar \
 ## Extracting Compilations using Bazel
 
 Kythe uses Bazel to build itself and has implemented Bazel
-[action_listener](http://bazel.io/docs/build-encyclopedia.html#action_listener)s
+[action_listener](https://docs.bazel.build/versions/master/be/extra-actions.html#action_listener)s
 that use Kythe's Java and C++ extractors.  This effectively allows Bazel to
 extract each compilation as it is run during the build.
 


### PR DESCRIPTION
There's also a link in the "Build System Integration" section of kythe/web/site/contributing.md that points to some cmake files that seem to have moved. I'm not sure where that code lives now.