### PR TITLE
fix: pin gcp extraction example and tests to :stable

### DIFF
--- a/kythe/extractors/gcp/examples/gradle.yaml
+++ b/kythe/extractors/gcp/examples/gradle.yaml
@@ -16,14 +16,14 @@ steps:
   args: ['mkdir', '/workspace/out']
   waitFor:
     - '-'
-- name: 'gcr.io/kythe-public/kythe-javac-extractor-artifacts'
+- name: 'gcr.io/kythe-public/kythe-javac-extractor-artifacts:stable'
   volumes:
     - name: 'kythe_extractors'
       path: '/opt/kythe/extractors'
   id: 'JAVA-ARTIFACTS'
   waitFor:
     - '-'
-- name: 'gcr.io/kythe-public/build-preprocessor'
+- name: 'gcr.io/kythe-public/build-preprocessor:stable'
   args: ['/workspace/code/build.gradle']
   id: 'PREPROCESS'
   waitFor:
@@ -53,7 +53,7 @@ steps:
   waitFor:
     - 'JAVA-ARTIFACTS'
     - 'PREPROCESS'
-- name: 'gcr.io/kythe-public/kzip-tools'
+- name: 'gcr.io/kythe-public/kzip-tools:stable'
   entrypoint: 'bash'
   args:
   - '-c'

--- a/kythe/extractors/gcp/examples/guava-android-mvn.yaml
+++ b/kythe/extractors/gcp/examples/guava-android-mvn.yaml
@@ -12,13 +12,13 @@ steps:
 - name: 'ubuntu'
   args: ['mkdir', '/workspace/out']
   waitFor: ['-']
-- name: 'gcr.io/kythe-public/kythe-javac-extractor-artifacts'
+- name: 'gcr.io/kythe-public/kythe-javac-extractor-artifacts:stable'
   volumes:
     - name: 'kythe_extractors'
       path: '/opt/kythe/extractors'
   id: 'JAVA-ARTIFACTS'
   waitFor: ['-']
-- name: 'gcr.io/kythe-public/build-preprocessor'
+- name: 'gcr.io/kythe-public/build-preprocessor:stable'
   args: ['/workspace/code/android/pom.xml']
   id: 'PREPROCESS'
   waitFor:
@@ -50,7 +50,7 @@ steps:
   waitFor:
     - 'JAVA-ARTIFACTS'
     - 'PREPROCESS'
-- name: 'gcr.io/kythe-public/kzip-tools'
+- name: 'gcr.io/kythe-public/kzip-tools:stable'
   entrypoint: 'bash'
   args: ['-c', '/opt/kythe/tools/kzip merge --output /workspace/out/guava-android-${_VERSION}.kzip /workspace/out/*.kzip']
 artifacts:

--- a/kythe/extractors/gcp/examples/guava-mvn.yaml
+++ b/kythe/extractors/gcp/examples/guava-mvn.yaml
@@ -12,13 +12,13 @@ steps:
 - name: 'ubuntu'
   args: ['mkdir', '/workspace/out']
   waitFor: ['-']
-- name: 'gcr.io/kythe-public/kythe-javac-extractor-artifacts'
+- name: 'gcr.io/kythe-public/kythe-javac-extractor-artifacts:stable'
   volumes:
     - name: 'kythe_extractors'
       path: '/opt/kythe/extractors'
   id: 'JAVA-ARTIFACTS'
   waitFor: ['-']
-- name: 'gcr.io/kythe-public/build-preprocessor'
+- name: 'gcr.io/kythe-public/build-preprocessor:stable'
   args: ['/workspace/code/pom.xml']
   id: 'PREPROCESS'
   waitFor:
@@ -50,7 +50,7 @@ steps:
   waitFor:
     - 'JAVA-ARTIFACTS'
     - 'PREPROCESS'
-- name: 'gcr.io/kythe-public/kzip-tools'
+- name: 'gcr.io/kythe-public/kzip-tools:stable'
   entrypoint: 'bash'
   args: ['-c', '/opt/kythe/tools/kzip merge --output /workspace/out/guava-${_VERSION}.kzip /workspace/out/*.kzip']
 artifacts:

--- a/kythe/extractors/gcp/examples/mvn.yaml
+++ b/kythe/extractors/gcp/examples/mvn.yaml
@@ -12,13 +12,13 @@ steps:
 - name: 'ubuntu'
   args: ['mkdir', '/workspace/out']
   waitFor: ['-']
-- name: 'gcr.io/kythe-public/kythe-javac-extractor-artifacts'
+- name: 'gcr.io/kythe-public/kythe-javac-extractor-artifacts:stable'
   volumes:
     - name: 'kythe_extractors'
       path: '/opt/kythe/extractors'
   id: 'JAVA-ARTIFACTS'
   waitFor: ['-']
