### PR TITLE
fix(examples): fix a missing dependency from a docker rule

### DIFF
--- a/kythe/examples/bazel/BUILD
+++ b/kythe/examples/bazel/BUILD
@@ -1,0 +1,5 @@
+package(
+    default_visibility = ["//visiblity:public"],
+)
+
+exports_files(["setup-bazel-repo.sh"])


### PR DESCRIPTION
Re-add the BUILD file to fix query failures when arcanist tries to find affected tests.