### PR TITLE
build: add visibility for buildinfo_cc_proto

### DIFF
--- a/kythe/proto/BUILD
+++ b/kythe/proto/BUILD
@@ -226,6 +226,7 @@ proto_library(
 
 cc_proto_library(
     name = "buildinfo_cc_proto",
+    visibility = [PUBLIC_PROTO_VISIBILITY],
     deps = [":buildinfo_proto"],
 )
 


### PR DESCRIPTION
Needed for the textproto indexer.