### PR TITLE
fix: remove javac-extractor.err and .out printing from javac-wrapper.sh

### DIFF
--- a/kythe/extractors/gcp/examples/gradle.yaml
+++ b/kythe/extractors/gcp/examples/gradle.yaml
@@ -41,7 +41,6 @@ steps:
     - 'KYTHE_ROOT_DIRECTORY=/workspace/code'
     - 'JAVAC_EXTRACTOR_JAR=/opt/kythe/extractors/javac_extractor.jar'
     - 'REAL_JAVAC=/usr/bin/javac'
-    - 'TMPDIR=/workspace/out'
     - 'KYTHE_JAVA_RUNTIME_OPTIONS=-Xbootclasspath/p:/opt/kythe/extractors/javac9_tools.jar'
   volumes:
     - name: 'kythe_extractors'
@@ -59,6 +58,5 @@ artifacts:
   objects:
     location: 'gs://${_BUCKET_NAME}/${_CORPUS}/'
     paths:
-      - '/workspace/out/javac-extractor.err'
       - '/workspace/out/${_COMMIT}.kzip'
 

--- a/kythe/extractors/gcp/examples/guava-android-mvn.yaml
+++ b/kythe/extractors/gcp/examples/guava-android-mvn.yaml
@@ -40,7 +40,6 @@ steps:
     - 'KYTHE_ROOT_DIRECTORY=/workspace/code/android'
     - 'JAVAC_EXTRACTOR_JAR=/opt/kythe/extractors/javac_extractor.jar'
     - 'REAL_JAVAC=/usr/bin/javac'
-    - 'TMPDIR=/workspace/out'
     - 'KYTHE_JAVA_RUNTIME_OPTIONS=-Xbootclasspath/p:/opt/kythe/extractors/javac9_tools.jar'
   volumes:
     - name: 'kythe_extractors'
@@ -56,6 +55,5 @@ artifacts:
   objects:
     location: 'gs://${_BUCKET_NAME}/guava-android/'
     paths:
-      - '/workspace/out/javac-extractor.err'
       - '/workspace/out/${_COMMIT}.kzip'
 

--- a/kythe/extractors/gcp/examples/guava-mvn.yaml
+++ b/kythe/extractors/gcp/examples/guava-mvn.yaml
@@ -40,7 +40,6 @@ steps:
     - 'KYTHE_ROOT_DIRECTORY=/workspace/code'
     - 'JAVAC_EXTRACTOR_JAR=/opt/kythe/extractors/javac_extractor.jar'
     - 'REAL_JAVAC=/usr/bin/javac'
-    - 'TMPDIR=/workspace/out'
     - 'KYTHE_JAVA_RUNTIME_OPTIONS=-Xbootclasspath/p:/opt/kythe/extractors/javac9_tools.jar'
   volumes:
     - name: 'kythe_extractors'
@@ -56,6 +55,5 @@ artifacts:
   objects:
     location: 'gs://${_BUCKET_NAME}/guava/'
     paths:
-      - '/workspace/out/javac-extractor.err'
       - '/workspace/out/${_COMMIT}.kzip'
 

--- a/kythe/extractors/gcp/examples/mvn.yaml
+++ b/kythe/extractors/gcp/examples/mvn.yaml
@@ -40,7 +40,6 @@ steps:
     - 'KYTHE_ROOT_DIRECTORY=/workspace/code'
     - 'JAVAC_EXTRACTOR_JAR=/opt/kythe/extractors/javac_extractor.jar'
     - 'REAL_JAVAC=/usr/bin/javac'
-    - 'TMPDIR=/workspace/out'
     - 'KYTHE_JAVA_RUNTIME_OPTIONS=-Xbootclasspath/p:/opt/kythe/extractors/javac9_tools.jar'
   volumes:
     - name: 'kythe_extractors'
@@ -56,6 +55,5 @@ artifacts:
   objects:
     location: 'gs://${_BUCKET_NAME}/${_CORPUS}/'
     paths:
-      - '/workspace/out/javac-extractor.err'
       - '/workspace/out/${_COMMIT}.kzip'
 

