### PR TITLE
fix(go_indexer): handle overrides for structs in a other packages

### DIFF
--- a/kythe/go/indexer/emit.go
+++ b/kythe/go/indexer/emit.go
@@ -607,8 +607,7 @@ func (e *emitter) emitSatisfactions() {
 
 		// Check whether x is a named type with methods; if not, skip it.
 		x := xobj.Type()
-		ximset := typeutil.IntuitiveMethodSet(x, &msets)
-		if len(ximset) == 0 {
+		if len(typeutil.IntuitiveMethodSet(x, &msets)) == 0 {
 			continue // no methods to consider
 		}
 
@@ -642,10 +641,13 @@ func (e *emitter) emitSatisfactions() {
 
 			case ifx:
 				// y is a concrete type
+				pymset := msets.MethodSet(types.NewPointer(y))
 				if types.AssignableTo(y, x) {
 					e.writeSatisfies(yobj, xobj)
+					e.emitOverrides(ymset, pymset, xmset, cache)
 				} else if py := types.NewPointer(y); types.AssignableTo(py, x) {
 					e.writeSatisfies(yobj, xobj)
+					e.emitOverrides(ymset, pymset, xmset, cache)
 				}
 
 			case ify && ymset.Len() > 0:

--- a/kythe/go/indexer/testdata/override.go
+++ b/kythe/go/indexer/testdata/override.go
@@ -2,7 +2,10 @@
 // methods of concrete types and the interfaces they satisfy.
 package override
 
-import _ "fmt"
+import (
+	_ "fmt"
+	"strings"
+)
 
 //- @Thinger defines/binding Thinger
 //- Thinger.node/kind interface
@@ -76,3 +79,20 @@ type Foil interface {
 	//- FoilThing childof Foil
 	Thing(bool)
 }
+
+//- @Grower defines/binding Grower
+//- Grower.node/kind interface
+//- StringBuilder satisfies Grower
+type Grower interface {
+	//- @Grow defines/binding Grow
+	//- Grow.node/kind function
+	Grow(int)
+
+	//- StringBuilderGrow overrides Grow
+}
+
+//- @Builder ref StringBuilder
+var _ Grower = &strings.Builder{}
+
+//- @Grow ref StringBuilderGrow
+func init() { (&strings.Builder{}).Grow(10) }


### PR DESCRIPTION
Instead of only adding `overrides` edges for methods of structs declared
within the same or a dependency package, also add `overrides` edges for
struct methods in dependency packages that satisfy a declared interface
in the analyzed package.