### PR TITLE
fix: don't use a string pointer when we don't have to

### DIFF
--- a/kythe/go/extractors/validation/validation.go
+++ b/kythe/go/extractors/validation/validation.go
@@ -41,7 +41,7 @@ type Settings struct {
 	// Language extensions to check, e.g. java, cpp, h.
 	Langs stringset.Set
 	// Optional file to output missing paths to.
-	MissingOutput *string
+	MissingOutput string
 }
 
 // Result explains a validation outcome.
@@ -118,8 +118,8 @@ func (s Settings) Validate() (*Result, error) {
 		}
 	}
 
-	if s.MissingOutput != nil {
-		err = outputMissing(missingFromKZIP, *s.MissingOutput)
+	if s.MissingOutput != "" {
+		err = outputMissing(missingFromKZIP, s.MissingOutput)
 	}
 
 	return &Result{

--- a/kythe/go/platform/tools/kzip_validator/kzip_validator.go
+++ b/kythe/go/platform/tools/kzip_validator/kzip_validator.go
@@ -202,7 +202,7 @@ func validate(config repoConfig) (retErr error) {
 		Compilations:  strings.Split(*kzip, ","),
 		Repo:          repoPath,
 		Langs:         stringset.FromKeys(strings.Split(*lang, ",")),
-		MissingOutput: missingFile,
+		MissingOutput: *missingFile,
 	}.Validate()
 	if err != nil {
 		return fmt.Errorf("failure validating: %v", err)


### PR DESCRIPTION
I was originally gonna do some hackery with a default output, but ended
up not doing so, and this means the string pointer I was using isn't
really useful anymore, so removing it because I'll probably shoot myself
in the foot with it later if I don't kill it now.