### PR TITLE
fix: The link to the new macos docs was broken

### DIFF
--- a/kythe/web/site/getting-started-macos.md
+++ b/kythe/web/site/getting-started-macos.md
@@ -7,7 +7,8 @@ permalink: /getting-started-macos/
 * toc
 {:toc}
 
-This document extends the [Getting Started guide](getting-started.md) to cover
+This document extends the
+[Getting Started guide]({{site.baseuri}}/getting-started) to cover
 installation of external dependencies on a macOS system. You will still need to
 follow all the other Getting Started instructions to get a working Kythe build.
 
@@ -66,8 +67,8 @@ installed.
 ## Verifying the Installation
 
 Once you have finished setting up your macOS installation (including
-[the parts that aren't macOS specific](getting-started.md)), you can verify
-that everything works by running:
+[the parts that aren't macOS specific]({{site.baseuri}}/getting-started)),
+you can verify that everything works by running:
 
 {% highlight bash %}
 cd $KYTHE_DIR
@@ -103,5 +104,5 @@ brew upgrade bazelbuild/tap/bazel
 The Docker application automatically checks for updates (you can disable this
 in the Preferences and select Check for Updates manually if you prefer).
 
-[ext]: https://kythe.io/getting-started/#external-dependencies
+[ext]: {{site.baseuri}}/getting-started#external-dependencies
 [dock]: https://store.docker.com/editions/community/docker-ce-desktop-mac

--- a/kythe/web/site/getting-started.md
+++ b/kythe/web/site/getting-started.md
@@ -50,7 +50,7 @@ Kythe relies on the following external dependencies:
 
 You will need to ensure these packages are installed on the system where you
 intend to build Kythe. There are instructions for using `apt-get` below.
-If you are using macOS, see [Instructions for macOS](install-macos.md).
+If you are using macOS, see [Instructions for macOS]({{site.baseuri}}/getting-started-macos).
 
 
 #### Installing Debian Jessie Packages


### PR DESCRIPTION
The link was wrong for the new macos docs. I also renamed the file so the link has the same name as the file.