### PR TITLE
feat: add (not yet working) poc bazel extraction on gcp

### DIFF
--- a/kythe/examples/bazel/BUILD
+++ b/kythe/examples/bazel/BUILD
@@ -1,3 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-exports_files(["kythe_config.json"])
+exports_files([
+    "kythe_config.json",
+    "setup-bazel-repo.sh",
+])

--- a/kythe/go/extractors/gcp/README.md
+++ b/kythe/go/extractors/gcp/README.md
@@ -32,7 +32,7 @@ authorize it, associate it with a valid project id, create a test gs bucket.
 ## Maven Proof of Concept
 
 To extract a maven repository using Kythe on Cloud Build, use
-`mvnpoc/cloudbuild.yaml`.  This assumes that you will specify a maven repository
+`examples/mvn.yaml`.  This assumes that you will specify a maven repository
 in `_REPO_NAME`, and that the repository has a top-level `pom.xml` file (right
 now it is a hard-coded location, but in the future it will be configurable).
 This also assumes you specify `_BUCKET_NAME` as per the Hello World Test above.
@@ -73,6 +73,28 @@ _BUCKET_NAME=$BUCKET_NAME,\
 _REPO_NAME=https://github.com/project-name/repo-name\
 --no-source
 ```
+
+## Bazel Proof of Concept
+
+**Not yet working on Google Cloud Build - see
+`kythe/examples/bazel` for a local script.**
+
+To extract a bazel repository using Kythe on Cloud Build, use
+`examples/bazel.yaml`.
+
+```
+gcloud builds submit --config examples/bazel.yaml \
+--substitutions=\
+_REPO_NAME=https://github.com/project-name/repo-name,\
+_BUILD_TARGET=//src/...\
+--no-source
+```
+
+### Extractor Artifacts
+
+gcr.io/kythe-public/kythe-bazel-extractor-artifacts created from
+`kythe/go/extractors/gcp/bazel:artifacts` contains a script for modifying a bazel
+WORKSPACE, similar to the build preprocessing logic in maven/gradle.
 
 ## Cloud Build REST API
 

--- a/kythe/go/extractors/gcp/bazel/BUILD
+++ b/kythe/go/extractors/gcp/bazel/BUILD
@@ -1,0 +1,16 @@
+package(default_visibility = ["//kythe:default_visibility"])
+
+load("//tools:build_rules/docker.bzl", "docker_build")
+
+# This target builds a docker image which contains bazel extraction artifacts
+# used for prepping a repo's WORKSPACE for extraction.
+docker_build(
+    name = "artifacts",
+    src = "Dockerfile",
+    data = [
+        "//kythe/examples/bazel:setup-bazel-repo.sh",
+    ],
+    image_name = "gcr.io/kythe-public/kythe-bazel-extractor-artifacts",
+    tags = ["manual"],
+    use_cache = True,
+)

--- a/kythe/go/extractors/gcp/bazel/Dockerfile
+++ b/kythe/go/extractors/gcp/bazel/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2018 The Kythe Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build: bazel build //kythe/go/extractors/gcp/bazel:artifacts
+# Usage:
+#   This container houses bazel extraction artifacts which are necessary for
+#   extracting a bazel repo.
+#
+FROM debian:jessie
+
+ADD kythe/examples/bazel/setup-bazel-repo.sh /opt/kythe/extractors/setup-bazel-repo.sh

--- a/kythe/go/extractors/gcp/examples/bazel.yaml
+++ b/kythe/go/extractors/gcp/examples/bazel.yaml
@@ -1,0 +1,25 @@
+steps:
+- name: 'gcr.io/cloud-builders/git'
+  args: ['clone', '${_REPO_NAME}', '/workspace/code']
+- name: 'ubuntu'
+  args:
+    - '/opt/kythe/extractors/setup-bazel-repo.sh'
+    - '/workspace/code/WORKSPACE'
+- name: 'gcr.io/cloud-builders/bazel'
+  args:
+    - 'build'
+    - '--keep_going'
+    - '--output_groups=compilation_outputs'
+    - '--experimental_extra_action_top_level_only'
+    - '--experimental_action_listener=@io_kythe//kythe/cxx/extractor:extract_kzip'
+    - '--experimental_action_listener=@io_kythe//kythe/java/com/google/devtools/kythe/extractors/java/bazel:extract_kzip'
+    - '${_BUILD_TARGET}'
+  dir: '/workspace/code'
+# TODO(danielmoy): we need a step to upload the resulting kzips to a specified
+# GCS bucket.
+- name: 'ubuntu'
+  args:
+    - 'find'
+    - '.'
+    - '-name'
+    - '*.kzip'


### PR DESCRIPTION
Also include the setup-bazel-repo.sh script in a docker image
gcr.io/kythe-public/kythe-bazel-extractor-artifacts.

Includes extraction command for java and c++, but lacks logic for exporting the resulting kzips anywhere.  The built in cloud build artifacts doesn't support any sort of glob/wildcard, so we'll have to do that ourselves in a follow-up step later.