### PR TITLE
fix: propagating a downstream fix on typescript

### DIFF
--- a/kythe/typescript/test.ts
+++ b/kythe/typescript/test.ts
@@ -30,7 +30,7 @@ import * as ts from 'typescript';
 
 import * as indexer from './indexer';
 
-const KYTHE_PATH = process.env.KYTHE || '/opt/kythe';
+const KYTHE_PATH = process.env.['KYTHE'] || '/opt/kythe';
 
 /**
  * createTestCompilerHost creates a ts.CompilerHost that caches its default


### PR DESCRIPTION
Replace property access on objects with an index signature type, with an index access.

Previously, you could write:

```
interface IdxSig {
  [key: string]: string;
}

function propAccess(x: IdxSig) {
  x.prop;
}
```