### PR TITLE
update llvm to r350964 

### DIFF
--- a/third_party/llvm/src/cxx_extractor_preprocessor_utils.cc
+++ b/third_party/llvm/src/cxx_extractor_preprocessor_utils.cc
@@ -110,6 +110,7 @@ std::string getMacroExpandedString(clang::Preprocessor &PP,
 
 std::string getSourceString(clang::Preprocessor &PP, clang::SourceRange Range) {
   return clang::Lexer::getSourceText(clang::CharSourceRange(Range, false),
-                                     PP.getSourceManager(), PP.getLangOpts());
+                                     PP.getSourceManager(), PP.getLangOpts())
+      .trim();
 }
 }  // namespace kythe

--- a/third_party/llvm/src/cxx_extractor_preprocessor_utils.cc
+++ b/third_party/llvm/src/cxx_extractor_preprocessor_utils.cc
@@ -31,7 +31,7 @@ std::string getMacroUnexpandedString(clang::SourceRange Range,
   if (MI->isFunctionLike()) {
     clang::SourceLocation EndLoc(Range.getEnd());
     const char *EndPtr = PP.getSourceManager().getCharacterData(EndLoc) + 1;
-    Length = (EndPtr - BeginPtr) + 1; // +1 is ')' width.
+    Length = (EndPtr - BeginPtr) + 1;  // +1 is ')' width.
   } else
     Length = MacroName.size();
   return llvm::StringRef(BeginPtr, Length).trim().str();
@@ -54,7 +54,7 @@ std::string getMacroExpandedStringInternal(
     if (ArgNo == -1) {
       // This isn't an argument, just add it.
       if (II == nullptr)
-        Expanded += PP.getSpelling((*I)); // Not an identifier.
+        Expanded += PP.getSpelling((*I));  // Not an identifier.
       else {
         // Token is for an identifier.
         std::string Name = II->getName().str();
@@ -75,17 +75,16 @@ std::string getMacroExpandedStringInternal(
       ResultArgToks = &(const_cast<clang::MacroArgs *>(Args))
                            ->getPreExpArgument(ArgNo, PP)[0];
     else
-      ResultArgToks = ArgTok; // Use non-preexpanded Tokens.
+      ResultArgToks = ArgTok;  // Use non-preexpanded Tokens.
     // If the arg token didn't expand into anything, ignore it.
-    if (ResultArgToks->is(clang::tok::eof))
-      continue;
+    if (ResultArgToks->is(clang::tok::eof)) continue;
     unsigned NumToks = clang::MacroArgs::getArgLength(ResultArgToks);
     // Append the resulting argument expansions.
     for (unsigned ArgumentIndex = 0; ArgumentIndex < NumToks; ++ArgumentIndex) {
       const clang::Token &AT = ResultArgToks[ArgumentIndex];
       clang::IdentifierInfo *II = AT.getIdentifierInfo();
       if (II == nullptr)
-        Expanded += PP.getSpelling(AT); // Not an identifier.
+        Expanded += PP.getSpelling(AT);  // Not an identifier.
       else {
         // It's an identifier.  Check for further expansion.
         std::string Name = II->getName().str();
@@ -110,18 +109,7 @@ std::string getMacroExpandedString(clang::Preprocessor &PP,
 }
 
 std::string getSourceString(clang::Preprocessor &PP, clang::SourceRange Range) {
-  clang::SourceLocation BeginLoc = Range.getBegin();
-  clang::SourceLocation EndLoc = Range.getEnd();
-  if (!BeginLoc.isValid() || !EndLoc.isValid() ||
-      BeginLoc.isFileID() != EndLoc.isFileID()) {
-    return llvm::StringRef();
-  }
-  const char *BeginPtr = PP.getSourceManager().getCharacterData(BeginLoc);
-  const char *EndPtr = PP.getSourceManager().getCharacterData(EndLoc);
-  if (BeginPtr > EndPtr) {
-    return llvm::StringRef();
-  }
-  size_t Length = EndPtr - BeginPtr;
-  return llvm::StringRef(BeginPtr, Length).trim().str();
+  return clang::Lexer::getSourceText(clang::CharSourceRange(Range, false),
+                                     PP.getSourceManager(), PP.getLangOpts());
 }
-}
+}  // namespace kythe

--- a/tools/modules/versions.sh
+++ b/tools/modules/versions.sh
@@ -23,13 +23,13 @@ set -e
 # shellcheck disable=SC2034
 {
 # llvm
-MIN_LLVM_SHA="cae2d736b319f1bb124c7bd21e9b65bb1734ccf5"
-MIN_LLVM_REV="350964"
+MIN_LLVM_SHA="a42cde684126a3797f3eda9c894c379e7a8c66c1"
+MIN_LLVM_REV="351207"
 # clang
 # NOTE: when updating Clang, make sure to adjust the path in
 # //third_party/llvm/BUILD:clang_builtin_headers_resources
-MIN_CLANG_SHA="4c57533ba3d00d3c41b96258eb7b6a4755b55b38"
-MIN_CLANG_REV="350958"
+MIN_CLANG_SHA="777055562de6505702ba0c36210491a2436872e0"
+MIN_CLANG_REV="351210"
 
 FULL_SHA="${MIN_LLVM_SHA}-${MIN_CLANG_SHA}"
 }

--- a/tools/modules/versions.sh
+++ b/tools/modules/versions.sh
@@ -20,6 +20,8 @@
 # be set to the new (matched) strings.
 set -e
 
+# shellcheck disable=SC2034
+{
 # llvm
 MIN_LLVM_SHA="cae2d736b319f1bb124c7bd21e9b65bb1734ccf5"
 MIN_LLVM_REV="350964"
@@ -30,3 +32,4 @@ MIN_CLANG_SHA="4c57533ba3d00d3c41b96258eb7b6a4755b55b38"
 MIN_CLANG_REV="350958"
 
 FULL_SHA="${MIN_LLVM_SHA}-${MIN_CLANG_SHA}"
+}

--- a/tools/modules/versions.sh
+++ b/tools/modules/versions.sh
@@ -21,12 +21,12 @@
 set -e
 
 # llvm
-MIN_LLVM_SHA="3fe1b12fca949399a3334a072ee7f96e2b6f557e"
-MIN_LLVM_REV="345798"
+MIN_LLVM_SHA="cae2d736b319f1bb124c7bd21e9b65bb1734ccf5"
+MIN_LLVM_REV="350964"
 # clang
 # NOTE: when updating Clang, make sure to adjust the path in
 # //third_party/llvm/BUILD:clang_builtin_headers_resources
-MIN_CLANG_SHA="d81da87531b6cd4829b939f433845b60ec1e00d6"
-MIN_CLANG_REV="345781"
+MIN_CLANG_SHA="4c57533ba3d00d3c41b96258eb7b6a4755b55b38"
+MIN_CLANG_REV="350958"
 
 FULL_SHA="${MIN_LLVM_SHA}-${MIN_CLANG_SHA}"


### PR DESCRIPTION
This also switches getSourceText to using the upstream static member function in Lexer, originally to workaround the bug in r350891 but now just to accomplish the same goal in cleaner way.

As `getThisType()` no longer accepts an ASTContext parameter, remove the extra Kythe plumbing passing it around.