### PR TITLE
fix(dev): use POSIX safe flags for tr

### DIFF
--- a/kythe/data/vnames.bzl
+++ b/kythe/data/vnames.bzl
@@ -28,7 +28,7 @@ def _construct_vnames_config_impl(ctx):
         command = "\n".join([
             "set -e -o pipefail",
             "cat " + " ".join([src.path for src in srcs]) + " | " +
-            "tr --delete '\n' | sed 's/\]\[/,/g' > " + merged.path,
+            "tr -d '\n' | sed 's/\]\[/,/g' > " + merged.path,
         ]),
     )
     ctx.actions.expand_template(


### PR DESCRIPTION
The build rules for the VName test data fail on macOS because we used the
GNU-supported --delete flag instead of POSIX-recommended -d. All the Linuces
support -d just fine with the same semantics, so this has no discernable effect
on the results.