### PR TITLE
fix(dev): provide a starting point for the find command

### DIFF
--- a/kythe/docs/asciidoc.bzl
+++ b/kythe/docs/asciidoc.bzl
@@ -67,7 +67,7 @@ def _asciidoc_impl(ctx):
             "fi",
 
             # Move any generated images to the out directory.
-            "find -name '*.svg' -maxdepth 1 -exec mv '{}' out/ \;",
+            "find . -name '*.svg' -maxdepth 1 -exec mv '{}' out/ \;",
 
             # Package up the outputs into the zip file.
             "(cd out; zip -9qr ../%s *)" % ctx.outputs.out.path,


### PR DESCRIPTION
GNU find will default to "." if run without any starting directories.  But in
POSIX the path is not optional, and macOS find fails if there is a flag before
any paths have been seen. The GNU behaviour is arguably better, but this makes
the docs build cleaner on macOS.