### PR TITLE
build: update github.com/mholt/archiver to tagged release v3.1.1

### DIFF
--- a/external.bzl
+++ b/external.bzl
@@ -563,9 +563,9 @@ def _go_dependencies():
     maybe(
         go_repository,
         name = "com_github_mholt_archiver",
-        commit = "d572b2e8b82726cee9476d1b9d63a7fe9b601ff1",
         custom = "archiver",
         importpath = "github.com/mholt/archiver",
+        tag = "v3.1.1",
     )
 
     maybe(


### PR DESCRIPTION
This does not actually change which version we are using, since the digest was
already set to this tag's digest in the original import, and thus the go.mod
and go.sum files do not need to change.