--- a/kythe/go/extractors/gcp/config/converter.go
+++ b/kythe/go/extractors/gcp/config/converter.go
@@ -107,7 +107,6 @@ func KytheToBuild(conf *rpb.Config) (*cloudbuild.Build, error) {
 	if err != nil {
 		return nil, err
 	}
-	build.Artifacts.Objects.Paths = append(g.additionalArtifacts(), build.Artifacts.Objects.Paths...)
 
 	build.Steps = append(build.Steps, g.preExtractSteps()...)
 
@@ -162,9 +161,6 @@ type buildSystemElaborator interface {
 	// configuration file for a repo of a given type.  For example for a bazel
 	// repo it might just be root/BUILD, or a maven repo will have repo/pom.xml.
 	defaultExtractionTarget() *rpb.ExtractionTarget
-	// additionalArtifacts should be prepended to the list of artifacts returned
-	// from the cloudbuild invocation.
-	additionalArtifacts() []string
 }
 
 func generator(b rpb.BuildSystem) (buildSystemElaborator, error) {

--- a/kythe/go/extractors/gcp/config/gradle.go
+++ b/kythe/go/extractors/gcp/config/gradle.go
@@ -70,7 +70,6 @@ func (g gradleGenerator) extractSteps(corpus string, target *rpb.ExtractionTarge
 				"KYTHE_ROOT_DIRECTORY=" + filepath.Join(codeDirectory, targetPath),
 				"JAVAC_EXTRACTOR_JAR=" + constants.DefaultJavaExtractorLocation,
 				"REAL_JAVAC=" + constants.DefaultJavacLocation,
-				"TMPDIR=" + outputDirectory,
 				"KYTHE_JAVA_RUNTIME_OPTIONS=-Xbootclasspath/p:" + constants.DefaultJava9ToolsLocation,
 			},
 			Id:      extractStepID + idSuffix,
@@ -91,9 +90,4 @@ func (g gradleGenerator) defaultExtractionTarget() *rpb.ExtractionTarget {
 	return &rpb.ExtractionTarget{
 		Path: "build.gradle",
 	}
-}
-
-// additionalArtifacts implements part of buildStepsGenerator
-func (g gradleGenerator) additionalArtifacts() []string {
-	return []string{path.Join(outputDirectory, "javac-extractor.err")}
 }

--- a/kythe/go/extractors/gcp/config/maven.go
+++ b/kythe/go/extractors/gcp/config/maven.go
@@ -74,7 +74,6 @@ func (m mavenGenerator) extractSteps(corpus string, target *rpb.ExtractionTarget
 				"KYTHE_ROOT_DIRECTORY=" + filepath.Join(codeDirectory, targetPath),
 				"JAVAC_EXTRACTOR_JAR=" + constants.DefaultJavaExtractorLocation,
 				"REAL_JAVAC=" + constants.DefaultJavacLocation,
-				"TMPDIR=" + outputDirectory,
 				"KYTHE_JAVA_RUNTIME_OPTIONS=-Xbootclasspath/p:" + constants.DefaultJava9ToolsLocation,
 			},
 			Id:      extractStepID + idSuffix,
@@ -95,9 +94,4 @@ func (m mavenGenerator) defaultExtractionTarget() *rpb.ExtractionTarget {
 	return &rpb.ExtractionTarget{
 		Path: "pom.xml",
 	}
-}
-
-// additionalArtifacts implements part of buildSystemElaborator
-func (m mavenGenerator) additionalArtifacts() []string {
-	return []string{path.Join(outputDirectory, "javac-extractor.err")}
 }

--- a/kythe/go/extractors/gcp/config/testdata/gradle-subdir.yaml
+++ b/kythe/go/extractors/gcp/config/testdata/gradle-subdir.yaml
@@ -2,7 +2,6 @@ artifacts:
   objects:
     location: gs://${_BUCKET_NAME}/${_CORPUS}/
     paths:
-    - /workspace/out/javac-extractor.err
     - /workspace/out/${_COMMIT}.kzip
 steps:
 - args:
@@ -52,7 +51,6 @@ steps:
   - KYTHE_ROOT_DIRECTORY=/workspace/code/othersubdir
   - JAVAC_EXTRACTOR_JAR=/opt/kythe/extractors/javac_extractor.jar
   - REAL_JAVAC=/usr/bin/javac
-  - TMPDIR=/workspace/out
   - KYTHE_JAVA_RUNTIME_OPTIONS=-Xbootclasspath/p:/opt/kythe/extractors/javac9_tools.jar
   id: EXTRACT
   name: gradle:5.2.1-jdk8-slim

--- a/kythe/go/extractors/gcp/config/testdata/gradle.yaml
+++ b/kythe/go/extractors/gcp/config/testdata/gradle.yaml
@@ -2,7 +2,6 @@ artifacts:
   objects:
     location: gs://${_BUCKET_NAME}/${_CORPUS}/
     paths:
-    - /workspace/out/javac-extractor.err
     - /workspace/out/${_COMMIT}.kzip
 steps:
 - args:
@@ -52,7 +51,6 @@ steps:
   - KYTHE_ROOT_DIRECTORY=/workspace/code
   - JAVAC_EXTRACTOR_JAR=/opt/kythe/extractors/javac_extractor.jar
   - REAL_JAVAC=/usr/bin/javac
-  - TMPDIR=/workspace/out
   - KYTHE_JAVA_RUNTIME_OPTIONS=-Xbootclasspath/p:/opt/kythe/extractors/javac9_tools.jar
   id: EXTRACT
   name: gradle:5.2.1-jdk8-slim

--- a/kythe/go/extractors/gcp/config/testdata/mvn-multi.yaml
+++ b/kythe/go/extractors/gcp/config/testdata/mvn-multi.yaml
@@ -2,7 +2,6 @@ artifacts:
   objects:
     location: gs://${_BUCKET_NAME}/${_CORPUS}/
     paths:
-    - /workspace/out/javac-extractor.err
     - /workspace/out/${_COMMIT}.kzip
 steps:
 - args:
@@ -56,7 +55,6 @@ steps:
   - KYTHE_ROOT_DIRECTORY=/workspace/code
   - JAVAC_EXTRACTOR_JAR=/opt/kythe/extractors/javac_extractor.jar
   - REAL_JAVAC=/usr/bin/javac
-  - TMPDIR=/workspace/out
   - KYTHE_JAVA_RUNTIME_OPTIONS=-Xbootclasspath/p:/opt/kythe/extractors/javac9_tools.jar
   id: EXTRACT0
   name: maven:3.6.0-jdk-8-slim
@@ -88,7 +86,6 @@ steps:
   - KYTHE_ROOT_DIRECTORY=/workspace/code/somesubdir
   - JAVAC_EXTRACTOR_JAR=/opt/kythe/extractors/javac_extractor.jar
   - REAL_JAVAC=/usr/bin/javac
-  - TMPDIR=/workspace/out
   - KYTHE_JAVA_RUNTIME_OPTIONS=-Xbootclasspath/p:/opt/kythe/extractors/javac9_tools.jar
   id: EXTRACT1
   name: maven:3.6.0-jdk-8-slim

--- a/kythe/go/extractors/gcp/config/testdata/mvn-subdir.yaml
+++ b/kythe/go/extractors/gcp/config/testdata/mvn-subdir.yaml
@@ -2,7 +2,6 @@ artifacts:
   objects:
     location: gs://${_BUCKET_NAME}/${_CORPUS}/
     paths:
-    - /workspace/out/javac-extractor.err
     - /workspace/out/${_COMMIT}.kzip
 steps:
 - args:
@@ -56,7 +55,6 @@ steps:
   - KYTHE_ROOT_DIRECTORY=/workspace/code/somesubdir
   - JAVAC_EXTRACTOR_JAR=/opt/kythe/extractors/javac_extractor.jar
   - REAL_JAVAC=/usr/bin/javac
-  - TMPDIR=/workspace/out
   - KYTHE_JAVA_RUNTIME_OPTIONS=-Xbootclasspath/p:/opt/kythe/extractors/javac9_tools.jar
   id: EXTRACT
   name: maven:3.6.0-jdk-8-slim

--- a/kythe/go/extractors/gcp/config/testdata/mvn.yaml
+++ b/kythe/go/extractors/gcp/config/testdata/mvn.yaml
@@ -2,7 +2,6 @@ artifacts:
   objects:
     location: gs://${_BUCKET_NAME}/${_CORPUS}/
     paths:
-    - /workspace/out/javac-extractor.err
     - /workspace/out/${_COMMIT}.kzip
 steps:
 - args:
@@ -56,7 +55,6 @@ steps:
   - KYTHE_ROOT_DIRECTORY=/workspace/code
   - JAVAC_EXTRACTOR_JAR=/opt/kythe/extractors/javac_extractor.jar
   - REAL_JAVAC=/usr/bin/javac
-  - TMPDIR=/workspace/out
   - KYTHE_JAVA_RUNTIME_OPTIONS=-Xbootclasspath/p:/opt/kythe/extractors/javac9_tools.jar
   id: EXTRACT
   name: maven:3.6.0-jdk-8-slim

--- a/kythe/java/com/google/devtools/kythe/extractors/java/standalone/javac-wrapper.sh
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/standalone/javac-wrapper.sh
@@ -38,7 +38,6 @@
 #
 # Other environment variables that may be passed to this script include:
 #   KYTHE_EXTRACT_ONLY: if set, suppress the call to javac after extraction
-#   TMPDIR: override the location of extraction logs and other temporary output
 
 if [[ -z "$JAVA_HOME" ]]; then
   readonly JAVABIN="$(which java)"

--- a/kythe/java/com/google/devtools/kythe/extractors/java/standalone/javac-wrapper.sh
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/standalone/javac-wrapper.sh
@@ -40,8 +40,6 @@
 #   KYTHE_EXTRACT_ONLY: if set, suppress the call to javac after extraction
 #   TMPDIR: override the location of extraction logs and other temporary output
 
-export TMPDIR="${TMPDIR:-/tmp}"
-
 if [[ -z "$JAVA_HOME" ]]; then
   readonly JAVABIN="$(which java)"
 else
@@ -71,8 +69,8 @@ fi
 
 "$JAVABIN" "${KYTHE_JAVA_RUNTIME_OPTIONS[@]}" \
   -jar "$JAVAC_EXTRACTOR_JAR" "$@" \
-  1>>"$TMPDIR"/javac-extractor.out \
-  2>>"$TMPDIR"/javac-extractor.err
+  1> >(sed -e 's/^/EXTRACT OUT: /') \
+  2> >(sed -e 's/^/EXTRACT ERR: /' >&2)
 if [[ -z "$KYTHE_EXTRACT_ONLY" ]]; then
   "$REAL_JAVAC" "$@"
 fi

--- a/kythe/release/release_test.sh
+++ b/kythe/release/release_test.sh
@@ -69,7 +69,6 @@ JAVAC_EXTRACTOR_JAR=$PWD/extractors/javac_extractor.jar \
   KYTHE_EXTRACT_ONLY=1 \
   extractors/javac-wrapper.sh \
   "$TEST_REPOSRCDIR/kythe/java/com/google/devtools/kythe/util"/*.java
-cat "$TMPDIR"/javac-extractor.{out,err}
 test -r "$KYTHE_OUTPUT_FILE"
 java "${KYTHE_JAVA_RUNTIME_OPTIONS[@]}" \
   -jar indexers/java_indexer.jar "$KYTHE_OUTPUT_FILE" | \


### PR DESCRIPTION
Since we won't be able to have all extractors and wrappers outputting
clean err/out files like this one does, we'll instead just always print
inline errors.  This also obviates the need to set TMPDIR in
maven/gradle extraction.

This "fixes" #3528 by making it obsolete - no more files, so nothing to
tag.

This starts the ball rolling for #3521, though doesn't really make the
experience around missing kzips any cleaner.