### PR TITLE
Riegeli: support parsing chunk_size option

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,3 +14,4 @@ Michel Alexandre Salim <michel@michel-slm.name>
 Misha Zatsman <mishaz@gmail.com>
 Jacob Parker <jacob@solidangle.ca>
 Spotify AB
+source{d}

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -34,3 +34,4 @@ Shahms King <shahms@google.com>
 Daniel Moy <danielmoy@google.com>
 Salvatore Guarnieri <salguarnieri@google.com>
 Jay Sachs <jsachs@google.com>
+Alexander Bezzubov <alex@sourced.tech>

--- a/kythe/go/util/riegeli/riegeli.go
+++ b/kythe/go/util/riegeli/riegeli.go
@@ -36,7 +36,7 @@ import (
 
 // Defaults for the WriterOptions.
 const (
-	DefaultChunkSize = 1 << 20
+	DefaultChunkSize uint64 = 1 << 20
 
 	DefaultBrotliLevel = 9
 	DefaultZSTDLevel   = 9
@@ -178,6 +178,16 @@ func ParseOptions(s string) (*WriterOptions, error) {
 			default:
 				return nil, fmt.Errorf("malformed option: %q", opt)
 			}
+		case chunkSizeOption:
+			chunkSize := DefaultChunkSize
+			if len(kv) != 1 {
+				var err error
+				chunkSize, err = strconv.ParseUint(kv[1], 10, 0)
+				if err != nil {
+					return nil, fmt.Errorf("malformed option: %q: %v", opt, err)
+				}
+			}
+			opts.ChunkSize = chunkSize
 		case uncompressedOption:
 			if len(kv) != 1 {
 				return nil, fmt.Errorf("malformed option: %q", opt)

--- a/kythe/go/util/riegeli/riegeli_test.go
+++ b/kythe/go/util/riegeli/riegeli_test.go
@@ -45,6 +45,7 @@ func TestParseOptions(t *testing.T) {
 		"brotli,transpose",
 		"transpose,uncompressed",
 		"brotli:5,transpose",
+		"chunk_size:524288",
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Otherwise 

```go
riegeli.ParseOptions("chunk_size:1024")
```

results in error `unknown option: "chunk_size:1024"`