### PR TITLE
build: remove manually written header include path

### DIFF
--- a/third_party/googlelog.BUILD
+++ b/third_party/googlelog.BUILD
@@ -39,7 +39,6 @@ cc_library(
         # Needed for Xcode 9.0+. It doesn't affect Linux builds. See D2013.
         "-D_DARWIN_C_SOURCE",
         "-D_XOPEN_SOURCE",
-        "-Iexternal/io_kythe/third_party/googlelog/src",
     ],
     includes = ["include"],
     linkopts = ["-lpthread"],

--- a/third_party/googlelog/BUILD
+++ b/third_party/googlelog/BUILD
@@ -5,5 +5,5 @@ licenses(["notice"])  # BSD
 cc_library(
     name = "config_h",
     hdrs = ["src/config.h"],
-    includes = ["src"],
+    strip_include_prefix = "src",
 )

--- a/third_party/googlelog/BUILD
+++ b/third_party/googlelog/BUILD
@@ -5,4 +5,5 @@ licenses(["notice"])  # BSD
 cc_library(
     name = "config_h",
     hdrs = ["src/config.h"],
+    includes = ["src"],
 )


### PR DESCRIPTION
This fixes `bazel build --incompatible_remap_main_repo //...`