### PR TITLE
feat: add visibility aliases and mark some protos/utils as public

### DIFF
--- a/kythe/cxx/common/BUILD
+++ b/kythe/cxx/common/BUILD
@@ -2,6 +2,8 @@ package(default_visibility = ["//kythe:default_visibility"])
 
 licenses(["notice"])
 
+load("//:visibility.bzl", "PUBLIC_VISIBILITY")
+
 cc_library(
     name = "scope_guard",
     hdrs = ["scope_guard.h"],
@@ -35,6 +37,7 @@ cc_library(
     name = "kythe_uri",
     srcs = ["kythe_uri.cc"],
     hdrs = ["kythe_uri.h"],
+    visibility = [PUBLIC_VISIBILITY],
     deps = [
         ":vname_ordering",
         "//kythe/proto:storage_cc_proto",
@@ -45,6 +48,7 @@ cc_library(
 cc_library(
     name = "vname_ordering",
     hdrs = ["vname_ordering.h"],
+    visibility = [PUBLIC_VISIBILITY],
     deps = [
         "//kythe/proto:storage_cc_proto",
     ],
@@ -68,9 +72,7 @@ cc_library(
         "-Wno-unused-variable",
         "-Wno-implicit-fallthrough",
     ],
-    visibility = [
-        "//kythe:default_visibility",
-    ],
+    visibility = [PUBLIC_VISIBILITY],
     deps = [
         ":json_proto",
         "//external:zlib",

--- a/kythe/proto/BUILD
+++ b/kythe/proto/BUILD
@@ -2,6 +2,7 @@ package(default_visibility = ["//kythe:proto_visibility"])
 
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load(":go.bzl", "go_kythe_proto")
+load("//:visibility.bzl", "PUBLIC_PROTO_VISIBILITY")
 
 filegroup(
     name = "public",
@@ -45,6 +46,7 @@ proto_library(
 
 cc_proto_library(
     name = "common_cc_proto",
+    visibility = [PUBLIC_PROTO_VISIBILITY],
     deps = [":common_proto"],
 )
 
@@ -52,7 +54,7 @@ go_kythe_proto(proto = ":common_proto")
 
 java_proto_library(
     name = "common_java_proto",
-    visibility = ["//visibility:public"],
+    visibility = [PUBLIC_PROTO_VISIBILITY],
     deps = [":common_proto"],
 )
 
@@ -68,6 +70,7 @@ proto_library(
 
 cc_proto_library(
     name = "storage_cc_proto",
+    visibility = [PUBLIC_PROTO_VISIBILITY],
     deps = [":storage_proto"],
 )
 
@@ -75,7 +78,7 @@ go_kythe_proto(proto = ":storage_proto")
 
 java_proto_library(
     name = "storage_java_proto",
-    visibility = ["//visibility:public"],
+    visibility = [PUBLIC_PROTO_VISIBILITY],
     deps = [":storage_proto"],
 )
 
@@ -136,7 +139,7 @@ go_kythe_proto(
 
 java_proto_library(
     name = "analysis_java_proto",
-    visibility = ["//visibility:public"],
+    visibility = [PUBLIC_PROTO_VISIBILITY],
     deps = [":analysis_proto"],
 )
 
@@ -350,6 +353,7 @@ proto_library(
 
 cc_proto_library(
     name = "xref_cc_proto",
+    visibility = [PUBLIC_PROTO_VISIBILITY],
     deps = [":xref_proto"],
 )
 

--- a/visibility.bzl
+++ b/visibility.bzl
@@ -1,0 +1,9 @@
+# This file exists so that visibility rules can be relaxed for open source
+# clients of kythe, but more restrictive for use within google. Targets that are
+# allowed to be used by kythe clients should be marked as "//visibility:public",
+# but separate aliases are used so they can map to different package groups
+# within google.
+
+PUBLIC_PROTO_VISIBILITY = "//visibility:public"
+
+PUBLIC_VISIBILITY = "//visibility:public"


### PR DESCRIPTION
* The aliases for //visibility:public in visibility.bzl allow us to restrict visibility to certain package groups within google.
* The newly-public targets are needed for the proto indexer


This is kind of a hack, so I'm definitely open to better ideas. This problem is somewhat similar to what's discussed here: https://github.com/bazelbuild/bazel/issues/3744.