### PR TITLE
build: update go.opencensus.io to tagged version v0.15.0

### DIFF
--- a/external.bzl
+++ b/external.bzl
@@ -499,10 +499,10 @@ def _go_dependencies():
     maybe(
         go_repository,
         name = "io_opencensus_go",
-        commit = "c40611a83b49d279ee5203c85e4fe169dcb158b6",
         custom = "opencensus",
         custom_git = "https://github.com/census-instrumentation/opencensus-go.git",
         importpath = "go.opencensus.io",
+        tag = "v0.15.0",
     )
 
     maybe(

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/syndtr/goleveldb v0.0.0-20180521045021-5d6fca44a948
 	github.com/ulikunitz/xz v0.5.5 // indirect
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
-	go.opencensus.io v0.0.0-20180405210956-c40611a83b49
+	go.opencensus.io v0.15.0
 	golang.org/x/net v0.0.0-20190125091013-d26f9f9a57f3
 	golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be
 	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,8 @@ github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofm
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
 go.opencensus.io v0.0.0-20180405210956-c40611a83b49 h1:D/lxRLFdKuCHBGoJKtI5ujWLQ7T5IMt9L1hjKtG6/vU=
 go.opencensus.io v0.0.0-20180405210956-c40611a83b49/go.mod h1:UffZAU+4sDEINUGP/B7UfBBkq4fqLu9zXAX7ke6CHW0=
+go.opencensus.io v0.15.0 h1:r1SzcjSm4ybA0qZs3B4QYX072f8gK61Kh0qtwyFpfdk=
+go.opencensus.io v0.15.0/go.mod h1:UffZAU+4sDEINUGP/B7UfBBkq4fqLu9zXAX7ke6CHW0=
 golang.org/x/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190125091013-d26f9f9a57f3 h1:ulvT7fqt0yHWzpJwI57MezWnYDVpCAYBVuYst/L+fAY=


### PR DESCRIPTION
This is not the most recent version, but is newer than we have been using so
far, and is the latest that does not bring in new ancillary dependencies.