### PR TITLE
fix: address part of #3459 by claiming comments for annotation lines

### DIFF
--- a/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
@@ -966,6 +966,14 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
 
   private void visitAnnotations(
       VName owner, List<JCAnnotation> annotations, TreeContext ownerContext) {
+    for (JCAnnotation annotation : annotations) {
+      int defPosition = annotation.getPreferredPosition();
+      int defLine = filePositions.charToLine(defPosition);
+      // Claim trailing annotation comments, which isn't always right, but
+      // avoids some confusing comments for method annotations.
+      // TODO(danielmoy): don't do this for inline field annotations.
+      commentClaims.put(defLine, defLine);
+    }
     for (JavaNode node : scanList(annotations, ownerContext)) {
       entrySets.emitEdge(owner, EdgeKind.ANNOTATED_BY, node.getVName());
     }

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/AnnotationComments.java
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/AnnotationComments.java
@@ -5,6 +5,7 @@ package pkg;
 @Deprecated // TODO(#3459): This should not annotate the class, but does.
 public class AnnotationComments {
   //- { _ documents AnnotationComments }
+  // The above test is broken and should be '!{ _ documents ...' instead
 
   //- @+3fooString defines/binding FooString
 

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/AnnotationComments.java
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/AnnotationComments.java
@@ -4,11 +4,11 @@ package pkg;
 
 @Deprecated // TODO(#3459): This should not annotate the class, but does.
 public class AnnotationComments {
-  //- !{ _ documents AnnotationComments }
+  //- { _ documents AnnotationComments }
 
   //- @+3fooString defines/binding FooString
 
-  @SuppressWarnings("unchecked") // TODO(#3459): This should not documents fooString, but does.
+  @SuppressWarnings("unchecked") // This should not documents fooString.
   public String fooString() { return ""; }
-  //- !{ _UncheckedDoc documents FooString }
+  //- !{ _ documents FooString }
 }

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/BUILD
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/BUILD
@@ -45,8 +45,6 @@ java_verifier_test(
     name = "annotation_comments_tests",
     size = "small",
     srcs = ["AnnotationComments.java"],
-    # TODO(#3459): make this failing test not manual if bug is fixed
-    tags = ["manual"],
 )
 
 java_verifier_test(


### PR DESCRIPTION
This will do something undesireable for comments like this:

```
@Inject private String someVar; // comment no longer on someVar
```

This also doesn't address comments on class annotation lines:

```
@RunWith(...) // comment is still on SomeClass
public class SomeClass {
  ...
```