### PR TITLE
fix: include wget in the list of packages to install on macOS

### DIFF
--- a/kythe/web/site/getting-started-macos.md
+++ b/kythe/web/site/getting-started-macos.md
@@ -34,7 +34,7 @@ rest of these instructions assume you have it.
 To install most of the [external dependencies][ext], run
 
 {% highlight bash %}
-for pkg in asciidoc cmake go graphviz node parallel source-highlight ; do
+for pkg in asciidoc cmake go graphviz node parallel source-highlight wget ; do
    brew install $pkg
 done
 


### PR DESCRIPTION
A follow-up to #3314, needed now that #3308 has landed.  macOS does not include
wget in the base install.