### PR TITLE
build: update github.com/nwaples/rardecode to tagged version v1.0.0

### DIFF
--- a/external.bzl
+++ b/external.bzl
@@ -587,9 +587,9 @@ def _go_dependencies():
     maybe(
         go_repository,
         name = "com_github_nwaples_rardecode",
-        commit = "197ef08ef68c4454ae5970a9c2692d6056ceb8d7",
         custom = "rardecode",
         importpath = "github.com/nwaples/rardecode",
+        tag = "v1.0.0",
     )
 
     maybe(

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/jmhodges/levigo v0.0.0-20161115193449-c42d9e0ca023
 	github.com/mholt/archiver v3.1.1+incompatible
 	github.com/minio/highwayhash v0.0.0-20180501080913-85fc8a2dacad
-	github.com/nwaples/rardecode v1.0.1-0.20181025094117-197ef08ef68c // indirect
+	github.com/nwaples/rardecode v1.0.0 // indirect
 	github.com/pborman/uuid v0.0.0-20180122190007-c65b2f87fee3
 	github.com/pierrec/lz4 v0.0.0-20190131084431-473cd7ce01a1 // indirect
 	github.com/pkg/errors v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,8 @@ github.com/mholt/archiver v3.1.1+incompatible h1:1dCVxuqs0dJseYEhi5pl7MYPH9zDa1w
 github.com/mholt/archiver v3.1.1+incompatible/go.mod h1:Dh2dOXnSdiLxRiPoVfIr/fI1TwETms9B8CTWfeh7ROU=
 github.com/minio/highwayhash v0.0.0-20180501080913-85fc8a2dacad h1:L+8skVz2lusCbtlalLXmJp+TK8XaGAsZ3utSC3k5Jc0=
 github.com/minio/highwayhash v0.0.0-20180501080913-85fc8a2dacad/go.mod h1:NL8wme5P5MoscwAkXfGroz3VgpCdhBw3KYOu5mEsvpU=
-github.com/nwaples/rardecode v1.0.1-0.20181025094117-197ef08ef68c h1:u2KzixJYvuGIaQ5mO+tFxJtaDmyCvdwprLFHrSvxi4k=
-github.com/nwaples/rardecode v1.0.1-0.20181025094117-197ef08ef68c/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWkRpHbbfGS0=
+github.com/nwaples/rardecode v1.0.0 h1:r7vGuS5akxOnR4JQSkko62RJ1ReCMXxQRPtxsiFMBOs=
+github.com/nwaples/rardecode v1.0.0/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWkRpHbbfGS0=
 github.com/pborman/uuid v0.0.0-20180122190007-c65b2f87fee3 h1:9J0mOv1rXIBlRjQCiAGyx9C3dZZh5uIa3HU0oTV8v1E=
 github.com/pborman/uuid v0.0.0-20180122190007-c65b2f87fee3/go.mod h1:VyrYX9gd7irzKovcSS6BIIEwPRkP2Wm2m9ufcdFSJ34=
 github.com/pierrec/lz4 v0.0.0-20181027085611-623b5a2f4d2a h1:AjoacEaTgu9mA3/ZNFtPfdIM9MP5WVngYdB2k/3xLJ4=


### PR DESCRIPTION
Interestingly we had a pointer to something claiming to be v1.0.1, but the
repository does not advertise such a tag. It's possible there was at one point
that was later removed, but we should probably not depend on that.