### PR TITLE
fix(build): remove duplicate src paths in java_extract_kzip

### DIFF
--- a/tools/build_rules/verifier_test/java_verifier_test.bzl
+++ b/tools/build_rules/verifier_test/java_verifier_test.bzl
@@ -88,8 +88,6 @@ def _java_extract_kzip_impl(ctx):
     ]
     for params in params_files:
         args += ["@" + params.path]
-    for src in srcs:
-        args += [src.short_path]
     extract(
         srcs = srcs,
         ctx = ctx,


### PR DESCRIPTION
java_extract_kzip() calls extract(), which handles passing src paths
to the underlying extractor:
https://github.com/kythe/kythe/blob/448d46e8bb30c16345d516f09b6904e92b7a05cf/tools/build_rules/verifier_test/verifier_test.bzl#L147-L157.