### PR TITLE
build: update github.com/google/subcommands to tagged version 1.0.1

### DIFF
--- a/external.bzl
+++ b/external.bzl
@@ -366,9 +366,9 @@ def _go_dependencies():
     maybe(
         go_repository,
         name = "com_github_google_subcommands",
-        commit = "a3682377147edf596d303faabd89f81977b3f678",
         custom = "subcommands",
         importpath = "github.com/google/subcommands",
+        tag = "1.0.1",
     )
 
     maybe(

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/google/go-github v0.0.0-20180509124334-8ea2e2657df8
 	github.com/google/go-querystring v0.0.0-20170111101155-53e6ce116135
 	github.com/google/orderedcode v0.0.0-20150706152543-05a79567b685
-	github.com/google/subcommands v0.0.0-20180305171600-a3682377147e
+	github.com/google/subcommands v0.0.0-20190211182706-d47216cd1784
 	github.com/googleapis/gax-go v0.0.0-20190111180537-ddfab93c3fae // indirect
 	github.com/jmhodges/levigo v0.0.0-20161115193449-c42d9e0ca023
 	github.com/mholt/archiver v3.1.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/google/orderedcode v0.0.0-20150706152543-05a79567b685 h1:aGnMdT4gPUkB
 github.com/google/orderedcode v0.0.0-20150706152543-05a79567b685/go.mod h1:iVyU4/qPKHY5h/wSd6rZZCDcLJNxiWO6dvsYES2Sb20=
 github.com/google/subcommands v0.0.0-20180305171600-a3682377147e h1:7OHlrhMiU9KC4cXeWfmYFHLACBw7a6sJ5rWdAICpn1g=
 github.com/google/subcommands v0.0.0-20180305171600-a3682377147e/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
+github.com/google/subcommands v0.0.0-20190211182706-d47216cd1784 h1:shVGySSLBc/LsgxQtxw7LgB1c1K47SzXJQar6Bx1tTQ=
+github.com/google/subcommands v0.0.0-20190211182706-d47216cd1784/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
 github.com/googleapis/gax-go v0.0.0-20190111180537-ddfab93c3fae/go.mod h1:5VvnLYVimBt+hOVlFtJDkYQHVmk4K27qHHioZjPbYAI=
 github.com/googleapis/gax-go/v2 v2.0.2/go.mod h1:LLvjysVCY1JZeum8Z6l8qUty8fiNwE08qbEPm1M08qg=
 github.com/jmhodges/levigo v0.0.0-20161115193449-c42d9e0ca023 h1:y5P5G9cANJZt3MXlMrgELo5mNLZPXH8aGFFFG7IzPU0=


### PR DESCRIPTION
After https://github.com/google/subcommands/pull/20 this package now has a
go.mod file and versioned tags.