### PR TITLE
fix: don't crash on empty function/enum bodies

### DIFF
--- a/kythe/cxx/indexer/cxx/IndexerASTHooks.cc
+++ b/kythe/cxx/indexer/cxx/IndexerASTHooks.cc
@@ -2221,7 +2221,7 @@ bool IndexerASTVisitor::VisitEnumDecl(const clang::EnumDecl* Decl) {
   GraphObserver::NodeId DeclNode(BuildNodeIdForDecl(Decl));
   SourceLocation DeclLoc = Decl->getLocation();
   SourceRange NameRange = RangeForNameOfDeclaration(Decl);
-  if (Decl->isThisDeclarationADefinition() && Decl->hasBody()) {
+  if (Decl->isThisDeclarationADefinition() && Decl->getBody() != nullptr) {
     Marks.set_marked_source_end(Decl->getBody()->getSourceRange().getBegin());
   } else {
     Marks.set_marked_source_end(GetLocForEndOfToken(
@@ -2893,7 +2893,7 @@ bool IndexerASTVisitor::VisitFunctionDecl(clang::FunctionDecl* Decl) {
   SourceLocation DeclLoc = Decl->getLocation();
   SourceRange NameRange = RangeForNameOfDeclaration(Decl);
   if (!DeclLoc.isMacroID() && Decl->isThisDeclarationADefinition() &&
-      Decl->hasBody()) {
+      Decl->getBody() != nullptr) {
     Marks.set_marked_source_end(Decl->getBody()->getSourceRange().getBegin());
   } else {
     Marks.set_marked_source_end(GetLocForEndOfToken(


### PR DESCRIPTION
In some cases, `FunctionDecl::hasBody` (and presumably `EnumDecl::hasBody`,
though I don't have a crasher for that) will report `true` when
`FunctionDecl::getBody` would return null. Prefer using `getBody`
to check whether a decl has a body.