### PR TITLE
release: support release archive as Bazel repository

### DIFF
--- a/kythe/extractors/bazel/BUILD
+++ b/kythe/extractors/bazel/BUILD
@@ -5,29 +5,12 @@ docker_build(
     src = "Dockerfile",
     data = [
         "extract.sh",
-        "extractors.BUILD",
-        "extractors.WORKSPACE",
         "extractors.bazelrc",
-        ":extractors",
-        "//kythe/data:raw_vnames_config",
-        "//kythe/data:vnames.bzl",
-        "//kythe/extractors:extractors.bzl",
         "//kythe/go/platform/tools/kzip",
+        "//kythe/release",
         "//kythe/release/base:fix_permissions.sh",
     ],
     image_name = "gcr.io/kythe-public/bazel-extractor",
     tags = ["manual"],
     use_cache = True,
-)
-
-filegroup(
-    name = "extractors",
-    srcs = [
-        "//kythe/cxx/extractor:cxx_extractor_bazel",
-        "//kythe/go/extractors/cmd/bazel:bazel_go_extractor",
-        "//kythe/go/extractors/cmd/bazel:extract_kzip",
-        "//kythe/java/com/google/devtools/kythe/extractors/java/bazel:java_extractor_deploy.jar",
-        "//kythe/java/com/google/devtools/kythe/extractors/jvm/bazel:bazel_jvm_extractor_deploy.jar",
-        "@io_kythe_lang_proto//kythe/go/extractors/proto:extract_proto_kzip",
-    ],
 )

--- a/kythe/extractors/bazel/Dockerfile
+++ b/kythe/extractors/bazel/Dockerfile
@@ -21,24 +21,19 @@ RUN apt-get update && \
       gcc clang && \
     apt-get clean
 
-# Kythe extractor binaries
-ADD external/io_kythe_lang_proto/kythe/go/extractors/proto/extract_proto_kzip /kythe/extractors/bazel_proto_extractor
-ADD kythe/cxx/extractor/cxx_extractor_bazel /kythe/extractors/bazel_cxx_extractor
-ADD kythe/go/extractors/cmd/bazel/bazel_go_extractor /kythe/extractors/bazel_go_extractor
-ADD kythe/go/extractors/cmd/bazel/extract_kzip /kythe/extractors/bazel_extract_kzip
-ADD kythe/java/com/google/devtools/kythe/extractors/java/bazel/java_extractor_deploy.jar /kythe/extractors/bazel_java_extractor.jar
-ADD kythe/java/com/google/devtools/kythe/extractors/jvm/bazel/bazel_jvm_extractor_deploy.jar /kythe/extractors/bazel_jvm_extractor.jar
+# Extract the Kythe release archive to /kythe
+COPY kythe/release/kythe-v*.tar.gz /tmp/
+RUN tar xzf /tmp/kythe-v*.tar.gz && \
+    mv kythe-v*/ /kythe && \
+    rm /tmp/kythe-v*.tar.gz
 
 # Tools and configuration
