### PR TITLE
fix: minor changes to gcp/config gen using examples

### DIFF
--- a/kythe/go/extractors/constants/constants.go
+++ b/kythe/go/extractors/constants/constants.go
@@ -18,7 +18,6 @@
 package constants
 
 var (
-
 	// KytheBuildPreprocessorImage is defiend in
 	// kythe/go/extractors/config/preprocessor, and is published to GCR.
 	KytheBuildPreprocessorImage = "gcr.io/kythe-public/build-preprocessor"
@@ -44,6 +43,16 @@ var (
 	// DefaultJava9ToolsLocation is the location of a jar which allows java9
 	// compatibility for java8.
 	DefaultJava9ToolsLocation = "/opt/kythe/extractors/javac9_tools.jar"
+
+	// KytheKzipToolsImage is defined in
+	// kythe/go/platform/tools/kzip and published to GCR via
+	// kythe/go/extractors/gcp/config/kziptool:artifacts.  It is a utility for
+	// manipulating .kzip files.
+	KytheKzipToolsImage = "gcr.io/kythe-public/kzip-tools"
+
+	// DefaultKzipToolLocation is the location of tools/kzip binary defined in
+	// the gcr.io/kythe-public/kzip-tools image.
+	DefaultKzipToolLocation = "/opt/kythe/tools/kzip"
 
 	// Google Cloud Builders described at
 	// https://cloud.google.com/cloud-build/docs/cloud-builders.

--- a/kythe/go/extractors/gcp/README.md
+++ b/kythe/go/extractors/gcp/README.md
@@ -22,7 +22,9 @@ To make sure you have done setup correctly, we have an example binary at
 `kythe/go/extractors/gcp/helloworld`, which you can run as follows:
 
 ```
-gcloud builds submit --config examples/helloworld/helloworld.yaml --substitutions=_BUCKET_NAME="$BUCKET_NAME" examples/helloworld
+gcloud builds submit --config examples/helloworld/helloworld.yaml \
+  --substitutions=_OUTPUT_GS_BUCKET="$BUCKET_NAME"\
+  examples/helloworld
 ```
 
 If that fails, you have to go back up to the [Cloud Build](#cloud-build) section
@@ -33,16 +35,19 @@ authorize it, associate it with a valid project id, create a test gs bucket.
 
 To extract a maven repository using Kythe on Cloud Build, use
 `examples/mvn.yaml`.  This assumes that you will specify a maven repository
-in `_REPO_NAME`, and that the repository has a top-level `pom.xml` file (right
+in `_REPO`, and that the repository has a top-level `pom.xml` file (right
 now it is a hard-coded location, but in the future it will be configurable).
-This also assumes you specify `_BUCKET_NAME` as per the Hello World Test above.
+This also assumes you specify `$BUCKET_NAME` as per the Hello World Test above.
+`_CORPUS` can be any identifying string for your repo, for example: "guava".
 
 ```
 gcloud builds submit --config examples/mvn.yaml \
---substitutions=\
-_BUCKET_NAME=$BUCKET_NAME,\
-_REPO_NAME=https://github.com/project-name/repo-name\
- --no-source
+  --substitutions=\
+_OUTPUT_GS_BUCKET=$BUCKET_NAME,\
+_REPO=https://github.com/project-name/repo-name,\
+_VERSION=<version-hash>,\
+_CORPUS=repo-name\
+  --no-source
 ```
 
 ### Guava specific example
@@ -52,10 +57,10 @@ To extract multiple parts of https://github.com/google/guava, use
 
 ```
 gcloud builds submit --config examples/guava-mvn.yaml \
---substitutions=\
-_BUCKET_NAME=$BUCKET_NAME,\
-_GUAVA_VERSION=<commit-hash>\
- --no-source
+  --substitutions=\
+_OUTPUT_GS_BUCKET=$BUCKET_NAME,\
+_VERSION=<commit-hash>,\
+  --no-source
 ```
 
 This outputs `guava-<commit-hash>.kzip` to `$BUCKET_NAME` on Google Cloud Storage.
@@ -70,10 +75,10 @@ of the guava tree, you would need a slightly different action:
 
 ```
 gcloud builds submit --config examples/guava-android-mvn.yaml \
---substitutions=\
-_BUCKET_NAME=$BUCKET_NAME,\
+  --substitutions=\
+_OUTPUT_GS_BUCKET=$BUCKET_NAME,\
 _GUAVA_VERSION=<commit-hash>\
- --no-source
+  --no-source
 ```
 
 This outputs `guava-android-<commit-hash>kzip` to `$BUCKET_NAME` on GCS.
@@ -84,10 +89,12 @@ Gradle is extracted similarly:
 
 ```
 gcloud builds submit --config examples/gradle.yaml \
---substitutions=\
-_BUCKET_NAME=$BUCKET_NAME,\
-_REPO_NAME=https://github.com/project-name/repo-name\
- --no-source
+  --substitutions=\
+_OUTPUT_GS_BUCKET=$BUCKET_NAME,\
+_REPO=https://github.com/project-name/repo-name,\
+_VERSION=<version-hash>,\
+_CORPUS=repo-name\
+  --no-source
 ```
 
 ## Cloud Build REST API

--- a/kythe/go/extractors/gcp/config/BUILD
+++ b/kythe/go/extractors/gcp/config/BUILD
@@ -22,7 +22,10 @@ go_library(
 go_test(
     name = "config_test",
     srcs = ["converter_test.go"],
-    data = [":testdatafiles"],
+    data = [
+        ":testdatafiles",
+        "//kythe/go/extractors/gcp/examples:yaml_examples",
+    ],
     library = ":config",
     deps = [
         "//kythe/go/test/testutil",

--- a/kythe/go/extractors/gcp/config/common.go
+++ b/kythe/go/extractors/gcp/config/common.go
@@ -17,6 +17,9 @@
 package config
 
 import (
+	"fmt"
+	"path"
+
 	"kythe.io/kythe/go/extractors/constants"
 
 	"google.golang.org/api/cloudbuild/v1"
@@ -69,5 +72,20 @@ func javaExtractorsStep() *cloudbuild.BuildStep {
 			},
 		},
 		WaitFor: []string{"-"},
+	}
+}
+
+func zipMergeStep() *cloudbuild.BuildStep {
+	return &cloudbuild.BuildStep{
+		Name:       constants.KytheKzipToolsImage,
+		Entrypoint: "bash",
+		Args: []string{
+			"-c",
+			fmt.Sprintf(
+				"%s merge --output %s %s/*.kzip",
+				constants.DefaultKzipToolLocation,
+				path.Join(outputDirectory, outputFilePattern),
+				outputDirectory),
+		},
 	}
 }

--- a/kythe/go/extractors/gcp/config/converter.go
+++ b/kythe/go/extractors/gcp/config/converter.go
@@ -34,9 +34,9 @@ import (
 // Constants that map input/output substitutions.
 const (
 	corpus            = "${_CORPUS}"
-	outputFilePattern = "${_OUTPUT_KZIP_NAME}"
+	outputFilePattern = "${_CORPUS}-${_VERSION}.kzip"
 	outputGsBucket    = "${_OUTPUT_GS_BUCKET}"
-	repoName          = "${_REPO_NAME}"
+	repoName          = "${_REPO}"
 )
 
 // Constants ephemeral to a single kythe cloudbuild run.

--- a/kythe/go/extractors/gcp/config/testdata/gradle.yaml
+++ b/kythe/go/extractors/gcp/config/testdata/gradle.yaml
@@ -3,11 +3,11 @@ artifacts:
     location: gs://${_OUTPUT_GS_BUCKET}/
     paths:
     - /workspace/out/javac-extractor.err
-    - /workspace/out/${_OUTPUT_KZIP_NAME}
+    - /workspace/out/${_CORPUS}-${_VERSION}.kzip
 steps:
 - args:
   - clone
-  - ${_REPO_NAME}
+  - ${_REPO}
   - /workspace/code
   id: CLONE
   name: gcr.io/cloud-builders/git
@@ -26,6 +26,11 @@ steps:
   waitFor:
   - '-'
 - args:
+  - /workspace/code/build.gradle
+  name: gcr.io/kythe-public/build-preprocessor
+  waitFor:
+    - CLONE
+- args:
   - clean
   - build
   - -s
@@ -36,7 +41,6 @@ steps:
   env:
   - KYTHE_CORPUS=${_CORPUS}
   - KYTHE_OUTPUT_DIRECTORY=/workspace/out
-  - KYTHE_OUTPUT_FILE=/workspace/out/${_OUTPUT_KZIP_NAME}
   - KYTHE_ROOT_DIRECTORY=/workspace/code
   - JAVAC_EXTRACTOR_JAR=/opt/kythe/extractors/javac_extractor.jar
   - REAL_JAVAC=/usr/bin/javac
@@ -46,3 +50,8 @@ steps:
   volumes:
   - name: kythe_extractors
     path: /opt/kythe/extractors
+- args:
+  - -c
+  - /opt/kythe/tools/kzip merge --output /workspace/out/${_CORPUS}-${_VERSION}.kzip /workspace/out/*.kzip
+  entrypoint: bash
+  name: gcr.io/kythe-public/kzip-tools

--- a/kythe/go/extractors/gcp/config/testdata/mvn.yaml
+++ b/kythe/go/extractors/gcp/config/testdata/mvn.yaml
@@ -3,11 +3,11 @@ artifacts:
     location: gs://${_OUTPUT_GS_BUCKET}/
     paths:
     - /workspace/out/javac-extractor.err
-    - /workspace/out/${_OUTPUT_KZIP_NAME}
+    - /workspace/out/${_CORPUS}-${_VERSION}.kzip
 steps:
 - args:
   - clone
-  - ${_REPO_NAME}
+  - ${_REPO}
   - /workspace/code
   name: gcr.io/cloud-builders/git
   id: CLONE
@@ -26,8 +26,14 @@ steps:
   waitFor:
   - '-'
 - args:
+  - /workspace/code/pom.xml
+  name: gcr.io/kythe-public/build-preprocessor
+  waitFor:
+    - CLONE
+- args:
   - clean
   - compile
+  - test-compile
   - -X
   - -f
   - /workspace/code/pom.xml
@@ -37,7 +43,6 @@ steps:
   env:
   - KYTHE_CORPUS=${_CORPUS}
   - KYTHE_OUTPUT_DIRECTORY=/workspace/out
-  - KYTHE_OUTPUT_FILE=/workspace/out/${_OUTPUT_KZIP_NAME}
   - KYTHE_ROOT_DIRECTORY=/workspace/code
   - JAVAC_EXTRACTOR_JAR=/opt/kythe/extractors/javac_extractor.jar
   - REAL_JAVAC=/usr/bin/javac
@@ -47,3 +52,8 @@ steps:
   volumes:
   - name: kythe_extractors
     path: /opt/kythe/extractors
+- args:
+  - -c
+  - /opt/kythe/tools/kzip merge --output /workspace/out/${_CORPUS}-${_VERSION}.kzip /workspace/out/*.kzip
+  entrypoint: bash
+  name: gcr.io/kythe-public/kzip-tools

--- a/kythe/go/extractors/gcp/examples/BUILD
+++ b/kythe/go/extractors/gcp/examples/BUILD
@@ -1,0 +1,7 @@
+package(default_visibility = ["//kythe:default_visibility"])
+
+filegroup(
+    name = "yaml_examples",
+    testonly = 1,
+    srcs = glob(["*.yaml"]),
+)

--- a/kythe/go/extractors/gcp/examples/guava-mvn.yaml
+++ b/kythe/go/extractors/gcp/examples/guava-mvn.yaml
@@ -3,7 +3,7 @@ steps:
   args: ['clone', 'https://github.com/google/guava', '/workspace/code']
   id: 'CLONE'
 - name: 'gcr.io/cloud-builders/git'
-  args: ['checkout', '$_GUAVA_VERSION']
+  args: ['checkout', '${_VERSION}']
   dir: '/workspace/code'
   id: 'CHECKOUT'
 - name: 'ubuntu'
@@ -40,11 +40,11 @@ steps:
   args: ['ls', '/workspace/out']
 - name: 'gcr.io/kythe-public/kzip-tools'
   entrypoint: 'bash'
-  args: ['-c', '/opt/kythe/tools/kzip merge --output /workspace/out/guava-$_GUAVA_VERSION.kzip /workspace/out/*.kzip']
+  args: ['-c', '/opt/kythe/tools/kzip merge --output /workspace/out/guava-${_VERSION}.kzip /workspace/out/*.kzip']
 artifacts:
   objects:
-    location: 'gs://${_BUCKET_NAME}/'
+    location: 'gs://${_OUTPUT_GS_BUCKET}/'
     paths:
-      - '/workspace/out/guava-$_GUAVA_VERSION.kzip'
+      - '/workspace/out/guava-${_VERSION}.kzip'
       - '/workspace/errs/javac-extractor.err'
 

--- a/kythe/go/extractors/gcp/examples/mvn.yaml
+++ b/kythe/go/extractors/gcp/examples/mvn.yaml
@@ -1,14 +1,15 @@
 steps:
 - name: 'gcr.io/cloud-builders/git'
-  args: ['clone', '${_REPO_NAME}', '/workspace/code']
+  args: ['clone', '${_REPO}', '/workspace/code']
   id: 'CLONE'
+  waitFor: ['-']
 - name: 'ubuntu'
   args: ['mkdir', '/workspace/out']
   waitFor: ['-']
 - name: 'gcr.io/kythe-public/kythe-javac-extractor-artifacts'
   volumes:
     - name: 'kythe_extractors'
-      path: '/opt/kythe/extractors/'
+      path: '/opt/kythe/extractors'
   waitFor: ['-']
 - name: 'gcr.io/kythe-public/build-preprocessor'
   args: ['/workspace/code/pom.xml']
@@ -18,6 +19,7 @@ steps:
   args:
     - 'clean'
     - 'compile'
+    - 'test-compile'
     - '-X'
     - '-f'
     - '/workspace/code/pom.xml'
@@ -25,9 +27,8 @@ steps:
     - '-Dmaven.compiler.fork=true'
     - '-Dmaven.compiler.executable=/opt/kythe/extractors/javac-wrapper.sh'
   env:
-    - 'KYTHE_CORPUS=mvnpoctest'
+    - 'KYTHE_CORPUS=${_CORPUS}'
     - 'KYTHE_OUTPUT_DIRECTORY=/workspace/out'
-    - 'KYTHE_OUTPUT_FILE=/workspace/out/test.kzip'
     - 'KYTHE_ROOT_DIRECTORY=/workspace/code'
     - 'JAVAC_EXTRACTOR_JAR=/opt/kythe/extractors/javac_extractor.jar'
     - 'REAL_JAVAC=/usr/bin/javac'
@@ -35,11 +36,14 @@ steps:
     - 'KYTHE_JAVA_RUNTIME_OPTIONS=-Xbootclasspath/p:/opt/kythe/extractors/javac9_tools.jar'
   volumes:
     - name: 'kythe_extractors'
-      path: '/opt/kythe/extractors/'
+      path: '/opt/kythe/extractors'
+- name: 'gcr.io/kythe-public/kzip-tools'
+  entrypoint: 'bash'
+  args: ['-c', '/opt/kythe/tools/kzip merge --output /workspace/out/${_CORPUS}-${_VERSION}.kzip /workspace/out/*.kzip']
 artifacts:
   objects:
-    location: 'gs://${_BUCKET_NAME}/'
+    location: 'gs://${_OUTPUT_GS_BUCKET}/'
     paths:
-      - '/workspace/out/test.kzip'
       - '/workspace/out/javac-extractor.err'
+      - '/workspace/out/${_CORPUS}-${_VERSION}.kzip'
 


### PR DESCRIPTION
Allow gcp/config tests to work off of existing examples that are
referenced from e.g. gcp/README.md, and modify the examples and testdata
slightly to fit this mold.  This should let us build up unit tests that
keep testdata and examples in line with what generator actually
produces.

Next steps will be making gen work with concrete guava example, subdirs
(e.g. guava-android extracts from a separate level), multiple compile
actions.

It's unclear to me exactly how this will work in a world where configs
themselves are being generated, but we can tackle that testdata
unification problem later.