### PR TITLE
build: kindex_tool public visibility

### DIFF
--- a/kythe/cxx/tools/BUILD
+++ b/kythe/cxx/tools/BUILD
@@ -70,6 +70,7 @@ cc_library(
 
 cc_binary(
     name = "kindex_tool",
+    visibility = ["//visibility:public"],
     deps = [
         ":cmdlib",
     ],


### PR DESCRIPTION
The standalone proto extractor (https://github.com/kythe/lang-proto/issues/14) will need to use this for testing.