### PR TITLE
fix: tag google cloud builds

### DIFF
--- a/kythe/extractors/gcp/examples/bazel.yaml
+++ b/kythe/extractors/gcp/examples/bazel.yaml
@@ -21,4 +21,4 @@ artifacts:
     paths: ['/workspace/output/${_COMMIT}.kzip']
 tags:
   - '${_CORPUS}'
-  - 'extract_bazel'
+  - 'kythe_extract_bazel'

--- a/kythe/extractors/gcp/examples/bazel.yaml
+++ b/kythe/extractors/gcp/examples/bazel.yaml
@@ -19,3 +19,6 @@ artifacts:
   objects:
     location: 'gs://${_BUCKET_NAME}/${_CORPUS}/'
     paths: ['/workspace/output/${_COMMIT}.kzip']
+tags:
+  - '${_CORPUS}'
+  - 'extract_bazel'

--- a/kythe/extractors/gcp/examples/gradle.yaml
+++ b/kythe/extractors/gcp/examples/gradle.yaml
@@ -56,4 +56,6 @@ artifacts:
     location: 'gs://${_BUCKET_NAME}/${_CORPUS}/'
     paths:
       - '/workspace/output/${_COMMIT}.kzip'
-
+tags:
+  - '${_CORPUS}'
+  - 'extract_gradle'

--- a/kythe/extractors/gcp/examples/gradle.yaml
+++ b/kythe/extractors/gcp/examples/gradle.yaml
@@ -58,4 +58,4 @@ artifacts:
       - '/workspace/output/${_COMMIT}.kzip'
 tags:
   - '${_CORPUS}'
-  - 'extract_gradle'
+  - 'kythe_extract_gradle'

--- a/kythe/extractors/gcp/examples/guava-android-mvn.yaml
+++ b/kythe/extractors/gcp/examples/guava-android-mvn.yaml
@@ -54,4 +54,6 @@ artifacts:
     location: 'gs://${_BUCKET_NAME}/guava-android/'
     paths:
       - '/workspace/output/${_COMMIT}.kzip'
-
+tags:
+  - 'guava-android'
+  - 'extract_maven'

--- a/kythe/extractors/gcp/examples/guava-android-mvn.yaml
+++ b/kythe/extractors/gcp/examples/guava-android-mvn.yaml
@@ -56,4 +56,4 @@ artifacts:
       - '/workspace/output/${_COMMIT}.kzip'
 tags:
   - 'guava-android'
-  - 'extract_maven'
+  - 'kythe_extract_maven'

--- a/kythe/extractors/gcp/examples/guava-mvn.yaml
+++ b/kythe/extractors/gcp/examples/guava-mvn.yaml
@@ -56,4 +56,4 @@ artifacts:
       - '/workspace/output/${_COMMIT}.kzip'
 tags:
   - 'github.com/google/guava'
-  - 'extract_maven'
+  - 'kythe_extract_maven'

--- a/kythe/extractors/gcp/examples/guava-mvn.yaml
+++ b/kythe/extractors/gcp/examples/guava-mvn.yaml
@@ -32,7 +32,7 @@ steps:
     - '-Dmaven.compiler.fork=true'
     - '-Dmaven.compiler.executable=/opt/kythe/extractors/javac-wrapper.sh'
   env:
-    - 'KYTHE_CORPUS=guava'
+    - 'KYTHE_CORPUS=github.com/google/guava'
     - 'KYTHE_OUTPUT_DIRECTORY=/workspace/output'
     - 'KYTHE_ROOT_DIRECTORY=/workspace/code'
     - 'JAVAC_EXTRACTOR_JAR=/opt/kythe/extractors/javac_extractor.jar'
@@ -51,7 +51,9 @@ steps:
   id: 'MERGE'
 artifacts:
   objects:
