### PR TITLE
chore: allow user-provided bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -50,3 +50,6 @@ build:remote --crosstool_top=@bazel_toolchains//configs/ubuntu16_04_clang/1.1/ba
 build:remote --extra_toolchains=@bazel_toolchains//configs/ubuntu16_04_clang/1.1/bazel_0.20.0/cpp:cc-toolchain-clang-x86_64-default
 
 build:remote --javabase=@bazel_toolchains//configs/ubuntu16_04_clang/1.1:jdk10
+
+# Support user-provided user.bazelrc
+try-import user.bazelrc

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ tools/node
 # Kythe website artifacts
 kythe/web/site/.bundle/
 kythe/web/site/_vendor/
+
+# User bazelrc overrides
+/user.bazelrc


### PR DESCRIPTION
Allow an unversioned user.bazelrc in the project root.  This will allow folks to provide project-specific bazel settings that aren't pushed broadly (like, say, `build --config=remote`).