### PR TITLE
release: remove sample web ui

### DIFF
--- a/kythe/release/BUILD
+++ b/kythe/release/BUILD
@@ -49,7 +49,6 @@ genrule(
         ":tools",
         ":misc",
         "//kythe/proto:public",
-        "//kythe/web/ui",
         "//third_party:licenses",
     ],
     outs = [
@@ -83,8 +82,6 @@ genrule(
         "--cp $(location cc_proto_metadata_plugin) tools/cc_proto_metadata_plugin",
         "--path tools/ $(locations tools)",
         "--path proto/ $(locations //kythe/proto:public)",
-        "--relpaths kythe/web/ui/resources/public",
-        "--path web/ui $(locations //kythe/web/ui)",
         "--relpaths 'third_party' --path 'third_party' $(locations //third_party:licenses)",
     ]),
     heuristic_label_expansion = False,

--- a/kythe/release/release_test.sh
+++ b/kythe/release/release_test.sh
@@ -63,7 +63,7 @@ tools/triples < "$TEST_REPOSRCDIR/kythe/testdata/test.entries" >/dev/null
 
 rm -rf "$TMPDIR/java_compilation"
 export KYTHE_OUTPUT_FILE="$TMPDIR/java_compilation/util.kzip"
-export KYTHE_JAVA_RUNTIME_OPTIONS="-Xbootclasspath/p:$JAVA_LANGTOOLS"
+export KYTHE_JAVA_RUNTIME_OPTIONS="-Xbootclasspath/a:$JAVA_LANGTOOLS"
 JAVAC_EXTRACTOR_JAR=$PWD/extractors/javac_extractor.jar \
   KYTHE_ROOT_DIRECTORY="$TEST_REPOSRCDIR" \
   KYTHE_EXTRACT_ONLY=1 \

--- a/kythe/release/release_test.sh
+++ b/kythe/release/release_test.sh
@@ -63,7 +63,12 @@ tools/triples < "$TEST_REPOSRCDIR/kythe/testdata/test.entries" >/dev/null
 
 rm -rf "$TMPDIR/java_compilation"
 export KYTHE_OUTPUT_FILE="$TMPDIR/java_compilation/util.kzip"
-export KYTHE_JAVA_RUNTIME_OPTIONS="-Xbootclasspath/a:$JAVA_LANGTOOLS"
+if (java -version |& head -1 | grep 1.8 >/dev/null);
+then
+  export KYTHE_JAVA_RUNTIME_OPTIONS="-Xbootclasspath/p:$JAVA_LANGTOOLS"
+else
+  export KYTHE_JAVA_RUNTIME_OPTIONS="-Xbootclasspath/a:$JAVA_LANGTOOLS"
+fi
 JAVAC_EXTRACTOR_JAR=$PWD/extractors/javac_extractor.jar \
   KYTHE_ROOT_DIRECTORY="$TEST_REPOSRCDIR" \
   KYTHE_EXTRACT_ONLY=1 \

--- a/kythe/release/release_test.sh
+++ b/kythe/release/release_test.sh
@@ -105,3 +105,26 @@ fi
 
 # Ensure kythe tool is functional
 tools/kythe --api srv nodes 'kythe:?lang=java#pkg.Names'
+tools/http_server \
+  --serving_table srv \
+  --listen $ADDR &
+pid=$!
+trap "kill $pid; kill -9 $pid" EXIT ERR INT
+
+while ! curl -s $ADDR >/dev/null; do
+  echo "Waiting for http_server..."
+  sleep 0.5
+done
+
+# Ensure basic HTTP handlers work
+curl -sf $ADDR/corpusRoots | jq . >/dev/null
+curl -sf $ADDR/dir | jq . >/dev/null
+curl -sf $ADDR/decorations -d '{"location": {"ticket": "kythe://kythe?path=kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Names.java"}, "source_text": true, "references": true}' | \
+  jq -e '(.reference | length) > 0
+     and (.nodes | length) == 0
+     and (.source_text | type) == "string"
+     and (.source_text | length) > 0'
+curl -sf $ADDR/decorations -d '{"location": {"ticket": "kythe://kythe?path=kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Names.java"}, "references": true, "filter": ["**"]}' | \
+  jq -e '(.reference | length) > 0
+     and (.nodes | length) > 0
+     and (.source_text | length) == 0'


### PR DESCRIPTION
lein is very finicky, and requires contortions to integrate into the bazel build (things like self-update, etc).

It's currently broken for internally used JDKs. It also only supports JDK8. 

#3600