### PR TITLE
build: add java_proto_verifier_test Starlark rule

### DIFF
--- a/external.bzl
+++ b/external.bzl
@@ -648,7 +648,7 @@ def _bindings():
 def _kythe_contributions():
     git_repository(
         name = "io_kythe_lang_proto",
-        commit = "e96bdcb5b31e8cd212334f8665c81943aec82fe3",
+        commit = "b6f38f05feaeeea1e38ceeeb92bee849926921cd",
         remote = "https://github.com/kythe/lang-proto",
     )
 

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/proto/BUILD
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/proto/BUILD
@@ -1,0 +1,7 @@
+load("//tools/build_rules/verifier_test:java_verifier_test.bzl", "java_proto_verifier_test")
+
+java_proto_verifier_test(
+    name = "proto",
+    srcs = ["Proto.java"],
+    proto_srcs = ["testdata.proto"],
+)

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/proto/BUILD
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/proto/BUILD
@@ -4,4 +4,6 @@ java_proto_verifier_test(
     name = "proto",
     srcs = ["Proto.java"],
     proto_srcs = ["testdata.proto"],
+    # TODO(schroederc): test does not work with RBE (https://github.com/bazelbuild/bazel/issues/1025)
+    tags = ["manual"],
 )

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/proto/BUILD
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/proto/BUILD
@@ -4,6 +4,4 @@ java_proto_verifier_test(
     name = "proto",
     srcs = ["Proto.java"],
     proto_srcs = ["testdata.proto"],
-    # TODO(schroederc): test does not work with RBE (https://github.com/bazelbuild/bazel/issues/1025)
-    tags = ["manual"],
 )

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/proto/Proto.java
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/proto/Proto.java
@@ -1,0 +1,12 @@
+package pkg.proto;
+
+public class Proto {
+  static void buildMessage() {
+    //- @Message ref JavaMessage
+    //- @setStringField ref JavaStringField
+    Testdata.Message.newBuilder().setStringField("blah").build();
+
+    //- Message generates JavaMessage
+    //- StringField generates JavaStringField
+  }
+}

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/proto/testdata.proto
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/proto/testdata.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+package pkg.proto;
+
+//- @Message defines/binding Message
+message Message {
+  //- @string_field defines/binding StringField
+  string string_field = 1;
+}

--- a/tools/build_rules/verifier_test/java_verifier_test.bzl
+++ b/tools/build_rules/verifier_test/java_verifier_test.bzl
@@ -224,11 +224,20 @@ def _generate_java_proto_impl(ctx):
     # Generate the Java protocol buffer sources into a directory.
     # Note: out contains .meta files with annotations for cross-language xrefs.
     out = ctx.actions.declare_directory(ctx.label.name + "_gen")
