### PR TITLE
fix(java_extractor): initial work enabling extraction of openjdk11

### DIFF
--- a/kythe/java/com/google/devtools/kythe/extractors/java/JavaCompilationUnitExtractor.java
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/JavaCompilationUnitExtractor.java
@@ -294,10 +294,12 @@ public class JavaCompilationUnitExtractor {
     return new CompilationDescription(compilationUnit, fileContents);
   }
 
-  /** Returns a new list with the same options except any destination directory options. */
+  /**
+   * Returns a new list with the same options except header/source destination directory options.
+   */
   private static List<String> removeDestDirOptions(Iterable<String> options) {
     return JavacOptionsUtils.removeOptions(
-        Lists.newArrayList(options), EnumSet.of(Option.D, Option.S, Option.H));
+        Lists.newArrayList(options), EnumSet.of(Option.S, Option.H));
   }
 
   /**

--- a/kythe/java/com/google/devtools/kythe/extractors/java/JavaCompilationUnitExtractor.java
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/JavaCompilationUnitExtractor.java
@@ -943,9 +943,10 @@ public class JavaCompilationUnitExtractor {
       // resides in jdk.compiler.iterim.  Rather than hard-code this, just fall back to the first
       // JavaCompiler we can find.
       logger.atWarning().log("Unable to find system compiler, using first available.");
-      JavaCompilationUnitExtractor.class.getModule().addUses(JavaCompiler.class);
+      Module thisModule = JavaCompilationUnitExtractor.class.getModule();
+      thisModule.addUses(JavaCompiler.class);
       ServiceLoader<JavaCompiler> sl =
-          ServiceLoader.load(JavaCompiler.class, ClassLoader.getSystemClassLoader());
+          ServiceLoader.load(JavaCompiler.class, thisModule.getClassLoader());
       return sl.findFirst().orElse(null);
     }
     return compiler;

--- a/kythe/java/com/google/devtools/kythe/extractors/java/UsageAsInputReportingFileManager.java
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/UsageAsInputReportingFileManager.java
@@ -146,6 +146,45 @@ class UsageAsInputReportingFileManager extends ForwardingJavaFileManager<Standar
     return fileManager.getLocation(location);
   }
 
+  // TOOD(shahms): @Override; method added in JDK9
+  public Location getLocationForModule(Location location, JavaFileObject fo) throws IOException {
+    try {
+      return (Location)
+          StandardJavaFileManager.class
+              .getMethod("getLocationForModule", Location.class, JavaFileObject.class)
+              .invoke(fileManager, location, unwrap(fo));
+    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+      throw new IllegalStateException("setLocationFromPaths called by unsupported Java version", e);
+    }
+  }
+
+  // TOOD(shahms): @Override; method added in JDK9
+  public boolean contains(Location location, FileObject fo) throws IOException {
+    try {
+      return (Boolean)
+          StandardJavaFileManager.class
+              .getMethod("contains", Location.class, FileObject.class)
+              .invoke(fileManager, location, unwrap(fo));
+    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+      throw new IllegalStateException("setLocationFromPaths called by unsupported Java version", e);
+    }
+  }
+
+  // TODO(shahms): @Override; method added in JDK9
+  public Iterable<? extends JavaFileObject> getJavaFileObjectsFromPaths(
+      Iterable<? extends Path> paths) {
+    try {
+      return Iterables.transform(
+          (Iterable<? extends JavaFileObject>)
+              StandardJavaFileManager.class
+                  .getMethod("getJavaFileObjectsFromPaths", Iterable.class)
+                  .invoke(fileManager, paths),
+          input -> map(input, null));
+    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+      throw new IllegalStateException("setLocationFromPaths called by unsupported Java version", e);
+    }
+  }
+
   // TODO(schroederc): @Override; method added in JDK9
   public void setLocationFromPaths(Location location, Collection<? extends Path> paths)
       throws IOException {
@@ -158,16 +197,40 @@ class UsageAsInputReportingFileManager extends ForwardingJavaFileManager<Standar
     }
   }
 
+  // TODO(shahms): @Override; method added in JDK9
+  public void setLocationForModule(
+      Location location, String moduleName, Collection<? extends Path> paths) throws IOException {
+    try {
+      StandardJavaFileManager.class
+          .getMethod("setLocationForModule", Location.class, String.class, Collection.class)
+          .invoke(fileManager, location, moduleName, paths);
+    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+      throw new IllegalStateException("setLocationForModule called by unsupported Java version", e);
+    }
+  }
+
+  // TODO(shahms): @Override; method added in JDK9
+  public Path asPath(FileObject fo) {
+    try {
+      return (Path)
+          StandardJavaFileManager.class
+              .getMethod("asPath", FileObject.class)
+              .invoke(fileManager, unwrap(fo));
+    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+      throw new IllegalStateException("setLocationForModule called by unsupported Java version", e);
+    }
+  }
+
   // StandardJavaFileManager doesn't like it when it's asked about a JavaFileObject
   // it didn't create, so we need to unwrap our objects.
-  private FileObject unwrap(FileObject jfo) {
+  private static FileObject unwrap(FileObject jfo) {
     if (jfo instanceof UsageAsInputReportingJavaFileObject) {
       return ((UsageAsInputReportingJavaFileObject) jfo).underlyingFileObject;
     }
     return jfo;
   }
 
-  private JavaFileObject unwrap(JavaFileObject jfo) {
+  private static JavaFileObject unwrap(JavaFileObject jfo) {
     if (jfo instanceof UsageAsInputReportingJavaFileObject) {
       return ((UsageAsInputReportingJavaFileObject) jfo).underlyingFileObject;
     }

--- a/kythe/java/com/google/devtools/kythe/extractors/java/UsageAsInputReportingFileManager.java
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/UsageAsInputReportingFileManager.java
@@ -20,7 +20,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -146,79 +145,38 @@ class UsageAsInputReportingFileManager extends ForwardingJavaFileManager<Standar
     return fileManager.getLocation(location);
   }
 
-  // TOOD(shahms): @Override; method added in JDK9
+  @Override
   public Location getLocationForModule(Location location, JavaFileObject fo) throws IOException {
-    try {
-      return (Location)
-          StandardJavaFileManager.class
-              .getMethod("getLocationForModule", Location.class, JavaFileObject.class)
-              .invoke(fileManager, location, unwrap(fo));
-    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-      throw new IllegalStateException("setLocationFromPaths called by unsupported Java version", e);
-    }
+    return fileManager.getLocationForModule(location, unwrap(fo));
   }
 
-  // TOOD(shahms): @Override; method added in JDK9
+  @Override
   public boolean contains(Location location, FileObject fo) throws IOException {
-    try {
-      return (Boolean)
-          StandardJavaFileManager.class
-              .getMethod("contains", Location.class, FileObject.class)
-              .invoke(fileManager, location, unwrap(fo));
-    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-      throw new IllegalStateException("setLocationFromPaths called by unsupported Java version", e);
-    }
+    return fileManager.contains(location, unwrap(fo));
   }
 
-  // TODO(shahms): @Override; method added in JDK9
+  @Override
   public Iterable<? extends JavaFileObject> getJavaFileObjectsFromPaths(
       Iterable<? extends Path> paths) {
-    try {
-      return Iterables.transform(
-          (Iterable<? extends JavaFileObject>)
-              StandardJavaFileManager.class
-                  .getMethod("getJavaFileObjectsFromPaths", Iterable.class)
-                  .invoke(fileManager, paths),
-          input -> map(input, null));
-    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-      throw new IllegalStateException("setLocationFromPaths called by unsupported Java version", e);
-    }
+    return Iterables.transform(
+        fileManager.getJavaFileObjectsFromPaths(paths), input -> map(input, null));
   }
 
-  // TODO(schroederc): @Override; method added in JDK9
+  @Override
   public void setLocationFromPaths(Location location, Collection<? extends Path> paths)
       throws IOException {
-    try {
-      StandardJavaFileManager.class
-          .getMethod("setLocationFromPaths", Location.class, Collection.class)
-          .invoke(fileManager, location, paths);
-    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-      throw new IllegalStateException("setLocationFromPaths called by unsupported Java version", e);
-    }
+    fileManager.setLocationFromPaths(location, paths);
   }
 
-  // TODO(shahms): @Override; method added in JDK9
+  @Override
   public void setLocationForModule(
       Location location, String moduleName, Collection<? extends Path> paths) throws IOException {
-    try {
-      StandardJavaFileManager.class
-          .getMethod("setLocationForModule", Location.class, String.class, Collection.class)
-          .invoke(fileManager, location, moduleName, paths);
-    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-      throw new IllegalStateException("setLocationForModule called by unsupported Java version", e);
-    }
+    fileManager.setLocationForModule(location, moduleName, paths);
   }
 
-  // TODO(shahms): @Override; method added in JDK9
+  @Override
   public Path asPath(FileObject fo) {
-    try {
-      return (Path)
-          StandardJavaFileManager.class
-              .getMethod("asPath", FileObject.class)
-              .invoke(fileManager, unwrap(fo));
-    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-      throw new IllegalStateException("setLocationForModule called by unsupported Java version", e);
-    }
+    return fileManager.asPath(unwrap(fo));
   }
 
   // StandardJavaFileManager doesn't like it when it's asked about a JavaFileObject

--- a/kythe/java/com/google/devtools/kythe/extractors/java/standalone/BUILD
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/standalone/BUILD
@@ -44,7 +44,6 @@ java_binary(
         ":abstract_javac_wrapper",
         "//kythe/java/com/google/devtools/kythe/extractors/java",
         "//kythe/java/com/google/devtools/kythe/extractors/shared",
-        "//kythe/proto:analysis_java_proto",
         "//kythe/proto:storage_java_proto",
         "//third_party/guava",
         "//third_party/javac:javac9",

--- a/kythe/java/com/google/devtools/kythe/extractors/java/standalone/BUILD
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/standalone/BUILD
@@ -44,6 +44,7 @@ java_binary(
         ":abstract_javac_wrapper",
         "//kythe/java/com/google/devtools/kythe/extractors/java",
         "//kythe/java/com/google/devtools/kythe/extractors/shared",
+        "//kythe/proto:analysis_java_proto",
         "//kythe/proto:storage_java_proto",
         "//third_party/guava",
         "//third_party/javac:javac9",

--- a/kythe/java/com/google/devtools/kythe/extractors/java/standalone/Javac9Wrapper.java
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/standalone/Javac9Wrapper.java
@@ -115,34 +115,17 @@ public class Javac9Wrapper extends AbstractJavacWrapper {
     String analysisTarget =
         readEnvironmentVariable("KYTHE_ANALYSIS_TARGET", createTargetFromSourceFiles(sources));
 
-    CompilationDescription desc =
-        javaCompilationUnitExtractor.extract(
-            analysisTarget,
-            sources,
-            classPaths,
-            bootclasspath,
-            sourcePaths,
-            processorPaths,
-            processors,
-            genSrcDir,
-            completeOptions,
-            outputDirectory);
-
-    // Restore output directory, if present. It will be stripped by the extractor but is required
-    // for modular compilations.
-    if (options.isSet(Option.D)) {
-      return new CompilationDescription(
-          desc.getCompilationUnit()
-              .toBuilder()
-              .clearArgument()
-              .addArgument("-d")
-              .addArgument(outputDirectory)
-              .addAllArgument(desc.getCompilationUnit().getArgumentList())
-              .build(),
-          desc.getFileContents());
-    }
-
-    return desc;
+    return javaCompilationUnitExtractor.extract(
+        analysisTarget,
+        sources,
+        classPaths,
+        bootclasspath,
+        sourcePaths,
+        processorPaths,
+        processors,
+        genSrcDir,
+        completeOptions,
+        outputDirectory);
   }
 
   @Override

--- a/kythe/javatests/com/google/devtools/kythe/extractors/java/JavaExtractorTest.java
+++ b/kythe/javatests/com/google/devtools/kythe/extractors/java/JavaExtractorTest.java
@@ -484,8 +484,8 @@ public class JavaExtractorTest extends TestCase {
   }
 
   /**
-   * Tests that unsupported flags do not crash the extractor and destination options are not present
-   * in the resulting {@link CompilationUnit}.
+   * Tests that unsupported flags do not crash the extractor and source/header destination options
+   * are not present in the resulting {@link CompilationUnit}.
    */
   public void testJavaExtractorArguments() throws Exception {
     String testDir = System.getenv("TEST_TMPDIR");
@@ -550,9 +550,11 @@ public class JavaExtractorTest extends TestCase {
     CompilationUnit unit = description.getCompilationUnit();
     assertThat(unit).isNotNull();
 
-    // Check that the -d, -s, and -h flags have been removed from the compilation's arguments
+    // Check that the -s, and -h flags have been removed from the compilation's arguments, but -d
+    // preserved (it is required by modular builds).
     assertThat(unit.getArgumentList())
-        .containsExactly("-Xdoclint:-Xdoclint:all/private", "-g:lines")
+        .containsExactly(
+            "-Xdoclint:-Xdoclint:all/private", "-g:lines", "-d", outputDirs.get(2).toString())
         .inOrder();
   }
 


### PR DESCRIPTION
This is some of the initial groundwork necessary for extracting OpenJDK9+ (focusing on 11).  Specifically, it implements the entirety of StandardJavaFileManager interface (which is required when compiling modular sources) and falls back to the first available compiler if the system compiler isn't available (because when compiling the JDK itself the newer compiler uses a non-standard name to avoid conflicting).

Finally, as a hack in Javac9Wrapper.java, restore the  -d flag if present as it is removed by JavaCompilationUnitExtractor but is required for modular builds.