### PR TITLE
fix(dev): pin the Go version to 1.11.5

### DIFF
--- a/external.bzl
+++ b/external.bzl
@@ -11,7 +11,10 @@ load("@io_kythe//third_party/leiningen:lein_repo.bzl", "lein_repository")
 def _rule_dependencies():
     gazelle_dependencies()
     go_rules_dependencies()
-    go_register_toolchains()
+
+    # TODO(https://github.com/kythe/kythe/issues/3551): Remove the pin once we
+    # figure out why 1.12 doesn't work correctly.
+    go_register_toolchains(go_version = "1.11.5")
     rules_nodejs_dependencies()
 
 def _cc_dependencies():


### PR DESCRIPTION
A workaround for #3551. It is not clear to me how the upgrade managed to pass CI, but builds fail locally on both macOS and Linux after #3548.