### PR TITLE
Make kythe/cxx/common/path_utils.cc relativize against root dir.

### DIFF
--- a/kythe/cxx/common/path_utils.cc
+++ b/kythe/cxx/common/path_utils.cc
@@ -132,14 +132,27 @@ absl::string_view Dirname(absl::string_view path) {
   return SplitPath(path).dir;
 }
 
+namespace {
+bool IsProperPathPrefix(absl::string_view s, absl::string_view prefix) {
+  return absl::StartsWith(s, prefix) &&
+         (s.size() == prefix.size() || s[prefix.size()] == '/');
+}
+}  // namespace
+
 std::string RelativizePath(absl::string_view to_relativize,
                            absl::string_view relativize_against) {
   std::string to_relativize_abs = MakeCleanAbsolutePath(to_relativize);
   std::string relativize_against_abs =
       MakeCleanAbsolutePath(relativize_against);
+  if (relativize_against_abs == "/") {
+    // We don't handle a generic case where the absolute path ends with slash,
+    // since users can work around by just dropping the slash. Except this case
+    // where relativization base is the root.
+    return to_relativize_abs.substr(1);
+  }
   std::string to_relativize_parent = std::string(Dirname(to_relativize_abs));
   std::string ret =
-      absl::StartsWith(to_relativize_parent, relativize_against_abs)
+      IsProperPathPrefix(to_relativize_parent, relativize_against_abs)
           ? to_relativize_abs.substr(relativize_against_abs.size() + 1)
           : to_relativize_abs;
   return ret;

--- a/kythe/cxx/common/path_utils.cc
+++ b/kythe/cxx/common/path_utils.cc
@@ -52,6 +52,11 @@ absl::string_view PathPrefix(absl::string_view path) {
   }
 }
 
+bool IsProperPathPrefix(absl::string_view s, absl::string_view prefix) {
+  return absl::StartsWith(s, prefix) &&
+         (s.size() == prefix.size() || s[prefix.size()] == '/');
+}
+
 }  // namespace
 
 std::string JoinPath(absl::string_view a, absl::string_view b) {
@@ -131,13 +136,6 @@ PathParts SplitPath(absl::string_view path) {
 absl::string_view Dirname(absl::string_view path) {
   return SplitPath(path).dir;
 }
-
-namespace {
-bool IsProperPathPrefix(absl::string_view s, absl::string_view prefix) {
-  return absl::StartsWith(s, prefix) &&
-         (s.size() == prefix.size() || s[prefix.size()] == '/');
-}
-}  // namespace
 
 std::string RelativizePath(absl::string_view to_relativize,
                            absl::string_view relativize_against) {

--- a/kythe/cxx/common/path_utils.h
+++ b/kythe/cxx/common/path_utils.h
@@ -36,7 +36,10 @@ bool IsAbsolutePath(absl::string_view path);
 /// \brief Relativize `to_relativize` with respect to `relativize_against`.
 ///
 /// If `to_relativize` does not name a path that is a child of
-/// `relativize_against`, `RelativizePath` will return an absolute path.
+/// `relativize_against`, `RelativizePath` will return an absolute path
+/// (resolved against the current working directory).
+///
+/// Note: arguments are assumed to be valid paths, but validity is not checked.
 ///
 /// \param to_relativize Relative or absolute path to a file.
 /// \param relativize_against Relative or absolute path to a directory.

--- a/kythe/cxx/common/path_utils_test.cc
+++ b/kythe/cxx/common/path_utils_test.cc
@@ -59,6 +59,13 @@ TEST(PathUtilsTest, RelativizePath) {
   EXPECT_EQ("bar", RelativizePath("foo/bar", cwd_foo));
   EXPECT_EQ("foo", RelativizePath(cwd_foo, "."));
   EXPECT_EQ(cwd_foo, RelativizePath(cwd_foo, "bar"));
+
+  // If all paths are absolute, then relativizing is unaffected by current_dir.
+  EXPECT_EQ("bar", RelativizePath("/foo/bar", "/foo"));
+  EXPECT_EQ("foo", RelativizePath("/foo", "/"));
+
+  // Test that we only accept proper path prefixes as parent.
+  EXPECT_EQ("/foooo/bar", RelativizePath("/foooo/bar", "/foo"));
 }
 
 TEST(PathUtilsTest, MakeCleanAbsolutePath) {


### PR DESCRIPTION
This is needed if `KYTHE_ROOT_DIRECTORY=/` is passed to the cxx
extractor.

Also check that relativization only happens if the relativization base
is a proper path prefix of the target, and not just a stringy prefix.