### PR TITLE
build: update github.com/dsnet/compress to tagged release v0.0.1

### DIFF
--- a/external.bzl
+++ b/external.bzl
@@ -579,9 +579,9 @@ def _go_dependencies():
     maybe(
         go_repository,
         name = "com_github_dsnet_compress",
-        commit = "cc9eb1d7ad760af14e8f918698f745e80377af4f",
         custom = "compress",
         importpath = "github.com/dsnet/compress",
+        tag = "v0.0.1",
     )
 
     maybe(

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/DataDog/zstd v1.3.5
 	github.com/apache/beam v0.0.0-20190215222049-2a4123528915
 	github.com/beevik/etree v1.1.0
-	github.com/dsnet/compress v0.0.0-20171208185109-cc9eb1d7ad76
+	github.com/dsnet/compress v0.0.1
 	github.com/ghodss/yaml v1.0.1-0.20180820084758-c7ce16629ff4
 	github.com/golang/protobuf v1.2.0
 	github.com/golang/snappy v0.0.1
@@ -29,7 +29,6 @@ require (
 	github.com/sourcegraph/go-langserver v0.0.0-20180529120946-e526744fd766
 	github.com/sourcegraph/jsonrpc2 v0.0.0-20180501180217-a3d86c792f0f
 	github.com/syndtr/goleveldb v0.0.0-20180521045021-5d6fca44a948
-	github.com/ulikunitz/xz v0.5.5 // indirect
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	go.opencensus.io v0.15.0
 	golang.org/x/net v0.0.0-20190125091013-d26f9f9a57f3

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,9 @@ github.com/beevik/etree v1.1.0/go.mod h1:r8Aw8JqVegEf0w2fDnATrX9VpkMcyFeM0FhwO62
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/dsnet/compress v0.0.0-20171208185109-cc9eb1d7ad76 h1:eX+pdPPlD279OWgdx7f6KqIRSONuK7egk+jDx7OM3Ac=
 github.com/dsnet/compress v0.0.0-20171208185109-cc9eb1d7ad76/go.mod h1:KjxHHirfLaw19iGT70HvVjHQsL1vq1SRQB4yOsAfy2s=
+github.com/dsnet/compress v0.0.1 h1:PlZu0n3Tuv04TzpfPbrnI0HW/YwodEXDS+oPKahKF0Q=
+github.com/dsnet/compress v0.0.1/go.mod h1:Aw8dCMJ7RioblQeTqt88akK31OvO8Dhf5JflhBbQEHo=
+github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780/go.mod h1:Lj+Z9rebOhdfkVLjJ8T6VcRQv3SXugXy999NBtR9aFY=
 github.com/ghodss/yaml v1.0.1-0.20180820084758-c7ce16629ff4 h1:PaTU+9BARuIOAz1ixvps39DJjfq/SxOj3axzIlh7nFo=
 github.com/ghodss/yaml v1.0.1-0.20180820084758-c7ce16629ff4/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
@@ -61,8 +64,8 @@ github.com/sourcegraph/jsonrpc2 v0.0.0-20180501180217-a3d86c792f0f h1:mHcjtPCPBj
 github.com/sourcegraph/jsonrpc2 v0.0.0-20180501180217-a3d86c792f0f/go.mod h1:eESpbCslcLDs8j2D7IEdGVgul7xuk9odqDTaor30IUU=
 github.com/syndtr/goleveldb v0.0.0-20180521045021-5d6fca44a948 h1:n8Rd8KkRs+zblDP/Wt1guL6IKr+IF9Vq9Mn+5KqvSpw=
 github.com/syndtr/goleveldb v0.0.0-20180521045021-5d6fca44a948/go.mod h1:Z4AUp2Km+PwemOoO/VB5AOx9XSsIItzFjoJlOSiYmn0=
-github.com/ulikunitz/xz v0.5.5 h1:pFrO0lVpTBXLpYw+pnLj6TbvHuyjXMfjGeCwSqCVwok=
-github.com/ulikunitz/xz v0.5.5/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
+github.com/ulikunitz/xz v0.5.6 h1:jGHAfXawEGZQ3blwU5wnWKQJvAraT7Ftq9EXjnXYgt8=
+github.com/ulikunitz/xz v0.5.6/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofmx9yWTog9BfvIu0q41lo=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
 go.opencensus.io v0.15.0 h1:r1SzcjSm4ybA0qZs3B4QYX072f8gK61Kh0qtwyFpfdk=


### PR DESCRIPTION
This commit also includes the required bump for xz.