### PR TITLE
fix: removing extraneous bits from guava exmaple yaml

### DIFF
--- a/kythe/go/extractors/gcp/examples/guava-mvn.yaml
+++ b/kythe/go/extractors/gcp/examples/guava-mvn.yaml
@@ -14,34 +14,10 @@ steps:
     - name: 'kythe_extractors'
       path: '/opt/kythe/extractors/'
   waitFor: ['-']
-- name: 'gcr.io/kythe-public/build-preprocessor'
-  args: ['/workspace/code/pom.xml']
-  waitFor:
-    - 'CHECKOUT'
 - name: 'gcr.io/cloud-builders/mvn'
   args:
     - 'clean'
     - 'compile'
-    - '-X'
-    - '-f'
-    - '/workspace/code/pom.xml'
-    - '-Dmaven.compiler.forceJavacCompilerUse=true'
-    - '-Dmaven.compiler.fork=true'
-    - '-Dmaven.compiler.executable=/opt/kythe/extractors/javac-wrapper.sh'
-  env:
-    - 'KYTHE_CORPUS=guava'
-    - 'KYTHE_OUTPUT_DIRECTORY=/workspace/out'
-    - 'KYTHE_ROOT_DIRECTORY=/workspace/code'
-    - 'JAVAC_EXTRACTOR_JAR=/opt/kythe/extractors/javac_extractor.jar'
-    - 'REAL_JAVAC=/usr/bin/javac'
-    - 'TMPDIR=/workspace/errs'
-    - 'KYTHE_JAVA_RUNTIME_OPTIONS=-Xbootclasspath/p:/opt/kythe/extractors/javac9_tools.jar'
-  volumes:
-    - name: 'kythe_extractors'
-      path: '/opt/kythe/extractors/'
-- name: 'gcr.io/cloud-builders/mvn'
-  args:
-    - 'clean'
     - 'test-compile'
     - '-X'
     - '-f'


### PR DESCRIPTION
Simplifying even more from the base example yaml, guava doesn't actually
need any pom modification because they specify `maven-compiler-plugin`
already.  Additionally I don't know why I had two separate actions there
isntead of just doing `compile` and `compile-test` at the same time, but
fix that too.