-- name: 'gcr.io/kythe-public/build-preprocessor'
+- name: 'gcr.io/kythe-public/build-preprocessor:stable'
   args: ['/workspace/code/pom.xml']
   id: 'PREPROCESS'
   waitFor:
@@ -50,7 +50,7 @@ steps:
   waitFor:
     - 'JAVA-ARTIFACTS'
     - 'PREPROCESS'
-- name: 'gcr.io/kythe-public/kzip-tools'
+- name: 'gcr.io/kythe-public/kzip-tools:stable'
   entrypoint: 'bash'
   args: ['-c', '/opt/kythe/tools/kzip merge --output /workspace/out/${_CORPUS}-${_VERSION}.kzip /workspace/out/*.kzip']
 artifacts:

--- a/kythe/go/extractors/constants/constants.go
+++ b/kythe/go/extractors/constants/constants.go
@@ -20,7 +20,7 @@ package constants
 var (
 	// KytheBuildPreprocessorImage is defiend in
 	// kythe/go/extractors/config/preprocessor, and is published to GCR.
-	KytheBuildPreprocessorImage = "gcr.io/kythe-public/build-preprocessor"
+	KytheBuildPreprocessorImage = "gcr.io/kythe-public/build-preprocessor:stable"
 
 	// DefaultExtractorsDir is the canonical directory for extractors that any
 	// kythe docker image will use.  This can be useful if you need to load that
@@ -33,7 +33,7 @@ var (
 	// KytheJavacExtractorArtifactsImage is defined in
 	// kythe/java/com/google/devtools/kythe/extractors/java/artifacts, and
 	// published to GCR.
-	KytheJavacExtractorArtifactsImage = "gcr.io/kythe-public/kythe-javac-extractor-artifacts"
+	KytheJavacExtractorArtifactsImage = "gcr.io/kythe-public/kythe-javac-extractor-artifacts:stable"
 
 	// DefaultJavacWrapperLocation is the location of the Kythe wrapper around
 	// javac that does extraction.
@@ -48,7 +48,7 @@ var (
 	// kythe/go/platform/tools/kzip and published to GCR via
 	// kythe/go/extractors/gcp/config/kziptool:artifacts.  It is a utility for
 	// manipulating .kzip files.
-	KytheKzipToolsImage = "gcr.io/kythe-public/kzip-tools"
+	KytheKzipToolsImage = "gcr.io/kythe-public/kzip-tools:stable"
 
 	// DefaultKzipToolLocation is the location of tools/kzip binary defined in
 	// the gcr.io/kythe-public/kzip-tools image.

--- a/kythe/go/extractors/gcp/config/testdata/gradle-subdir.yaml
+++ b/kythe/go/extractors/gcp/config/testdata/gradle-subdir.yaml
@@ -28,7 +28,7 @@ steps:
   waitFor:
   - '-'
 - id: JAVA-ARTIFACTS
-  name: gcr.io/kythe-public/kythe-javac-extractor-artifacts
+  name: gcr.io/kythe-public/kythe-javac-extractor-artifacts:stable
   volumes:
   - name: kythe_extractors
     path: /opt/kythe/extractors
@@ -37,7 +37,7 @@ steps:
 - args:
   - /workspace/code/othersubdir/build.gradle
   id: PREPROCESS
-  name: gcr.io/kythe-public/build-preprocessor
+  name: gcr.io/kythe-public/build-preprocessor:stable
   waitFor:
   - CHECKOUT
 - args:
@@ -70,4 +70,4 @@ steps:
   - /opt/kythe/tools/kzip merge --output /workspace/out/${_CORPUS}-${_VERSION}.kzip
     /workspace/out/*.kzip
   entrypoint: bash
-  name: gcr.io/kythe-public/kzip-tools
+  name: gcr.io/kythe-public/kzip-tools:stable

--- a/kythe/go/extractors/gcp/config/testdata/gradle.yaml
+++ b/kythe/go/extractors/gcp/config/testdata/gradle.yaml
@@ -28,7 +28,7 @@ steps:
   waitFor:
   - '-'
 - id: JAVA-ARTIFACTS
-  name: gcr.io/kythe-public/kythe-javac-extractor-artifacts
+  name: gcr.io/kythe-public/kythe-javac-extractor-artifacts:stable
   volumes:
   - name: kythe_extractors
     path: /opt/kythe/extractors
@@ -37,7 +37,7 @@ steps:
 - args:
   - /workspace/code/build.gradle
   id: PREPROCESS
-  name: gcr.io/kythe-public/build-preprocessor
+  name: gcr.io/kythe-public/build-preprocessor:stable
   waitFor:
   - CHECKOUT
 - args:
@@ -70,4 +70,4 @@ steps:
   - /opt/kythe/tools/kzip merge --output /workspace/out/${_CORPUS}-${_VERSION}.kzip
     /workspace/out/*.kzip
   entrypoint: bash
-  name: gcr.io/kythe-public/kzip-tools
+  name: gcr.io/kythe-public/kzip-tools:stable

--- a/kythe/go/extractors/gcp/config/testdata/mvn-multi.yaml
+++ b/kythe/go/extractors/gcp/config/testdata/mvn-multi.yaml
@@ -27,7 +27,7 @@ steps:
   name: ubuntu
   waitFor:
   - '-'
-- name: gcr.io/kythe-public/kythe-javac-extractor-artifacts
+- name: gcr.io/kythe-public/kythe-javac-extractor-artifacts:stable
   id: JAVA-ARTIFACTS
   volumes:
   - name: kythe_extractors
@@ -37,7 +37,7 @@ steps:
 - args:
   - /workspace/code/pom.xml
   id: PREPROCESS0
-  name: gcr.io/kythe-public/build-preprocessor
+  name: gcr.io/kythe-public/build-preprocessor:stable
   waitFor:
     - CHECKOUT
 - args:
@@ -70,7 +70,7 @@ steps:
 - args:
   - /workspace/code/somesubdir/pom.xml
   id: PREPROCESS1
-  name: gcr.io/kythe-public/build-preprocessor
+  name: gcr.io/kythe-public/build-preprocessor:stable
   waitFor:
     - CHECKOUT
 - args:
@@ -104,4 +104,4 @@ steps:
   - -c
   - /opt/kythe/tools/kzip merge --output /workspace/out/${_CORPUS}-${_VERSION}.kzip /workspace/out/*.kzip
   entrypoint: bash
-  name: gcr.io/kythe-public/kzip-tools
+  name: gcr.io/kythe-public/kzip-tools:stable

--- a/kythe/go/extractors/gcp/config/testdata/mvn-subdir.yaml
+++ b/kythe/go/extractors/gcp/config/testdata/mvn-subdir.yaml
@@ -27,7 +27,7 @@ steps:
   name: ubuntu
   waitFor:
   - '-'
-- name: gcr.io/kythe-public/kythe-javac-extractor-artifacts
+- name: gcr.io/kythe-public/kythe-javac-extractor-artifacts:stable
   id: JAVA-ARTIFACTS
   volumes:
   - name: kythe_extractors
@@ -37,7 +37,7 @@ steps:
 - args:
   - /workspace/code/somesubdir/pom.xml
   id: PREPROCESS
-  name: gcr.io/kythe-public/build-preprocessor
+  name: gcr.io/kythe-public/build-preprocessor:stable
   waitFor:
     - CHECKOUT
 - args:
@@ -71,4 +71,4 @@ steps:
   - -c
   - /opt/kythe/tools/kzip merge --output /workspace/out/${_CORPUS}-${_VERSION}.kzip /workspace/out/*.kzip
   entrypoint: bash
-  name: gcr.io/kythe-public/kzip-tools
+  name: gcr.io/kythe-public/kzip-tools:stable

--- a/kythe/go/extractors/gcp/config/testdata/mvn.yaml
+++ b/kythe/go/extractors/gcp/config/testdata/mvn.yaml
@@ -27,7 +27,7 @@ steps:
   name: ubuntu
   waitFor:
   - '-'
-- name: gcr.io/kythe-public/kythe-javac-extractor-artifacts
+- name: gcr.io/kythe-public/kythe-javac-extractor-artifacts:stable
   id: JAVA-ARTIFACTS
   volumes:
   - name: kythe_extractors
@@ -37,7 +37,7 @@ steps:
 - args:
   - /workspace/code/pom.xml
   id: PREPROCESS
-  name: gcr.io/kythe-public/build-preprocessor
+  name: gcr.io/kythe-public/build-preprocessor:stable
   waitFor:
     - CHECKOUT
 - args:
@@ -71,4 +71,4 @@ steps:
   - -c
   - /opt/kythe/tools/kzip merge --output /workspace/out/${_CORPUS}-${_VERSION}.kzip /workspace/out/*.kzip
   entrypoint: bash
-  name: gcr.io/kythe-public/kzip-tools
+  name: gcr.io/kythe-public/kzip-tools:stable


### PR DESCRIPTION
I have separately tagged all of our gcr.io/kythe-public images with
stable.