### PR TITLE
fix(bazel): Ensure extra actions actually get hooked up.

### DIFF
--- a/kythe/extractors/bazel/Dockerfile
+++ b/kythe/extractors/bazel/Dockerfile
@@ -33,7 +33,6 @@ ADD kythe/release/base/fix_permissions.sh /kythe/
 
 # Bazel repository setup
 ADD kythe/extractors/bazel/extractors.bazelrc /kythe/bazelrc
-RUN cat /kythe/bazelrc > ~/.bazelrc
 
 # Bazelisk
 ADD external/com_github_philwo_bazelisk/linux_amd64_stripped/bazelisk /kythe/

--- a/kythe/extractors/bazel/extract.sh
+++ b/kythe/extractors/bazel/extract.sh
@@ -45,7 +45,7 @@
 
 : ${KYTHE_OUTPUT_DIRECTORY:?Missing output directory}
 
-/kythe/bazelisk "$@"
+/kythe/bazelisk --bazelrc=/kythe/bazelrc "$@"
 
 # Collect any extracted compilations.
 mkdir -p "$KYTHE_OUTPUT_DIRECTORY"


### PR DESCRIPTION
Instead of clobbering ~/.bazelrc, just ensure we use the kythe extractor bazelrc directly.