### PR TITLE
feat(bazel_extractor): infer corpus from source files

### DIFF
--- a/kythe/go/extractors/bazel/extractor.go
+++ b/kythe/go/extractors/bazel/extractor.go
@@ -198,6 +198,10 @@ func (c *Config) extract(ctx context.Context, info *ActionInfo, file fileReader)
 		return nil, err
 	}
 
+	if c.Corpus == "" {
+		c.Corpus = c.inferCorpus(info)
+	}
+
 	// Construct the basic compilation.
 	cu := &apb.CompilationUnit{
 		VName: &spb.VName{
@@ -273,6 +277,31 @@ func (c *Config) fetchInputs(ctx context.Context, paths []string, file func(int,
 		})
 	}
 	return g.Wait()
+}
+
+func (c *Config) inferCorpus(info *ActionInfo) string {
+	var sourceCorpora stringset.Set
+	for _, in := range info.Inputs {
+		path, ok := c.checkInput(in)
+		if !ok || !c.isSource(path) {
+			continue
+		}
+
+		vname, ok := c.Rules.Apply(path)
+		if ok && vname.Corpus != "" {
+			sourceCorpora.Add(vname.Corpus)
+		}
+	}
+
+	corpora := sourceCorpora.Elements()
+	if len(sourceCorpora) != 1 {
+		log.Printf("WARNING: could not infer compilation corpus from source files: %v", corpora)
+		return ""
+	}
+
+	corpus := corpora[0]
+	c.logPrintf("Inferred compilation corpus from source files: %q", corpus)
+	return corpus
 }
 
 // classifyInputs updates unit to add required inputs for each matching path

--- a/kythe/go/extractors/bazel/settings.go
+++ b/kythe/go/extractors/bazel/settings.go
@@ -31,7 +31,7 @@ import (
 // Settings control the construction of an extractor config from common path
 // and name filtering settings.
 type Settings struct {
-	Corpus      string // the corpus label to assign (required)
+	Corpus      string // the corpus label to assign
 	Language    string // the language label to assign (required)
 	ExtraAction string // path of blaze.ExtraActionInfo file (required)
 	VNameRules  string // path of vnames.json file (optional)
@@ -103,8 +103,6 @@ Options:
 
 func (s *Settings) validate() error {
 	switch {
-	case s.Corpus == "":
-		return errors.New("you must provide a non-empty corpus label")
 	case s.Language == "":
 		return errors.New("you must provide a non-empty language label")
 	case s.ExtraAction == "":

--- a/kythe/typescript/BUILD
+++ b/kythe/typescript/BUILD
@@ -9,7 +9,6 @@ extra_action(
     name = "extra_action",
     cmd = " ".join([
         "$(location //kythe/go/extractors/cmd/bazel:extract_kzip)",
-        "--corpus=github.com/kythe/kythe",
         "--extra_action=$(EXTRA_ACTION_FILE)",
         "--include='\\.(js|json|tsx?|d\\.ts)$$'",
         "--language=typescript",


### PR DESCRIPTION
This allows a caller to push all corpus configuration logic to the VName rules file.