### PR TITLE
fix: add BUILD visibility for targets required for proto indexer

### DIFF
--- a/kythe/cxx/common/BUILD
+++ b/kythe/cxx/common/BUILD
@@ -22,6 +22,7 @@ cc_library(
         "-Wno-unused-variable",
         "-Wno-implicit-fallthrough",
     ],
+    visibility = [PUBLIC_VISIBILITY],
     deps = [
         ":status_or",
         "@com_github_gflags_gflags//:gflags",
@@ -50,6 +51,7 @@ cc_library(
     name = "path_utils",
     srcs = ["path_utils.cc"],
     hdrs = ["path_utils.h"],
+    visibility = [PUBLIC_VISIBILITY],
     deps = [
         "@com_google_absl//absl/strings",
     ],
@@ -353,7 +355,7 @@ cc_library(
 cc_library(
     name = "status_or",
     hdrs = ["status_or.h"],
-    visibility = ["//visibility:private"],
+    visibility = [PUBLIC_VISIBILITY],
     deps = [
         ":status",
         "@com_github_google_glog//:glog",
@@ -388,6 +390,7 @@ cc_library(
     name = "utf8_line_index",
     srcs = ["utf8_line_index.cc"],
     hdrs = ["utf8_line_index.h"],
+    visibility = [PUBLIC_VISIBILITY],
     deps = [
         "@com_github_google_glog//:glog",
         "@com_google_absl//absl/algorithm:container",

--- a/kythe/cxx/common/indexing/BUILD
+++ b/kythe/cxx/common/indexing/BUILD
@@ -1,5 +1,7 @@
 package(default_visibility = ["//kythe:default_visibility"])
 
+load("//:visibility.bzl", "PUBLIC_VISIBILITY")
+
 cc_library(
     name = "output",
     srcs = [
@@ -9,9 +11,7 @@ cc_library(
         "KytheGraphRecorder.h",
         "KytheOutputStream.h",
     ],
-    visibility = [
-        "//visibility:public",
-    ],
+    visibility = ["//visibility:public"],
     deps = [
         "//kythe/proto:analysis_cc_proto",
         "//kythe/proto:common_cc_proto",
@@ -32,6 +32,7 @@ cc_library(
     hdrs = [
         "KytheCachingOutput.h",
     ],
+    visibility = [PUBLIC_VISIBILITY],
     deps = [
         ":output",
         "//external:libmemcached",

--- a/kythe/cxx/extractor/BUILD
+++ b/kythe/cxx/extractor/BUILD
@@ -1,5 +1,7 @@
 package(default_visibility = ["//kythe:default_visibility"])
 
+load("//:visibility.bzl", "PUBLIC_VISIBILITY")
+
 cc_library(
     name = "index_pack",
     srcs = ["index_pack.cc"],
@@ -10,6 +12,7 @@ cc_library(
         "-Wno-implicit-fallthrough",
     ],
     deprecation = "Please use :kzip_{reader,writer}",
+    visibility = [PUBLIC_VISIBILITY],
     deps = [
         "//external:libuuid",
         "//external:zlib",

--- a/kythe/cxx/verifier/BUILD
+++ b/kythe/cxx/verifier/BUILD
@@ -1,6 +1,7 @@
 package(default_visibility = ["//kythe:default_visibility"])
 
 load("//tools:build_rules/lexyacc.bzl", "genlex", "genyacc")
+load("//:visibility.bzl", "PUBLIC_VISIBILITY")
 
 genyacc(
     name = "parser",
@@ -99,6 +100,7 @@ cc_library(
 
 cc_binary(
     name = "verifier",
+    visibility = [PUBLIC_VISIBILITY],
     deps = [
         ":cmd_lib",
     ],

--- a/kythe/go/extractors/bazel/BUILD
+++ b/kythe/go/extractors/bazel/BUILD
@@ -1,4 +1,5 @@
 load("//tools:build_rules/shims.bzl", "go_test", "go_library")
+load("//:visibility.bzl", "PUBLIC_VISIBILITY")
 
 package(default_visibility = ["//kythe:default_visibility"])
 
@@ -9,6 +10,7 @@ go_library(
         "settings.go",
         "utils.go",
     ],
+    visibility = [PUBLIC_VISIBILITY],
     deps = [
         "//kythe/go/platform/kindex",
         "//kythe/go/platform/kzip",

--- a/kythe/go/extractors/bazel/extutil/BUILD
+++ b/kythe/go/extractors/bazel/extutil/BUILD
@@ -1,4 +1,5 @@
 load("//tools:build_rules/shims.bzl", "go_library")
+load("//:visibility.bzl", "PUBLIC_VISIBILITY")
 
 package(default_visibility = ["//kythe:default_visibility"])
 
@@ -7,6 +8,7 @@ package(default_visibility = ["//kythe:default_visibility"])
 go_library(
     name = "extutil",
     srcs = ["extutil.go"],
+    visibility = [PUBLIC_VISIBILITY],
     deps = [
         "//kythe/go/extractors/bazel",
         "//kythe/go/platform/kindex",

--- a/kythe/go/extractors/govname/BUILD
+++ b/kythe/go/extractors/govname/BUILD
@@ -1,10 +1,12 @@
 load("//tools:build_rules/shims.bzl", "go_test", "go_library")
+load("//:visibility.bzl", "PUBLIC_VISIBILITY")
 
 package(default_visibility = ["//kythe:default_visibility"])
 
 go_library(
     name = "govname",
     srcs = ["govname.go"],
+    visibility = [PUBLIC_VISIBILITY],
     deps = [
         "//kythe/go/util/kytheuri",
         "//kythe/go/util/vnameutil",

--- a/kythe/go/util/vnameutil/BUILD
+++ b/kythe/go/util/vnameutil/BUILD
@@ -1,5 +1,6 @@
 load("//tools:build_rules/shims.bzl", "go_test")
 load("//tools:build_rules/shims.bzl", "go_binary", "go_library")
+load("//:visibility.bzl", "PUBLIC_VISIBILITY")
 
 package(default_visibility = ["//kythe:default_visibility"])
 
@@ -9,6 +10,7 @@ go_library(
         "order.go",
         "rewrite.go",
     ],
+    visibility = [PUBLIC_VISIBILITY],
     deps = ["//kythe/proto:storage_go_proto"],
 )
 

--- a/kythe/proto/BUILD
+++ b/kythe/proto/BUILD
@@ -100,6 +100,7 @@ cc_proto_library(
 
 go_kythe_proto(
     proto = ":storage_service_proto",
+    visibility = [PUBLIC_PROTO_VISIBILITY],
     deps = [":storage_go_proto"],
 )
 
@@ -125,11 +126,13 @@ proto_library(
 
 cc_proto_library(
     name = "analysis_cc_proto",
+    visibility = [PUBLIC_PROTO_VISIBILITY],
     deps = [":analysis_proto"],
 )
 
 go_kythe_proto(
     proto = ":analysis_proto",
+    visibility = [PUBLIC_PROTO_VISIBILITY],
     deps = [
         ":filecontext_go_proto",
         ":storage_go_proto",

--- a/kythe/proto/go.bzl
+++ b/kythe/proto/go.bzl
@@ -33,7 +33,7 @@ _go_proto_src = rule(
     },
 )
 
-def go_kythe_proto(proto = None, deps = [], importpath = None):
+def go_kythe_proto(proto = None, deps = [], importpath = None, visibility=None):
     """Helper for go_proto_library for kythe project.
 
     A shorthand for a go_proto_library with its import path set to the
@@ -71,6 +71,7 @@ def go_kythe_proto(proto = None, deps = [], importpath = None):
         deps = deps,
         importpath = importpath,
         proto = proto,
+        visibility=visibility,
     )
 
     # Copy the generated source from the proto library so we can compare it to


### PR DESCRIPTION
Note that the "PUBLIC_VISIBILITY" alias means public externally, but restricted within google3. It's part of a terrible hack added in https://github.com/kythe/kythe/pull/3278.