### PR TITLE
refactor(cxx_indexer): enumerate compilations as they're read

### DIFF
--- a/kythe/cxx/indexer/cxx/KytheIndexerMain.cc
+++ b/kythe/cxx/indexer/cxx/KytheIndexerMain.cc
@@ -80,7 +80,6 @@ int main(int argc, char* argv[]) {
                             : FLAGS_experimental_usr_byte_size;
   options.DropInstantiationIndependentData =
       FLAGS_experimental_drop_instantiation_independent_data;
-  options.AllowFSAccess = context.allow_filesystem_access();
   if (FLAGS_report_profiling_events) {
     options.ReportProfileEvent = [](const char* counter, ProfilingEvent event) {
       fprintf(stderr, "%s: %s\n", counter,
@@ -91,8 +90,9 @@ int main(int argc, char* argv[]) {
   bool had_errors = false;
   NullOutputStream null_stream;
 
-  for (auto& job : *context.jobs()) {
+  context.EnumerateCompilations([&](IndexerJob& job) {
     options.EffectiveWorkingDirectory = job.working_directory;
+    options.AllowFSAccess = job.allow_filesystem_access;
 
     kythe::MetadataSupports meta_supports;
     meta_supports.Add(llvm::make_unique<ProtobufMetadataSupport>());
@@ -117,7 +117,7 @@ int main(int argc, char* argv[]) {
       fprintf(stderr, "Error: %s\n", result.c_str());
       had_errors = true;
     }
-  }
+  });
 
   return (had_errors ? 1 : 0);
 }

--- a/kythe/cxx/indexer/cxx/KytheIndexerMain.cc
+++ b/kythe/cxx/indexer/cxx/KytheIndexerMain.cc
@@ -90,7 +90,7 @@ int main(int argc, char* argv[]) {
   bool had_errors = false;
   NullOutputStream null_stream;
 
-  context.EnumerateCompilations([&](IndexerJob& job) {
+  IndexerContext::CompilationVisitCallback callback = [&](IndexerJob& job) {
     options.EffectiveWorkingDirectory = job.working_directory;
     options.AllowFSAccess = job.allow_filesystem_access;
 
@@ -117,7 +117,8 @@ int main(int argc, char* argv[]) {
       fprintf(stderr, "Error: %s\n", result.c_str());
       had_errors = true;
     }
-  });
+  };
+  context.EnumerateCompilations(callback);
 
   return (had_errors ? 1 : 0);
 }

--- a/kythe/cxx/indexer/cxx/KytheIndexerMain.cc
+++ b/kythe/cxx/indexer/cxx/KytheIndexerMain.cc
@@ -80,6 +80,7 @@ int main(int argc, char* argv[]) {
                             : FLAGS_experimental_usr_byte_size;
   options.DropInstantiationIndependentData =
       FLAGS_experimental_drop_instantiation_independent_data;
+  options.AllowFSAccess = context.allow_filesystem_access();
   if (FLAGS_report_profiling_events) {
     options.ReportProfileEvent = [](const char* counter, ProfilingEvent event) {
       fprintf(stderr, "%s: %s\n", counter,
@@ -92,7 +93,6 @@ int main(int argc, char* argv[]) {
 
   context.EnumerateCompilations([&](IndexerJob& job) {
     options.EffectiveWorkingDirectory = job.working_directory;
-    options.AllowFSAccess = job.allow_filesystem_access;
 
     kythe::MetadataSupports meta_supports;
     meta_supports.Add(llvm::make_unique<ProtobufMetadataSupport>());

--- a/kythe/cxx/indexer/cxx/KytheIndexerMain.cc
+++ b/kythe/cxx/indexer/cxx/KytheIndexerMain.cc
@@ -90,7 +90,7 @@ int main(int argc, char* argv[]) {
   bool had_errors = false;
   NullOutputStream null_stream;
 
-  IndexerContext::CompilationVisitCallback callback = [&](IndexerJob& job) {
+  context.EnumerateCompilations([&](IndexerJob& job) {
     options.EffectiveWorkingDirectory = job.working_directory;
     options.AllowFSAccess = job.allow_filesystem_access;
 
@@ -117,8 +117,7 @@ int main(int argc, char* argv[]) {
       fprintf(stderr, "Error: %s\n", result.c_str());
       had_errors = true;
     }
-  };
-  context.EnumerateCompilations(callback);
+  });
 
   return (had_errors ? 1 : 0);
 }

--- a/kythe/cxx/indexer/cxx/frontend.cc
+++ b/kythe/cxx/indexer/cxx/frontend.cc
@@ -103,6 +103,28 @@ void DecodeStaticClaimTable(const std::string& path,
   close(fd);
 }
 
+/// \brief Normalize input file vnames by cleaning paths and clearing
+/// signatures.
+void MaybeNormalizeFileVNames(IndexerJob* job) {
+  if (!FLAGS_normalize_file_vnames) {
+    return;
+  }
+  for (auto& input : *job->unit.mutable_required_input()) {
+    input.mutable_v_name()->set_path(CleanPath(llvm::StringRef(
+        input.v_name().path().data(), input.v_name().path().size())));
+    input.mutable_v_name()->clear_signature();
+  }
+}
+
+void UpdateJobWdirFromUnit(IndexerJob* job) {
+  job->working_directory = job->unit.working_directory();
+  if (!llvm::sys::path::is_absolute(job->working_directory)) {
+    llvm::SmallString<1024> stored_wd;
+    CHECK(!llvm::sys::fs::make_absolute(stored_wd));
+    job->working_directory = stored_wd.str();
+  }
+}
+
 /// \brief Reads data from a .kindex file into memory.
 /// \param path The path from which the file should be read.
 /// \param virtual_files A vector to be filled with FileData.
@@ -142,17 +164,14 @@ void DecodeIndexFile(const std::string& path,
 /// \param jobs A vector to add a job to for each compilation in the kzip.
 /// \param silent The silent flag is copied to each of the jobs created from the
 /// kzip file.
-void DecodeKZipFile(const std::string& path, std::vector<IndexerJob>* jobs,
-                    bool silent) {
+void DecodeKZipFile(const std::string& path, bool silent,
+                    IndexerContext::CompilationVisitCallback visit) {
   StatusOr<IndexReader> reader = kythe::KzipReader::Open(path);
   CHECK(reader) << "Couldn't open kzip from " << path;
   bool compilation_read = false;
   auto status = reader->Scan([&](absl::string_view digest) {
-    // TODO(#3233): Process compilation units as they're read rather than
-    // storing them all in memory and processing later.
-    jobs->emplace_back();
-    auto* job = &jobs->back();
-    job->silent = silent;
+    IndexerJob job;
+    job.silent = silent;
 
     auto compilation = reader->ReadUnit(digest);
     for (const auto& file : compilation->unit().required_input()) {
@@ -163,9 +182,14 @@ void DecodeKZipFile(const std::string& path, std::vector<IndexerJob>* jobs,
       file_data.set_content(*content);
       file_data.mutable_info()->set_path(file.info().path());
       file_data.mutable_info()->set_digest(file.info().digest());
-      job->virtual_files.push_back(std::move(file_data));
+      job.virtual_files.push_back(std::move(file_data));
     }
-    job->unit = compilation->unit();
+    job.unit = compilation->unit();
+
+    UpdateJobWdirFromUnit(&job);
+    MaybeNormalizeFileVNames(&job);
+    visit(job);
+
     compilation_read = true;
     return true;
   });
@@ -255,16 +279,16 @@ bool IndexerContext::HasIndexArguments() {
   return had_index;
 }
 
-void IndexerContext::LoadDataFromIndex(const std::string& file_or_cu) {
+void IndexerContext::LoadDataFromIndex(const std::string& file_or_cu,
+                                       CompilationVisitCallback visit) {
   std::string name = strip_silent_input_prefix(file_or_cu);
   const bool silent = !name.empty();
   if (name.empty()) {
     name = file_or_cu;
   }
   if (!FLAGS_index_pack.empty()) {
-    jobs_.emplace_back();
-    auto* job = &jobs_.back();
-    job->silent = silent;
+    IndexerJob job;
+    job.silent = silent;
 
     std::string error_text;
     auto filesystem = kythe::IndexPackPosixFilesystem::Open(
@@ -273,27 +297,31 @@ void IndexerContext::LoadDataFromIndex(const std::string& file_or_cu) {
     CHECK(filesystem) << "Couldn't open index pack from " << FLAGS_index_pack
                       << ": " << error_text;
     DecodeIndexPack(name, llvm::make_unique<IndexPack>(std::move(filesystem)),
-                    &job->virtual_files, &job->unit);
+                    &job.virtual_files, &job.unit);
+    UpdateJobWdirFromUnit(&job);
+    MaybeNormalizeFileVNames(&job);
+    visit(job);
   } else if (llvm::StringRef(file_or_cu).endswith(".kzip")) {
-    DecodeKZipFile(name, &jobs_, silent);
+    DecodeKZipFile(name, silent, visit);
   } else {
-    jobs_.emplace_back();
-    auto* job = &jobs_.back();
-    job->silent = silent;
-    DecodeIndexFile(name, &job->virtual_files, &job->unit);
+    IndexerJob job;
+    job.silent = silent;
+    DecodeIndexFile(name, &job.virtual_files, &job.unit);
+    UpdateJobWdirFromUnit(&job);
+    MaybeNormalizeFileVNames(&job);
+    visit(job);
   }
 }
 
 void IndexerContext::LoadDataFromUnpackedFile(
-    const std::string& default_filename) {
-  jobs_.emplace_back();
-  auto* job = &jobs_.back();
-  allow_filesystem_access_ = true;
+    const std::string& default_filename, CompilationVisitCallback visit) {
+  IndexerJob job;
+  job.allow_filesystem_access = true;
   int read_fd = STDIN_FILENO;
   std::string source_file_name = default_filename;
   llvm::SmallString<1024> cwd;
   CHECK(!llvm::sys::fs::current_path(cwd));
-  job->working_directory = cwd.str();
+  job.working_directory = cwd.str();
   if (FLAGS_i != "-") {
     read_fd = open(FLAGS_i.c_str(), O_RDONLY);
     if (read_fd == -1) {
@@ -319,11 +347,13 @@ void IndexerContext::LoadDataFromUnpackedFile(
   proto::FileData file_data;
   file_data.mutable_info()->set_path(source_file_name);
   file_data.set_content(source_data.str());
-  job->virtual_files.push_back(std::move(file_data));
+  job.virtual_files.push_back(std::move(file_data));
   for (const auto& arg : args_) {
-    job->unit.add_argument(arg);
+    job.unit.add_argument(arg);
   }
-  job->unit.mutable_v_name()->set_corpus(FLAGS_icorpus);
+  job.unit.mutable_v_name()->set_corpus(FLAGS_icorpus);
+  MaybeNormalizeFileVNames(&job);
+  visit(job);
 }
 
 void IndexerContext::InitializeClaimClient() {
@@ -343,16 +373,6 @@ void IndexerContext::InitializeClaimClient() {
     }
     static_claims->set_process_unknown_status(FLAGS_claim_unknown);
     claim_client_ = std::move(static_claims);
-  }
-}
-
-void IndexerContext::NormalizeFileVNames() {
-  for (auto& job : jobs_) {
-    for (auto& input : *job.unit.mutable_required_input()) {
-      input.mutable_v_name()->set_path(CleanPath(llvm::StringRef(
-          input.v_name().path().data(), input.v_name().path().size())));
-      input.mutable_v_name()->clear_signature();
-    }
   }
 }
 
@@ -395,38 +415,31 @@ void IndexerContext::OpenHashCache() {
 
 IndexerContext::IndexerContext(const std::vector<std::string>& args,
                                const std::string& default_filename)
-    : args_(args), ignore_unimplemented_(FLAGS_ignore_unimplemented) {
+    : args_(args),
+      default_filename_(default_filename),
+      ignore_unimplemented_(FLAGS_ignore_unimplemented) {
   args_.erase(std::remove(args_.begin(), args_.end(), std::string()),
               args_.end());
-  if (HasIndexArguments()) {
-    // This forces the BuildDetails proto descriptor to be added to the pool so
-    // we can deserialize it.
-    proto::BuildDetails needed_for_proto_deserialization;
 
-    for (size_t arg = 1; arg < args_.size(); ++arg) {
-      LoadDataFromIndex(args[arg]);
-
-      // Set the working_directory for each job from the corresponding unit.
-      for (auto& job : jobs_) {
-        job.working_directory = job.unit.working_directory();
-        if (!llvm::sys::path::is_absolute(job.working_directory)) {
-          llvm::SmallString<1024> stored_wd;
-          CHECK(!llvm::sys::fs::make_absolute(stored_wd));
-          job.working_directory = stored_wd.str();
-        }
-      }
-    }
-  } else {
-    LoadDataFromUnpackedFile(default_filename);
-  }
-  if (FLAGS_normalize_file_vnames) {
-    NormalizeFileVNames();
-  }
   InitializeClaimClient();
   OpenOutputStreams();
   OpenHashCache();
 }
 
 IndexerContext::~IndexerContext() { CloseOutputStreams(); }
+
+void IndexerContext::EnumerateCompilations(CompilationVisitCallback visit) {
+  // This forces the BuildDetails proto descriptor to be added to the pool so
+  // we can deserialize it.
+  proto::BuildDetails needed_for_proto_deserialization;
+
+  if (HasIndexArguments()) {
+    for (size_t arg = 1; arg < args_.size(); ++arg) {
+      LoadDataFromIndex(args_[arg], visit);
+    }
+  } else {
+    LoadDataFromUnpackedFile(default_filename_, visit);
+  }
+}
 
 }  // namespace kythe

--- a/kythe/cxx/indexer/cxx/frontend.cc
+++ b/kythe/cxx/indexer/cxx/frontend.cc
@@ -165,7 +165,7 @@ void DecodeIndexFile(const std::string& path,
 /// \param silent The silent flag is copied to each of the jobs created from the
 /// kzip file.
 void DecodeKZipFile(const std::string& path, bool silent,
-                    IndexerContext::CompilationVisitCallback visit) {
+                    IndexerContext::CompilationVisitCallback& visit) {
   StatusOr<IndexReader> reader = kythe::KzipReader::Open(path);
   CHECK(reader) << "Couldn't open kzip from " << path;
   bool compilation_read = false;
@@ -280,7 +280,7 @@ bool IndexerContext::HasIndexArguments() {
 }
 
 void IndexerContext::LoadDataFromIndex(const std::string& file_or_cu,
-                                       CompilationVisitCallback visit) {
+                                       CompilationVisitCallback& visit) {
   std::string name = strip_silent_input_prefix(file_or_cu);
   const bool silent = !name.empty();
   if (name.empty()) {
@@ -314,7 +314,7 @@ void IndexerContext::LoadDataFromIndex(const std::string& file_or_cu,
 }
 
 void IndexerContext::LoadDataFromUnpackedFile(
-    const std::string& default_filename, CompilationVisitCallback visit) {
+    const std::string& default_filename, CompilationVisitCallback& visit) {
   IndexerJob job;
   job.allow_filesystem_access = true;
   int read_fd = STDIN_FILENO;
@@ -428,7 +428,7 @@ IndexerContext::IndexerContext(const std::vector<std::string>& args,
 
 IndexerContext::~IndexerContext() { CloseOutputStreams(); }
 
-void IndexerContext::EnumerateCompilations(CompilationVisitCallback visit) {
+void IndexerContext::EnumerateCompilations(CompilationVisitCallback& visit) {
   // This forces the BuildDetails proto descriptor to be added to the pool so
   // we can deserialize it.
   proto::BuildDetails needed_for_proto_deserialization;

--- a/kythe/cxx/indexer/cxx/frontend.cc
+++ b/kythe/cxx/indexer/cxx/frontend.cc
@@ -165,7 +165,7 @@ void DecodeIndexFile(const std::string& path,
 /// \param silent The silent flag is copied to each of the jobs created from the
 /// kzip file.
 void DecodeKZipFile(const std::string& path, bool silent,
-                    IndexerContext::CompilationVisitCallback& visit) {
+                    const IndexerContext::CompilationVisitCallback& visit) {
   StatusOr<IndexReader> reader = kythe::KzipReader::Open(path);
   CHECK(reader) << "Couldn't open kzip from " << path;
   bool compilation_read = false;
@@ -280,7 +280,7 @@ bool IndexerContext::HasIndexArguments() {
 }
 
 void IndexerContext::LoadDataFromIndex(const std::string& file_or_cu,
-                                       CompilationVisitCallback& visit) {
+                                       const CompilationVisitCallback& visit) {
   std::string name = strip_silent_input_prefix(file_or_cu);
   const bool silent = !name.empty();
   if (name.empty()) {
@@ -314,7 +314,8 @@ void IndexerContext::LoadDataFromIndex(const std::string& file_or_cu,
 }
 
 void IndexerContext::LoadDataFromUnpackedFile(
-    const std::string& default_filename, CompilationVisitCallback& visit) {
+    const std::string& default_filename,
+    const CompilationVisitCallback& visit) {
   IndexerJob job;
   job.allow_filesystem_access = true;
   int read_fd = STDIN_FILENO;
@@ -428,7 +429,8 @@ IndexerContext::IndexerContext(const std::vector<std::string>& args,
 
 IndexerContext::~IndexerContext() { CloseOutputStreams(); }
 
-void IndexerContext::EnumerateCompilations(CompilationVisitCallback& visit) {
+void IndexerContext::EnumerateCompilations(
+    const CompilationVisitCallback& visit) {
   // This forces the BuildDetails proto descriptor to be added to the pool so
   // we can deserialize it.
   proto::BuildDetails needed_for_proto_deserialization;

--- a/kythe/cxx/indexer/cxx/frontend.cc
+++ b/kythe/cxx/indexer/cxx/frontend.cc
@@ -420,7 +420,6 @@ IndexerContext::IndexerContext(const std::vector<std::string>& args,
       ignore_unimplemented_(FLAGS_ignore_unimplemented) {
   args_.erase(std::remove(args_.begin(), args_.end(), std::string()),
               args_.end());
-  // Only allow filesystem access for unpacked inputs
   unpacked_inputs_ = !HasIndexArguments();
 
   InitializeClaimClient();

--- a/kythe/cxx/indexer/cxx/frontend.h
+++ b/kythe/cxx/indexer/cxx/frontend.h
@@ -60,11 +60,11 @@ class IndexerContext {
   ~IndexerContext();
 
   /// \brief A callback used when enumerating compilations.
-  typedef std::function<void(IndexerJob&)> CompilationVisitCallback;
+  using CompilationVisitCallback = std::function<void(IndexerJob&)>;
   /// \brief Reads compilations from the file(s) specified in the constructor
   /// and calls the callback for each one.
   /// \param visit A callback to call for each compilation unit.
-  void EnumerateCompilations(CompilationVisitCallback visit);
+  void EnumerateCompilations(CompilationVisitCallback& visit);
 
   /// \brief If non-null, the hash cache to use. Owned by `IndexerContext`.
   HashCache* hash_cache() const { return hash_cache_.get(); }
@@ -98,12 +98,12 @@ class IndexerContext {
   /// compilation unit hash.
   /// \param visit A callback to call for each compilation unit.
   void LoadDataFromIndex(const std::string& file_or_cu,
-                         CompilationVisitCallback visit);
+                         CompilationVisitCallback& visit);
   /// \brief Load data from an unpacked file.
   /// \param default_filename The filename to use if we're reading from stdin.
   /// \param visit A callback to call for each compilation unit.
   void LoadDataFromUnpackedFile(const std::string& default_filename,
-                                CompilationVisitCallback visit);
+                                CompilationVisitCallback& visit);
   /// \brief Initialize a claim client.
   void InitializeClaimClient();
   /// \brief Prepare to write to output.

--- a/kythe/cxx/indexer/cxx/frontend.h
+++ b/kythe/cxx/indexer/cxx/frontend.h
@@ -42,9 +42,6 @@ struct IndexerJob {
   std::string working_directory;
   /// If set, this job should not produce any output.
   bool silent = false;
-  /// If true, the indexer is permitted to touch the local filesystem for this
-  /// job.
-  bool allow_filesystem_access = false;
 };
 
 /// \brief Handles common tasks related to invoking a Kythe indexer from the
@@ -68,6 +65,12 @@ class IndexerContext {
 
   /// \brief If non-null, the hash cache to use. Owned by `IndexerContext`.
   HashCache* hash_cache() const { return hash_cache_.get(); }
+  /// \brief If true, the indexer is permitted to touch the local filesystem.
+  bool allow_filesystem_access() const {
+    // Only allow filesystem access for unpacked inputs. Indexes already contain
+    // all the necessary files.
+    return unpacked_inputs_;
+  }
   /// \brief If true, the indexer should handle unknown elements gracefully.
   bool ignore_unimplemented() const { return ignore_unimplemented_; }
   /// \brief The claim client to use for this compilation. Not null.
@@ -127,6 +130,8 @@ class IndexerContext {
   std::unique_ptr<kythe::KytheClaimClient> claim_client_;
   /// The hash cache to use during analysis (or null).
   std::unique_ptr<HashCache> hash_cache_;
+  /// Whether the args specify an unpacked input file as opposed to an index.
+  bool unpacked_inputs_ = false;
   /// Whether to ignore missing cases during analysis.
   bool ignore_unimplemented_ = false;
 };

--- a/kythe/cxx/indexer/cxx/frontend.h
+++ b/kythe/cxx/indexer/cxx/frontend.h
@@ -41,7 +41,10 @@ struct IndexerJob {
   /// not exist on the local filesystem.
   std::string working_directory;
   /// If set, this job should not produce any output.
-  bool silent;
+  bool silent = false;
+  /// If true, the indexer is permitted to touch the local filesystem for this
+  /// job.
+  bool allow_filesystem_access = false;
 };
 
 /// \brief Handles common tasks related to invoking a Kythe indexer from the
@@ -56,14 +59,17 @@ class IndexerContext {
                  const std::string& default_filename);
   ~IndexerContext();
 
+  /// \brief A callback used when enumerating compilations.
+  typedef std::function<void(IndexerJob&)> CompilationVisitCallback;
+  /// \brief Reads compilations from the file(s) specified in the constructor
+  /// and calls the callback for each one.
+  /// \param visit A callback to call for each compilation unit.
+  void EnumerateCompilations(CompilationVisitCallback visit);
+
   /// \brief If non-null, the hash cache to use. Owned by `IndexerContext`.
   HashCache* hash_cache() const { return hash_cache_.get(); }
-  /// \brief If true, the indexer is permitted to touch the local filesystem.
-  bool allow_filesystem_access() const { return allow_filesystem_access_; }
   /// \brief If true, the indexer should handle unknown elements gracefully.
   bool ignore_unimplemented() const { return ignore_unimplemented_; }
-  /// \brief Indexer jobs to complete.
-  std::vector<IndexerJob>* jobs() { return &jobs_; }
   /// \brief The claim client to use for this compilation. Not null.
   KytheClaimClient* claim_client() const {
     CHECK(claim_client_ != nullptr);
@@ -90,15 +96,16 @@ class IndexerContext {
   /// \brief Loads from an index pack or .kindex.
   /// \param file_or_cu The name of the .kzip or .kindex (with extension) or the
   /// compilation unit hash.
-  void LoadDataFromIndex(const std::string& file_or_cu);
+  /// \param visit A callback to call for each compilation unit.
+  void LoadDataFromIndex(const std::string& file_or_cu,
+                         CompilationVisitCallback visit);
   /// \brief Load data from an unpacked file.
   /// \param default_filename The filename to use if we're reading from stdin.
-  void LoadDataFromUnpackedFile(const std::string& default_filename);
+  /// \param visit A callback to call for each compilation unit.
+  void LoadDataFromUnpackedFile(const std::string& default_filename,
+                                CompilationVisitCallback visit);
   /// \brief Initialize a claim client.
   void InitializeClaimClient();
-  /// \brief Normalize input file vnames by cleaning paths and clearing
-  /// signatures.
-  void NormalizeFileVNames();
   /// \brief Prepare to write to output.
   void OpenOutputStreams();
   /// \brief Flush output.
@@ -108,8 +115,8 @@ class IndexerContext {
 
   /// Command-line arguments, pruned of empty strings and gflags.
   std::vector<std::string> args_;
-  /// Indexer jobs to complete.
-  std::vector<IndexerJob> jobs_;
+  /// Default_filename The filename to use if we're reading from stdin.
+  std::string default_filename_;
   /// The file descriptor to which we're writing output.
   int write_fd_ = -1;
   /// Wraps `write_fd_`.
@@ -120,8 +127,6 @@ class IndexerContext {
   std::unique_ptr<kythe::KytheClaimClient> claim_client_;
   /// The hash cache to use during analysis (or null).
   std::unique_ptr<HashCache> hash_cache_;
-  /// Whether access to the local filesystem is allowed during analysis.
-  bool allow_filesystem_access_ = false;
   /// Whether to ignore missing cases during analysis.
   bool ignore_unimplemented_ = false;
 };

--- a/kythe/cxx/indexer/cxx/frontend.h
+++ b/kythe/cxx/indexer/cxx/frontend.h
@@ -64,7 +64,7 @@ class IndexerContext {
   /// \brief Reads compilations from the file(s) specified in the constructor
   /// and calls the callback for each one.
   /// \param visit A callback to call for each compilation unit.
-  void EnumerateCompilations(CompilationVisitCallback& visit);
+  void EnumerateCompilations(const CompilationVisitCallback& visit);
 
   /// \brief If non-null, the hash cache to use. Owned by `IndexerContext`.
   HashCache* hash_cache() const { return hash_cache_.get(); }
@@ -98,12 +98,12 @@ class IndexerContext {
   /// compilation unit hash.
   /// \param visit A callback to call for each compilation unit.
   void LoadDataFromIndex(const std::string& file_or_cu,
-                         CompilationVisitCallback& visit);
+                         const CompilationVisitCallback& visit);
   /// \brief Load data from an unpacked file.
   /// \param default_filename The filename to use if we're reading from stdin.
   /// \param visit A callback to call for each compilation unit.
   void LoadDataFromUnpackedFile(const std::string& default_filename,
-                                CompilationVisitCallback& visit);
+                                const CompilationVisitCallback& visit);
   /// \brief Initialize a claim client.
   void InitializeClaimClient();
   /// \brief Prepare to write to output.


### PR DESCRIPTION
This way there is only one compilation in memory at a time (#3233), which is more memory-efficient than building a list of all compilations and processing them all afterwards.

Previously the `IndexerContext` constructor did all the work and saved a list of jobs. Now the constructor just does some basic setup and the `EnumerateCompilations()` method handles reading files and passing compilations to the indexer callback.