### PR TITLE
refactor: write kzip always for JavaStandalone extractor

### DIFF
--- a/kythe/java/com/google/devtools/kythe/extractors/java/standalone/AbstractJavacWrapper.java
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/standalone/AbstractJavacWrapper.java
@@ -52,10 +52,11 @@ import java.util.List;
  * <p>KYTHE_ROOT_DIRECTORY: required root path for file inputs; the {@link FileData} paths stored in
  * the {@link CompilationUnit} will be made to be relative to this directory
  *
- * <p>KYTHE_OUTPUT_FILE: if set to a non-empty value, write the resulting .kindex file to this path
+ * <p>KYTHE_OUTPUT_FILE: if set to a non-empty value, write the resulting .kzip file to this path
  * instead of using KYTHE_OUTPUT_DIRECTORY
  *
- * <p>KYTHE_OUTPUT_DIRECTORY: required directory path to store the resulting .kindex file
+ * <p>KYTHE_OUTPUT_DIRECTORY: directory path to store the resulting .kzip file, if KYTHE_OUTPUT_FILE
+ * is not set
  *
  * <p>KYTHE_INDEX_PACK: if set to a non-empty value, interpret KYTHE_OUTPUT_DIRECTORY as the root of
  * an indexpack instead of a collection of .kindex files

--- a/kythe/java/com/google/devtools/kythe/extractors/shared/IndexInfoUtils.java
+++ b/kythe/java/com/google/devtools/kythe/extractors/shared/IndexInfoUtils.java
@@ -129,6 +129,7 @@ public class IndexInfoUtils {
 
   public static void writeKzipToFile(CompilationDescription description, String path)
       throws IOException {
+    Paths.get(path).getParent().toFile().mkdirs();
     try (KZip.Writer writer = new KZipWriter(new File(path))) {
       Analysis.IndexedCompilation indexedCompilation =
           Analysis.IndexedCompilation.newBuilder()

--- a/kythe/java/com/google/devtools/kythe/extractors/shared/IndexInfoUtils.java
+++ b/kythe/java/com/google/devtools/kythe/extractors/shared/IndexInfoUtils.java
@@ -144,4 +144,8 @@ public class IndexInfoUtils {
   public static Path getKindexPath(String rootDirectory, String basename) {
     return Paths.get(rootDirectory, basename + KINDEX_FILE_EXT);
   }
+
+  public static Path getKzipPath(String rootDirectory, String basename) {
+    return Paths.get(rootDirectory, basename + KZIP_FILE_EXT);
+  }
 }

--- a/kythe/release/release_test.sh
+++ b/kythe/release/release_test.sh
@@ -62,7 +62,7 @@ tools/triples < "$TEST_REPOSRCDIR/kythe/testdata/test.entries" >/dev/null
 # TODO(zarko): add cxx extractor tests
 
 rm -rf "$TMPDIR/java_compilation"
-export KYTHE_OUTPUT_FILE="$TMPDIR/java_compilation/util.kindex"
+export KYTHE_OUTPUT_FILE="$TMPDIR/java_compilation/util.kzip"
 export KYTHE_JAVA_RUNTIME_OPTIONS="-Xbootclasspath/p:$JAVA_LANGTOOLS"
 JAVAC_EXTRACTOR_JAR=$PWD/extractors/javac_extractor.jar \
   KYTHE_ROOT_DIRECTORY="$TEST_REPOSRCDIR" \


### PR DESCRIPTION
Follow-up to #3297, getting rid of kindex and indexpack support.

Relevantly, this will mean that setting KYTHE_OUTPUT_DIRECTORY now
writes potentially multiple kzips, instead of kindex.  We can bundle
those together later with zipmerge if we want.