### PR TITLE
fix(cxx_common): anticipate changes in Bison 3.3 syntax

### DIFF
--- a/kythe/cxx/verifier/assertions.yy
+++ b/kythe/cxx/verifier/assertions.yy
@@ -1,5 +1,4 @@
 // Started from the calc++ example code as part of the Bison-3.0 distribution.
-// NOTE: This file must remain compatible with Bison 2.3.
 %skeleton "lalr1.cc"
 %defines
 %define "parser_class_name" "AssertionParserImpl"
@@ -40,7 +39,7 @@ class AssertionParser;
   @$.begin.column = 1;
   @$.end.column = 1;
 };
-%define "parse.trace"
+%define parse.trace
 %{
 #include "kythe/cxx/verifier/assertions.h"
 #define newAst new (context.arena_) kythe::verifier::

--- a/kythe/web/site/getting-started.md
+++ b/kythe/web/site/getting-started.md
@@ -30,7 +30,7 @@ git clone git@github.com:kythe/kythe.git
 Kythe relies on the following external dependencies:
 
 * asciidoc
-* bison-3.0.4 (2.3 is also acceptable)
+* bison-3.0.4
 * clang >= 3.6
 * cmake >= 3.4.3
 * [docker](https://www.docker.com/) (for release images `//kythe/release/...` and `//buildtools/docker`)


### PR DESCRIPTION
Also drop official support for ancient Bisons.