### PR TITLE
Make pipeline more tolerant to some errors (affects write_tables tool).

### DIFF
--- a/kythe/go/serving/pipeline/beam.go
+++ b/kythe/go/serving/pipeline/beam.go
@@ -18,6 +18,7 @@ package pipeline
 
 import (
 	"fmt"
+	"log"
 	"reflect"
 	"sort"
 	"strconv"
@@ -709,7 +710,11 @@ func normalizeAnchors(file *srvpb.File, anchor func(**scpb.Node) bool, emit func
 		}
 		a, err := assemble.ExpandAnchor(raw, file, norm, "")
 		if err != nil {
-			return err
+			if *lenientErrors {
+				log.Printf("error expanding anchor {%+v}: %v", raw, err)
+				break
+			}
+			return fmt.Errorf("error expanding anchor {%+v}: %v", raw, err)
 		}
 
 		var parent *spb.VName

--- a/kythe/go/serving/pipeline/beam.go
+++ b/kythe/go/serving/pipeline/beam.go
@@ -710,11 +710,8 @@ func normalizeAnchors(file *srvpb.File, anchor func(**scpb.Node) bool, emit func
 		}
 		a, err := assemble.ExpandAnchor(raw, file, norm, "")
 		if err != nil {
-			if *lenientErrors {
-				log.Printf("error expanding anchor {%+v}: %v", raw, err)
-				break
-			}
-			return fmt.Errorf("error expanding anchor {%+v}: %v", raw, err)
+			log.Printf("error expanding anchor {%+v}: %v", raw, err)
+			break
 		}
 
 		var parent *spb.VName

--- a/kythe/go/serving/pipeline/pipeline.go
+++ b/kythe/go/serving/pipeline/pipeline.go
@@ -22,6 +22,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"flag"
 	"fmt"
 	"log"
 	"sort"
@@ -49,6 +50,10 @@ import (
 	ipb "kythe.io/kythe/proto/internal_go_proto"
 	srvpb "kythe.io/kythe/proto/serving_go_proto"
 	spb "kythe.io/kythe/proto/storage_go_proto"
+)
+
+var (
+	lenientErrors = flag.Bool("lenient_errors", false, "Don't die on errors, rather warn and skip processing.")
 )
 
 // Options controls the behavior of pipeline.Run.
@@ -430,6 +435,10 @@ func writeDecorAndRefs(ctx context.Context, opts *Options, edges <-chan *srvpb.E
 				targets[n.Ticket] = n
 			}
 			if file == nil {
+				if *lenientErrors {
+					log.Printf("Warning: no file set for anchor. fileTicket:[%v] curFile:[%v] fragment:[%v]", fileTicket, curFile, fragment)
+					return nil
+				}
 				return errors.New("missing file for anchors")
 			}
 

--- a/kythe/go/serving/pipeline/pipeline.go
+++ b/kythe/go/serving/pipeline/pipeline.go
@@ -22,7 +22,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"flag"
 	"fmt"
 	"log"
 	"sort"
@@ -50,10 +49,6 @@ import (
 	ipb "kythe.io/kythe/proto/internal_go_proto"
 	srvpb "kythe.io/kythe/proto/serving_go_proto"
 	spb "kythe.io/kythe/proto/storage_go_proto"
-)
-
-var (
-	lenientErrors = flag.Bool("lenient_errors", false, "Don't die on errors, rather warn and skip processing.")
 )
 
 // Options controls the behavior of pipeline.Run.
@@ -435,11 +430,8 @@ func writeDecorAndRefs(ctx context.Context, opts *Options, edges <-chan *srvpb.E
 				targets[n.Ticket] = n
 			}
 			if file == nil {
-				if *lenientErrors {
-					log.Printf("Warning: no file set for anchor. fileTicket:[%v] curFile:[%v] fragment:[%v]", fileTicket, curFile, fragment)
-					return nil
-				}
-				return errors.New("missing file for anchors")
+				log.Printf("Warning: no file set for anchor. fileTicket:[%v] curFile:[%v] fragment:[%v]", fileTicket, curFile, fragment)
+				return nil
 			}
 
 			// Reverse each fragment.Decoration to create a *ipb.CrossReference


### PR DESCRIPTION
There were two places that bailed out on error. I observed these happening when using the `beam` pipeline or the older `graphstore`-based one. The added flag can turn bailing out to just logging the warning but continuing processing.