### PR TITLE
fix(dev): include brotli and leveldb in the macOS package list

### DIFF
--- a/kythe/web/site/getting-started-macos.md
+++ b/kythe/web/site/getting-started-macos.md
@@ -59,7 +59,7 @@ rest of these instructions assume you have it.
 To install most of the [external dependencies][ext], run
 
 {% highlight bash %}
-for pkg in asciidoc bison cmake go graphviz node parallel source-highlight wget ; do
+for pkg in asciidoc bison brotli cmake go graphviz leveldb node parallel source-highlight wget ; do
    brew install $pkg
 done
 


### PR DESCRIPTION
In order for the native Go build to work on macOS, we need brotli and leveldb
to satisfy C++ header dependencies. Homebrew has cromulent packages for these,
so it suffices to include them in the install list.