### PR TITLE
fix: add an ordering-agnostic yaml comparator in testutil

### DIFF
--- a/kythe/go/extractors/gcp/config/converter_test.go
+++ b/kythe/go/extractors/gcp/config/converter_test.go
@@ -44,11 +44,8 @@ func TestYAMLConversion(t *testing.T) {
 				t.Fatalf("reading expected testdata %s: %v", tcase.basename, err)
 			}
 
-			eq, diff := testutil.TrimmedEqual(actual, expected)
-			if !eq {
-				t.Errorf("Expected config %s to be equal, but got diff %s", tcase.basename, diff)
-				t.Errorf("actual:\n%s", actual)
-				t.Errorf("expected:\n%s", expected)
+			if err := testutil.YAMLEqual(actual, expected); err != nil {
+				t.Errorf("Expected config %s to be equal: %v", tcase.basename, err)
 			}
 		})
 	}

--- a/kythe/go/extractors/gcp/config/testdata/mvn.yaml
+++ b/kythe/go/extractors/gcp/config/testdata/mvn.yaml
@@ -9,8 +9,8 @@ steps:
   - clone
   - ${_REPO_NAME}
   - /workspace/code
-  id: CLONE
   name: gcr.io/cloud-builders/git
+  id: CLONE
   waitFor:
   - '-'
 - args:

--- a/kythe/go/test/testutil/BUILD
+++ b/kythe/go/test/testutil/BUILD
@@ -6,6 +6,7 @@ go_library(
     name = "testutil",
     srcs = ["testutil.go"],
     deps = [
+        "@com_github_ghodss_yaml//:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_google_go_cmp//cmp:go_default_library",
     ],

--- a/kythe/go/test/testutil/testutil.go
+++ b/kythe/go/test/testutil/testutil.go
@@ -18,6 +18,7 @@
 package testutil
 
 import (
+	"encoding/json"
 	"fmt"
 	"math/rand"
 	"os"
@@ -28,6 +29,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ghodss/yaml"
 	"github.com/golang/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
 )
@@ -162,6 +164,32 @@ func TrimmedEqual(got, want []byte) (bool, string) {
 	// diff want vs got
 	diff := cmp.Diff(gotStr, wantStr)
 	return diff == "", diff
+}
+
+// YAMLEqual compares two bytes assuming they are yaml, by converting to json
+// and doing an ordering-agnostic comparison.  Note this carries some
+// restrictions because yaml->json conversion fails for nil or binary map keys.
+func YAMLEqual(expected, got []byte) error {
+	e, err := yaml.YAMLToJSON(expected)
+	if err != nil {
+		return fmt.Errorf("yaml->json failure for expected: %v", err)
+	}
+	g, err := yaml.YAMLToJSON(got)
+	if err != nil {
+		return fmt.Errorf("yaml->json failure for got: %v", err)
+	}
+	return JSONEqual(e, g)
+}
+
+func JSONEqual(expected, got []byte) error {
+	var e, g interface{}
+	if err := json.Unmarshal(expected, &e); err != nil {
+		return fmt.Errorf("decoding expected json: %v", err)
+	}
+	if err := json.Unmarshal(got, &g); err != nil {
+		return fmt.Errorf("decoding got json: %v", err)
+	}
+	return DeepEqual(e, g)
 }
 
 func caller(up int) (file string, line int) {

--- a/kythe/go/test/testutil/testutil.go
+++ b/kythe/go/test/testutil/testutil.go
@@ -181,6 +181,8 @@ func YAMLEqual(expected, got []byte) error {
 	return JSONEqual(e, g)
 }
 
+// JSONEqual compares two bytes assuming they are json, using encoding/json
+// and DeepEqual.
 func JSONEqual(expected, got []byte) error {
 	var e, g interface{}
 	if err := json.Unmarshal(expected, &e); err != nil {


### PR DESCRIPTION
For testdata at least, this means we can compare proper example yaml
that are checked in and ordered according to proto order.  This
unfortunately doesn't fix the underlying ordering problem we have
reported up in googleapis/google-api-go-client/issues/302, but sidesteps
it for increased test coverage at least.