### PR TITLE
Add newlines between verifier -show_protos output.

### DIFF
--- a/kythe/cxx/verifier/verifier_main.cc
+++ b/kythe/cxx/verifier/verifier_main.cc
@@ -114,6 +114,7 @@ Example:
     }
     if (FLAGS_show_protos) {
       entry.PrintDebugString();
+      putchar('\n');
     }
     if (!v.AssertSingleFact(&dbname, facts, entry)) {
       fprintf(stderr, "Error asserting fact %zu\n", facts);


### PR DESCRIPTION
Visually separating adjacent entries makes it a lot easier to read.