### PR TITLE
fix(cxx frontend): set CompilationUnit.source_file for unpacked input

### DIFF
--- a/kythe/cxx/indexer/cxx/frontend.cc
+++ b/kythe/cxx/indexer/cxx/frontend.cc
@@ -348,6 +348,7 @@ void IndexerContext::LoadDataFromUnpackedFile(
   file_data.mutable_info()->set_path(source_file_name);
   file_data.set_content(source_data.str());
   job.virtual_files.push_back(std::move(file_data));
+  job.unit.add_source_file(source_file_name);
   for (const auto& arg : args_) {
     job.unit.add_argument(arg);
   }


### PR DESCRIPTION
When using the indexer like: `indexer -i file.cc`, sets the `source_file` field to `["file.cc"]`.

The C++ indexer seems to work fine without this field set, but other indexers do require it. Setting this field could allow for other indexers implemented in C++ to reuse `IndexerContext`. Why does C++ not require this field? Does it just read thorough all of the files in the list passed alongside the `CompilationUnit`?