### PR TITLE
release(dev): add stricter checking of commit messages

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -16,5 +16,57 @@
 
 module.exports = {
   // https://www.conventionalcommits.org/en/v1.0.0-beta.2/
-  extends: ['@commitlint/config-conventional']
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'scope-case': [2, 'always', 'snake-case'],
+    'scope-empty': [1, 'never'],
+    'scope-enum': [
+      1, 'always',
+      [
+        'api',              // user-facing API (e.g. XRefService)
+        'dev',              // developer tooling/scripting (e.g. linting)
+        'example',          // example tools or docs (e.g. sample web ui)
+        'extraction',       // compilation extraction
+        'indexing',         // semantic analysis over compilations
+        'post_processing',  // serving data construction
+        'serving',          // server logic or data formats
+        'tooling',          // CLI utilities (e.g. entrystream)
+
+        // Language-specific scopes
+        'cxx_common',
+        'cxx_extractor',
+        'cxx_indexer',
+        'go_common',
+        'go_extractor',
+        'go_indexer',
+        'java_common',
+        'java_extractor',
+        'java_indexer',
+        'jvm_common',
+        'jvm_extractor',
+        'jvm_indexer',
+        'typescript_common',
+        'typescript_extractor',
+        'typescript_indexer',
+      ]
+    ],
+    'type-enum': [
+      2, 'always',
+      [
+        'build',
+        'chore',
+        'ci',
+        'deprecation',
+        'docs',
+        'feat',
+        'fix',
+        'perf',
+        'refactor',
+        'release',
+        'revert',
+        'style',
+        'test',
+      ]
+    ],
+  },
 }


### PR DESCRIPTION
Add 'deprecation' as a commit type.

Warn when a commit does not specify a scope or it is not a standard scope.