### PR TITLE
Use rules_docker to build http_server image

### DIFF
--- a/external.bzl
+++ b/external.bzl
@@ -7,6 +7,14 @@ load("@io_kythe//:setup.bzl", "maybe")
 load("@io_bazel_rules_go//go:def.bzl", "go_register_toolchains", "go_rules_dependencies")
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
 load("@build_bazel_rules_nodejs//:package.bzl", "rules_nodejs_dependencies")
+load(
+    "@io_bazel_rules_docker//container:container.bzl",
+    _container_repositories = "repositories",
+)
+load(
+    "@io_bazel_rules_docker//go:image.bzl",
+    _go_image_repos = "repositories",
+)
 
 def _rule_dependencies():
     gazelle_dependencies()
@@ -609,6 +617,11 @@ def _bindings():
         actual = "@net_zlib//:zlib",
     )
 
+def _docker_dependencies():
+    _container_repositories()
+
+    _go_image_repos()
+
 def kythe_dependencies():
     """Defines external repositories for Kythe dependencies.
 
@@ -617,6 +630,7 @@ def kythe_dependencies():
     _cc_dependencies()
     _go_dependencies()
     _java_dependencies()
+    _docker_dependencies()
 
     # proto_library, cc_proto_library, and java_proto_library rules implicitly
     # depend on @com_google_protobuf for protoc and proto runtimes.

--- a/kythe/go/serving/tools/http_server/BUILD
+++ b/kythe/go/serving/tools/http_server/BUILD
@@ -1,3 +1,4 @@
+load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("//tools:build_rules/shims.bzl", "go_binary")
 
 package(default_visibility = ["//kythe:default_visibility"])
@@ -5,6 +6,28 @@ package(default_visibility = ["//kythe:default_visibility"])
 go_binary(
     name = "http_server",
     srcs = ["http_server.go"],
+    deps = [
+        "//kythe/go/services/filetree",
+        "//kythe/go/services/graph",
+        "//kythe/go/services/graphstore",
+        "//kythe/go/services/graphstore/proxy",
+        "//kythe/go/services/xrefs",
+        "//kythe/go/serving/filetree",
+        "//kythe/go/serving/graph",
+        "//kythe/go/serving/xrefs",
+        "//kythe/go/storage/leveldb",
+        "//kythe/go/storage/table",
+        "//kythe/go/util/flagutil",
+        "@org_golang_x_net//http2:go_default_library",
+    ],
+)
+
+go_image(
+    name = "http_server_image",
+    srcs = ["http_server.go"],
+    goarch = "amd64",
+    goos = "linux",
+    static = "on",
     deps = [
         "//kythe/go/services/filetree",
         "//kythe/go/services/graph",

--- a/setup.bzl
+++ b/setup.bzl
@@ -33,3 +33,11 @@ def kythe_rule_repositories():
         remote = "https://github.com/bazelbuild/rules_nodejs.git",
         tag = "0.16.0",
     )
+
+    maybe(
+        http_archive,
+        name = "io_bazel_rules_docker",
+        sha256 = "29d109605e0d6f9c892584f07275b8c9260803bf0c6fcb7de2623b2bedc910bd",
+        strip_prefix = "rules_docker-0.5.1",
+        urls = ["https://github.com/bazelbuild/rules_docker/archive/v0.5.1.tar.gz"],
+    )


### PR DESCRIPTION
This is in addition to the existing docker rules and shouldn't interfere
with the normal release process and provides a toehold for moving more
of that logic into rules_docker.