### PR TITLE
refactor: remove deprecated kindex from cxx extractor

### DIFF
--- a/kythe/cxx/extractor/BUILD
+++ b/kythe/cxx/extractor/BUILD
@@ -183,6 +183,7 @@ cc_library(
         "//kythe/cxx/common:json_proto",
         "//kythe/cxx/common:kzip_writer",
         "//kythe/cxx/common:lib",
+        "//kythe/cxx/common:path_utils",
         "//kythe/cxx/indexer/cxx:clang_utils",
         "//kythe/proto:analysis_cc_proto",
         "//kythe/proto:buildinfo_cc_proto",

--- a/kythe/cxx/extractor/cxx_extractor.cc
+++ b/kythe/cxx/extractor/cxx_extractor.cc
@@ -915,11 +915,11 @@ KzipWriterSink::KzipWriterSink(const std::string& path,
     : path_(path), path_type_(path_type) {}
 
 void KzipWriterSink::OpenIndex(const std::string& unit_hash) {
-  CHECK(writer_ == nullptr) << "OpenIndex() called twice";
+  CHECK(!writer_.has_value()) << "OpenIndex() called twice";
   std::string path = path_type_ == OutputPathType::SingleFile
                          ? path_
                          : JoinPath(path_, unit_hash + ".kzip");
-  writer_ = absl::make_unique<IndexWriter>(OpenKzipWriterOrDie(path));
+  writer_ = IndexWriter(OpenKzipWriterOrDie(path));
 }
 
 void KzipWriterSink::WriteHeader(const kythe::proto::CompilationUnit& header) {
@@ -943,7 +943,7 @@ void KzipWriterSink::WriteFileContent(const kythe::proto::FileData& file) {
 }
 
 KzipWriterSink::~KzipWriterSink() {
-  if (writer_ != nullptr) {
+  if (writer_) {
     auto status = writer_->Close();
     if (!status.ok()) {
       LOG(ERROR) << "Error closing kzip output: " << status;

--- a/kythe/cxx/extractor/cxx_extractor.h
+++ b/kythe/cxx/extractor/cxx_extractor.h
@@ -21,6 +21,7 @@
 #include <string>
 #include <unordered_map>
 
+#include "absl/types/optional.h"
 #include "clang/Tooling/Tooling.h"
 #include "glog/logging.h"
 #include "google/protobuf/io/coded_stream.h"
@@ -135,7 +136,7 @@ class KzipWriterSink : public CompilationWriterSink {
  private:
   std::string path_;
   OutputPathType path_type_;
-  std::unique_ptr<IndexWriter> writer_;
+  absl::optional<IndexWriter> writer_;
 };
 
 /// \brief Collects information about compilation arguments and targets and

--- a/kythe/cxx/extractor/cxx_extractor.h
+++ b/kythe/cxx/extractor/cxx_extractor.h
@@ -117,12 +117,16 @@ class CompilationWriterSink {
 /// See https://www.kythe.io/docs/kythe-kzip.html for a description.
 class KzipWriterSink : public CompilationWriterSink {
  public:
+  enum class OutputPathType {
+    Directory,
+    SingleFile,
+  };
   /// \param path The file to which to write.
-  /// \param single_file If true, the kzip is written to the specified path
+  /// \param path_type If SingleFile, the kzip is written to the specified path
   /// directly. Otherwise the path is interpreted as a directory and the kzip is
   /// written within it using a filename derived from an identifying hash of the
   /// compilation unit.
-  explicit KzipWriterSink(const std::string& path, bool single_file);
+  explicit KzipWriterSink(const std::string& path, OutputPathType path_type);
   void OpenIndex(const std::string& unit_hash) override;
   void WriteHeader(const kythe::proto::CompilationUnit& header) override;
   void WriteFileContent(const kythe::proto::FileData& content) override;
@@ -130,7 +134,7 @@ class KzipWriterSink : public CompilationWriterSink {
 
  private:
   std::string path_;
-  bool single_file_;
+  OutputPathType path_type_;
   std::unique_ptr<IndexWriter> writer_;
 };
 

--- a/kythe/cxx/extractor/cxx_extractor.h
+++ b/kythe/cxx/extractor/cxx_extractor.h
@@ -113,49 +113,25 @@ class CompilationWriterSink {
   virtual ~CompilationWriterSink() = default;
 };
 
-/// \brief An `CompilationWriterSink` that writes to physical .kindex files.
-class KindexWriterSink : public CompilationWriterSink {
- public:
-  /// \param path The file to which to write.
-  /// \param single_file Whether to write to the single file or as a directory.
-  explicit KindexWriterSink(const std::string& path, bool single_file)
-      : path_(path), single_file_(single_file) {}
-  void OpenIndex(const std::string& unit_hash) override;
-  void WriteHeader(const kythe::proto::CompilationUnit& header) override;
-  void WriteFileContent(const kythe::proto::FileData& content) override;
-  ~KindexWriterSink();
-
- private:
-  /// The file descriptor in use, opened in `OpenIndex` and closed in the dtor
-  /// after `file_stream_` is destroyed. Owned by this object.
-  int fd_ = -1;
-  /// Wraps `fd_`. Destroyed after `gzip_stream_`.
-  std::unique_ptr<google::protobuf::io::FileOutputStream> file_stream_;
-  /// Wraps `file_stream_`. Destroyed after `coded_stream_`.
-  std::unique_ptr<google::protobuf::io::GzipOutputStream> gzip_stream_;
-  /// Wraps `gzip_stream_`. Destroyed first in the destructor.
-  std::unique_ptr<google::protobuf::io::CodedOutputStream> coded_stream_;
-  /// The path to the file whose handle is held by `fd_`.
-  std::string open_path_;
-  /// The path to use.
-  std::string path_;
-  /// Whether to use a single file or directory.
-  bool single_file_ = false;
-};
-
 /// \brief A `CompilationWriterSink` which writes to .kzip files.\
 /// See https://www.kythe.io/docs/kythe-kzip.html for a description.
 class KzipWriterSink : public CompilationWriterSink {
  public:
   /// \param path The file to which to write.
-  explicit KzipWriterSink(const std::string& path);
-  void OpenIndex(const std::string&) override {}
+  /// \param single_file If true, the kzip is written to the specified path
+  /// directly. Otherwise the path is interpreted as a directory and the kzip is
+  /// written within it using a filename derived from an identifying hash of the
+  /// compilation unit.
+  explicit KzipWriterSink(const std::string& path, bool single_file);
+  void OpenIndex(const std::string& unit_hash) override;
   void WriteHeader(const kythe::proto::CompilationUnit& header) override;
   void WriteFileContent(const kythe::proto::FileData& content) override;
   ~KzipWriterSink() override;
 
  private:
-  IndexWriter writer_;
+  std::string path_;
+  bool single_file_;
+  std::unique_ptr<IndexWriter> writer_;
 };
 
 /// \brief Collects information about compilation arguments and targets and
@@ -285,7 +261,7 @@ class ExtractorConfiguration {
   void InitializeFromEnvironment();
   /// \brief Load the VName config file from `path` or terminate.
   void SetVNameConfig(const std::string& path);
-  /// \brief If a kindex file will be written, write it here.
+  /// \brief If a kzip file will be written, write it here.
   void SetOutputFile(const std::string& path) { output_file_ = path; }
   /// \brief Record the name of the target that generated this compilation.
   void SetTargetName(const std::string& target) { target_name_ = target; }
@@ -314,7 +290,7 @@ class ExtractorConfiguration {
   bool map_builtin_resources_ = true;
   /// The directory to use for index files.
   std::string output_directory_ = ".";
-  /// If nonempty, emit kindex/kzip files to this exact path.
+  /// If nonempty, emit kzip files to this exact path.
   std::string output_file_;
   /// If nonempty, the name of the target that generated this compilation.
   std::string target_name_;

--- a/kythe/cxx/extractor/testdata/test_alternate_platform.sh
+++ b/kythe/cxx/extractor/testdata/test_alternate_platform.sh
@@ -21,8 +21,8 @@ KYTHE_OUTPUT_DIRECTORY="${OUT_DIR}" \
     -mcpu=cortex-a15 \
     -I./kythe/cxx/extractor \
     ./kythe/cxx/extractor/testdata/arm.cc
-[[ $(ls -1 "${OUT_DIR}"/*.kindex | wc -l) -eq 1 ]]
-INDEX_PATH=$(ls -1 "${OUT_DIR}"/*.kindex)
+[[ $(ls -1 "${OUT_DIR}"/*.kzip | wc -l) -eq 1 ]]
+INDEX_PATH=$(ls -1 "${OUT_DIR}"/*.kzip)
 "${KINDEX_TOOL}" -canonicalize_hashes -suppress_details -explode "${INDEX_PATH}"
 
 # Remove lines that will change depending on the machine the test is run on.

--- a/kythe/cxx/extractor/testdata/test_extract_transcript.sh
+++ b/kythe/cxx/extractor/testdata/test_extract_transcript.sh
@@ -23,8 +23,8 @@ KYTHE_OUTPUT_DIRECTORY="${OUT_DIR}" \
     "./${EXTRACTOR}" --with_executable "/usr/bin/g++" \
     -I./kythe/cxx/extractor/testdata \
     ./kythe/cxx/extractor/testdata/transcript_main.cc
-[[ $(ls -1 "${OUT_DIR}"/*.kindex | wc -l) -eq 1 ]]
-INDEX_PATH=$(ls -1 "${OUT_DIR}"/*.kindex)
+[[ $(ls -1 "${OUT_DIR}"/*.kzip | wc -l) -eq 1 ]]
+INDEX_PATH=$(ls -1 "${OUT_DIR}"/*.kzip)
 "${KINDEX_TOOL}" -canonicalize_hashes -suppress_details -explode "${INDEX_PATH}"
 
 # Remove lines that will change depending on the machine the test is run on.

--- a/kythe/cxx/extractor/testdata/test_has_include.sh
+++ b/kythe/cxx/extractor/testdata/test_has_include.sh
@@ -23,8 +23,8 @@ KYTHE_OUTPUT_DIRECTORY="${OUT_DIR}" \
     "./${EXTRACTOR}" --with_executable "/usr/bin/clang++" \
     -I./kythe/cxx/extractor \
     ./kythe/cxx/extractor/testdata/has_include_test.cc
-[[ $(ls -1 "${OUT_DIR}"/*.kindex | wc -l) -eq 1 ]]
-INDEX_PATH=$(ls -1 "${OUT_DIR}"/*.kindex)
+[[ $(ls -1 "${OUT_DIR}"/*.kzip | wc -l) -eq 1 ]]
+INDEX_PATH=$(ls -1 "${OUT_DIR}"/*.kzip)
 "${KINDEX_TOOL}" -canonicalize_hashes -suppress_details -explode "${INDEX_PATH}"
 
 # Remove lines that will change depending on the machine the test is run on.

--- a/kythe/cxx/extractor/testdata/test_indirect_has_include.sh
+++ b/kythe/cxx/extractor/testdata/test_indirect_has_include.sh
@@ -24,8 +24,8 @@ KYTHE_OUTPUT_DIRECTORY="${OUT_DIR}" \
     "./${EXTRACTOR}" --with_executable "/usr/bin/clang++" \
     -I./kythe/cxx/extractor \
     ./kythe/cxx/extractor/testdata/indirect_has_include_test.cc
-[[ $(ls -1 "${OUT_DIR}"/*.kindex | wc -l) -eq 1 ]]
-INDEX_PATH=$(ls -1 "${OUT_DIR}"/*.kindex)
+[[ $(ls -1 "${OUT_DIR}"/*.kzip | wc -l) -eq 1 ]]
+INDEX_PATH=$(ls -1 "${OUT_DIR}"/*.kzip)
 "${KINDEX_TOOL}" -canonicalize_hashes -suppress_details -explode "${INDEX_PATH}"
 
 # Remove lines that will change depending on the machine the test is run on.

--- a/kythe/cxx/extractor/testdata/test_main_source_file_env_dep.sh
+++ b/kythe/cxx/extractor/testdata/test_main_source_file_env_dep.sh
@@ -31,10 +31,10 @@ KYTHE_OUTPUT_DIRECTORY="${OUT_DIR}/with" \
     "./${EXTRACTOR}" --with_executable "/usr/bin/g++" \
     -I./kythe/cxx/extractor/testdata -DMACRO \
     ./kythe/cxx/extractor/testdata/main_source_file_env_dep.cc
-[[ $(ls -1 "${OUT_DIR}"/with/*.kindex | wc -l) -eq 1 ]]
-INDEX_PATH_WITH_MACRO=$(ls -1 "${OUT_DIR}"/with/*.kindex)
-[[ $(ls -1 "${OUT_DIR}"/without/*.kindex | wc -l) -eq 1 ]]
-INDEX_PATH_WITHOUT_MACRO=$(ls -1 "${OUT_DIR}"/without/*.kindex)
+[[ $(ls -1 "${OUT_DIR}"/with/*.kzip | wc -l) -eq 1 ]]
+INDEX_PATH_WITH_MACRO=$(ls -1 "${OUT_DIR}"/with/*.kzip)
+[[ $(ls -1 "${OUT_DIR}"/without/*.kzip | wc -l) -eq 1 ]]
+INDEX_PATH_WITHOUT_MACRO=$(ls -1 "${OUT_DIR}"/without/*.kzip)
 "${KINDEX_TOOL}" -suppress_details -explode "${INDEX_PATH_WITH_MACRO}"
 "${KINDEX_TOOL}" -suppress_details -explode "${INDEX_PATH_WITHOUT_MACRO}"
 

--- a/kythe/cxx/extractor/testdata/test_main_source_file_no_env_dep.sh
+++ b/kythe/cxx/extractor/testdata/test_main_source_file_no_env_dep.sh
@@ -32,10 +32,10 @@ KYTHE_OUTPUT_DIRECTORY="${OUT_DIR}/with" \
     "./${EXTRACTOR}" --with_executable "/usr/bin/g++" \
     -I./kythe/cxx/extractor/testdata \
     -DMACRO ./kythe/cxx/extractor/testdata/main_source_file_no_env_dep.cc
-[[ $(ls -1 "${OUT_DIR}"/with/*.kindex | wc -l) -eq 1 ]]
-INDEX_PATH_WITH_MACRO=$(ls -1 "${OUT_DIR}"/with/*.kindex)
-[[ $(ls -1 "${OUT_DIR}"/without/*.kindex | wc -l) -eq 1 ]]
-INDEX_PATH_WITHOUT_MACRO=$(ls -1 "${OUT_DIR}"/without/*.kindex)
+[[ $(ls -1 "${OUT_DIR}"/with/*.kzip | wc -l) -eq 1 ]]
+INDEX_PATH_WITH_MACRO=$(ls -1 "${OUT_DIR}"/with/*.kzip)
+[[ $(ls -1 "${OUT_DIR}"/without/*.kzip | wc -l) -eq 1 ]]
+INDEX_PATH_WITHOUT_MACRO=$(ls -1 "${OUT_DIR}"/without/*.kzip)
 "${KINDEX_TOOL}" -suppress_details -explode "${INDEX_PATH_WITH_MACRO}"
 "${KINDEX_TOOL}" -suppress_details -explode "${INDEX_PATH_WITHOUT_MACRO}"
 

--- a/kythe/cxx/extractor/testdata/test_metadata.sh
+++ b/kythe/cxx/extractor/testdata/test_metadata.sh
@@ -23,8 +23,8 @@ KYTHE_OUTPUT_DIRECTORY="${OUT_DIR}" \
     "./${EXTRACTOR}" --with_executable "/usr/bin/g++" \
     -I./kythe/cxx/extractor \
     ./kythe/cxx/extractor/testdata/metadata.cc
-[[ $(ls -1 "${OUT_DIR}"/*.kindex | wc -l) -eq 1 ]]
-INDEX_PATH=$(ls -1 "${OUT_DIR}"/*.kindex)
+[[ $(ls -1 "${OUT_DIR}"/*.kzip | wc -l) -eq 1 ]]
+INDEX_PATH=$(ls -1 "${OUT_DIR}"/*.kzip)
 "${KINDEX_TOOL}" -canonicalize_hashes -suppress_details -explode "${INDEX_PATH}"
 
 # Remove lines that will change depending on the machine the test is run on.

--- a/kythe/cxx/extractor/testdata/test_modules.sh
+++ b/kythe/cxx/extractor/testdata/test_modules.sh
@@ -22,8 +22,8 @@ KYTHE_OUTPUT_DIRECTORY="${OUT_DIR}" \
     -fmodule-map-file="kythe/cxx/extractor/testdata/modfoo.modulemap" \
     -I./kythe/cxx/extractor \
     ./kythe/cxx/extractor/testdata/modules.cc
-[[ $(ls -1 "${OUT_DIR}"/*.kindex | wc -l) -eq 1 ]]
-INDEX_PATH=$(ls -1 "${OUT_DIR}"/*.kindex)
+[[ $(ls -1 "${OUT_DIR}"/*.kzip | wc -l) -eq 1 ]]
+INDEX_PATH=$(ls -1 "${OUT_DIR}"/*.kzip)
 "${KINDEX_TOOL}" -canonicalize_hashes -suppress_details -explode "${INDEX_PATH}"
 
 # Remove lines that will change depending on the machine the test is run on.

--- a/kythe/cxx/extractor/testdata/test_root_directory.sh
+++ b/kythe/cxx/extractor/testdata/test_root_directory.sh
@@ -26,8 +26,8 @@ KYTHE_OUTPUT_DIRECTORY="${OUT_DIR}" \
 KYTHE_ROOT_DIRECTORY="${BASE_DIR}/altroot" \
     "../../../cxx_extractor" --with_executable "/usr/bin/g++" \
     file.cc
-[[ $(ls -1 "${OUT_DIR}"/*.kindex | wc -l) -eq 1 ]]
-INDEX_PATH=$(ls -1 "${OUT_DIR}"/*.kindex)
+[[ $(ls -1 "${OUT_DIR}"/*.kzip | wc -l) -eq 1 ]]
+INDEX_PATH=$(ls -1 "${OUT_DIR}"/*.kzip)
 "${REAL_KINDEX_TOOL}" -canonicalize_hashes -suppress_details -explode "${INDEX_PATH}"
 
 # Remove lines that will change depending on the machine the test is run on.

--- a/kythe/go/extractors/config/runextractor/compdb/BUILD
+++ b/kythe/go/extractors/config/runextractor/compdb/BUILD
@@ -23,6 +23,6 @@ go_test(
     library = ":compdb",
     rundir = ".",  # Use Bazel conventions for PWD.
     deps = [
-        "//kythe/go/platform/kindex",
+        "//kythe/go/platform/kzip",
     ],
 )


### PR DESCRIPTION
KZip has replaced the index pack and kindex formats.

Previously the extractor only wrote kzip files if KYTHE_OUTPUT_FILE was
specified in the environment and ended with '.kzip'. This remains
unchanged, but now the extractor also writes kzip files if
KYTHE_OUTPUT_DIRECTORY is specified - this used to result in .kindex
files being written instead. When given a directory, the extractor names
the .kzip files based on a hash of the compilation unit just as it did
with kindex.

Extractor tests have been updated to use kzip instead of kindex.

Part of #2867