### PR TITLE
feat(extraction): add Bazel extraction Docker image

### DIFF
--- a/kythe/data/BUILD
+++ b/kythe/data/BUILD
@@ -3,18 +3,26 @@ package(default_visibility = ["//kythe:default_visibility"])
 load("//tools:build_rules/testing.bzl", "shell_tool_test")
 load(":vnames.bzl", "construct_vnames_config")
 
-exports_files(["schema_index.textproto"])
+exports_files([
+    "schema_index.textproto",
+    "vnames.bzl",
+])
 
 construct_vnames_config(
     name = "vnames_config",
+    srcs = [":raw_vnames_config"],
+    corpus = "kythe",
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "raw_vnames_config",
     srcs = [
         "vnames.cxx.json",
         "vnames.go.json",
         "vnames.java.json",
         "vnames.json",
     ],
-    corpus = "kythe",
-    visibility = ["//visibility:public"],
 )
 
 filegroup(

--- a/kythe/data/vnames.bzl
+++ b/kythe/data/vnames.bzl
@@ -21,16 +21,14 @@ def _construct_vnames_config_impl(ctx):
         # Use workspace name as default
         corpus = ctx.workspace_name
     srcs = ctx.files.srcs
-    jq = ctx.executable._jq
     merged = ctx.actions.declare_file(ctx.label.name + "_merged.json")
     ctx.actions.run_shell(
         outputs = [merged],
         inputs = srcs,
-        tools = [jq],
         command = "\n".join([
             "set -e -o pipefail",
             "cat " + " ".join([src.path for src in srcs]) + " | " +
-            jq.path + " --slurp -S [.[][]] > " + merged.path,
+            "tr --delete '\n' | sed 's/\]\[/,/g' > " + merged.path,
         ]),
     )
     ctx.actions.expand_template(
@@ -50,11 +48,6 @@ construct_vnames_config = rule(
             allow_files = True,
         ),
         "corpus": attr.string(),
-        "_jq": attr.label(
-            executable = True,
-            default = Label("@com_github_stedolan_jq//:jq"),
-            cfg = "host",
-        ),
     },
     outputs = {"vnames": "%{name}.json"},
     implementation = _construct_vnames_config_impl,

--- a/kythe/extractors/BUILD
+++ b/kythe/extractors/BUILD
@@ -2,6 +2,8 @@ package(default_visibility = ["//visibility:public"])
 
 load(":extractors.bzl", "extractor_action")
 
+exports_files(["extractors.bzl"])
+
 # Clone of default Java proto toolchain with "annotate_code" enabled for
 # cross-language metadata file generation.
 #

--- a/kythe/extractors/bazel/BUILD
+++ b/kythe/extractors/bazel/BUILD
@@ -1,0 +1,33 @@
+load("//tools:build_rules/docker.bzl", "docker_build")
+
+docker_build(
+    name = "docker",
+    src = "Dockerfile",
+    data = [
+        "extract.sh",
+        "extractors.BUILD",
+        "extractors.WORKSPACE",
+        "extractors.bazelrc",
+        ":extractors",
+        "//kythe/data:raw_vnames_config",
+        "//kythe/data:vnames.bzl",
+        "//kythe/extractors:extractors.bzl",
+        "//kythe/go/platform/tools/kzip",
+        "//kythe/release/base:fix_permissions.sh",
+    ],
+    image_name = "gcr.io/kythe-public/bazel-extractor",
+    tags = ["manual"],
+    use_cache = True,
+)
+
+filegroup(
+    name = "extractors",
+    srcs = [
+        "//kythe/cxx/extractor:cxx_extractor_bazel",
+        "//kythe/go/extractors/cmd/bazel:bazel_go_extractor",
+        "//kythe/go/extractors/cmd/bazel:extract_kzip",
+        "//kythe/java/com/google/devtools/kythe/extractors/java/bazel:java_extractor_deploy.jar",
+        "//kythe/java/com/google/devtools/kythe/extractors/jvm/bazel:bazel_jvm_extractor_deploy.jar",
+        "@io_kythe_lang_proto//kythe/go/extractors/proto:extract_proto_kzip",
+    ],
+)

--- a/kythe/extractors/bazel/Dockerfile
+++ b/kythe/extractors/bazel/Dockerfile
@@ -1,0 +1,45 @@
+# Copyright 2019 The Kythe Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/cloud-builders/bazel
+
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y \
+      # Install C++ compilers for cc_* rule support.
+      gcc clang && \
+    apt-get clean
+
+# Kythe extractor binaries
+ADD external/io_kythe_lang_proto/kythe/go/extractors/proto/extract_proto_kzip /kythe/extractors/bazel_proto_extractor
+ADD kythe/cxx/extractor/cxx_extractor_bazel /kythe/extractors/bazel_cxx_extractor
+ADD kythe/go/extractors/cmd/bazel/bazel_go_extractor /kythe/extractors/bazel_go_extractor
+ADD kythe/go/extractors/cmd/bazel/extract_kzip /kythe/extractors/bazel_extract_kzip
+ADD kythe/java/com/google/devtools/kythe/extractors/java/bazel/java_extractor_deploy.jar /kythe/extractors/bazel_java_extractor.jar
+ADD kythe/java/com/google/devtools/kythe/extractors/jvm/bazel/bazel_jvm_extractor_deploy.jar /kythe/extractors/bazel_jvm_extractor.jar
+
+# Tools and configuration
+ADD kythe/data/* /kythe/
+ADD kythe/extractors/bazel/extract.sh /kythe/
+ADD kythe/extractors/extractors.bzl /kythe/
+ADD kythe/go/platform/tools/kzip/kzip /kythe/
+ADD kythe/release/base/fix_permissions.sh /kythe/
+
+# Bazel repository setup
+ADD kythe/extractors/bazel/extractors.BUILD /kythe/BUILD
+ADD kythe/extractors/bazel/extractors.WORKSPACE /kythe/WORKSPACE
+ADD kythe/extractors/bazel/extractors.bazelrc /kythe/bazelrc
+RUN cat /kythe/bazelrc > ~/.bazelrc
+
+ENTRYPOINT ["/kythe/extract.sh"]

--- a/kythe/extractors/bazel/README.md
+++ b/kythe/extractors/bazel/README.md
@@ -1,0 +1,34 @@
+# Bazel Kythe extraction
+
+This package contains a Docker image that configures the `gcr.io/cloud-builders/bazel` Cloud Builder
+to extract Kythe `.kzip` compilations from supported targets.
+
+## Supported Bazel rules
+
+* cc_{library,binary,test} (`CppCompile` action mnemonic)
+* go_{library,binary,test} (`GoCompile` action mnemonic)
+* java_{library,binary,test,import,proto_library} (`Javac` and `JavaIjar` action mnemonics)
+* proto_library (`GenProtoDescriptorSet` action mnemonic)
+* typescript_library (`TypeScriptCompile` action mnemonic)
+
+## Building
+
+```shell
+bazel build -c opt --stamp //kythe/extractors/bazel:docker
+```
+
+## Example usage
+
+```shell
+git clone https://github.com/protocolbuffers/protobuf.git
+
+mkdir -p output
+docker run \
+  --mount type=bind,source=$PWD/protobuf,target=/workspace/code \
+  --mount type=bind,source=$PWD/output,target=/workspace/output \
+  -w /workspace/code \
+  gcr.io/kythe-public/bazel-extractor build \
+  --define kythe_corpus=github.com/protocolbuffers/protobuf //...
+  
+viewindex output/compilations.kzip
+```

--- a/kythe/extractors/bazel/extract.sh
+++ b/kythe/extractors/bazel/extract.sh
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/bin/bash
 
-# Copyright 2015 The Kythe Authors. All rights reserved.
+# Copyright 2019 The Kythe Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,103 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Script to extract compilations from a Bazel repository.  See usage() below.
+bazel "$@"
 
-usage() {
-  cat >&2 <<EOF
-Usage: $(basename "$0") [--java] [--go] [--cxx] [--bazel_arg arg] [bazel-root] <output-dir>
-
-Run the Kythe extractors as Bazel extra actions and copy the outputs to a given directory.  By
-default, C++, Java, and Go are extracted, but if --java, --go, or --cxx are given, then the set of
-extractors used are determined by the flags given.  In other words, giving --java, --go, and --cxx
-is the same as no flags.
-
-Flags:
-  --cxx:        turn on the use of the Bazel/Kythe C++ extractor
-  --go:         turn on the use of the Bazel/Kythe Go extractor
-  --java:       turn on the use of the Bazel/Kythe Java extractor
-  --bazel_arg:  add the given argument to Bazel during the build
-EOF
-  exit 1
-}
-
-ALL=1
-JAVA=
-CXX=
-GO=
-BAZEL_ARGS=(build -k --output_groups=compilation_outputs)
-
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --help|-h)
-      usage ;;
-    --java)
-      ALL=
-      JAVA=1 ;;
-    --cxx)
-      ALL=
-      CXX=1 ;;
-    --go)
-      ALL=
-      GO=1 ;;
-    --bazel_arg)
-      BAZEL_ARGS+=("$2")
-      shift ;;
-    *)
-      break ;;
-  esac
-  shift
-done
-
-if [[ -n "$ALL" ]]; then
-  JAVA=1
-  CXX=1
-  GO=1
-fi
-
-ROOT=$PWD
-case $# in
-  1)
-    OUTPUT="$1" ;;
-  2)
-    ROOT="$1"
-    OUTPUT="$2" ;;
-  *)
-    usage ;;
-esac
-
-mkdir -p "$OUTPUT"
-OUTPUT="$(readlink -e "$OUTPUT")"
-
-cd "$ROOT"
-if [[ -d bazel-out ]]; then
-  find -L bazel-out -type d -name extra_actions -exec rm -rf '{}' +
-fi
-
-if [[ -n "$JAVA" ]]; then
-  BAZEL_ARGS+=(--experimental_action_listener=@io_kythe//kythe/extractors:extract_kzip_java)
-fi
-if [[ -n "$CXX" ]]; then
-  BAZEL_ARGS+=(--experimental_action_listener=@io_kythe//kythe/extractors:extract_kzip_cxx)
-fi
-if [[ -n "$GO" ]]; then
-  BAZEL_ARGS+=(--experimental_action_listener=@io_kythe//kythe/extractors:extract_kzip_go)
-fi
-
-set -x
-bazel "${BAZEL_ARGS[@]}" //... || \
-  echo "Bazel exited with error code $?; trying to continue..." >&2
-set +x
-
-xad="$(find -L bazel-out -type d -name extra_actions)"
-INDICES=($(find "$xad" -name '*.kzip'))
-echo "Found ${#INDICES[@]} .kzip files in $xad"
-for idx in "${INDICES[@]}"; do
-  name="$(basename "$idx" .kzip)"
-  lang="${name##*.}"
-  dir="$OUTPUT/$lang"
-
-  mkdir -p "$dir"
-  dest="$dir/$(tr '/' '_' <<<"${idx#$xad/}")"
-  cp -vf "$idx" "$dest"
-done
+# Collect any extracted compilations.
+mkdir -p /workspace/output
+find bazel-out/*/extra_actions/external/kythe_extractors -name '*.kzip' | \
+  xargs /kythe/kzip merge --output /workspace/output/compilations.kzip
+/kythe/fix_permissions.sh /workspace/output/

--- a/kythe/extractors/bazel/extractors.BUILD
+++ b/kythe/extractors/bazel/extractors.BUILD
@@ -1,0 +1,137 @@
+package(default_visibility = ["//visibility:public"])
+
+load(":extractors.bzl", "extractor_action")
+load(":vnames.bzl", "construct_vnames_config")
+
+construct_vnames_config(
+    name = "vnames_config",
+    srcs = [
+        "vnames.cxx.json",
+        "vnames.go.json",
+        "vnames.java.json",
+        "vnames.json",
+    ],
+)
+
+# Clone of default Java proto toolchain with "annotate_code" enabled for
+# cross-language metadata file generation.
+proto_lang_toolchain(
+    name = "java_proto_toolchain",
+    command_line = "--java_out=annotate_code:$(OUT)",
+    runtime = "@com_google_protobuf//:protobuf_java",
+)
+
+filegroup(
+    name = "bazel_cxx_extractor",
+    srcs = ["extractors/bazel_cxx_extractor"],
+)
+
+java_binary(
+    name = "bazel_java_extractor",
+    main_class = "com.google.devtools.kythe.extractors.java.bazel.JavaExtractor",
+    runtime_deps = ["extractors/bazel_java_extractor.jar"],
+)
+
+java_binary(
+    name = "bazel_jvm_extractor",
+    main_class = "com.google.devtools.kythe.extractors.jvm.bazel.BazelJvmExtractor",
+    runtime_deps = ["extractors/bazel_jvm_extractor.jar"],
+)
+
+filegroup(
+    name = "bazel_go_extractor",
+    srcs = ["extractors/bazel_go_extractor"],
+)
+
+filegroup(
+    name = "bazel_extract_kzip",
+    srcs = ["extractors/bazel_extract_kzip"],
+)
+
+filegroup(
+    name = "bazel_proto_extractor",
+    srcs = ["extractors/bazel_proto_extractor"],
+)
+
+extractor_action(
+    name = "extract_kzip_cxx",
+    args = [
+        "$(EXTRA_ACTION_FILE)",
+        "$(output $(ACTION_ID).cxx.kzip)",
+        "$(location :vnames_config)",
+    ],
+    data = [":vnames_config"],
+    extractor = ":bazel_cxx_extractor",
+    mnemonics = ["CppCompile"],
+    output = "$(ACTION_ID).cxx.kzip",
+)
+
+extractor_action(
+    name = "extract_kzip_java",
+    args = [
+        "$(EXTRA_ACTION_FILE)",
+        "$(output $(ACTION_ID).java.kzip)",
+        "$(location :vnames_config)",
+    ],
+    data = [":vnames_config"],
+    extractor = ":bazel_java_extractor",
+    mnemonics = ["Javac"],
+    output = "$(ACTION_ID).java.kzip",
+)
+
+extractor_action(
+    name = "extract_kzip_jvm",
+    args = [
+        "$(EXTRA_ACTION_FILE)",
+        "$(output $(ACTION_ID).jvm.kzip)",
+        "$(location :vnames_config)",
+    ],
+    data = [":vnames_config"],
+    extractor = ":bazel_jvm_extractor",
+    mnemonics = ["JavaIjar"],
+    output = "$(ACTION_ID).jvm.kzip",
+)
+
+extractor_action(
+    name = "extract_kzip_go",
+    args = [
+        "$(EXTRA_ACTION_FILE)",
+        "$(output $(ACTION_ID).go.kzip)",
+        "$(location :vnames_config)",
+    ],
+    data = [":vnames_config"],
+    extractor = ":bazel_go_extractor",
+    mnemonics = ["GoCompile"],
+    output = "$(ACTION_ID).go.kzip",
+)
+
+extractor_action(
+    name = "extract_kzip_typescript",
+    args = [
+        "--extra_action=$(EXTRA_ACTION_FILE)",
+        "--include='\\.(js|json|tsx?|d\\.ts)$$'",
+        "--language=typescript",
+        "--output=$(output $(ACTION_ID).typescript.kzip)",
+        "--rules=$(location :vnames_config)",
+        "--scoped=true",
+        "--source='\\.ts$$'",
+    ],
+    data = [":vnames_config"],
+    extractor = ":bazel_extract_kzip",
+    mnemonics = ["TypeScriptCompile"],
+    output = "$(ACTION_ID).typescript.kzip",
+)
+
+extractor_action(
+    name = "extract_kzip_protobuf",
+    args = [
+        "--extra_action=$(EXTRA_ACTION_FILE)",
+        "--language=protobuf",
+        "--rules=$(location :vnames_config)",
+        "--output=$(output $(ACTION_ID).protobuf.kzip)",
+    ],
+    data = [":vnames_config"],
+    extractor = ":bazel_proto_extractor",
+    mnemonics = ["GenProtoDescriptorSet"],
+    output = "$(ACTION_ID).protobuf.kzip",
+)

--- a/kythe/extractors/bazel/extractors.WORKSPACE
+++ b/kythe/extractors/bazel/extractors.WORKSPACE
@@ -1,0 +1,1 @@
+workspace(name = "kythe_extractors")

--- a/kythe/extractors/bazel/extractors.bazelrc
+++ b/kythe/extractors/bazel/extractors.bazelrc
@@ -1,0 +1,19 @@
+# Setup the local repository for the Kythe extraction tools.
+build --override_repository kythe_extractors=/kythe
+
+# By default, keep building after errors.
+build --keep_going
+
+# By default, only extract specified top level targets.
+build --experimental_extra_action_top_level_only
+
+# Generate metadata for Java protocol buffer generated code.
+build --proto_toolchain_for_java=@kythe_extractors//:java_proto_toolchain
+
+# Enable all supported Kythe extractors.
+build --experimental_action_listener=@kythe_extractors//:extract_kzip_cxx
+build --experimental_action_listener=@kythe_extractors//:extract_kzip_go
+build --experimental_action_listener=@kythe_extractors//:extract_kzip_java
+build --experimental_action_listener=@kythe_extractors//:extract_kzip_jvm
+build --experimental_action_listener=@kythe_extractors//:extract_kzip_protobuf
+build --experimental_action_listener=@kythe_extractors//:extract_kzip_typescript

--- a/tools/build_rules/docker.bzl
+++ b/tools/build_rules/docker.bzl
@@ -10,7 +10,7 @@ def docker_build(
 
     data_locs = []
     for d in data:
-        data_locs += ["$(location " + d + ")"]
+        data_locs += ["$(locations " + d + ")"]
 
     args = []
     if not use_cache:


### PR DESCRIPTION
Use pre-built extractor binaries to create a local Bazel repository to
use as a source of extra actions.  Add all common Kythe configuration to
the builder's .bazelrc file and use a simple script to collect the .kzip
artifacts after a Bazel execution.