### PR TITLE
fix(bazel extractor): print file counts after handling source args

### DIFF
--- a/kythe/go/extractors/bazel/extractor.go
+++ b/kythe/go/extractors/bazel/extractor.go
@@ -246,7 +246,11 @@ func (c *Config) extract(ctx context.Context, info *ActionInfo, file fileReader)
 		return nil, fmt.Errorf("reading input files failed: %v", err)
 	}
 	log.Printf("Finished reading required inputs [%v elapsed]", time.Since(start))
-	return cu, c.fixup(cu)
+	if err := c.fixup(cu); err != nil {
+		return nil, err
+	}
+	log.Printf("Found %d required inputs, %d source files", len(cu.RequiredInput), len(cu.SourceFile))
+	return cu, nil
 }
 
 // fetchInputs concurrently fetches the contents of all the specified file
@@ -343,7 +347,6 @@ func (c *Config) classifyInputs(info *ActionInfo, unit *apb.CompilationUnit) []s
 		}
 	}
 	unit.SourceFile = sourceFiles.Elements()
-	log.Printf("Found %d required inputs, %d source files", len(inputs), len(sourceFiles))
 	return inputs.Elements()
 }
 


### PR DESCRIPTION
Source files can be specified with a regex over the inputs OR as a regex
over the arguments. The arguments regex is applied during the "fixup"
stage at the end. This change moves a log statement to print out the
number of source files after the count is finalized.

Before this change, textproto extraction was consistently logging that there were zero source files, even though the kzip correctly had one.