### PR TITLE
refactor: replace iteration over depsets with explicit .to_list() call

### DIFF
--- a/kythe/java/com/google/devtools/kythe/extractors/java/standalone/aspect.bzl
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/standalone/aspect.bzl
@@ -60,7 +60,7 @@ def _extract_java_aspect(target, ctx):
         vnames_config = ctx.file._java_aspect_vnames_config,
         srcs = ctx.rule.files.srcs,
         opts = args,
-        deps = list(deps),
+        deps = deps.to_list(),
         mnemonic = "JavaExtractKZip",
     )
 

--- a/tools/build_rules/verifier_test/verifier_test.bzl
+++ b/tools/build_rules/verifier_test/verifier_test.bzl
@@ -49,12 +49,12 @@ def _atomize_entries_impl(ctx):
     sorted_entries = ctx.new_file(ctx.outputs.entries, ctx.label.name + "_sorted_entries")
     ctx.action(
         outputs = [sorted_entries],
-        inputs = [zcat, entrystream] + list(inputs),
+        inputs = [zcat, entrystream] + inputs.to_list(),
         mnemonic = "SortEntries",
         command = '("$1" "${@:4}" | "$2" --sort) > "$3" || rm -f "$3"',
         arguments = (
             [zcat.path, entrystream.path, sorted_entries.path] +
-            [s.path for s in inputs]
+            [s.path for s in inputs.to_list()]
         ),
     )
     leveldb = ctx.new_file(ctx.outputs.entries, ctx.label.name + "_serving_tables")


### PR DESCRIPTION
The old pattern did an implicit iteration over a depset which is potentially expensive. The new to_list() call is still expensive but it will be more visible.