-    location: 'gs://${_BUCKET_NAME}/guava/'
+    location: 'gs://${_BUCKET_NAME}/github.com/google/guava/'
     paths:
       - '/workspace/output/${_COMMIT}.kzip'
-
+tags:
+  - 'github.com/google/guava'
+  - 'extract_maven'

--- a/kythe/extractors/gcp/examples/mvn.yaml
+++ b/kythe/extractors/gcp/examples/mvn.yaml
@@ -56,5 +56,5 @@ artifacts:
       - '/workspace/output/${_COMMIT}.kzip'
 tags:
   - '${_CORPUS}'
-  - 'extract_maven'
+  - 'kythe_extract_maven'
 

--- a/kythe/extractors/gcp/examples/mvn.yaml
+++ b/kythe/extractors/gcp/examples/mvn.yaml
@@ -54,4 +54,7 @@ artifacts:
     location: 'gs://${_BUCKET_NAME}/${_CORPUS}/'
     paths:
       - '/workspace/output/${_COMMIT}.kzip'
+tags:
+  - '${_CORPUS}'
+  - 'extract_maven'
 

--- a/kythe/go/extractors/gcp/config/converter.go
+++ b/kythe/go/extractors/gcp/config/converter.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path"
 	"strconv"
+	"strings"
 
 	rpb "kythe.io/kythe/proto/repo_go_proto"
 
@@ -101,12 +102,14 @@ func KytheToBuild(conf *rpb.Config) (*cloudbuild.Build, error) {
 		// if there is refactoring work done as described below to make steps
 		// more granular, this will have to hook into that logic.
 		Steps: commonSteps(repo),
+		Tags:  []string{hints.Corpus},
 	}
 
 	g, err := generator(hints.BuildSystem)
 	if err != nil {
 		return nil, err
 	}
+	build.Tags = append(build.Tags, "extract_"+strings.ToLower(hints.BuildSystem.String()))
 
 	build.Steps = append(build.Steps, g.preExtractSteps()...)
 

--- a/kythe/go/extractors/gcp/config/converter.go
+++ b/kythe/go/extractors/gcp/config/converter.go
@@ -109,7 +109,7 @@ func KytheToBuild(conf *rpb.Config) (*cloudbuild.Build, error) {
 	if err != nil {
 		return nil, err
 	}
-	build.Tags = append(build.Tags, "extract_"+strings.ToLower(hints.BuildSystem.String()))
+	build.Tags = append(build.Tags, "kythe_extract_"+strings.ToLower(hints.BuildSystem.String()))
 
 	build.Steps = append(build.Steps, g.preExtractSteps()...)
 

--- a/kythe/go/extractors/gcp/config/testdata/bazel-multi.yaml
+++ b/kythe/go/extractors/gcp/config/testdata/bazel-multi.yaml
@@ -37,3 +37,6 @@ steps:
   - /workspace/output/${_COMMIT}.kzip
   id: RENAME
   name: ubuntu
+tags:
+  - ${_CORPUS}
+  - extract_bazel

--- a/kythe/go/extractors/gcp/config/testdata/bazel-multi.yaml
+++ b/kythe/go/extractors/gcp/config/testdata/bazel-multi.yaml
@@ -39,4 +39,4 @@ steps:
   name: ubuntu
 tags:
   - ${_CORPUS}
-  - extract_bazel
+  - kythe_extract_bazel

--- a/kythe/go/extractors/gcp/config/testdata/gradle-subdir.yaml
+++ b/kythe/go/extractors/gcp/config/testdata/gradle-subdir.yaml
@@ -63,4 +63,4 @@ steps:
   name: gcr.io/kythe-public/kzip-tools:stable
 tags:
   - ${_CORPUS}
-  - extract_gradle
+  - kythe_extract_gradle

--- a/kythe/go/extractors/gcp/config/testdata/gradle-subdir.yaml
+++ b/kythe/go/extractors/gcp/config/testdata/gradle-subdir.yaml
@@ -61,3 +61,6 @@ steps:
   entrypoint: bash
   id: MERGE
   name: gcr.io/kythe-public/kzip-tools:stable
+tags:
+  - ${_CORPUS}
+  - extract_gradle

--- a/kythe/go/extractors/gcp/config/testdata/gradle.yaml
+++ b/kythe/go/extractors/gcp/config/testdata/gradle.yaml
@@ -63,4 +63,4 @@ steps:
   name: gcr.io/kythe-public/kzip-tools:stable
 tags:
   - ${_CORPUS}
-  - extract_gradle
+  - kythe_extract_gradle

--- a/kythe/go/extractors/gcp/config/testdata/gradle.yaml
+++ b/kythe/go/extractors/gcp/config/testdata/gradle.yaml
@@ -61,3 +61,6 @@ steps:
   entrypoint: bash
   id: MERGE
   name: gcr.io/kythe-public/kzip-tools:stable
+tags:
+  - ${_CORPUS}
+  - extract_gradle

--- a/kythe/go/extractors/gcp/config/testdata/guava-mvn.json
+++ b/kythe/go/extractors/gcp/config/testdata/guava-mvn.json
@@ -3,7 +3,7 @@
   "extractions": [
     {
       "build_system": "MAVEN",
-      "corpus": "guava"
+      "corpus": "github.com/google/guava"
     }
   ]
 }

