### PR TITLE
feat(gotool_extractor): use Go tool to extract package data

### DIFF
--- a/kythe/docs/schema/example-go.sh
+++ b/kythe/docs/schema/example-go.sh
@@ -20,7 +20,6 @@ set -o pipefail
 #
 # The script assumes its working directory is the schema output directory and
 # requires the following environment variables:
-#   GOROOT
 #   TMP
 #   LANGUAGE
 #   LABEL
@@ -35,7 +34,8 @@ mkdir "$PKGDIR"
 cat > "$SRCFILE"
 
 readonly ENTRIES="$TMP/example.entries"
-"$GO_INDEXER_BIN" --package kythe/schema "$SRCFILE" > "$ENTRIES"
+GOCACHE="$TMP/gocache" \
+  "$GO_INDEXER_BIN" --package kythe/schema "$SRCFILE" > "$ENTRIES"
 "$VERIFIER_BIN" --nocheck_for_singletons --use_file_nodes < "$ENTRIES"
 
 trap 'error FORMAT' ERR

--- a/kythe/go/extractors/cmd/gotool/gotool.go
+++ b/kythe/go/extractors/cmd/gotool/gotool.go
@@ -100,16 +100,31 @@ func main() {
 	}
 	if *extraFiles != "" {
 		ext.ExtraFiles = strings.Split(*extraFiles, ",")
+		for i, path := range ext.ExtraFiles {
+			var err error
+			ext.ExtraFiles[i], err = filepath.Abs(path)
+			if err != nil {
+				log.Fatalf("Error finding absolute path of %s: %v", path, err)
+			}
+		}
 	}
 
 	locate := ext.Locate
 	if *byDir {
-		locate = ext.ImportDir
+		locate = func(path string) ([]*golang.Package, error) {
+			pkg, err := ext.ImportDir(path)
+			if err != nil {
+				return nil, err
+			}
+			return []*golang.Package{pkg}, nil
+		}
 	}
 	for _, path := range flag.Args() {
-		pkg, err := locate(path)
+		pkgs, err := locate(path)
 		if err == nil {
-			maybeLog("Found %q in %s", pkg.Path, pkg.BuildPackage.Dir)
+			for _, pkg := range pkgs {
+				maybeLog("Found %q in %s", pkg.Path, pkg.BuildPackage.Dir)
+			}
 		} else {
 			maybeFatal("Error locating %q: %v", path, err)
 		}

--- a/kythe/go/extractors/golang/BUILD
+++ b/kythe/go/extractors/golang/BUILD
@@ -4,7 +4,10 @@ package(default_visibility = ["//kythe:default_visibility"])
 
 go_library(
     name = "golang",
-    srcs = ["golang.go"],
+    srcs = [
+        "golang.go",
+        "packages.go",
+    ],
     deps = [
         "//kythe/go/extractors/govname",
         "//kythe/go/platform/indexpack",

--- a/kythe/go/extractors/golang/golang.go
+++ b/kythe/go/extractors/golang/golang.go
@@ -196,10 +196,12 @@ func (e *Extractor) dirToImport(dir string) (string, error) {
 	return dir, nil
 }
 
-// Locate attempts to locate the specified import path in the build context.
-// If the package has already been located, its existing package is returned.
-// Otherwise, if importing succeeds, a new *Package value is returned, and also
-// appended to the Packages field.
+// Locate attempts to resolve and locate the specified import path in the build
+// context.  If a package has already been located, its existing *Package is
+// returned.  Otherwise, a new *Package value is returned and appended to the
+// Packages field.
+//
+// Note: multiple packages may be resolved for "/..." import paths
 func (e *Extractor) Locate(importPath string) ([]*Package, error) {
 	listedPackages, err := e.listPackages(importPath)
 	if err != nil {

--- a/kythe/go/extractors/golang/golang.go
+++ b/kythe/go/extractors/golang/golang.go
@@ -200,21 +200,38 @@ func (e *Extractor) dirToImport(dir string) (string, error) {
 // If the package has already been located, its existing package is returned.
 // Otherwise, if importing succeeds, a new *Package value is returned, and also
 // appended to the Packages field.
-func (e *Extractor) Locate(importPath string) (*Package, error) {
-	if pkg := e.findPackage(importPath); pkg != nil {
-		return pkg, nil
-	}
-	bp, err := e.addPackage(importPath, e.LocalPath)
+func (e *Extractor) Locate(importPath string) ([]*Package, error) {
+	listedPackages, err := e.listPackages(importPath)
 	if err != nil {
 		return nil, err
 	}
-	pkg := &Package{
-		ext:          e,
-		Path:         importPath,
-		BuildPackage: bp,
+
+	var pkgs []*Package
+	for _, pkg := range listedPackages {
+		if pkg.ForTest != "" || strings.HasSuffix(pkg.ImportPath, ".test") {
+			// ignore constructed test packages
+			continue
+		} else if pkg.Error != nil {
+			return nil, pkg.Error
+		}
+
+		importPath := pkg.ImportPath
+		p := e.findPackage(importPath)
+		if p == nil {
+			p = &Package{
+				ext:          e,
+				Path:         importPath,
+				DepOnly:      pkg.DepOnly,
+				BuildPackage: pkg.buildPackage(),
+			}
+			e.Packages = append(e.Packages, p)
+			e.mapPackage(importPath, p.BuildPackage)
+		}
+		if !pkg.DepOnly {
+			pkgs = append(pkgs, p)
+		}
 	}
-	e.Packages = append(e.Packages, pkg)
-	return pkg, nil
+	return pkgs, nil
 }
 
 // ImportDir attempts to import the Go package located in the given directory.
@@ -249,6 +266,9 @@ func (e *Extractor) ImportDir(dir string) (*Package, error) {
 func (e *Extractor) Extract() error {
 	var err error
 	for _, pkg := range e.Packages {
+		if pkg.DepOnly {
+			continue
+		}
 		pkg.Err = pkg.Extract()
 		if pkg.Err != nil && err == nil {
 			err = pkg.Err
@@ -263,6 +283,7 @@ type Package struct {
 	seen stringset.Set // input files already added to this package
 
 	Path         string                 // Import or directory path
+	DepOnly      bool                   // Whether the package is only seen as a dependency
 	Err          error                  // Error discovered during processing
 	BuildPackage *build.Package         // Package info from the go/build library
 	VName        *spb.VName             // The package's Kythe vname
@@ -295,7 +316,7 @@ func (p *Package) Extract() error {
 
 	// Add required inputs from this package (source files of various kinds).
 	bp := p.BuildPackage
-	srcBase := filepath.Join(bp.SrcRoot, bp.ImportPath)
+	srcBase := bp.Dir
 	p.addSource(cu, bp.Root, srcBase, bp.GoFiles)
 	p.addFiles(cu, bp.Root, srcBase, bp.CgoFiles)
 	p.addFiles(cu, bp.Root, srcBase, bp.CFiles)

--- a/kythe/go/extractors/golang/packages.go
+++ b/kythe/go/extractors/golang/packages.go
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2018 The Kythe Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package golang
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"go/build"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// Fields must match go list;
+// see $GOROOT/src/cmd/go/internal/load/pkg.go.
+type jsonPackage struct {
+	Dir        string
+	ImportPath string
+	Name       string
+	Doc        string
+	Root       string
+	Export     string
+	Goroot     bool
+
+	GoFiles      []string
+	CFiles       []string
+	CgoFiles     []string
+	CXXFiles     []string
+	MFiles       []string
+	HFiles       []string
+	FFiles       []string
+	SFiles       []string
+	SwigFiles    []string
+	SwigCXXFiles []string
+	SysoFiles    []string
+
+	CgoCFLAGS    []string
+	CgoCPPFLAGS  []string
+	CgoCXXFLAGS  []string
+	CgoFFLAGS    []string
+	CgoLDFLAGS   []string
+	CgoPkgConfig []string
+
+	Imports []string
+
+	TestGoFiles  []string
+	TestImports  []string
+	XTestGoFiles []string
+	XTestImports []string
+
+	ForTest string // q in a "p [q.test]" package, else ""
+	DepOnly bool
+
+	Error *jsonPackageError
+}
+
+func (pkg *jsonPackage) buildPackage() *build.Package {
+	bp := &build.Package{
+		Dir:        pkg.Dir,
+		ImportPath: pkg.ImportPath,
+		Name:       pkg.Name,
+		Doc:        pkg.Doc,
+		Root:       pkg.Root,
+		PkgObj:     pkg.Export,
+		Goroot:     pkg.Goroot,
+
+		GoFiles:      pkg.GoFiles,
+		CgoFiles:     pkg.CgoFiles,
+		CFiles:       pkg.CFiles,
+		CXXFiles:     pkg.CXXFiles,
+		MFiles:       pkg.MFiles,
+		HFiles:       pkg.HFiles,
+		FFiles:       pkg.FFiles,
+		SFiles:       pkg.SFiles,
+		SwigFiles:    pkg.SwigFiles,
+		SwigCXXFiles: pkg.SwigCXXFiles,
+		SysoFiles:    pkg.SysoFiles,
+
+		CgoCFLAGS:    pkg.CgoCFLAGS,
+		CgoCPPFLAGS:  pkg.CgoCPPFLAGS,
+		CgoCXXFLAGS:  pkg.CgoCXXFLAGS,
+		CgoFFLAGS:    pkg.CgoFFLAGS,
+		CgoLDFLAGS:   pkg.CgoLDFLAGS,
+		CgoPkgConfig: pkg.CgoPkgConfig,
+
+		Imports: pkg.Imports,
+
+		TestGoFiles:  pkg.TestGoFiles,
+		TestImports:  pkg.TestImports,
+		XTestGoFiles: pkg.XTestGoFiles,
+		XTestImports: pkg.XTestImports,
+	}
+	if bp.Root != "" {
+		bp.SrcRoot = filepath.Join(bp.Root, "src")
+		bp.PkgRoot = filepath.Join(bp.Root, "pkg")
+		bp.BinDir = filepath.Join(bp.Root, "bin")
+	}
+	return bp
+}
+
+type jsonPackageError struct {
+	ImportStack []string
+	Pos         string
+	Err         string
+}
+
+func (e jsonPackageError) Error() string { return fmt.Sprintf("%s: %s", e.Pos, e.Err) }
+
+func buildContextEnv(bc build.Context) ([]string, error) {
+	vars := []string{
+		"GOARCH=" + bc.GOARCH,
+		"GOOS=" + bc.GOOS,
+	}
+	envPaths := map[string]string{
+		"GOROOT": bc.GOROOT,
+		"GOPATH": bc.GOPATH,
+	}
+	for name, path := range envPaths {
+		abs, err := filepath.Abs(path)
+		if err != nil {
+			return nil, fmt.Errorf("error finding absolute path for %q: %v", path, err)
+		}
+		vars = append(vars, fmt.Sprintf("%s=%s", name, abs))
+	}
+	return vars, nil
+}
+
+func (e *Extractor) listPackages(query ...string) ([]*jsonPackage, error) {
+	// TODO(schroederc): support GOPACKAGESDRIVER
+	args := append([]string{"list", "-test", "-deps", "-e", "-export", "-compiled", "-json", "--"}, query...)
+	goTool := "go"
+	if e.BuildContext.GOROOT != "" {
+		goTool = filepath.Join(e.BuildContext.GOROOT, "bin/go")
+	}
+	cmd := exec.Command(goTool, args...)
+	env, err := buildContextEnv(e.BuildContext)
+	if err != nil {
+		return nil, err
+	}
+	cmd.Env = append(os.Environ(), env...)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("go list error: %v", err)
+	}
+
+	var pkgs []*jsonPackage
+	for de := json.NewDecoder(&out); de.More(); {
+		var pkg jsonPackage
+		if err := de.Decode(&pkg); err != nil {
+			return nil, err
+		}
+		pkgs = append(pkgs, &pkg)
+	}
+	return pkgs, nil
+}

--- a/kythe/go/indexer/cmd/go_example/BUILD
+++ b/kythe/go/indexer/cmd/go_example/BUILD
@@ -5,6 +5,7 @@ package(default_visibility = ["//kythe:default_visibility"])
 go_binary(
     name = "go_example",
     srcs = ["go_example.go"],
+    data = ["@go_sdk//:files"],
     deps = [
         "//kythe/go/extractors/golang",
         "//kythe/go/indexer",

--- a/kythe/go/indexer/cmd/go_example/go_example.go
+++ b/kythe/go/indexer/cmd/go_example/go_example.go
@@ -45,7 +45,7 @@ var (
 )
 
 func init() {
-	flag.StringVar(&bc.GOROOT, "goroot", bc.GOROOT,
+	flag.StringVar(&bc.GOROOT, "goroot", filepath.Join(filepath.Dir(os.Args[0]), "go_example.runfiles/go_sdk"),
 		"Use this directory as the root for Go library packages")
 
 	flag.Usage = func() {

--- a/kythe/go/indexer/cmd/go_example/go_example.go
+++ b/kythe/go/indexer/cmd/go_example/go_example.go
@@ -93,7 +93,7 @@ func main() {
 	if err := os.Chdir(base); err != nil {
 		log.Fatalf("Error changing directory to %q: %v", dir, err)
 	}
-	pkg, err := ext.Locate(*importPath)
+	pkgs, err := ext.Locate(*importPath)
 	if err != nil {
 		log.Fatalf("Error locating package: %v", err)
 	}
@@ -102,18 +102,20 @@ func main() {
 	}
 
 	rw := delimited.NewWriter(os.Stdout)
-	if err := pkg.EachUnit(ctx, func(unit *kindex.Compilation) error {
-		pi, err := indexer.Resolve(unit.Proto, unit, &indexer.ResolveOptions{
-			Info: indexer.XRefTypeInfo(),
-		})
-		if err != nil {
-			return err
+	for _, pkg := range pkgs {
+		if err := pkg.EachUnit(ctx, func(unit *kindex.Compilation) error {
+			pi, err := indexer.Resolve(unit.Proto, unit, &indexer.ResolveOptions{
+				Info: indexer.XRefTypeInfo(),
+			})
+			if err != nil {
+				return err
+			}
+			return pi.Emit(ctx, func(_ context.Context, entry *spb.Entry) error {
+				return rw.PutProto(entry)
+			}, nil)
+		}); err != nil {
+			log.Fatalf("Error indexing: %v", err)
 		}
-		return pi.Emit(ctx, func(_ context.Context, entry *spb.Entry) error {
-			return rw.PutProto(entry)
-		}, nil)
-	}); err != nil {
-		log.Fatalf("Error indexing: %v", err)
 	}
 }
 

--- a/kythe/go/indexer/testdata/go_indexer_test.bzl
+++ b/kythe/go/indexer/testdata/go_indexer_test.bzl
@@ -60,6 +60,8 @@ def _emit_extractor_script(ctx, mode, script, output, srcs, deps, ipath, data):
 
     # Invoke the extractor on the temp directory.
     goroot = "/".join(ctx.files._sdk_files[0].path.split("/")[:-2])
+    cmds.append("export GOCACHE=" + tmpdir + "/cache")
+    cmds.append("export CGO_ENABLED=0")
     cmds.append(" ".join([
         ctx.files._extractor[-1].path,
         "-output",


### PR DESCRIPTION
As a consequence, the `gotool` extractor now supports extracting Go 1.11 modules (#2881).