### PR TITLE
fix: add documentation on the limitations of `build //...`

### DIFF
--- a/kythe/web/site/getting-started.md
+++ b/kythe/web/site/getting-started.md
@@ -141,6 +141,10 @@ may provide the jdk7 version by default. To determine if you are using an
 incompatible version of Bazel, look for `jdk7` in the build label that
 is printed by `bazel version`.
 
+Also note that not all targets build with `//...` - some targets aer
+purposefully omitted.  This includes `//kythe/web/ui`, `//kythe/release`, and
+many of the docker images we push.
+
 ### Build a release of Kythe using Bazel and unpack it in /opt/kythe
 
 Many examples on the site assume you have installed kythe in /opt/kythe.

--- a/kythe/web/site/getting-started.md
+++ b/kythe/web/site/getting-started.md
@@ -141,7 +141,7 @@ may provide the jdk7 version by default. To determine if you are using an
 incompatible version of Bazel, look for `jdk7` in the build label that
 is printed by `bazel version`.
 
-Also note that not all targets build with `//...` - some targets aer
+Also note that not all targets build with `//...` - some targets are
 purposefully omitted.  This includes `//kythe/web/ui`, `//kythe/release`, and
 many of the docker images we push.
 

--- a/kythe/web/ui/BUILD
+++ b/kythe/web/ui/BUILD
@@ -1,5 +1,9 @@
 package(default_visibility = ["//kythe:default_visibility"])
 
+# The targets in kythe/web/ui are marked "manual", so they will not build if you
+# blaze build //..., due to the behavior described in
+# https://docs.bazel.build/versions/master/guide.html#target-patterns.
+
 filegroup(
     name = "ui",
     srcs = [":prod-js"] + glob(["resources/public/**"]),


### PR DESCRIPTION
Bazel doesn't build everything by default with `//...`, and we have a
good number of packages that use `tags = ["manual"]` to avoid this,
including release, docker images, etc.