### PR TITLE
Create a new path_utils library in kythe/cxx/common that doesn't depend on llvm

### DIFF
--- a/kythe/cxx/common/BUILD
+++ b/kythe/cxx/common/BUILD
@@ -39,9 +39,28 @@ cc_library(
     hdrs = ["kythe_uri.h"],
     visibility = [PUBLIC_VISIBILITY],
     deps = [
+        ":path_utils",
         ":vname_ordering",
         "//kythe/proto:storage_cc_proto",
         "@com_google_absl//absl/strings",
+    ],
+)
+
+cc_library(
+    name = "path_utils",
+    srcs = ["path_utils.cc"],
+    hdrs = ["path_utils.h"],
+    deps = [
+        "@com_google_absl//absl/strings",
+    ],
+)
+
+cc_test(
+    name = "path_utils_test",
+    srcs = ["path_utils_test.cc"],
+    deps = [
+        ":path_utils",
+        "//third_party:gtest_main",
     ],
 )
 

--- a/kythe/cxx/common/kythe_uri.cc
+++ b/kythe/cxx/common/kythe_uri.cc
@@ -16,10 +16,9 @@
 
 #include <utility>
 
-#include "absl/strings/match.h"
-#include "absl/strings/str_join.h"
 #include "absl/strings/str_split.h"
 #include "kythe/cxx/common/kythe_uri.h"