-    ctx.actions.run(
+    protoc = ctx.executable._protoc
+    ctx.actions.run_shell(
         outputs = [out],
         inputs = ctx.files.srcs,
-        executable = ctx.executable._protoc,
-        arguments = ["--java_out=annotate_code:" + out.path] + [src.path for src in ctx.files.srcs],
+        tools = [protoc],
+        command = "\n".join([
+            "#/bin/bash",
+            "set -e",
+            "mkdir -p " + out.path,
+            " ".join([
+                protoc.path,
+                "--java_out=annotate_code:" + out.path,
+            ] + [src.path for src in ctx.files.srcs]),
+        ]),
     )
 
     # List the Java sources in a files for the javac_extractor to take as a @params file.

--- a/tools/build_rules/verifier_test/java_verifier_test.bzl
+++ b/tools/build_rules/verifier_test/java_verifier_test.bzl
@@ -19,6 +19,19 @@ load(
     "index_compilation",
     "verifier_test",
 )
+load(
+    "@io_kythe_lang_proto//kythe/cxx/indexer/proto/testdata:proto_verifier_test.bzl",
+    "proto_extract_kzip",
+)
+
+KytheJavaParams = provider(
+    doc = "Java source jar unpacked into parameters file.",
+    fields = {
+        "srcjars": "Original source jars generating files in params file.",
+        "params": "File with list of Java parameters.",
+        "dir": "Directory of files referenced in params file.",
+    },
+)
 
 def _invoke(rulefn, name, **kwargs):
     """Invoke rulefn with name and kwargs, returning the label of the rule."""
@@ -30,6 +43,19 @@ def _java_extract_kzip_impl(ctx):
     for dep in ctx.attr.deps:
         deps += [dep[JavaInfo]]
 
+    srcs = []
+    srcjars = []
+    params_files = []
+    dirs = []
+    for src in ctx.attr.srcs:
+        if KytheJavaParams in src:
+            srcjars += src[KytheJavaParams].srcjars
+            params_files += [src[KytheJavaParams].params]
+            dirs += [src[KytheJavaParams].dir]
+        else:
+            srcs += [src.files]
+    srcs = depset(transitive = srcs).to_list()
+
     # Actually compile the sources to be used as a dependency for other tests
     jar = ctx.actions.declare_file(ctx.outputs.kzip.basename + ".jar", sibling = ctx.outputs.kzip)
     java_info = java_common.compile(
@@ -40,7 +66,7 @@ def _java_extract_kzip_impl(ctx):
         ) + ctx.attr.opts,
         java_toolchain = ctx.attr._java_toolchain,
         host_javabase = ctx.attr._host_javabase,
-        source_files = ctx.files.srcs,
+        source_files = srcs + srcjars,
         output = jar,
         deps = deps,
     )
@@ -52,21 +78,23 @@ def _java_extract_kzip_impl(ctx):
         "-cp",
         ":".join([j.path for j in jars]),
     ]
