### PR TITLE
fix: fix #3459 by removing call to emitComment

### DIFF
--- a/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
@@ -477,9 +477,6 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
     }
 
     if (bindingAnchor != null) {
-      if (!documented) {
-        emitComment(methodDef, methodNode);
-      }
       if (absNode != null) {
         emitAnchor(bindingAnchor, EdgeKind.DEFINES_BINDING, absNode.getVName(), getScope(ctx));
         Span span = filePositions.findIdentifier(methodDef.name, methodDef.getPreferredPosition());

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/AnnotationComments.java
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/AnnotationComments.java
@@ -4,10 +4,7 @@ package pkg;
 public class AnnotationComments {
   //- @+3fooString defines/binding FooString
 
-  @SuppressWarnings("unchecked") // TODO(#3459): This should not documents fooString, but does.
+  @SuppressWarnings("unchecked") // This does not documents fooString.
   public String fooString() { return ""; }
-  // These tests are all busted:
-  //- !{ UncheckedDoc2 documents FooString }
-  //- UncheckedDoc2.node/kind doc
-  //- UncheckedDoc2.text "TODO(#3459): This should not documents fooString, but does."
+  //- !{ _UncheckedDoc documents FooString }
 }

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/BUILD
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/BUILD
@@ -45,8 +45,6 @@ java_verifier_test(
     name = "annotation_comments_tests",
     size = "small",
     srcs = ["AnnotationComments.java"],
-    # TODO(#3459): make this failing test not manual if bug is fixed
-    tags = ["manual"],
 )
 
 java_verifier_test(


### PR DESCRIPTION
I am not clear what would have been relying on the documents edges emitted by this before, so I'm really uncomfortable with this fix.

I also suspect maybe we just don't have ample test coverage or something.