+#include "kythe/cxx/common/path_utils.h"
 
 namespace kythe {
 namespace {
@@ -57,46 +56,6 @@ std::pair<absl::string_view, absl::string_view> Split(absl::string_view input,
   return absl::StrSplit(input, absl::MaxSplits(ch, 1));
 }
 
-// Predicate used in CleanPath for skipping empty components
-// and components consistening of a single '.'.
-struct SkipEmptyDot {
-  bool operator()(absl::string_view sp) { return !(sp.empty() || sp == "."); }
-};
-
-// Deal with relative paths as well as '/' and '//'.
-absl::string_view PathPrefix(absl::string_view path) {
-  int slash_count = 0;
-  for (char ch : path) {
-    if (ch == '/' && ++slash_count <= 2) continue;
-    break;
-  }
-  switch (slash_count) {
-    case 0:
-      return "";
-    case 2:
-      return "//";
-    default:
-      return "/";
-  }
-}
-
-// TODO(shahms): Use path_utils.h when it doesn't depend on LLVM.
-std::string CleanPath(absl::string_view input) {
-  const bool is_absolute_path = absl::StartsWith(input, "/");
-  std::vector<absl::string_view> parts;
-  for (absl::string_view comp : absl::StrSplit(input, '/', SkipEmptyDot{})) {
-    if (comp == "..") {
-      if (!parts.empty() && parts.back() != "..") {
-        parts.pop_back();
-        continue;
-      }
-      if (is_absolute_path) continue;
-    }
-    parts.push_back(comp);
-  }
-  // Deal with leading '//' as well as '/'.
-  return absl::StrCat(PathPrefix(input), absl::StrJoin(parts, "/"));
-}
 }  // namespace
 
 std::string UriEscape(UriEscapeMode mode, absl::string_view uri) {

--- a/kythe/cxx/common/path_utils.cc
+++ b/kythe/cxx/common/path_utils.cc
@@ -51,13 +51,7 @@ absl::string_view PathPrefix(absl::string_view path) {
 }  // namespace
 
 std::string JoinPath(absl::string_view a, absl::string_view b) {
-  if (absl::EndsWith(a, "/")) {
-    a.remove_suffix(1);
-  }
-  if (absl::StartsWith(b, "/")) {
-    b.remove_prefix(1);
-  }
-  return absl::StrCat(a, "/", b);
+  return absl::StrCat(absl::StripSuffix(a, "/"), "/", absl::StripPrefix(b, "/"));
 }
 
 std::string CleanPath(absl::string_view input) {

--- a/kythe/cxx/common/path_utils.cc
+++ b/kythe/cxx/common/path_utils.cc
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2018 The Kythe Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <vector>
+
+#include "absl/strings/match.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_join.h"
+#include "absl/strings/str_split.h"
+#include "kythe/cxx/common/path_utils.h"
+
+namespace kythe {
+namespace {
+
+// Predicate used in CleanPath for skipping empty components
+// and components consistening of a single '.'.
+struct SkipEmptyDot {
+  bool operator()(absl::string_view sp) { return !(sp.empty() || sp == "."); }
+};
+
+// Deal with relative paths as well as '/' and '//'.
+absl::string_view PathPrefix(absl::string_view path) {
+  int slash_count = 0;
+  for (char ch : path) {
+    if (ch == '/' && ++slash_count <= 2) continue;
+    break;
+  }
+  switch (slash_count) {
+    case 0:
+      return "";
+    case 2:
+      return "//";
+    default:
+      return "/";
+  }
+}
+
+}  // namespace
+
+std::string JoinPath(absl::string_view a, absl::string_view b) {
+  if (absl::EndsWith(a, "/")) {
+    a.remove_suffix(1);
+  }
+  if (absl::StartsWith(b, "/")) {
+    b.remove_prefix(1);
+  }
+  return absl::StrCat(a, "/", b);
+}
+
+std::string CleanPath(absl::string_view input) {
+  const bool is_absolute_path = absl::StartsWith(input, "/");
+  std::vector<absl::string_view> parts;
+  for (absl::string_view comp : absl::StrSplit(input, '/', SkipEmptyDot{})) {
+    if (comp == "..") {
+      if (!parts.empty() && parts.back() != "..") {
+        parts.pop_back();
+        continue;
+      }
+      if (is_absolute_path) continue;
+    }
+    parts.push_back(comp);
+  }
+  // Deal with leading '//' as well as '/'.
+  return absl::StrCat(PathPrefix(input), absl::StrJoin(parts, "/"));
+}
+
+}  // namespace kythe

--- a/kythe/cxx/common/path_utils.h
+++ b/kythe/cxx/common/path_utils.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 The Kythe Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef KYTHE_CXX_COMMON_PATH_UTILS_H_
+#define KYTHE_CXX_COMMON_PATH_UTILS_H_
+
+#include <string>
+
+#include "absl/strings/string_view.h"
+
+namespace kythe {
+
+/// \brief Append path `b` to path `a`, cleaning and returning the result.
+std::string JoinPath(absl::string_view a, absl::string_view b);
+
+/// \brief Collapse duplicate "/"s, resolve ".." and "." path elements, remove
+/// trailing "/".
+std::string CleanPath(absl::string_view input);
+
+}  // namespace kythe
+
+#endif // KYTHE_CXX_COMMON_PATH_UTILS_H_

--- a/kythe/cxx/common/path_utils_test.cc
+++ b/kythe/cxx/common/path_utils_test.cc
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018 The Kythe Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <string>
+
+#include "gtest/gtest.h"
+#include "kythe/cxx/common/path_utils.h"
+
+namespace kythe {
+namespace {
+
+TEST(PathUtilsTest, CleanPath) {
+  EXPECT_EQ("/a/c", CleanPath("/../../a/c"));
+  EXPECT_EQ("", CleanPath(""));
+  // CleanPath should match the semantics of Go's path.Clean (except for
+  // "" => "", not "" => "."); the examples from the documentation at
+  // http://golang.org/pkg/path/#example_Clean are checked here.
+  EXPECT_EQ("a/c", CleanPath("a/c"));
+  EXPECT_EQ("a/c", CleanPath("a//c"));
+  EXPECT_EQ("a/c", CleanPath("a/c/."));
+  EXPECT_EQ("a/c", CleanPath("a/c/b/.."));
+  EXPECT_EQ("/a/c", CleanPath("/../a/c"));
+  EXPECT_EQ("/a/c", CleanPath("/../a/b/../././/c"));
+  EXPECT_EQ("/Users", CleanPath("/Users"));
+  // "//Users" denotes a path with the root name "//Users"
+  EXPECT_EQ("//Users", CleanPath("//Users"));
+  EXPECT_EQ("/Users", CleanPath("///Users"));
+  EXPECT_EQ("..", CleanPath("a/../../"));
+}
+
+TEST(PathUtilsTest, JoinPath) {
+  EXPECT_EQ("a/c", JoinPath("a", "c"));
+  EXPECT_EQ("a/c", JoinPath("a/", "c"));
+  EXPECT_EQ("a/c", JoinPath("a", "/c"));
+}
+
+}  // namespace
+}  // namespace kythe

--- a/kythe/cxx/extractor/cxx_extractor.cc
+++ b/kythe/cxx/extractor/cxx_extractor.cc
@@ -60,6 +60,9 @@ llvm::StringRef ToStringRef(absl::string_view sv) {
   return {sv.data(), sv.size()};
 }
 
+using cxx_extractor::RelativizePath;
+using cxx_extractor::LookupFileForIncludePragma;
+
 // We need "the lowercase ascii hex SHA-256 digest of the file contents."
 constexpr char kHexDigits[] = "0123456789abcdef";
 

--- a/kythe/cxx/extractor/path_utils.cc
+++ b/kythe/cxx/extractor/path_utils.cc
@@ -29,12 +29,6 @@ std::string CleanPath(llvm::StringRef in_path) {
   return out_path.str();
 }
 
-std::string JoinPath(llvm::StringRef a, llvm::StringRef b) {
-  llvm::SmallString<1024> out_path = a;
-  llvm::sys::path::append(out_path, b);
-  return out_path.str();
-}
-
 std::string MakeCleanAbsolutePath(const std::string& in_path) {
   std::string abs_path = clang::tooling::getAbsolutePath(in_path);
   return CleanPath(abs_path);

--- a/kythe/cxx/extractor/path_utils.cc
+++ b/kythe/cxx/extractor/path_utils.cc
@@ -23,6 +23,7 @@
 #include "llvm/Support/Path.h"
 
 namespace kythe {
+namespace cxx_extractor {
 std::string CleanPath(llvm::StringRef in_path) {
   llvm::SmallString<1024> out_path = in_path;
   llvm::sys::path::remove_dots(out_path, true);
@@ -114,4 +115,5 @@ const clang::FileEntry* LookupFileForIncludePragma(
   return file;
 }
 
+}  // namespace cxx_extractor
 }  // namespace kythe

--- a/kythe/cxx/extractor/path_utils.h
+++ b/kythe/cxx/extractor/path_utils.h
@@ -49,9 +49,6 @@ std::string MakeCleanAbsolutePath(const std::string& in_path);
 /// \param in_path The path to convert.
 std::string CleanPath(llvm::StringRef in_path);
 
-/// \brief Append path `b` to path `a`, cleaning and returning the result.
-std::string JoinPath(llvm::StringRef a, llvm::StringRef b);
-
 /// \brief Looks up a file for an #include-ish pragma.
 /// \param preprocessor The preprocessor to use to consume the filename tokens.
 /// \param search_path The path used to find the file in the filesystem.

--- a/kythe/cxx/extractor/path_utils.h
+++ b/kythe/cxx/extractor/path_utils.h
@@ -28,6 +28,7 @@ class Preprocessor;
 }  // namespace clang
 
 namespace kythe {
+namespace cxx_extractor {
 /// \brief Relativize `to_relativize` with respect to `relativize_against`.
 ///
 /// If `to_relativize` does not name a path that is a child of
@@ -59,6 +60,7 @@ const clang::FileEntry* LookupFileForIncludePragma(
     clang::Preprocessor* preprocessor, llvm::SmallVectorImpl<char>* search_path,
     llvm::SmallVectorImpl<char>* relative_path,
     llvm::SmallVectorImpl<char>* filename);
+}  // namespace cxx_extractor
 }  // namespace kythe
 
 #endif  // KYTHE_CXX_EXTRACTOR_PATH_UTILS_H_

--- a/kythe/cxx/extractor/path_utils_test.cc
+++ b/kythe/cxx/extractor/path_utils_test.cc
@@ -24,6 +24,7 @@
 #include "llvm/Support/Path.h"
 
 namespace kythe {
+namespace cxx_extractor {
 namespace {
 
 TEST(PathUtilsTest, RelativizePath) {
@@ -82,6 +83,7 @@ TEST(PathUtilsTest, CleanPath) {
 }
 
 }  // anonymous namespace
+}  // namespace cxx_extractor
 }  // namespace kythe
 
 int main(int argc, char** argv) {

--- a/kythe/cxx/extractor/path_utils_test.cc
+++ b/kythe/cxx/extractor/path_utils_test.cc
@@ -81,12 +81,6 @@ TEST(PathUtilsTest, CleanPath) {
   EXPECT_EQ("..", CleanPath("a/../../"));
 }
 
-TEST(PathUtilsTest, JoinPath) {
-  EXPECT_EQ("a/c", JoinPath("a", "c"));
-  EXPECT_EQ("a/c", JoinPath("a/", "c"));
-  EXPECT_EQ("a/c", JoinPath("a", "/c"));
-}
-
 }  // anonymous namespace
 }  // namespace kythe
 

--- a/kythe/cxx/indexer/cxx/BUILD
+++ b/kythe/cxx/indexer/cxx/BUILD
@@ -46,7 +46,7 @@ cc_library(
         ":clang_utils",
         ":kythe_claim_client",
         "//kythe/cxx/common:kzip_reader",
-        "//kythe/cxx/extractor:path_utils",
+        "//kythe/cxx/common:path_utils",
         "//kythe/proto:buildinfo_cc_proto",
         "//kythe/proto:claim_cc_proto",
         "@com_google_absl//absl/memory",

--- a/kythe/cxx/indexer/cxx/IndexerPPCallbacks.cc
+++ b/kythe/cxx/indexer/cxx/IndexerPPCallbacks.cc
@@ -323,7 +323,7 @@ void IndexerPPCallbacks::HandleKytheMetadataPragma(
   llvm::SmallString<1024> search_path;
   llvm::SmallString<1024> relative_path;
   llvm::SmallString<1024> filename;
-  const auto* file = LookupFileForIncludePragma(&preprocessor, &search_path,
+  const auto* file = cxx_extractor::LookupFileForIncludePragma(&preprocessor, &search_path,
                                                 &relative_path, &filename);
   if (!file) {
     fprintf(stderr, "Missing metadata file: %s\n", filename.c_str());

--- a/kythe/cxx/indexer/cxx/KytheGraphObserver.cc
+++ b/kythe/cxx/indexer/cxx/KytheGraphObserver.cc
@@ -104,7 +104,7 @@ kythe::proto::VName KytheGraphObserver::VNameFromFileEntry(
     llvm::StringRef working_directory = vfs_->working_directory();
     llvm::StringRef file_name(file_entry->getName());
     if (file_name.startswith(working_directory)) {
-      out_name.set_path(RelativizePath(file_name, working_directory));
+      out_name.set_path(cxx_extractor::RelativizePath(file_name, working_directory));
     } else {
       out_name.set_path(file_entry->getName());
     }

--- a/kythe/cxx/indexer/cxx/frontend.cc
+++ b/kythe/cxx/indexer/cxx/frontend.cc
@@ -28,7 +28,7 @@
 #include "google/protobuf/io/zero_copy_stream.h"
 #include "google/protobuf/io/zero_copy_stream_impl.h"
 #include "kythe/cxx/common/kzip_reader.h"
-#include "kythe/cxx/extractor/path_utils.h"
+#include "kythe/cxx/common/path_utils.h"
 #include "kythe/cxx/indexer/cxx/proto_conversions.h"
 #include "kythe/proto/buildinfo.pb.h"
 #include "kythe/proto/claim.pb.h"
@@ -110,8 +110,7 @@ void MaybeNormalizeFileVNames(IndexerJob* job) {
     return;
   }
   for (auto& input : *job->unit.mutable_required_input()) {
-    input.mutable_v_name()->set_path(CleanPath(llvm::StringRef(
-        input.v_name().path().data(), input.v_name().path().size())));
+    input.mutable_v_name()->set_path(CleanPath(input.v_name().path()));
     input.mutable_v_name()->clear_signature();
   }
 }


### PR DESCRIPTION
I'll need these utility functions for the proto indexer.