-ADD kythe/data/* /kythe/
 ADD kythe/extractors/bazel/extract.sh /kythe/
-ADD kythe/extractors/extractors.bzl /kythe/
+# TODO(schroederc): add kzip tool to release
 ADD kythe/go/platform/tools/kzip/kzip /kythe/
 ADD kythe/release/base/fix_permissions.sh /kythe/
 
 # Bazel repository setup
-ADD kythe/extractors/bazel/extractors.BUILD /kythe/BUILD
-ADD kythe/extractors/bazel/extractors.WORKSPACE /kythe/WORKSPACE
 ADD kythe/extractors/bazel/extractors.bazelrc /kythe/bazelrc
 RUN cat /kythe/bazelrc > ~/.bazelrc
 

--- a/kythe/extractors/bazel/extract.sh
+++ b/kythe/extractors/bazel/extract.sh
@@ -43,12 +43,12 @@
 # Also assumes you have extractors installed as per
 # kythe/extractors/bazel/extractors.bazelrc.
 
-${KYTHE_OUTPUT_DIRECTORY:?Missing output directory}
+: ${KYTHE_OUTPUT_DIRECTORY:?Missing output directory}
 
 bazel "$@"
 
 # Collect any extracted compilations.
 mkdir -p $KYTHE_OUTPUT_DIRECTORY
-find bazel-out/*/extra_actions/external/kythe_extractors -name '*.kzip' | \
+find bazel-out/*/extra_actions/external/kythe_release -name '*.kzip' | \
   xargs /kythe/kzip merge --output $KYTHE_OUTPUT_DIRECTORY/compilations.kzip
 /kythe/fix_permissions.sh $KYTHE_OUTPUT_DIRECTORY

--- a/kythe/extractors/bazel/extractors.WORKSPACE
+++ b/kythe/extractors/bazel/extractors.WORKSPACE
@@ -1,1 +1,0 @@
-workspace(name = "kythe_extractors")

--- a/kythe/extractors/bazel/extractors.bazelrc
+++ b/kythe/extractors/bazel/extractors.bazelrc
@@ -1,5 +1,5 @@
 # Setup the local repository for the Kythe extraction tools.
-build --override_repository kythe_extractors=/kythe
+build --override_repository kythe_release=/kythe
 
 # By default, keep building after errors.
 build --keep_going
@@ -8,12 +8,14 @@ build --keep_going
 build --experimental_extra_action_top_level_only
 
 # Generate metadata for Java protocol buffer generated code.
-build --proto_toolchain_for_java=@kythe_extractors//:java_proto_toolchain
+build --proto_toolchain_for_java=@kythe_release//:java_proto_toolchain
 
 # Enable all supported Kythe extractors.
-build --experimental_action_listener=@kythe_extractors//:extract_kzip_cxx
-build --experimental_action_listener=@kythe_extractors//:extract_kzip_go
-build --experimental_action_listener=@kythe_extractors//:extract_kzip_java
-build --experimental_action_listener=@kythe_extractors//:extract_kzip_jvm
-build --experimental_action_listener=@kythe_extractors//:extract_kzip_protobuf
-build --experimental_action_listener=@kythe_extractors//:extract_kzip_typescript
+build --experimental_action_listener=@kythe_release//:extract_kzip_cxx
+build --experimental_action_listener=@kythe_release//:extract_kzip_go
+build --experimental_action_listener=@kythe_release//:extract_kzip_java
+build --experimental_action_listener=@kythe_release//:extract_kzip_protobuf
+build --experimental_action_listener=@kythe_release//:extract_kzip_typescript
+
+# TODO(schroederc): add C++ proto toolchain plugin to release
+# TODO(schroederc): add JVM extractor to release

--- a/kythe/release/BUILD
+++ b/kythe/release/BUILD
@@ -28,6 +28,8 @@ release_version = "v0.0.30"
 genrule(
     name = "release",
     srcs = [
+        "release.BUILD",
+        "release.WORKSPACE",
         ":bazel_cxx_extractor",
         ":bazel_extract_kzip",
         ":bazel_go_extractor",
@@ -59,6 +61,8 @@ genrule(
         "$(location //kythe/go/platform/tools/shasum_tool)",
         "$(location kythe-" + release_version + ".tar.gz)",
         "$(locations misc)",
+        "--cp $(location release.BUILD) BUILD",
+        "--cp $(location release.WORKSPACE) WORKSPACE",
         "--cp $(location java_indexer) indexers/java_indexer.jar",
         "--cp $(location jvm_indexer) indexers/jvm_indexer.jar",
         "--cp $(location cxx_indexer) indexers/cxx_indexer",
@@ -85,6 +89,7 @@ genrule(
         "package_release.sh",
         "//kythe/go/platform/tools/shasum_tool",
     ],
+    visibility = ["//visibility:public"],
 )
 
 filegroup(
@@ -93,6 +98,9 @@ filegroup(
         ":README.md",
         "//:LICENSE",
         "//:RELEASES.md",
+        "//kythe/data:raw_vnames_config",
+        "//kythe/data:vnames.bzl",
+        "//kythe/extractors:extractors.bzl",
     ],
 )
 

--- a/kythe/release/release.BUILD
+++ b/kythe/release/release.BUILD
@@ -1,5 +1,13 @@
 package(default_visibility = ["//visibility:public"])
 
+exports_files([
+    "LICENSE",
+    "extractors/*",
+    "indexers/*",
+    "proto/*",
+    "tools/*",
+])
+
 load(":extractors.bzl", "extractor_action")
 load(":vnames.bzl", "construct_vnames_config")
 
@@ -30,12 +38,6 @@ java_binary(
     name = "bazel_java_extractor",
     main_class = "com.google.devtools.kythe.extractors.java.bazel.JavaExtractor",
     runtime_deps = ["extractors/bazel_java_extractor.jar"],
-)
-
-java_binary(
-    name = "bazel_jvm_extractor",
-    main_class = "com.google.devtools.kythe.extractors.jvm.bazel.BazelJvmExtractor",
-    runtime_deps = ["extractors/bazel_jvm_extractor.jar"],
 )
 
 filegroup(
@@ -77,19 +79,6 @@ extractor_action(
     extractor = ":bazel_java_extractor",
     mnemonics = ["Javac"],
     output = "$(ACTION_ID).java.kzip",
-)
-
-extractor_action(
-    name = "extract_kzip_jvm",
-    args = [
-        "$(EXTRA_ACTION_FILE)",
-        "$(output $(ACTION_ID).jvm.kzip)",
-        "$(location :vnames_config)",
-    ],
-    data = [":vnames_config"],
-    extractor = ":bazel_jvm_extractor",
-    mnemonics = ["JavaIjar"],
-    output = "$(ACTION_ID).jvm.kzip",
 )
 
 extractor_action(

--- a/kythe/release/release.WORKSPACE
+++ b/kythe/release/release.WORKSPACE
@@ -1,0 +1,1 @@
+workspace(name = "kythe_release")


### PR DESCRIPTION
Convert Bazel extraction Docker image to use the Kythe release archive as its embedded tooling repository.