### PR TITLE
feat(objc_indexer): support marked source for @property

### DIFF
--- a/kythe/cxx/indexer/cxx/IndexerASTHooks.cc
+++ b/kythe/cxx/indexer/cxx/IndexerASTHooks.cc
@@ -5178,6 +5178,8 @@ bool IndexerASTVisitor::VisitObjCPropertyDecl(
   auto Marks = MarkedSources.Generate(Decl);
   GraphObserver::NodeId DeclNode(BuildNodeIdForDecl(Decl));
   SourceRange NameRange = RangeForNameOfDeclaration(Decl);
+  Marks.set_name_range(NameRange);
+  Marks.set_marked_source_end(Decl->getSourceRange().getEnd());
   MaybeRecordDefinitionRange(
       RangeInCurrentContext(Decl->isImplicit(), DeclNode, NameRange), DeclNode,
       absl::nullopt);

--- a/kythe/cxx/indexer/cxx/marked_source.cc
+++ b/kythe/cxx/indexer/cxx/marked_source.cc
@@ -374,6 +374,17 @@ class DeclAnnotator : public clang::DeclVisitor<DeclAnnotator> {
       }
     }
   }
+  void VisitObjCPropertyDecl(clang::ObjCPropertyDecl* decl) {
+    if (const auto* type_source_info = decl->getTypeSourceInfo()) {
+      if (!ShouldSkipDecl(decl, type_source_info->getType(),
+                          type_source_info->getTypeLoc().getSourceRange())) {
+        auto type_loc = ExpandRangeBySingleToken(
+            cache_->source_manager(), cache_->lang_options(),
+            type_source_info->getTypeLoc().getSourceRange());
+        InsertTypeAnnotation(type_loc, clang::SourceRange{});
+      }
+    }
+  }
   void VisitFunctionDecl(clang::FunctionDecl* decl) {
     clang::SourceRange arg_list;
     if (const auto* type_info = decl->getTypeSourceInfo()) {
@@ -524,7 +535,8 @@ bool MarkedSourceGenerator::WillGenerateMarkedSource() const {
          llvm::isa<clang::TemplateTypeParmDecl>(decl_) ||
          llvm::isa<clang::NonTypeTemplateParmDecl>(decl_) ||
          llvm::isa<clang::TemplateTemplateParmDecl>(decl_) ||
-         llvm::isa<clang::ObjCTypeParamDecl>(decl_);
+         llvm::isa<clang::ObjCTypeParamDecl>(decl_) ||
+         llvm::isa<clang::ObjCPropertyDecl>(decl_);
 }
 
 std::string GetDeclName(const clang::LangOptions& lang_options,
@@ -850,6 +862,8 @@ absl::optional<MarkedSource> MarkedSourceGenerator::GenerateMarkedSource(
     } else {
       return GenerateMarkedSourceUsingSource(decl_id);
     }
+  } else if (llvm::isa<clang::ObjCPropertyDecl>(decl_)) {
+    return GenerateMarkedSourceUsingSource(decl_id);
   } else if (llvm::isa<clang::ObjCMethodDecl>(decl_)) {
     return GenerateMarkedSourceUsingSource(decl_id);
   } else if (llvm::isa<clang::TemplateTypeParmDecl>(decl_) ||

--- a/kythe/cxx/indexer/cxx/testdata/BUILD
+++ b/kythe/cxx/indexer/cxx/testdata/BUILD
@@ -2577,8 +2577,19 @@ objc_indexer_test(
 objc_indexer_test(
     name = "objc_marked_source_method",
     srcs = ["objc/marked_method.m"],
-    convert_marked_source = True,
     check_for_singletons = True,
+    convert_marked_source = True,
+    tags = [
+        "marked_source",
+        "objc",
+    ],
+)
+
+objc_indexer_test(
+    name = "objc_marked_source_property",
+    srcs = ["objc/marked_property.m"],
+    check_for_singletons = True,
+    convert_marked_source = True,
     tags = [
         "marked_source",
         "objc",

--- a/kythe/cxx/indexer/cxx/testdata/objc/marked_property.m
+++ b/kythe/cxx/indexer/cxx/testdata/objc/marked_property.m
@@ -1,0 +1,34 @@
+// Test marked source for properties.
+
+@class Data;
+
+@interface Box {
+  int _testwidth;
+}
+
+
+//- @width defines/binding WidthPropDecl
+//- WidthPropDecl code WPCodeRoot
+//- WPCodeRoot.pre_text "@property "
+//- WPCodeRoot.kind "BOX"
+//- WPCodeRoot child.0 WPRootType
+//- WPRootType.kind "TYPE"
+//- WPRootType.pre_text "int"
+//- WPCodeRoot child.1 WPContext
+//- WPContext.kind "CONTEXT"
+//- WPContext.post_child_text "::"
+//- WPContext child.0 WPContextIdent
+//- WPContextIdent.kind "IDENTIFIER"
+//- WPContextIdent.pre_text "Box"
+//- WPCodeRoot child.2 WPIdent
+//- WPIdent.kind "IDENTIFIER"
+//- WPIdent.pre_text "width"
+@property int width;
+
+@end
+
+@implementation Box
+
+@synthesize width = _testwidth;
+
+@end


### PR DESCRIPTION
Add basic support for generating marked source for properties in
Objective-C. This should offer similar support to what we do for class
members in C++. It doesn't do anything special for the automatically
generated getter and setter methods. It also doesn't do anything special
with the @property string (though it is present in the marked source).