### PR TITLE
fix: extract guava tests as well

### DIFF
--- a/kythe/go/extractors/gcp/examples/guava-mvn.yaml
+++ b/kythe/go/extractors/gcp/examples/guava-mvn.yaml
@@ -39,6 +39,27 @@ steps:
   volumes:
     - name: 'kythe_extractors'
       path: '/opt/kythe/extractors/'
+- name: 'gcr.io/cloud-builders/mvn'
+  args:
+    - 'clean'
+    - 'test-compile'
+    - '-X'
+    - '-f'
+    - '/workspace/code/pom.xml'
+    - '-Dmaven.compiler.forceJavacCompilerUse=true'
+    - '-Dmaven.compiler.fork=true'
+    - '-Dmaven.compiler.executable=/opt/kythe/extractors/javac-wrapper.sh'
+  env:
+    - 'KYTHE_CORPUS=guava'
+    - 'KYTHE_OUTPUT_DIRECTORY=/workspace/out'
+    - 'KYTHE_ROOT_DIRECTORY=/workspace/code'
+    - 'JAVAC_EXTRACTOR_JAR=/opt/kythe/extractors/javac_extractor.jar'
+    - 'REAL_JAVAC=/usr/bin/javac'
+    - 'TMPDIR=/workspace/errs'
+    - 'KYTHE_JAVA_RUNTIME_OPTIONS=-Xbootclasspath/p:/opt/kythe/extractors/javac9_tools.jar'
+  volumes:
+    - name: 'kythe_extractors'
+      path: '/opt/kythe/extractors/'
 - name: 'ubuntu'
   args: ['ls', '/workspace/out']
 - name: 'gcr.io/kythe-public/kzip-tools'


### PR DESCRIPTION
Tested using `install` instead (see #3126), didn't work as well.