### PR TITLE
fix: use kzip tool instead of zipmerge for gcp extraction

### DIFF
--- a/kythe/go/extractors/gcp/README.md
+++ b/kythe/go/extractors/gcp/README.md
@@ -148,7 +148,7 @@ specify all of the above custom javac extraction logic.
 
 ### gcr.io/kythe-public/kzip-tools
 
-For now this is a simple wrapper around
+This image exposes the binary
 [kythe/go/platform/tools/kzip](https://github.com/kythe/kythe/blob/master/kythe/go/platform/tools/kzip/kzip.go),
 which for now just supports merging multiple kzips together.
 

--- a/kythe/go/extractors/gcp/README.md
+++ b/kythe/go/extractors/gcp/README.md
@@ -42,7 +42,7 @@ gcloud builds submit --config examples/mvn.yaml \
 --substitutions=\
 _BUCKET_NAME=$BUCKET_NAME,\
 _REPO_NAME=https://github.com/project-name/repo-name\
---no-source
+ --no-source
 ```
 
 ### Guava specific example
@@ -55,7 +55,7 @@ gcloud builds submit --config examples/guava-mvn.yaml \
 --substitutions=\
 _BUCKET_NAME=$BUCKET_NAME,\
 _GUAVA_VERSION=<commit-hash>\
---no-source
+ --no-source
 ```
 
 This outputs `guava-<commit-hash>.kzip` to $BUCKET_NAME on Google Cloud Storage.
@@ -69,7 +69,7 @@ gcloud builds submit --config examples/gradle.yaml \
 --substitutions=\
 _BUCKET_NAME=$BUCKET_NAME,\
 _REPO_NAME=https://github.com/project-name/repo-name\
---no-source
+ --no-source
 ```
 
 ## Cloud Build REST API
@@ -148,8 +148,9 @@ specify all of the above custom javac extraction logic.
 
 ### gcr.io/kythe-public/kzip-tools
 
-For now this is a simple wrapper around `zipmerge`, but will hopefully later
-contain other useful tools for dealing with kzip archives.
+For now this is a simple wrapper around
+[kythe/go/platform/tools/kzip](https://github.com/kythe/kythe/blob/master/kythe/go/platform/tools/kzip/kzip.go),
+which for now just supports merging multiple kzips together.
 
 ## Troubleshooting
 

--- a/kythe/go/extractors/gcp/config/kziptool/BUILD
+++ b/kythe/go/extractors/gcp/config/kziptool/BUILD
@@ -2,11 +2,13 @@ package(default_visibility = ["//kythe:default_visibility"])
 
 load("//tools:build_rules/docker.bzl", "docker_build")
 
-# This target builds a docker image which contains zipmerge.
-# TODO(danielmoy): expand this to include other useful tools for managing kzips.
+# This target builds a docker image which contains the kzip tool binary.
 docker_build(
     name = "artifacts",
     src = "Dockerfile",
+    data = [
+        "//kythe/go/platform/tools/kzip",
+    ],
     image_name = "gcr.io/kythe-public/kzip-tools",
     tags = ["manual"],
     use_cache = True,

--- a/kythe/go/extractors/gcp/config/kziptool/Dockerfile
+++ b/kythe/go/extractors/gcp/config/kziptool/Dockerfile
@@ -14,7 +14,7 @@
 
 # Build: bazel build //kythe/go/extractors/gcp/config/kziptool:artifacts
 # Usage:
-#   This container exposes the tool kzip, useful for combining multiple kzip
+#   This container exposes the kzip tool, useful for combining multiple kzip
 #   output files into a single kzip.
 #
 #   From Google Cloud Build:

--- a/kythe/go/extractors/gcp/config/kziptool/Dockerfile
+++ b/kythe/go/extractors/gcp/config/kziptool/Dockerfile
@@ -14,18 +14,16 @@
 
 # Build: bazel build //kythe/go/extractors/gcp/config/kziptool:artifacts
 # Usage:
-#   This container exposes zipmerge, useful for combining multiple kzip
+#   This container exposes the tool kzip, useful for combining multiple kzip
 #   output files into a single kzip.
-#   TODO(danielmoy): include other useful tools for kzip handling.
 #
 #   From Google Cloud Build:
 #     - name: 'gcr.io/kythe-public/kzip-tools'
 #       entrypoint: 'bash'
-#       args: ['-c', 'zipmerge /some/output.kzip /input/files/*.kzip']
+#       args: ['-c', '/opt/kythe/tools/kzip merge --output /some/output.kzip /input/files/*.kzip']
 
 FROM launcher.gcr.io/google/ubuntu16_04
 
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y --no-install-recommends zipmerge && \
-    apt-get clean
+ADD kythe/go/platform/tools/kzip/kzip /opt/kythe/tools/kzip
+
+CMD ["/opt/kythe/tools/kzip"]

--- a/kythe/go/extractors/gcp/examples/guava-mvn.yaml
+++ b/kythe/go/extractors/gcp/examples/guava-mvn.yaml
@@ -64,7 +64,7 @@ steps:
   args: ['ls', '/workspace/out']
 - name: 'gcr.io/kythe-public/kzip-tools'
   entrypoint: 'bash'
-  args: ['-c', 'zipmerge /workspace/out/guava-$_GUAVA_VERSION.kzip /workspace/out/*.kzip']
+  args: ['-c', '/opt/kythe/tools/kzip merge --output /workspace/out/guava-$_GUAVA_VERSION.kzip /workspace/out/*.kzip']
 artifacts:
   objects:
     location: 'gs://${_BUCKET_NAME}/'


### PR DESCRIPTION
Cody added kzip cli tool in #3354, which we should use instead of
zipmerge.

This change also exposes kzip cli tool as a docker image hosted at
gcr.io/kythe-public/kzip-tools, so you can now run:

```
docker run --rm gcr.io/kythe-public/kzip-tools merge \
--output <some-file> <bunch-of-kzip-files>
```

Or alternatively, on GCP:

```
- name: 'gcr.io/kythe-public/kzip-tools'
  entrypoint: 'bash'
  args:
    - '-c'
    - '/opt/kythe/tools/kzip merge --output out inputs*.kzip'
```