-    for src in ctx.files.srcs:
+    for params in params_files:
+        args += ["@" + params.path]
+    for src in srcs:
         args += [src.short_path]
     extract(
-        srcs = ctx.files.srcs,
+        srcs = srcs,
         ctx = ctx,
         extractor = ctx.executable.extractor,
         kzip = ctx.outputs.kzip,
         mnemonic = "JavaExtractKZip",
         opts = args,
         vnames_config = ctx.file.vnames_config,
-        deps = jars + ctx.files.data,
+        deps = jars + ctx.files.data + params_files + dirs,
     )
     return [
         java_info,
-        KytheVerifierSources(files = depset(ctx.files.srcs)),
+        KytheVerifierSources(files = depset(srcs)),
     ]
 
 java_extract_kzip = rule(
@@ -186,6 +214,134 @@ def java_verifier_test(
         name = name,
         size = size,
         srcs = [entries] + extra_goals,
+        opts = verifier_opts,
+        tags = tags,
+        visibility = visibility,
+        deps = [entries],
+    )
+
+def _generate_java_proto_impl(ctx):
+    # Generate the Java protocol buffer sources into a directory.
+    # Note: out contains .meta files with annotations for cross-language xrefs.
+    out = ctx.actions.declare_directory(ctx.label.name + "_gen")
+    ctx.actions.run(
+        outputs = [out],
+        inputs = ctx.files.srcs,
+        executable = ctx.executable._protoc,
+        arguments = ["--java_out=annotate_code:" + out.path] + [src.path for src in ctx.files.srcs],
+    )
+
+    # List the Java sources in a files for the javac_extractor to take as a @params file.
+    files = ctx.actions.declare_file(ctx.label.name + ".files")
+    ctx.actions.run_shell(
+        outputs = [files],
+        inputs = [out],
+        command = "find " + out.path + " -name '*.java' >" + files.path,
+    )
+
+    # Produce a source jar file for the native Java compilation in the java_extract_kzip rule.
+    # Note: we can't use java_common.pack_sources because our input is a directory.
+    singlejar = ctx.attr._java_toolchain.java_toolchain.single_jar
+    srcjar = ctx.actions.declare_file(ctx.label.name + ".srcjar")
+    ctx.actions.run(
+        outputs = [srcjar],
+        inputs = [out, files],
+        executable = singlejar,
+        arguments = ["--output", srcjar.path, "--resources", "@" + files.path],
+    )
+
+    return struct(
+        files = depset([files, out, srcjar]),
+        providers = [KytheJavaParams(dir = out, params = files, srcjars = [srcjar])],
+    )
+
+_generate_java_proto = rule(
+    attrs = {
+        "srcs": attr.label_list(
+            mandatory = True,
+            allow_files = True,
+            providers = [JavaInfo],
+        ),
+        "_protoc": attr.label(
+            default = Label("@com_google_protobuf//:protoc"),
+            executable = True,
+            cfg = "host",
+        ),
+        "_java_toolchain": attr.label(
+            default = Label("@bazel_tools//tools/jdk:current_java_toolchain"),
+        ),
+    },
+    implementation = _generate_java_proto_impl,
+)
+
+def java_proto_verifier_test(
+        name,
+        srcs,
+        size = "small",
+        proto_srcs = [],
+        java_proto = None,
+        tags = [],
+        verifier_opts = ["--ignore_dups"],
+        vnames_config = None,
+        visibility = None):
+    """Verify cross-language references between Java and Proto.
+
+    Args:
+      srcs: The compilation's source file inputs; each file's verifier goals will be checked
+      verifier_opts: List of options passed to the verifier tool
+      vnames_config: Optional path to a VName configuration file
+    """
+    proto_kzip = _invoke(
+        proto_extract_kzip,
+        name = name + "_proto_kzip",
+        testonly = True,
+        srcs = proto_srcs,
+        tags = tags,
+        visibility = visibility,
+        vnames_config = vnames_config,
+    )
+    proto_entries = _invoke(
+        index_compilation,
+        name = name + "_proto_entries",
+        testonly = True,
+        indexer = "@io_kythe_lang_proto//kythe/cxx/indexer/proto:indexer",
+        opts = ["--index_file"],
+        tags = tags,
+        visibility = visibility,
+        deps = [proto_kzip],
+    )
+
+    _generate_java_proto(
+        name = name + "_proto_gensrc",
+        srcs = proto_srcs,
+    )
+
+    kzip = _invoke(
+        java_extract_kzip,
+        name = name + "_kzip",
+        testonly = True,
+        srcs = srcs + [":" + name + "_proto_gensrc"],
+        tags = tags,
+        visibility = visibility,
+        vnames_config = vnames_config,
+        deps = ["@com_google_protobuf//:protobuf_java"],
+    )
+
+    entries = _invoke(
+        index_compilation,
+        name = name + "_entries",
+        testonly = True,
+        indexer = "//kythe/java/com/google/devtools/kythe/analyzers/java:indexer",
+        opts = ["--verbose"],
+        tags = tags,
+        visibility = visibility,
+        deps = [kzip],
+    )
+    return _invoke(
+        verifier_test,
+        name = name,
+        size = size,
+        srcs = [entries, proto_entries] + proto_srcs,
         opts = verifier_opts,
         tags = tags,
         visibility = visibility,

--- a/tools/build_rules/verifier_test/java_verifier_test.bzl
+++ b/tools/build_rules/verifier_test/java_verifier_test.bzl
@@ -232,6 +232,10 @@ def _generate_java_proto_impl(ctx):
         command = "\n".join([
             "#/bin/bash",
             "set -e",
+            # Creating the declared directory in this action is necessary for
+            # remote execution environments.  This differs from local execution
+            # where Bazel will create the directory before this action is
+            # executed.
             "mkdir -p " + out.path,
             " ".join([
                 protoc.path,


### PR DESCRIPTION
java_proto_verifier_test extracts/analyzes/verifies protocol buffer
sources, their generated Java sources, and Java sources depending on the
generated sources as test of the cross-language references between Java
and proto.

A single test is implemented as a proof-of-concept for the Starlark
rule.  More tests will follow.