### PR TITLE
fix(go_indexer): always emit anchor for anon value types

### DIFF
--- a/kythe/go/indexer/emit.go
+++ b/kythe/go/indexer/emit.go
@@ -294,11 +294,10 @@ func (e *emitter) visitValueSpec(spec *ast.ValueSpec, stack stackFunc) {
 	// Handle fields of anonymous struct types declared in situ.
 	if spec.Type != nil {
 		e.emitAnonFields(spec.Type)
-	} else {
-		for _, v := range spec.Values {
-			if lit, ok := v.(*ast.CompositeLit); ok {
-				e.emitAnonFields(lit.Type)
-			}
+	}
+	for _, v := range spec.Values {
+		if lit, ok := v.(*ast.CompositeLit); ok {
+			e.emitAnonFields(lit.Type)
 		}
 	}
 }

--- a/kythe/go/indexer/testdata/basic/anonymous.go
+++ b/kythe/go/indexer/testdata/basic/anonymous.go
@@ -51,6 +51,25 @@ var w struct {
 //- @X ref X
 var _ = w.X
 
+var y struct {
+	//- @Y defines/binding Y
+	//- Y.node/kind variable
+	//- Y.subkind field
+	Y int
+} = struct {
+	//- @Y defines/binding Y2
+	//- !{ @Y defines/binding Y
+	//-    @Y ref Y }
+	Y int
+	// TODO(schroederc): investigate joining the duplicate anon types
+}{
+	//- @Y ref Y2
+	Y: 25,
+}
+
+//- @Y ref Y
+var _ = y.Y
+
 //- @elt defines/binding Elt
 //- Elt.node/kind variable
 var g = func(elt struct {


### PR DESCRIPTION
Do not miss emitting definitions for anonymous value types when a
variable declaration duplicates the anonymous type.

Whether to join the duplicate types is left to a later decision.  This
change ensures that the reference to Y2 at least has *a* definition
location.