### PR TITLE
build: remove unused dependency on github.com/google/go-github

### DIFF
--- a/external.bzl
+++ b/external.bzl
@@ -428,14 +428,6 @@ def _go_dependencies():
 
     maybe(
         go_repository,
-        name = "com_github_google_go_github",
-        commit = "8ea2e2657df890db8fb434a9274799d641bd698c",
-        custom = "github",
-        importpath = "github.com/google/go-github",
-    )
-
-    maybe(
-        go_repository,
         name = "org_golang_google_grpc",
         custom = "grpc",
         custom_git = "https://github.com/grpc/grpc-go.git",

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/golang/snappy v0.0.0-20170215233205-553a64147049
 	github.com/google/brotli v0.0.0-20180626090807-ee2a5e1540
 	github.com/google/go-cmp v0.2.0
-	github.com/google/go-github v0.0.0-20180509124334-8ea2e2657df8
 	github.com/google/go-querystring v1.0.0
 	github.com/google/orderedcode v0.0.0-20150706152543-05a79567b685
 	github.com/google/subcommands v0.0.0-20190211182706-d47216cd1784

--- a/go.sum
+++ b/go.sum
@@ -26,7 +26,6 @@ github.com/google/brotli v0.0.0-20180626090807-ee2a5e1540 h1:p7yBiLWuNlevGWjy6uv
 github.com/google/brotli v0.0.0-20180626090807-ee2a5e1540/go.mod h1:XpGqLY1HgMKTQI5TU8iAKE/okaKqS9h1e6KRlRztlOU=
 github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
-github.com/google/go-github v0.0.0-20180509124334-8ea2e2657df8/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-querystring v0.0.0-20170111101155-53e6ce116135/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -15,7 +15,6 @@ filegroup(
         "@go_errors//:LICENSE",
         "@go_etree//:LICENSE",
         "@go_ghodss_yaml//:LICENSE",
-        "@go_github//:LICENSE",
         "@go_google_api//:LICENSE",
         "@go_google_cloud//:LICENSE",
         "@go_googleapis_gax//:LICENSE",


### PR DESCRIPTION
There are no imports of this package anywhere. If we do want to take a
dependency on it in the future, we should do so at one of the release tags.
For now, doing so at any recent tag will pull in extra dependencies, so I
propose to drop it till we need it concretely.