### PR TITLE
build: use github.com/google/uuid for Go UUID generation

### DIFF
--- a/external.bzl
+++ b/external.bzl
@@ -300,10 +300,10 @@ def _go_dependencies():
 
     maybe(
         go_repository,
-        name = "com_github_pborman_uuid",
-        commit = "c65b2f87fee37d1c7854c9164a450713c28d50cd",
+        name = "com_github_google_uuid",
         custom = "uuid",
-        importpath = "github.com/pborman/uuid",
+        importpath = "github.com/google/uuid",
+        tag = "v1.1.0",
     )
 
     maybe(

--- a/go.mod
+++ b/go.mod
@@ -16,12 +16,12 @@ require (
 	github.com/google/go-querystring v1.0.0
 	github.com/google/orderedcode v0.0.0-20150706152543-05a79567b685
 	github.com/google/subcommands v0.0.0-20190211182706-d47216cd1784
+	github.com/google/uuid v1.1.0 // indirect
 	github.com/googleapis/gax-go v0.0.0-20190111180537-ddfab93c3fae // indirect
 	github.com/jmhodges/levigo v0.0.0-20161115193449-c42d9e0ca023
 	github.com/mholt/archiver v3.1.1+incompatible
 	github.com/minio/highwayhash v0.0.0-20180501080913-85fc8a2dacad
 	github.com/nwaples/rardecode v1.0.0 // indirect
-	github.com/pborman/uuid v0.0.0-20180122190007-c65b2f87fee3
 	github.com/pierrec/lz4 v0.0.0-20190131084431-473cd7ce01a1 // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/sergi/go-diff v0.0.0-20180205163309-da645544ed44

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,8 @@ github.com/google/subcommands v0.0.0-20180305171600-a3682377147e h1:7OHlrhMiU9KC
 github.com/google/subcommands v0.0.0-20180305171600-a3682377147e/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
 github.com/google/subcommands v0.0.0-20190211182706-d47216cd1784 h1:shVGySSLBc/LsgxQtxw7LgB1c1K47SzXJQar6Bx1tTQ=
 github.com/google/subcommands v0.0.0-20190211182706-d47216cd1784/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
+github.com/google/uuid v1.1.0 h1:Jf4mxPC/ziBnoPIdpQdPJ9OeiomAUHLvxmPRSPH9m4s=
+github.com/google/uuid v1.1.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go v0.0.0-20190111180537-ddfab93c3fae/go.mod h1:5VvnLYVimBt+hOVlFtJDkYQHVmk4K27qHHioZjPbYAI=
 github.com/googleapis/gax-go/v2 v2.0.2/go.mod h1:LLvjysVCY1JZeum8Z6l8qUty8fiNwE08qbEPm1M08qg=
 github.com/jmhodges/levigo v0.0.0-20161115193449-c42d9e0ca023 h1:y5P5G9cANJZt3MXlMrgELo5mNLZPXH8aGFFFG7IzPU0=
@@ -46,8 +48,6 @@ github.com/minio/highwayhash v0.0.0-20180501080913-85fc8a2dacad h1:L+8skVz2lusCb
 github.com/minio/highwayhash v0.0.0-20180501080913-85fc8a2dacad/go.mod h1:NL8wme5P5MoscwAkXfGroz3VgpCdhBw3KYOu5mEsvpU=
 github.com/nwaples/rardecode v1.0.0 h1:r7vGuS5akxOnR4JQSkko62RJ1ReCMXxQRPtxsiFMBOs=
 github.com/nwaples/rardecode v1.0.0/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWkRpHbbfGS0=
-github.com/pborman/uuid v0.0.0-20180122190007-c65b2f87fee3 h1:9J0mOv1rXIBlRjQCiAGyx9C3dZZh5uIa3HU0oTV8v1E=
-github.com/pborman/uuid v0.0.0-20180122190007-c65b2f87fee3/go.mod h1:VyrYX9gd7irzKovcSS6BIIEwPRkP2Wm2m9ufcdFSJ34=
 github.com/pierrec/lz4 v0.0.0-20181027085611-623b5a2f4d2a h1:AjoacEaTgu9mA3/ZNFtPfdIM9MP5WVngYdB2k/3xLJ4=
 github.com/pierrec/lz4 v0.0.0-20181027085611-623b5a2f4d2a/go.mod h1:3/3N9NVKO0jef7pBehbT1qWhCMrIgbYNnFAZCqQ5LRc=
 github.com/pierrec/lz4 v0.0.0-20190131084431-473cd7ce01a1 h1:0utzB5Mn6QyMzIeOn+oD7pjKQLjJwfM9bz6TkPPdxcw=

--- a/kythe/go/extractors/config/runextractor/cmakecmd/BUILD
+++ b/kythe/go/extractors/config/runextractor/cmakecmd/BUILD
@@ -9,6 +9,6 @@ go_library(
         "//kythe/go/extractors/config/runextractor/compdb",
         "//kythe/go/util/cmdutil",
         "@com_github_google_subcommands//:go_default_library",
-        "@com_github_pborman_uuid//:go_default_library",
+        "@com_github_google_uuid//:go_default_library",
     ],
 )

--- a/kythe/go/extractors/config/runextractor/cmakecmd/cmakecmd.go
+++ b/kythe/go/extractors/config/runextractor/cmakecmd/cmakecmd.go
@@ -30,7 +30,7 @@ import (
 	"kythe.io/kythe/go/util/cmdutil"
 
 	"github.com/google/subcommands"
-	"github.com/pborman/uuid"
+	"github.com/google/uuid"
 )
 
 type cmakeCommand struct {
@@ -88,7 +88,7 @@ func (c *cmakeCommand) Execute(ctx context.Context, fs *flag.FlagSet, args ...in
 	var buildDir string
 	if c.buildDir == "" {
 		// sourceDir is already an absolute directory
-		buildDir = filepath.Join(sourceDir, "build-"+uuid.New())
+		buildDir = filepath.Join(sourceDir, "build-"+uuid.New().String())
 		if err := os.Mkdir(buildDir, 0755); err != nil {
 			// Unlike below, we need to fail if the "unique" directory exists.
 			return c.Fail("unable to create build directory: %v", err)

--- a/kythe/go/extractors/config/runextractor/compdbcmd/BUILD
+++ b/kythe/go/extractors/config/runextractor/compdbcmd/BUILD
@@ -9,6 +9,6 @@ go_library(
         "//kythe/go/extractors/config/runextractor/compdb",
         "//kythe/go/util/cmdutil",
         "@com_github_google_subcommands//:go_default_library",
-        "@com_github_pborman_uuid//:go_default_library",
+        "@com_github_google_uuid//:go_default_library",
     ],
 )

--- a/kythe/go/platform/indexpack/BUILD
+++ b/kythe/go/platform/indexpack/BUILD
@@ -12,7 +12,7 @@ go_library(
         "//kythe/go/platform/vfs/zip",
         "@com_github_golang_protobuf//jsonpb:go_default_library_gen",
         "@com_github_golang_protobuf//proto:go_default_library",
-        "@com_github_pborman_uuid//:go_default_library",
+        "@com_github_google_uuid//:go_default_library",
     ],
 )
 

--- a/kythe/go/platform/indexpack/indexpack.go
+++ b/kythe/go/platform/indexpack/indexpack.go
@@ -86,7 +86,7 @@ import (
 
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
-	"github.com/pborman/uuid"
+	"github.com/google/uuid"
 )
 
 const (
@@ -259,7 +259,7 @@ func CreateOrOpen(ctx context.Context, path string, opts ...Option) (*Archive, e
 }
 
 func (a *Archive) writeFile(ctx context.Context, dir, name string, data []byte) error {
-	tmp := filepath.Join(dir, uuid.New()) + newSuffix
+	tmp := filepath.Join(dir, uuid.New().String()) + newSuffix
 	f, err := a.fs.Create(ctx, tmp)
 	if err != nil {
 		return err

--- a/third_party/go/uuid.BUILD
+++ b/third_party/go/uuid.BUILD
@@ -6,4 +6,4 @@ licenses(["notice"])
 
 exports_files(["LICENSE"])
 
-external_go_package(base_pkg = "github.com/pborman/uuid")
+external_go_package(base_pkg = "github.com/google/uuid")


### PR DESCRIPTION
Recent updates of the github.com/pborman/uuid library have become thin wrappers
around the Google version, and in fact they're both maintained at least in part
by the same person. Instead of updating the wrapper, which would require us to
also depend on the underlying library, just use the Google one directly.

This required a small change to the call site for uuid.New(), since the type
has changed slightly. However, otherwise this is a fairly straightforward update.