### PR TITLE
Use std::string and string_view-like APIs more uniformly

### DIFF
--- a/external.bzl
+++ b/external.bzl
@@ -129,9 +129,9 @@ def _cc_dependencies():
     maybe(
         http_archive,
         name = "com_googlesource_code_re2",
-        # Gitiles creates gzip files with an embedded timestamp, so we cannot use
-        # sha256 to validate the archives.  We must rely on the commit hash and https.
-        url = "https://code.googlesource.com/re2/+archive/2c220e7df3c10d42d74cb66290ec89116bb5e6be.tar.gz",
+        url = "https://github.com/google/re2/archive/2019-01-01.zip",
+        sha256 = "ae9b962dbd6427565efd3e9503acb40a1385b21962c29050546c9347ac7fa93f",
+        strip_prefix = "re2-2019-01-01",
     )
 
     maybe(

--- a/kythe/cxx/common/file_vname_generator.cc
+++ b/kythe/cxx/common/file_vname_generator.cc
@@ -40,7 +40,7 @@ std::string FileVNameGenerator::ApplyRule(const StringConsRule& rule,
         break;
       case StringConsNode::Kind::kUseSubstitution:
         // Invariant: 0 <= node.capture_index < argc
-        ret.append(argv[node.capture_index].ToString());
+        ret.append(std::string(argv[node.capture_index]));
         break;
     }
   }
@@ -63,13 +63,13 @@ bool FileVNameGenerator::ParseRule(const std::string& rule, int max_capture,
     if (!prefix.empty()) {
       StringConsNode node;
       node.kind = StringConsNode::Kind::kEmitText;
-      node.raw_text = prefix.ToString();
+      node.raw_text = std::string(prefix);
       result->push_back(node);
     }
     if (!substitution.empty()) {
       StringConsNode node;
       node.kind = StringConsNode::Kind::kUseSubstitution;
-      node.capture_index = std::stoi(substitution.ToString());
+      node.capture_index = std::stoi(std::string(substitution));
       if (node.capture_index == 0 || node.capture_index > max_capture) {
         *error_text =
             "Capture index out of range: " + std::to_string(node.capture_index);

--- a/kythe/cxx/indexer/cxx/GraphObserver.h
+++ b/kythe/cxx/indexer/cxx/GraphObserver.h
@@ -20,9 +20,11 @@
 /// \file
 /// \brief Defines the class kythe::GraphObserver
 
+#include <string>
 #include <openssl/sha.h>  // for SHA256
 
 #include "absl/strings/escaping.h"
+#include "absl/strings/string_view.h"
 #include "absl/types/optional.h"
 #include "absl/types/span.h"
 #include "clang/Basic/SourceLocation.h"
@@ -46,18 +48,17 @@ namespace kythe {
 constexpr size_t kSha256DigestBase64MaxEncodingLength = 42;
 
 /// \brief A one-way hash for `InString`.
-template <typename String>
-String CompressString(const String& InString, bool Force = false) {
+inline std::string CompressString(absl::string_view InString, bool Force = false) {
   if (InString.size() <= kSha256DigestBase64MaxEncodingLength && !Force) {
-    return InString;
+    return std::string(InString);
   }
   ::SHA256_CTX Sha;
   ::SHA256_Init(&Sha);
   ::SHA256_Update(&Sha, reinterpret_cast<const unsigned char*>(InString.data()),
                   InString.size());
-  String Hash(SHA256_DIGEST_LENGTH, '\0');
+  std::string Hash(SHA256_DIGEST_LENGTH, '\0');
   ::SHA256_Final(reinterpret_cast<unsigned char*>(&Hash[0]), &Sha);
-  String Result;
+  std::string Result;
   absl::Base64Escape(Hash, &Result);
   return Result;
 }

--- a/kythe/cxx/indexer/cxx/GraphObserver.h
+++ b/kythe/cxx/indexer/cxx/GraphObserver.h
@@ -20,8 +20,8 @@
 /// \file
 /// \brief Defines the class kythe::GraphObserver
 
-#include <string>
 #include <openssl/sha.h>  // for SHA256
+#include <string>
 
 #include "absl/strings/escaping.h"
 #include "absl/strings/string_view.h"
@@ -48,7 +48,8 @@ namespace kythe {
 constexpr size_t kSha256DigestBase64MaxEncodingLength = 42;
 
 /// \brief A one-way hash for `InString`.
-inline std::string CompressString(absl::string_view InString, bool Force = false) {
+inline std::string CompressString(absl::string_view InString,
+                                  bool Force = false) {
   if (InString.size() <= kSha256DigestBase64MaxEncodingLength && !Force) {
     return std::string(InString);
   }


### PR DESCRIPTION
This requires updating RE2 to include the `explicit operator std::string` conversion so that we can use it.  I'm sure there are additional such cleanups to be made, but this is a good start.