### PR TITLE
fix(sh_test): use "set -e" instead of adding "-e" to shebang

### DIFF
--- a/kythe/cxx/common/testdata/net_client_test_runner.sh
+++ b/kythe/cxx/common/testdata/net_client_test_runner.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 # Copyright 2015 The Kythe Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-set -o pipefail
+set -eo pipefail
 BASE_DIR="$PWD/kythe/cxx/common/testdata"
 TEST_JSON="${BASE_DIR}/net_client_test_data.json"
 TEST_BIN="kythe/cxx/common/net_client_test"

--- a/kythe/cxx/common/testdata/start_http_service.sh
+++ b/kythe/cxx/common/testdata/start_http_service.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 # Copyright 2015 The Kythe Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -40,6 +40,8 @@
 #   "//kythe/go/storage/tools:write_tables",
 #   "//kythe/go/storage/tools:write_entries",
 #   "//kythe/go/test/tools:http_server",
+
+set -e
 
 : ${KYTHE_WRITE_TABLES?:missing write_tables}
 : ${KYTHE_WRITE_ENTRIES?:missing write_entries}

--- a/kythe/cxx/extractor/testdata/test_alternate_platform.sh
+++ b/kythe/cxx/extractor/testdata/test_alternate_platform.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 # Copyright 2015 The Kythe Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+set -e
 TEST_NAME="test_alternate_platform"
 . ./kythe/cxx/extractor/testdata/test_common.sh
 . ./kythe/cxx/extractor/testdata/skip_functions.sh

--- a/kythe/cxx/extractor/testdata/test_extract_transcript.sh
+++ b/kythe/cxx/extractor/testdata/test_extract_transcript.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 # Copyright 2015 The Kythe Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,6 +15,7 @@
 #
 # This test checks that the extractor handles transcripts.
 # It should be run from the Kythe root.
+set -e
 TEST_NAME="test_extract_transcript"
 . ./kythe/cxx/extractor/testdata/test_common.sh
 . ./kythe/cxx/extractor/testdata/skip_functions.sh

--- a/kythe/cxx/extractor/testdata/test_has_include.sh
+++ b/kythe/cxx/extractor/testdata/test_has_include.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 # Copyright 2017 The Kythe Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,6 +15,7 @@
 #
 # This test checks that the extractor handles __has_include.
 # It should be run from the Kythe root.
+set -e
 TEST_NAME="test_has_include"
 . ./kythe/cxx/extractor/testdata/test_common.sh
 . ./kythe/cxx/extractor/testdata/skip_functions.sh

--- a/kythe/cxx/extractor/testdata/test_indirect_has_include.sh
+++ b/kythe/cxx/extractor/testdata/test_indirect_has_include.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 # Copyright 2017 The Kythe Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +16,7 @@
 # This test checks that the extractor handles __has_include with redundant
 # file output.
 # It should be run from the Kythe root.
+set -e
 TEST_NAME="test_indirect_has_include"
 . ./kythe/cxx/extractor/testdata/test_common.sh
 . ./kythe/cxx/extractor/testdata/skip_functions.sh

--- a/kythe/cxx/extractor/testdata/test_kzip.sh
+++ b/kythe/cxx/extractor/testdata/test_kzip.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 # Copyright 2015 The Kythe Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,6 +15,7 @@
 #
 # This test checks that the extractor will emit kzip files.
 # It should be run from the Kythe root.
+set -e
 TEST_NAME="test_index_pack"
 . ./kythe/cxx/extractor/testdata/test_common.sh
 . ./kythe/cxx/extractor/testdata/skip_functions.sh

--- a/kythe/cxx/extractor/testdata/test_main_source_file_env_dep.sh
+++ b/kythe/cxx/extractor/testdata/test_main_source_file_env_dep.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 # Copyright 2015 The Kythe Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,6 +17,7 @@
 # Specifically, the main source file transcript for the _without.UNIT file
 # should differ from the main source file transcript for the _with.UNIT file.
 # It should be run from the Kythe root.
