### PR TITLE
fix(cxx_common): add enumerator for kDocUri fact

### DIFF
--- a/kythe/cxx/common/indexing/KytheGraphRecorder.cc
+++ b/kythe/cxx/common/indexing/KytheGraphRecorder.cc
@@ -112,6 +112,7 @@ static const std::string* const kPropertySpellings[] = {
     new std::string("/kythe/message"),
     new std::string("/kythe/details"),
     new std::string("/kythe/context/url"),
+    new std::string("/kythe/doc/uri"),
 };
 
 static const std::string* const kEmptyStringSpelling = new std::string("");

--- a/kythe/cxx/common/indexing/KytheGraphRecorder.h
+++ b/kythe/cxx/common/indexing/KytheGraphRecorder.h
@@ -70,7 +70,8 @@ enum class PropertyID {
   kTagDeprecated,
   kDiagnosticMessage,
   kDiagnosticDetails,
-  kDiagnosticContextOrUrl
+  kDiagnosticContextOrUrl,
+  kDocUri
 };
 
 /// \brief Known edge kinds. See the schema for details.


### PR DESCRIPTION
This fact is already supported, but wasn't present in the common enumerator.