### PR TITLE
feat(cxx_common): Add ref imports edge field

### DIFF
--- a/kythe/cxx/common/indexing/KytheGraphRecorder.cc
+++ b/kythe/cxx/common/indexing/KytheGraphRecorder.cc
@@ -38,6 +38,7 @@ static const std::string* kEdgeKindSpellings[] = {
     new std::string("/kythe/edge/typed"),
     new std::string("/kythe/edge/ref"),
     new std::string("/kythe/edge/ref/implicit"),
+    new std::string("/kythe/edge/ref/imports"),
     new std::string("/kythe/edge/param"),
     new std::string("/kythe/edge/aliases"),
     new std::string("/kythe/edge/aliases/root"),

--- a/kythe/cxx/common/indexing/KytheGraphRecorder.h
+++ b/kythe/cxx/common/indexing/KytheGraphRecorder.h
@@ -81,6 +81,7 @@ enum class EdgeKindID {
   kHasType,
   kRef,
   kRefImplicit,
+  kRefImports,
   kParam,
   kAliases,
   kAliasesRoot,


### PR DESCRIPTION
This field isn't used by the C++ indexer, but may be used by other indexers written in C++