+set -e
 TEST_NAME="test_main_source_file_env_dep"
 . ./kythe/cxx/extractor/testdata/test_common.sh
 . ./kythe/cxx/extractor/testdata/skip_functions.sh

--- a/kythe/cxx/extractor/testdata/test_main_source_file_no_env_dep.sh
+++ b/kythe/cxx/extractor/testdata/test_main_source_file_no_env_dep.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 # Copyright 2015 The Kythe Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,6 +18,7 @@
 # _without.UNIT file should equal the main source file transcript for the
 # _with.UNIT file.
 # It should be run from the Kythe root.
+set -e
 TEST_NAME="test_main_source_file_no_env_dep"
 . ./kythe/cxx/extractor/testdata/test_common.sh
 . ./kythe/cxx/extractor/testdata/skip_functions.sh

--- a/kythe/cxx/extractor/testdata/test_metadata.sh
+++ b/kythe/cxx/extractor/testdata/test_metadata.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 # Copyright 2015 The Kythe Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,6 +15,7 @@
 #
 # This test checks that the extractor handles transcripts.
 # It should be run from the Kythe root.
+set -e
 TEST_NAME="test_metadata"
 . ./kythe/cxx/extractor/testdata/test_common.sh
 . ./kythe/cxx/extractor/testdata/skip_functions.sh

--- a/kythe/cxx/extractor/testdata/test_modules.sh
+++ b/kythe/cxx/extractor/testdata/test_modules.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 # Copyright 2015 The Kythe Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+set -e
 TEST_NAME="test_modules"
 . ./kythe/cxx/extractor/testdata/test_common.sh
 . ./kythe/cxx/extractor/testdata/skip_functions.sh

--- a/kythe/cxx/extractor/testdata/test_root_directory.sh
+++ b/kythe/cxx/extractor/testdata/test_root_directory.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 # Copyright 2015 The Kythe Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,6 +15,7 @@
 #
 # This test checks that the extractor handles transcripts.
 # It should be run from the Kythe root.
+set -e
 TEST_NAME="test_root_directory"
 . ./kythe/cxx/extractor/testdata/test_common.sh
 . ./kythe/cxx/extractor/testdata/skip_functions.sh

--- a/kythe/cxx/extractor/testdata/test_stdin_names.sh
+++ b/kythe/cxx/extractor/testdata/test_stdin_names.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 # Copyright 2015 The Kythe Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-set -o pipefail
+set -eo pipefail
 TEST_NAME="test_stdin_names"
 . ./kythe/cxx/extractor/testdata/test_common.sh
 rm -rf -- "${OUT_DIR}/*"

--- a/kythe/cxx/indexer/cxx/testdata/test_kindex.sh
+++ b/kythe/cxx/indexer/cxx/testdata/test_kindex.sh
@@ -1,5 +1,6 @@
-#!/bin/bash -e
+#!/bin/bash
 # Tests whether the indexer will read from kindex files.
+set -e
 BASE_DIR="$PWD/kythe/cxx/indexer/cxx/testdata"
 OUT_DIR="$TEST_TMPDIR"
 VERIFIER="kythe/cxx/verifier/verifier"

--- a/kythe/cxx/tools/fyi/testdata/basic_test.sh
+++ b/kythe/cxx/tools/fyi/testdata/basic_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 # Copyright 2015 The Kythe Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,5 +12,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+set -e
 . ./kythe/cxx/tools/fyi/testdata/test_case.sh basic.cc

--- a/kythe/cxx/tools/fyi/testdata/hopeless_test.sh
+++ b/kythe/cxx/tools/fyi/testdata/hopeless_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 # Copyright 2015 The Kythe Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,4 +14,5 @@
 # limitations under the License.
 
 # This source file can't be repaired.
