### PR TITLE
typescript: enable strict mode and fix errors

### DIFF
--- a/kythe/typescript/tsconfig.json
+++ b/kythe/typescript/tsconfig.json
@@ -2,8 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "target": "es6",
-        "noImplicitAny": true,
-        "strictNullChecks": true,
+        "strict": true,
         "sourceMap": true
     },
     "include": [


### PR DESCRIPTION
TypeScript rolled all of its strictness flags into a single `--strict`
flag.  Enable this and fix the errors it found.

- The central `Visitor` class had a weird API where it took some params
  as ctor arguments and then it took the input file as a function
  argument, despite the fact that you need a new instance per file.
  Fix this by making everything into ctor arguments and moving some
  code.
- Fix a nullability issue when iterating input files.  Handle a
  potential null by just throwing with a nicer error message.