### PR TITLE
chore: remove mkdir step from gcp extraction

### DIFF
--- a/kythe/extractors/gcp/examples/bazel.yaml
+++ b/kythe/extractors/gcp/examples/bazel.yaml
@@ -8,9 +8,6 @@ steps:
   args: ['checkout', '${_COMMIT}']
   dir: '/workspace/code'
   waitFor: ['CLONE']
-- name: 'ubuntu'
-  args: ['mkdir', '/workspace/output']
-  waitFor: ['-']
 - id: 'EXTRACT'
   name: 'gcr.io/kythe-public/bazel-extractor:stable'
   args: ['build', '-k', '--define', 'kythe_corpus=${_CORPUS}', '//...']

--- a/kythe/extractors/gcp/examples/gradle.yaml
+++ b/kythe/extractors/gcp/examples/gradle.yaml
@@ -12,10 +12,6 @@ steps:
   id: 'CHECKOUT'
   waitFor:
     - 'CLONE'
-- name: 'ubuntu'
-  args: ['mkdir', '/workspace/output']
-  waitFor:
-    - '-'
 - name: 'gcr.io/kythe-public/kythe-javac-extractor-artifacts:stable'
   volumes:
     - name: 'kythe_extractors'

--- a/kythe/extractors/gcp/examples/guava-android-mvn.yaml
+++ b/kythe/extractors/gcp/examples/guava-android-mvn.yaml
@@ -9,9 +9,6 @@ steps:
   id: 'CHECKOUT'
   waitFor:
     - 'CLONE'
-- name: 'ubuntu'
-  args: ['mkdir', '/workspace/output']
-  waitFor: ['-']
 - name: 'gcr.io/kythe-public/kythe-javac-extractor-artifacts:stable'
   volumes:
     - name: 'kythe_extractors'

--- a/kythe/extractors/gcp/examples/guava-mvn.yaml
+++ b/kythe/extractors/gcp/examples/guava-mvn.yaml
@@ -9,9 +9,6 @@ steps:
   id: 'CHECKOUT'
   waitFor:
     - 'CLONE'
-- name: 'ubuntu'
-  args: ['mkdir', '/workspace/output']
-  waitFor: ['-']
 - name: 'gcr.io/kythe-public/kythe-javac-extractor-artifacts:stable'
   volumes:
     - name: 'kythe_extractors'

--- a/kythe/extractors/gcp/examples/mvn.yaml
+++ b/kythe/extractors/gcp/examples/mvn.yaml
@@ -9,9 +9,6 @@ steps:
   id: 'CHECKOUT'
   waitFor:
     - 'CLONE'
-- name: 'ubuntu'
-  args: ['mkdir', '/workspace/output']
-  waitFor: ['-']
 - name: 'gcr.io/kythe-public/kythe-javac-extractor-artifacts:stable'
   volumes:
     - name: 'kythe_extractors'

--- a/kythe/go/extractors/gcp/config/common.go
+++ b/kythe/go/extractors/gcp/config/common.go
@@ -57,11 +57,6 @@ func commonSteps(repo string) []*cloudbuild.BuildStep {
 			Id:      checkoutStepID,
 			WaitFor: []string{cloneStepID},
 		},
-		&cloudbuild.BuildStep{
-			Name:    "ubuntu", // This, however, has no entrypoint command.
-			Args:    []string{"mkdir", outputDirectory},
-			WaitFor: []string{"-"},
-		},
 	}
 }
 

--- a/kythe/go/extractors/gcp/config/testdata/bazel-multi.yaml
+++ b/kythe/go/extractors/gcp/config/testdata/bazel-multi.yaml
@@ -21,12 +21,6 @@ steps:
   waitFor:
   - CLONE
 - args:
-  - mkdir
-  - /workspace/output
-  name: ubuntu
-  waitFor:
-  - '-'
-- args:
   - build
   - -k
   - --define

--- a/kythe/go/extractors/gcp/config/testdata/gradle-subdir.yaml
+++ b/kythe/go/extractors/gcp/config/testdata/gradle-subdir.yaml
@@ -20,12 +20,6 @@ steps:
   name: gcr.io/cloud-builders/git
   waitFor:
   - CLONE
-- args:
-  - mkdir
-  - /workspace/output
-  name: ubuntu
-  waitFor:
-  - '-'
 - id: JAVA-ARTIFACTS
   name: gcr.io/kythe-public/kythe-javac-extractor-artifacts:stable
   volumes:

--- a/kythe/go/extractors/gcp/config/testdata/gradle.yaml
+++ b/kythe/go/extractors/gcp/config/testdata/gradle.yaml
@@ -20,12 +20,6 @@ steps:
   name: gcr.io/cloud-builders/git
   waitFor:
   - CLONE
-- args:
-  - mkdir
-  - /workspace/output
-  name: ubuntu
-  waitFor:
-  - '-'
 - id: JAVA-ARTIFACTS
   name: gcr.io/kythe-public/kythe-javac-extractor-artifacts:stable
   volumes:

--- a/kythe/go/extractors/gcp/config/testdata/mvn-multi.yaml
+++ b/kythe/go/extractors/gcp/config/testdata/mvn-multi.yaml
@@ -20,12 +20,6 @@ steps:
   id: CHECKOUT
   waitFor:
    - CLONE
-- args:
-  - mkdir
-  - /workspace/output
-  name: ubuntu
-  waitFor:
-  - '-'
 - name: gcr.io/kythe-public/kythe-javac-extractor-artifacts:stable
   id: JAVA-ARTIFACTS
   volumes:

--- a/kythe/go/extractors/gcp/config/testdata/mvn-subdir.yaml
+++ b/kythe/go/extractors/gcp/config/testdata/mvn-subdir.yaml
@@ -20,12 +20,6 @@ steps:
   id: CHECKOUT
   waitFor:
    - CLONE
-- args:
-  - mkdir
-  - /workspace/output
-  name: ubuntu
-  waitFor:
-  - '-'
 - name: gcr.io/kythe-public/kythe-javac-extractor-artifacts:stable
   id: JAVA-ARTIFACTS
   volumes:

--- a/kythe/go/extractors/gcp/config/testdata/mvn.yaml
+++ b/kythe/go/extractors/gcp/config/testdata/mvn.yaml
@@ -20,12 +20,6 @@ steps:
   id: CHECKOUT
   waitFor:
    - CLONE
-- args:
-  - mkdir
-  - /workspace/output
-  name: ubuntu
-  waitFor:
-  - '-'
 - name: gcr.io/kythe-public/kythe-javac-extractor-artifacts:stable
   id: JAVA-ARTIFACTS
   volumes:


### PR DESCRIPTION
This should have been done when I ported from zipmerge to kzip tool.
It's no longer necessary to make the output directory.