+set -e
 . ./kythe/cxx/tools/fyi/testdata/test_case.sh hopeless.cc

--- a/kythe/cxx/tools/fyi/testdata/nothing_test.sh
+++ b/kythe/cxx/tools/fyi/testdata/nothing_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 # Copyright 2015 The Kythe Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,4 +14,5 @@
 # limitations under the License.
 
 # This file is expected to be unchanged.
+set -e
 . ./kythe/cxx/tools/fyi/testdata/test_case.sh nothing.cc

--- a/kythe/cxx/tools/fyi/testdata/test_case.sh
+++ b/kythe/cxx/tools/fyi/testdata/test_case.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 # Copyright 2015 The Kythe Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,7 +21,7 @@
 #   compile_commands.json.in -- shared compilation database
 #     will substitute "OUT_DIR" for the test output directory
 
-set -o pipefail
+set -eo pipefail
 : ${FYI?:missing fyi}
 TEST_NAME="$1"
 BASE_DIR="$PWD/kythe/cxx/tools/fyi/testdata"

--- a/kythe/cxx/tools/testdata/test_claim_tool_index_pack.sh
+++ b/kythe/cxx/tools/testdata/test_claim_tool_index_pack.sh
@@ -1,5 +1,6 @@
-#!/bin/bash -e
+#!/bin/bash
 # This script checks that the claiming tool works on index packs.
+set -e
 BASE_DIR="$PWD/kythe/cxx/tools/testdata"
 OUT_DIR="$TEST_TMPDIR"
 : ${KINDEX_TOOL_BIN?:missing kindex_tool}

--- a/kythe/cxx/tools/testdata/test_claim_tool_kindex.sh
+++ b/kythe/cxx/tools/testdata/test_claim_tool_kindex.sh
@@ -1,5 +1,6 @@
-#!/bin/bash -e
+#!/bin/bash
 # This script checks that the claiming tool works on kindex files.
+set -e
 BASE_DIR="$PWD/kythe/cxx/tools/testdata"
 OUT_DIR="$TEST_TMPDIR"
 : ${KINDEX_TOOL_BIN?:missing kindex_tool}

--- a/kythe/data/test_filevnames.sh
+++ b/kythe/data/test_filevnames.sh
@@ -1,5 +1,4 @@
-#!/bin/bash -e
-
+#!/bin/bash
 # Copyright 2014 The Kythe Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,6 +14,8 @@
 # limitations under the License.
 
 # Ensures that vnames.json can be read by the //kythe/storage/go/filevnames library
+
+set -e
 
 DIRECTORY_INDEXER="$PWD/${DIR_INDEXER?:missing directory_indexer}"
 CONFIG="$PWD/kythe/data/vnames.json"

