### PR TITLE
Remove workaround for clang bug

### DIFF
--- a/kythe/cxx/indexer/cxx/IndexerASTHooks.cc
+++ b/kythe/cxx/indexer/cxx/IndexerASTHooks.cc
@@ -1041,20 +1041,6 @@ void IndexerASTVisitor::VisitRecordDeclComment(
   }
 }
 
-bool IndexerASTVisitor::TraverseLambdaExpr(clang::LambdaExpr* Expr) {
-  // Clang does not reliably visit the implicitly generated class or (more
-  // importantly) call operator.
-  // Specifically, it only does so for lambdas defined at the top level,
-  // which is a vanishingly small number of them.
-  // TODO(shahms): Figure out *why* Clang behaves this way and fix that.
-  return Base::TraverseLambdaExpr(Expr) && [this, Expr] {
-    if (Expr->getLambdaClass()->getDeclContext()->isFunctionOrMethod()) {
-      return TraverseDecl(Expr->getCallOperator());
-    }
-    return true;
-  }();
-}
-
 bool IndexerASTVisitor::TraverseDecl(clang::Decl* Decl) {
   if (ShouldStopIndexing()) {
     return false;

--- a/kythe/cxx/indexer/cxx/IndexerASTHooks.h
+++ b/kythe/cxx/indexer/cxx/IndexerASTHooks.h
@@ -168,8 +168,6 @@ class IndexerASTVisitor : public clang::RecursiveASTVisitor<IndexerASTVisitor> {
   bool VisitFunctionDecl(clang::FunctionDecl* Decl);
   bool TraverseDecl(clang::Decl* Decl);
 
-  bool TraverseLambdaExpr(clang::LambdaExpr* Expr);
-
   bool TraverseConstructorInitializer(clang::CXXCtorInitializer* Init);
   bool TraverseCXXNewExpr(clang::CXXNewExpr* E);
   bool TraverseCXXFunctionalCastExpr(clang::CXXFunctionalCastExpr* E);


### PR DESCRIPTION
Since clang r351047 the implicit classes for lambdas are visited for
lambdas in all scopes, not just the global scope.