--- a/kythe/go/extractors/gcp/config/testdata/mvn-multi.yaml
+++ b/kythe/go/extractors/gcp/config/testdata/mvn-multi.yaml
@@ -95,3 +95,6 @@ steps:
   entrypoint: bash
   id: MERGE
   name: gcr.io/kythe-public/kzip-tools:stable
+tags:
+  - ${_CORPUS}
+  - extract_maven

--- a/kythe/go/extractors/gcp/config/testdata/mvn-multi.yaml
+++ b/kythe/go/extractors/gcp/config/testdata/mvn-multi.yaml
@@ -97,4 +97,4 @@ steps:
   name: gcr.io/kythe-public/kzip-tools:stable
 tags:
   - ${_CORPUS}
-  - extract_maven
+  - kythe_extract_maven

--- a/kythe/go/extractors/gcp/config/testdata/mvn-subdir.yaml
+++ b/kythe/go/extractors/gcp/config/testdata/mvn-subdir.yaml
@@ -64,3 +64,6 @@ steps:
   entrypoint: bash
   id: MERGE
   name: gcr.io/kythe-public/kzip-tools:stable
+tags:
+  - ${_CORPUS}
+  - extract_maven

--- a/kythe/go/extractors/gcp/config/testdata/mvn-subdir.yaml
+++ b/kythe/go/extractors/gcp/config/testdata/mvn-subdir.yaml
@@ -66,4 +66,4 @@ steps:
   name: gcr.io/kythe-public/kzip-tools:stable
 tags:
   - ${_CORPUS}
-  - extract_maven
+  - kythe_extract_maven

--- a/kythe/go/extractors/gcp/config/testdata/mvn.yaml
+++ b/kythe/go/extractors/gcp/config/testdata/mvn.yaml
@@ -64,3 +64,6 @@ steps:
   entrypoint: bash
   id: MERGE
   name: gcr.io/kythe-public/kzip-tools:stable
+tags:
+  - ${_CORPUS}
+  - extract_maven

--- a/kythe/go/extractors/gcp/config/testdata/mvn.yaml
+++ b/kythe/go/extractors/gcp/config/testdata/mvn.yaml
@@ -66,4 +66,4 @@ steps:
   name: gcr.io/kythe-public/kzip-tools:stable
 tags:
   - ${_CORPUS}
-  - extract_maven
+  - kythe_extract_maven


### PR DESCRIPTION
Include the corpus (optionally substituted at request time).  Also
include the builder used (maven, gradle, bazel).

Don't prefix with `kythe_` though, maybe there's disagreement there.