### PR TITLE
build(bazel): support upcoming Bazel 0.23.0 release

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -6,7 +6,7 @@ load("//:version.bzl", "check_version")
 
 # Check that the user has a version between our minimum supported version of
 # Bazel and our maximum supported version of Bazel.
-check_version("0.20", "0.22")
+check_version("0.20", "0.23")
 
 http_archive(
     name = "bazel_toolchains",

--- a/tools/build_rules/verifier_test/java_verifier_test.bzl
+++ b/tools/build_rules/verifier_test/java_verifier_test.bzl
@@ -132,6 +132,13 @@ java_extract_kzip = rule(
     implementation = _java_extract_kzip_impl,
 )
 
+_default_java_extractor_opts = [
+    "-source",
+    "9",
+    "-target",
+    "9",
+]
+
 def java_verifier_test(
         name,
         srcs,
@@ -140,12 +147,7 @@ def java_verifier_test(
         size = "small",
         tags = [],
         extractor = None,
-        extractor_opts = [
-            "-source",
-            "9",
-            "-target",
-            "9",
-        ],
+        extractor_opts = _default_java_extractor_opts,
         indexer_opts = ["--verbose"],
         verifier_opts = ["--ignore_dups"],
         load_plugin = None,
@@ -291,6 +293,7 @@ def java_proto_verifier_test(
         size = "small",
         proto_srcs = [],
         tags = [],
+        java_extractor_opts = _default_java_extractor_opts,
         verifier_opts = ["--ignore_dups"],
         vnames_config = None,
         visibility = None):
@@ -336,6 +339,7 @@ def java_proto_verifier_test(
         java_extract_kzip,
         name = name + "_java_kzip",
         srcs = srcs + [":" + name + "_gensrc"],
+        opts = java_extractor_opts,
         tags = tags,
         visibility = visibility,
         vnames_config = vnames_config,


### PR DESCRIPTION
Tested against https://releases.bazel.build/0.23.0/rc1/.