### PR TITLE
build: add visibility for cxx/common:index_writer

### DIFF
--- a/kythe/cxx/common/BUILD
+++ b/kythe/cxx/common/BUILD
@@ -248,6 +248,7 @@ cc_library(
     name = "index_writer",
     srcs = ["index_writer.cc"],
     hdrs = ["index_writer.h"],
+    visibility = [PUBLIC_VISIBILITY],
     deps = [
         ":status_or",
         "//kythe/proto:analysis_cc_proto",


### PR DESCRIPTION
Needed for textproto extractor.