### PR TITLE
fix(dev): allow specification of a correct Bison version

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -7,6 +7,9 @@ build --auto_cpu_environment_group=//buildenv:cpu
 # Ensure clang is used, by default, over any other C++ installation (e.g. gcc).
 build --client_env=CC=clang
 
+# Allow the user to override the Bison installation.
+build --action_env=BISON
+
 # Ensure environment variables are static across machines; allows for cross-user caching.
 build --experimental_strict_action_env
 

--- a/kythe/cxx/verifier/assertions.yy
+++ b/kythe/cxx/verifier/assertions.yy
@@ -1,7 +1,7 @@
 // Started from the calc++ example code as part of the Bison-3.0 distribution.
 %skeleton "lalr1.cc"
 %defines
-%define "parser_class_name" "AssertionParserImpl"
+%define api.parser.class {AssertionParserImpl}
 %{
 /*
  * Copyright 2014 The Kythe Authors. All rights reserved.
@@ -76,7 +76,7 @@ class AssertionParser;
 %type <int_> location_spec
 %type <int_> location_spec_hash
 %type <size_t_> exp_tuple_plus
-%error-verbose
+%define parse.error verbose
 %%
 %start unit;
 unit: goals  { };

--- a/kythe/cxx/verifier/assertions.yy
+++ b/kythe/cxx/verifier/assertions.yy
@@ -1,7 +1,7 @@
 // Started from the calc++ example code as part of the Bison-3.0 distribution.
 %skeleton "lalr1.cc"
 %defines
-%define api.parser.class {AssertionParserImpl}
+%define parser_class_name {AssertionParserImpl}
 %{
 /*
  * Copyright 2014 The Kythe Authors. All rights reserved.

--- a/kythe/data/vnames.bzl
+++ b/kythe/data/vnames.bzl
@@ -28,7 +28,7 @@ def _construct_vnames_config_impl(ctx):
         command = "\n".join([
             "set -e -o pipefail",
             "cat " + " ".join([src.path for src in srcs]) + " | " +
-            "tr --delete '\n' | sed 's/\]\[/,/g' > " + merged.path,
+            "tr -d '\n' | sed 's/\]\[/,/g' > " + merged.path,
         ]),
     )
     ctx.actions.expand_template(

--- a/kythe/web/site/getting-started-macos.md
+++ b/kythe/web/site/getting-started-macos.md
@@ -59,7 +59,7 @@ rest of these instructions assume you have it.
 To install most of the [external dependencies][ext], run
 
 {% highlight bash %}
-for pkg in asciidoc cmake go graphviz node parallel source-highlight wget ; do
+for pkg in asciidoc bison cmake go graphviz node parallel source-highlight wget ; do
    brew install $pkg
 done
 
@@ -71,6 +71,10 @@ done
 brew tap bazelbuild/tap
 brew tap-pin bazelbuild/tap
 brew install bazelbuild/tap/bazel
+
+# Bison. The stock version is too old, but Bison is keg-only and Bazel uses
+# a restricted PATH, so we need to tell Bazel where to find bison (see #3514):
+export BISON=/usr/local/opt/bison/bin/bison
 
 # Docker: See the instructions below.
 # DO NOT use brew install docker (or if you did: brew uninstall docker).

--- a/tools/build_rules/lexyacc.bzl
+++ b/tools/build_rules/lexyacc.bzl
@@ -25,8 +25,7 @@ def genyacc(name, src, header_out, source_out, extra_outs = []):
       source_out: The generated source file.
       extra_outs: Additional generated outputs.
     """
-    arg_adjust = "$$(bison --version | grep -qE '^bison .* 3\..*' && echo -Wno-deprecated)"
-    cmd = "bison %s -o $(@D)/%s $(location %s)" % (arg_adjust, source_out, src)
+    cmd = "$${BISON:-bison} -o $(@D)/%s $(location %s)" % (source_out, src)
     native.genrule(
         name = name,
         outs = [source_out, header_out] + extra_outs,


### PR DESCRIPTION
Updates #3514. In #3513 we stipulated that Bison 3 must be used. On macOS,
which ships with Bison 2, this requires installing a new version.

However, the obvious way to do so, via Homebrew, brings in Bison 3.3.2 for
which the verifier's grammar file (assertions.yy) contains some no-longer-valid
definitions.  Moreover, Homebrew installs bison as "keg-only" meaning it is not
linked into the user's PATH. This presents a tricky setup problem, since users
configure their path in very different ways.

To address these issues, this change does several small things:

1. Add bison as a macOS dependency.

2. Allow a BISON environment variable to be set, that will be plumbed through
   by Bazel to the environmento of actions.

3. Update the build rules to address the environment variable where set, with a
   default fallback to the existing ("use ambient") behaviour.

N.B.: This change depends on (and incorporates) #3515. I recommend landing that one before merging this.