### PR TITLE
Fix govnames.json to reflect actual patterns.

### DIFF
--- a/kythe/go/extractors/cmd/bazel/govnames.json
+++ b/kythe/go/extractors/cmd/bazel/govnames.json
@@ -1,23 +1,60 @@
 [
   {
-    "pattern": "bazel-out/[^~]*~/(github\\.com(?:/[-.\\w]+){2})(?:/(.+))?\\.a$",
+    "pattern": "bazel-out/[^%]*%/(github\\.com(?:/[-.\\w]+){2})(?:/([^~]+))?\\.a(?:~partial.a)?$",
     "vname": {
       "corpus": "@1@",
       "path": "@2@"
     }
   },
   {
-    "pattern": "bazel-out/[^~]*~/(bitbucket\\.org(?:/[-.\\w]+){2})(?:/(.+))?\\.a$",
+    "pattern": "bazel-out/[^%]*%/(bitbucket\\.org(?:/[-.\\w]+){2})(?:/(.+))?\\.a$",
     "vname": {
       "corpus": "@1@",
       "path": "@2@"
     }
   },
   {
-    "pattern": "bazel-out/[^~]*~/(golang\\.org(?:/x/\\w+))/(.+)\\.a$",
+    "pattern": "bazel-out/[^%]*%/(golang\\.org(?:/x/\\w+))/(.+)\\.a$",
     "vname": {
       "corpus": "@1@",
       "path": "@2@"
+    }
+  },
+  {
+    "pattern": "bazel-out/[^/]+/(\\w+)/[^%]*%/([-.\\w]+)/(.+\\.go)$",
+    "vname": {
+      "corpus": "@2@",
+      "root": "bazel-out/@1@",
+      "path": "@3@"
+    }
+  },
+  {
+    "pattern": "bazel-out/[^/]+/(\\w+)/([^%]+)/\\w+/(\\w+)+%/testmain.go$",
+    "vname": {
+      "root": "bazel-out/@1@",
+      "path": "@2@/@3@/testmain.go"
+    }
+  },
+  {
+    "pattern": ".*/go_sdk/pkg/\\w+/vendor/golang_org/x/(\\w+)/(.*)\\.a$",
+    "vname": {
+      "corpus": "golang.org/x/@1@",
+      "path": "@2@"
+    }
+  },
+  {
+    "pattern": ".*/go_sdk/pkg/\\w+/(.*)\\.a$",
+    "vname": {
+      "corpus": "golang.org",
+      "path": "@1@"
+    }
+  },
+  {
+    "pattern": "bazel-out/[^/]+/(\\w+)/[^%]*%/([-.\\w]+)/(.+)\\.a(?:~partial.a)?$",
+    "vname": {
+      "root" : "bazel-out/@1@",
+      "corpus": "@2@",
+      "path": "@3@"
     }
   },
   {
@@ -25,35 +62,6 @@
     "vname": {
       "root": "bazel-out/@1@",
       "path": "@2@"
-    }
-  },
-  {
-    "pattern": "bazel-out/[^/]+/(\\w+)/[^~]*~/([-.\\w]+)/(.+\\.go)$",
-    "vname": {
-      "corpus": "@2@",
-      "root": "bazel-out/@1@",
-      "path": "@3@"
-    }
-  },
-  {
-    "pattern": "bazel-out/.*stdlib~/pkg/\\w+/vendor/golang_org/x/(\\w+)/(.*)\\.a$",
-    "vname": {
-      "corpus": "golang.org/x/@1@",
-      "path": "@2@"
-    }
-  },
-  {
-    "pattern": "bazel-out/.*stdlib~/pkg/\\w+/(.*)\\.a$",
-    "vname": {
-      "corpus": "golang.org",
-      "path": "@1@"
-    }
-  },
-  {
-    "pattern": "bazel-out/[^/]+/(\\w+)/[^~]*~/([-.\\w]+)/(.+)\\.a$",
-    "vname": {
-      "corpus": "@2@",
-      "path": "@3@"
     }
   }
 ]

--- a/kythe/go/extractors/cmd/bazel/govnames_test.json
+++ b/kythe/go/extractors/cmd/bazel/govnames_test.json
@@ -5,7 +5,7 @@
     "want": null
   },
   {
-    "input": "bazel-out/foo/bin/nonce~/github.com/kythe/kythe/blah.a",
+    "input": "bazel-out/foo/bin/nonce%/github.com/kythe/kythe/blah.a",
     "match": true,
     "want": {
       "corpus": "github.com/kythe/kythe",
@@ -13,12 +13,27 @@
     }
   },
   {
-    "input": "bazel-out/foo/bin/nonce~/bitbucket.org/creachadair/stringset.a",
+    "input": "bazel-out/foo/bin/nonce%/bitbucket.org/creachadair/stringset.a",
     "match": true,
     "want": {"corpus": "bitbucket.org/creachadair/stringset"}
   },
   {
-    "input": "bazel-out/itty/bin/nonce~/bitbucket.org/nobble/fleem/wharrgarbl.a",
+    "_note": "cgo output has this pattern.",
+    "input": "bazel-out/foo/bin/nonce%/github.com/google/brotli/go/cbrotli.a~partial.a",
+    "match": true,
+    "want": {
+      "corpus": "github.com/google/brotli",
+      "path": "go/cbrotli"
+    }
+  },
+  {
+    "_note": "cgo output has this pattern as well.",
+    "input": "bazel-out/foo/bin/nonce%/github.com/bar/baz.a~partial.a",
+    "match": true,
+    "want": {"corpus": "github.com/bar/baz"}
+  },
+  {
+    "input": "bazel-out/itty/bin/nonce%/bitbucket.org/nobble/fleem/wharrgarbl.a",
     "match": true,
     "want": {"corpus": "bitbucket.org/nobble/fleem", "path": "wharrgarbl"}
   },
@@ -31,11 +46,20 @@
     }
   },
   {
-    "input": "bazel-out/external/stdlib~/pkg/linux_amd64/io/ioutil.a",
+    "input": "external/go_sdk/pkg/linux_amd64/io/ioutil.a",
     "match": true,
     "want": {
       "corpus": "golang.org",
       "path": "io/ioutil"
+    }
+  },
+  {
+    "_note": "Go generated test binary wrappers have this pattern.",
+    "input": "bazel-out/foo/bin/bar/baz/nonce/quux%/testmain.go",
+    "match": true,
+    "want": {
+      "root": "bazel-out/bin",
+      "path": "bar/baz/quux/testmain.go"
     }
   }
 ]


### PR DESCRIPTION
This lets sane extraction of kythe/go. There are some unpleasant file vnames left due to `cgo`, these can be rewritten as well later if bothers.

TESTED=indexed //kythe/go/...
Fixes #3096.