### PR TITLE
chore: rename header guards (#945)

### DIFF
--- a/kythe/cxx/extractor/cxx_details.h
+++ b/kythe/cxx/extractor/cxx_details.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef KYTHE_CXX_COMMON_CXX_DETAILS_H_
-#define KYTHE_CXX_COMMON_CXX_DETAILS_H_
+#ifndef KYTHE_CXX_EXTRACTOR_CXX_DETAILS_H_
+#define KYTHE_CXX_EXTRACTOR_CXX_DETAILS_H_
 
 #include "clang/Basic/SourceManager.h"
 #include "clang/Lex/HeaderSearch.h"
@@ -63,4 +63,4 @@ struct HeaderSearchInfo {
 extern const char kCxxCompilationUnitDetailsURI[];
 }  // namespace kythe
 
-#endif  // KYTHE_CXX_COMMON_CXX_DETAILS_H_
+#endif  // KYTHE_CXX_EXTRACTOR_CXX_DETAILS_H_

--- a/kythe/cxx/extractor/index_pack.h
+++ b/kythe/cxx/extractor/index_pack.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef KYTHE_CXX_COMMON_INDEX_PACK_H_
-#define KYTHE_CXX_COMMON_INDEX_PACK_H_
+#ifndef KYTHE_CXX_EXTRACTOR_INDEX_PACK_H_
+#define KYTHE_CXX_EXTRACTOR_INDEX_PACK_H_
 
 #include <functional>
 #include <memory>
@@ -254,4 +254,4 @@ class IndexPack {
 };
 }  // namespace kythe
 
-#endif  // KYTHE_CXX_COMMON_INDEX_PACK_H_
+#endif  // KYTHE_CXX_EXTRACTOR_INDEX_PACK_H_

--- a/kythe/cxx/extractor/language.h
+++ b/kythe/cxx/extractor/language.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef KYTHE_CXX_EXTRACTOR_KYTHE_LANGUAGE_H_
-#define KYTHE_CXX_EXTRACTOR_KYTHE_LANGUAGE_H_
+#ifndef KYTHE_CXX_EXTRACTOR_LANGUAGE_H_
+#define KYTHE_CXX_EXTRACTOR_LANGUAGE_H_
 
 #include <string>
 
@@ -36,4 +36,4 @@ std::string ToString(Language l);
 };  // namespace supported_language
 };  // namespace kythe
 
-#endif  // KYTHE_CXX_EXTRACTOR_KYTHE_LANGUAGE_H_
+#endif  // KYTHE_CXX_EXTRACTOR_LANGUAGE_H_

--- a/kythe/cxx/extractor/language.h
+++ b/kythe/cxx/extractor/language.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef KYTHE_CXX_COMMON_KYTHE_LANGUAGE_H_
-#define KYTHE_CXX_COMMON_KYTHE_LANGUAGE_H_
+#ifndef KYTHE_CXX_EXTRACTOR_KYTHE_LANGUAGE_H_
+#define KYTHE_CXX_EXTRACTOR_KYTHE_LANGUAGE_H_
 
 #include <string>
 
@@ -36,4 +36,4 @@ std::string ToString(Language l);
 };  // namespace supported_language
 };  // namespace kythe
 
-#endif  // KYTHE_CXX_COMMON_KYTHE_LANGUAGE_H_
+#endif  // KYTHE_CXX_EXTRACTOR_KYTHE_LANGUAGE_H_

--- a/kythe/cxx/extractor/path_utils.h
+++ b/kythe/cxx/extractor/path_utils.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef KYTHE_CXX_COMMON_PATH_UTILS_H_
-#define KYTHE_CXX_COMMON_PATH_UTILS_H_
+#ifndef KYTHE_CXX_EXTRACTOR_PATH_UTILS_H_
+#define KYTHE_CXX_EXTRACTOR_PATH_UTILS_H_
 
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringRef.h"
@@ -64,4 +64,4 @@ const clang::FileEntry* LookupFileForIncludePragma(
     llvm::SmallVectorImpl<char>* filename);
 }  // namespace kythe
 
-#endif  // KYTHE_CXX_COMMON_PATH_UTILS_H_
+#endif  // KYTHE_CXX_EXTRACTOR_PATH_UTILS_H_

--- a/kythe/cxx/indexer/cxx/KytheClaimClient.h
+++ b/kythe/cxx/indexer/cxx/KytheClaimClient.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef KYTHE_CXX_COMMON_INDEXING_KYTHE_CLAIM_CLIENT_H_
-#define KYTHE_CXX_COMMON_INDEXING_KYTHE_CLAIM_CLIENT_H_
+#ifndef KYTHE_CXX_INDEXER_CXX_KYTHE_CLAIM_CLIENT_H_
+#define KYTHE_CXX_INDEXER_CXX_KYTHE_CLAIM_CLIENT_H_
 
 #include <map>
 
@@ -125,4 +125,4 @@ class DynamicClaimClient : public KytheClaimClient {
 
 }  // namespace kythe
 
-#endif
+#endif  // KYTHE_CXX_INDEXER_CXX_KYTHE_CLAIM_CLIENT_H_

--- a/kythe/cxx/indexer/cxx/frontend.h
+++ b/kythe/cxx/indexer/cxx/frontend.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef KYTHE_CXX_COMMON_FRONTEND_H_
-#define KYTHE_CXX_COMMON_FRONTEND_H_
+#ifndef KYTHE_CXX_INDEXER_CXX_FRONTEND_H_
+#define KYTHE_CXX_INDEXER_CXX_FRONTEND_H_
 
 #include <string>
 #include <vector>
@@ -128,4 +128,4 @@ class IndexerContext {
 
 }  // namespace kythe
 
-#endif  // KYTHE_CXX_COMMON_FRONTEND_H_
+#endif  // KYTHE_CXX_INDEXER_CXX_FRONTEND_H_

--- a/kythe/cxx/indexer/cxx/proto_conversions.h
+++ b/kythe/cxx/indexer/cxx/proto_conversions.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef KYTHE_CXX_COMMON_PROTO_CONVERSIONS_H_
-#define KYTHE_CXX_COMMON_PROTO_CONVERSIONS_H_
+#ifndef KYTHE_CXX_INDEXER_CXX_PROTO_CONVERSIONS_H_
+#define KYTHE_CXX_INDEXER_CXX_PROTO_CONVERSIONS_H_
 
 #include "llvm/ADT/StringRef.h"
 
@@ -30,4 +30,4 @@ inline llvm::StringRef ToStringRef(const google::protobuf::string& string) {
 }
 }  // namespace kythe
 
-#endif  // KYTHE_CXX_COMMON_PROTO_CONVERSIONS_H_
+#endif  // KYTHE_CXX_INDEXER_CXX_PROTO_CONVERSIONS_H_


### PR DESCRIPTION
We need a stronger tag than `chore` for changes like this