### PR TITLE
fix: change tools/modules/update.sh to use an archive instead of clone

### DIFF
--- a/kythe/web/site/getting-started.md
+++ b/kythe/web/site/getting-started.md
@@ -44,6 +44,7 @@ Kythe relies on the following external dependencies:
 * libssl-dev
 * bison-3.0.4 (2.3 is also acceptable)
 * flex-2.5
+* wget
 * [docker](https://www.docker.com/) (for release images `//kythe/release/...` and `//buildtools/docker`)
 * [leiningen](http://leiningen.org/) (used to build `kythe/web/ui`)
 * [ninja](https://ninja-build.org/) (optional; improves LLVM build speed)

--- a/kythe/web/site/getting-started.md
+++ b/kythe/web/site/getting-started.md
@@ -61,7 +61,8 @@ apt-get install \
     asciidoc asciidoctor source-highlight graphviz \
     gcc libssl-dev uuid-dev libncurses-dev libcurl4-openssl-dev flex clang-3.5 bison \
     openjdk-8-jdk \
-    parallel
+    parallel \
+    wget
 
 # https://golang.org/dl/ for Golang installation
 # https://docs.docker.com/installation/debian/#debian-jessie-80-64-bit for Docker installation

--- a/tools/modules/update.sh
+++ b/tools/modules/update.sh
@@ -22,21 +22,24 @@
 # repositories are at the correct version and will configure and build them.
 
 wget_copy_archive() {
+  # The dependency to download (llvm, clang).
   local target="$1"
-  local dir="$2"
+  # The directory to download the dependency into.
+  local dir="${2:?missing directory}"
+  # The specific version of the dependency to use.
   local sha="$3"
 
   if [[ ! -f "$dir/$sha.sentinel" ]]; then
     wget "https://github.com/llvm-mirror/$target/archive/$sha.zip"
+    trap 'rm "$sha.zip"' EXIT ERR INT
     rm -rf "$dir"
     mkdir -p "$dir"
     local tmpdir=$(mktemp -d)
+    trap 'rm -rf "$tmpdir"' EXIT ERR INT
     unzip "$sha.zip" -d "$tmpdir/"
     # This relies on the behavior of github to always produce a zip archive with
     # a subdirectory named "repo-###sha###" that contains the repo inside it.
     mv -T "$tmpdir/$target-$sha" "$dir"
-    rmdir "$tmpdir"
-    rm "$sha.zip"
     # Leave an empty file so that we know what version we have checked out.
     touch "$dir/$sha.sentinel"
   fi

--- a/tools/modules/update.sh
+++ b/tools/modules/update.sh
@@ -16,28 +16,30 @@
 # update_modules.sh updates the repositories for external code (to the precise
 # revisions used for testing).
 #
-# If the single argument `--git_only` is passed, the repositories will be
+# If the single argument `--fetch_only` is passed, the repositories will be
 # updated to the pinned versions without configuring or building them.
 # If the argument `--build_only` is passed, the script will assume that the
 # repositories are at the correct version and will configure and build them.
 
-git_maybe_clone() {
-  local repo="$1"
+wget_copy_archive() {
+  local target="$1"
   local dir="$2"
-  if [[ ! -d "$dir/.git" ]]; then
-    git clone "$repo" "$dir"
-  fi
-}
+  local sha="$3"
 
-git_checkout_sha() {
-  local repo="$1"
-  local sha="$2"
-  cd "$repo"
-  if [[ "$sha" != "$(git rev-parse HEAD)" ]]; then
-    git fetch origin master
-    git checkout -f "$sha"
+  if [[ ! -f "$dir/$sha.sentinel" ]]; then
+    wget "https://github.com/llvm-mirror/$target/archive/$sha.zip"
+    rm -rf "$dir"
+    mkdir -p "$dir"
+    local tmpdir=$(mktemp -d)
+    unzip "$sha.zip" -d "$tmpdir/"
+    # This relies on the behavior of github to always produce a zip archive with
+    # a subdirectory named "repo-###sha###" that contains the repo inside it.
+    mv -T "$tmpdir/$target-$sha" "$dir"
+    rmdir "$tmpdir"
+    rm "$sha.zip"
+    # Leave an empty file so that we know what version we have checked out.
+    touch "$dir/$sha.sentinel"
   fi
-  cd - >/dev/null
 }
 
 cd "$(dirname $0)/../.."
@@ -58,15 +60,12 @@ if [[ -d "$LLVM_REPO/build" && ! -h "$LLVM_REPO/build" ]]; then
 fi
 
 . ./tools/modules/versions.sh
-if [[ -z "$1" || "$1" == "--git_only" ]]; then
+if [[ -z "$1" || "$1" == "--fetch_only" ]]; then
   echo "Using repository in $LLVM_REPO"
 
-  git_maybe_clone https://github.com/llvm-mirror/llvm "$LLVM_REPO"
-  git_maybe_clone https://github.com/llvm-mirror/clang "$LLVM_REPO/tools/clang"
+  wget_copy_archive "llvm" "$LLVM_REPO" "$MIN_LLVM_SHA"
+  wget_copy_archive "clang" "$LLVM_REPO/tools/clang" "$MIN_CLANG_SHA"
   rm -rf "$LLVM_REPO/tools/clang/tools/extra"
-
-  git_checkout_sha "$LLVM_REPO" "$MIN_LLVM_SHA"
-  git_checkout_sha "$LLVM_REPO/tools/clang" "$MIN_CLANG_SHA"
 fi
 
 if [[ -z "$1" || "$1" == "--build_only" ]]; then

--- a/tools/modules/update.sh
+++ b/tools/modules/update.sh
@@ -100,7 +100,6 @@ if [[ -z "$1" || "$1" == "--build_only" ]]; then
       -exec rm -rf \{} \;
   if [[ ! -d "$vbuild_dir" ]]; then
     mkdir -p "$vbuild_dir"
-    llvm_cleanup
     trap "rm -rf '$LLVM_REPO/$vbuild_dir'" ERR INT
     cd "$vbuild_dir"
     CXX=$(basename "${BAZEL_CC}" | sed -E 's/(cc)?(-.*)?$/++\2/')

--- a/tools/modules/update.sh
+++ b/tools/modules/update.sh
@@ -22,20 +22,15 @@
 # repositories are at the correct version and will configure and build them.
 
 # This section is used for cleanup during/after fetching.
-ZIPFILES=()
 TMPDIRS=()
 
 wget_cleanup() {
-  ZIPFILES+=("$1")
-  TMPDIRS+=("${2?:missing directory}")
+  TMPDIRS+=("${1?:missing directory}")
   trap trap_cleanup EXIT ERR INT
 }
 
 trap_cleanup() {
   cd "$ROOT"
-  for file in "${ZIPFILES[@]}"; do
-    rm "$file"
-  done
   for dir in "${TMPDIRS[@]}"; do
     rm -rf "$dir"
   done
@@ -51,10 +46,10 @@ wget_copy_archive() {
 
   if [[ ! -f "$dir/$sha.sentinel" ]]; then
     rm -rf "$dir"
-    wget "https://github.com/llvm-mirror/$target/archive/$sha.zip"
     local tmpdir=$(mktemp -d)
-    wget_cleanup $sha.zip $tmpdir
-    unzip "$sha.zip" -d "$tmpdir/"
+    wget -O "$tmpdir/$sha.zip" "https://github.com/llvm-mirror/$target/archive/$sha.zip"
+    wget_cleanup $tmpdir
+    unzip "$tmpdir/$sha.zip" -d "$tmpdir/"
     # This relies on the behavior of github to always produce a zip archive with
     # a subdirectory named "repo-###sha###" that contains the repo inside it.
     mv "$tmpdir/$target-$sha" "$dir"

--- a/tools/modules/update.sh
+++ b/tools/modules/update.sh
@@ -27,7 +27,7 @@ TMPDIRS=()
 trap_cleanup() {
   ZIPFILES+=("$1")
   TMPDIRS+=("${2?:missing directory}")
-  trap wget_cleanup EXIT
+  trap wget_cleanup EXIT ERR INT
 }
 
 wget_cleanup() {


### PR DESCRIPTION
One way of fixing #3307.

This will make the initial download of llvm and clang faster, by not
requiring a clone of the entire ~3GB repo.  It also save on the ongoing
disk used.  However, it does make updates marginally slower because you
have to re-download a new archive.  Given that updates are vastly
dominated by the cost of building llvm&clang, this is probably ok.

Also this has the side effect of making images for Google Cloud Build +
bazel significantly smaller, which will be nice for #3210.