### PR TITLE
feat(java_indexer): emit implicit anchors for default constructors

### DIFF
--- a/kythe/java/com/google/devtools/kythe/analyzers/base/KytheEntrySets.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/base/KytheEntrySets.java
@@ -173,7 +173,7 @@ public class KytheEntrySets {
       return null;
     }
     EntrySet.Builder builder =
-        newNode(NodeKind.ANCHOR)
+        newNode(loc.getStart() == loc.getEnd() ? NodeKind.ANCHOR_IMPLICIT : NodeKind.ANCHOR)
             .setCorpusPath(CorpusPath.fromVName(fileVName))
             .addSignatureSalt(fileVName)
             .setProperty("loc/start", "" + loc.getStart())

--- a/kythe/java/com/google/devtools/kythe/analyzers/java/SourceText.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/SourceText.java
@@ -225,7 +225,9 @@ public final class SourceText {
 
     /** Returns the byte span for the given tree in the source text. */
     public Span getSpan(JCTree tree) {
-      return new Span(getStart(tree), getEnd(tree));
+      int start = getStart(tree);
+      int end = getEnd(tree);
+      return start >= 0 && end == -1 ? new Span(start, start) : new Span(start, end);
     }
 
     /**

--- a/kythe/java/com/google/devtools/kythe/util/Span.java
+++ b/kythe/java/com/google/devtools/kythe/util/Span.java
@@ -40,6 +40,10 @@ public final class Span implements Comparable<Span> {
     return start <= end && start >= 0;
   }
 
+  public boolean isValidAndNonZero() {
+    return isValid() && start != end;
+  }
+
   /** Determines if the given integer is contained within {@code this} {@link Span}. */
   public boolean contains(int n) {
     return getStart() <= n && n < getEnd();

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Classes.java
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Classes.java
@@ -5,6 +5,8 @@ package pkg;
 //- @Classes defines/binding N
 //- N.node/kind record
 //- N.subkind class
+//- DefaultCtrAnchor.loc/start @^class
+//- DefaultCtrAnchor.loc/end @^class
 public class Classes {
 
   //- DefaultCtor childof N
@@ -12,7 +14,35 @@ public class Classes {
   //- DefaultCtor typed DefaultCtorType
   //- DefaultCtorType param.0 FnBuiltin
   //- DefaultCtorType param.1 N
-  //- !{ _DefaultCtorAnchor defines/binding DefaultCtor }
+  //- DefaultCtrAnchor defines DefaultCtor
+  //- !{ _DefaultCtorBindingAnchor defines/binding DefaultCtor }
+  
+  private static class Subclass extends Classes {
+    //- ImplicitSuperCall ref/call DefaultCtor
+    //- ImplicitSuperCall.loc/start @^"{}"
+    //- ImplicitSuperCall.loc/end @^"{}"
+    //- ImplicitSuperCall childof SubclassCtor
+    //- @Subclass defines/binding SubclassCtor
+    Subclass() {}
+  }
+
+  //- @Subclass2 defines/binding SubclassTwo
+  //- ImplicitSubclassTwoCtorDef.node/kind anchor
+  //- ImplicitSubclassTwoCtorDef.subkind implicit
+  //- ImplicitSubclassTwoCtorDef defines ImplicitSubclassTwoCtor
+  //- ImplicitSubclassTwoCtorDef.loc/start @^#0class
+  //- ImplicitSubclassTwoCtorDef.loc/end @^#0class
+  //- ExtraImplicitSuperCall.node/kind anchor
+  //- ExtraImplicitSuperCall.subkind implicit
+  //- ExtraImplicitSuperCall.loc/start @^#0class
+  //- ExtraImplicitSuperCall.loc/end @^#0class
+  private static class Subclass2 extends Classes {
+    //- ImplicitSubclassTwoCtor.node/kind function
+    //- ImplicitSubclassTwoCtor.subkind constructor
+    //- ImplicitSubclassTwoCtor childof SubclassTwo
+    //- ExtraImplicitSuperCall ref/call DefaultCtor
+    //- ExtraImplicitSuperCall childof ImplicitSubclassTwoCtor
+  }
 
   //- @StaticInner defines/binding SI
   //- SI.node/kind record


### PR DESCRIPTION
Emit implicit `defines` anchors for default constructors and emit
implicit `ref/call` edges for implicit `super` constructor calls (even
if the callsites are in an implicit constructor).