### PR TITLE
test: add tests for line comments on methods

### DIFF
--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/AnnotationComments.java
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/AnnotationComments.java
@@ -1,13 +1,14 @@
 package pkg;
 
-// Tests for comments that should be ignored.
+//- @+3AnnotationComments defines/binding AnnotationComments
+
+@Deprecated // TODO(#3459): This should not annotate the class, but does.
 public class AnnotationComments {
+  //- !{ _DeprecatedDoc documents AnnotationComments }
+
   //- @+3fooString defines/binding FooString
 
   @SuppressWarnings("unchecked") // TODO(#3459): This should not documents fooString, but does.
   public String fooString() { return ""; }
-  // These tests are all busted:
-  //- !{ UncheckedDoc2 documents FooString }
-  //- UncheckedDoc2.node/kind doc
-  //- UncheckedDoc2.text "TODO(#3459): This should not documents fooString, but does."
+  //- !{ _UncheckedDoc documents FooString }
 }

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/AnnotationComments.java
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/AnnotationComments.java
@@ -4,7 +4,7 @@ package pkg;
 
 @Deprecated // TODO(#3459): This should not annotate the class, but does.
 public class AnnotationComments {
-  //- !{ _DeprecatedDoc documents AnnotationComments }
+  //- !{ _ documents AnnotationComments }
 
   //- @+3fooString defines/binding FooString
 

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Comments.java
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Comments.java
@@ -126,4 +126,12 @@ public class Comments
   //- OverrideDoc.node/kind doc
   //- OverrideDoc param.0 _Override
   //- OverrideDoc.text "This documents {@link #compareTo()} over {@link [Override]}. "
+
+  //- @+3fooFunction defines/binding FooFunction
+
+  // This documents FooFunction
+  void fooFunction() { return; }
+  //- FooFunctionDoc documents FooFunction
+  //- FooFunctionDoc.node/kind doc
+  //- FooFunctionDoc.text "This documents FooFunction"
 }


### PR DESCRIPTION
Shows why #3462 is a terrible, terrible idea.

Also add test for class annotation docs as well.