--- a/kythe/go/platform/tools/indexpack_test.sh
+++ b/kythe/go/platform/tools/indexpack_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 #
 # Copyright 2014 The Kythe Authors. All rights reserved.
 #
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 # This script tests the indexpack binary. It requires the jq command (≥ 1.4).
+set -e
 
 kindex_contents() {
   $viewindex --files "$1" | $jq -c -S .

--- a/kythe/go/serving/tools/testdata/kwazthis_test.sh
+++ b/kythe/go/serving/tools/testdata/kwazthis_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 # Copyright 2015 The Kythe Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,8 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-set -o pipefail
-set -x
+set -eox pipefail
 
 BASE_DIR="$PWD/kythe/go/serving/tools/testdata"
 OUT_DIR="$TEST_TMPDIR"

--- a/kythe/go/serving/tools/testdata/kwazthis_test.sh
+++ b/kythe/go/serving/tools/testdata/kwazthis_test.sh
@@ -25,11 +25,12 @@ kwazthis() { "$KWAZTHIS" --local_repo=NONE --api "http://$LISTEN_AT" "$@" | tee 
 
 FILE_PATH=kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Generics.java
 
-JSON=$(kwazthis --corpus kythe --path $FILE_PATH --offset 934)
-jq --slurp 'length == 3'
+JSON=$(kwazthis --corpus kythe --path $FILE_PATH --offset 965)
+jq --slurp 'length == 4'
 # .[0] is Generics class def
 # .[1] is f method def
 # .[2] is gs variable def
+# .[3] is gs variable defines/binding
 jq --slurp '.[] | (.kind == "ref" or .kind == "defines" or .kind == "defines/binding")'
 jq --slurp '.[].node.ticket
         and .[].node.ticket != ""'

--- a/kythe/go/serving/tools/testdata/write_tables_test.sh
+++ b/kythe/go/serving/tools/testdata/write_tables_test.sh
@@ -1,5 +1,5 @@
-#!/bin/bash -e
-set -o pipefail
+#!/bin/bash
+set -eo pipefail
 # Copyright 2016 The Kythe Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/indexer_empty_cu_test.sh
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/indexer_empty_cu_test.sh
@@ -1,5 +1,5 @@
-#!/bin/bash -e
-set -o pipefail
+#!/bin/bash
+set -eo pipefail
 # Copyright 2016 The Kythe Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/indexer_source_root_test.sh
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/indexer_source_root_test.sh
@@ -1,5 +1,5 @@
-#!/bin/bash -e
-set -o pipefail
+#!/bin/bash
+set -eo pipefail
 # Copyright 2015 The Kythe Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/indexer_test.sh
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/indexer_test.sh
@@ -1,5 +1,5 @@
-#!/bin/bash -e
-set -o pipefail
+#!/bin/bash
+set -eo pipefail
 # Copyright 2015 The Kythe Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/kythe/release/package_release.sh
+++ b/kythe/release/package_release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 # Copyright 2015 The Kythe Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -46,6 +46,7 @@
 #       kythe-storage.txt
 #       schema.html
 #       how-to-contribute.md
+set -e
 
 SHASUM_TOOL="$1"
 shift

--- a/kythe/release/release_test.sh
+++ b/kythe/release/release_test.sh
@@ -1,5 +1,5 @@
-#!/bin/bash -e
-set -o pipefail
+#!/bin/bash
+set -eo pipefail
 
 # Copyright 2015 The Kythe Authors. All rights reserved.
 #

--- a/kythe/rust/indexer/testdata/one_case.sh
+++ b/kythe/rust/indexer/testdata/one_case.sh
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+set -e
 
 VERIFIER="kythe/cxx/verifier/verifier"
 INDEXER="rustc -L kythe/rust/indexer/ -Z extra-plugins=kythe_indexer -Z no-trans"

--- a/tools/build_rules/rust/run_cargo.sh
+++ b/tools/build_rules/rust/run_cargo.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/bin/bash
+set -e
 
 loc=$1
 cargo_args=$2

--- a/tools/modules/check.sh
+++ b/tools/modules/check.sh
@@ -15,6 +15,7 @@
 #
 # This script checks that required libraries have been checked out at the
 # versions we expect.
+set -e
 
 LLVM_REPO='third_party/llvm/llvm'
 . "$(dirname "$0")/versions.sh"

--- a/tools/modules/versions.sh
+++ b/tools/modules/versions.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/sh
 # Copyright 2015 The Kythe Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,6 +18,7 @@
 # git-svn sha. (The svn revision will appear in the git log entry.) When a
 # checkout is updated to a new minimum version, both its _SHA and _REV should
 # be set to the new (matched) strings.
+set -e
 
 # llvm
 MIN_LLVM_SHA="3fe1b12fca949399a3334a072ee7f96e2b6f557e"


### PR DESCRIPTION
Bazel ignores the shebang for sh_test targets, so the "-e" was previously being ignored.

//kythe/go/serving/tools/testdata:kwazthis_test is now failing and I'm not sure why. Any ideas? It looks like the `jq` commands at the end aren't passed any json input.