### PR TITLE
fix(java_extractor): use reflection to access/override JDK bits.

### DIFF
--- a/kythe/java/com/google/devtools/kythe/extractors/java/JavaCompilationUnitExtractor.java
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/JavaCompilationUnitExtractor.java
@@ -63,6 +63,7 @@ import java.io.File;
 import java.io.IOError;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
 import java.net.JarURLConnection;
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -943,11 +944,19 @@ public class JavaCompilationUnitExtractor {
       // resides in jdk.compiler.iterim.  Rather than hard-code this, just fall back to the first
       // JavaCompiler we can find.
       logger.atWarning().log("Unable to find system compiler, using first available.");
-      Module thisModule = JavaCompilationUnitExtractor.class.getModule();
-      thisModule.addUses(JavaCompiler.class);
-      ServiceLoader<JavaCompiler> sl =
-          ServiceLoader.load(JavaCompiler.class, thisModule.getClassLoader());
-      return sl.findFirst().orElse(null);
+      try {
+        // TODO(shahms): Use the proper methods when we can rely on JDK 9.
+        Object thisModule = JavaCompilationUnitExtractor.class.getMethod("getModule").invoke(null);
+        thisModule
+            .getClass()
+            .getMethod("addUses", Class.class)
+            .invoke(thisModule, JavaCompiler.class);
+        ClassLoader loader =
+            (ClassLoader) thisModule.getClass().getMethod("getClassLoader").invoke(thisModule);
+        return ServiceLoader.load(JavaCompiler.class, loader).findFirst().orElse(null);
+      } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+        logger.atWarning().log("Running on a pre-modular JDK; failing to find compiler.");
+      }
     }
     return compiler;
   }

--- a/kythe/java/com/google/devtools/kythe/extractors/java/JavaCompilationUnitExtractor.java
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/JavaCompilationUnitExtractor.java
@@ -946,7 +946,8 @@ public class JavaCompilationUnitExtractor {
       logger.atWarning().log("Unable to find system compiler, using first available.");
       try {
         // TODO(shahms): Use the proper methods when we can rely on JDK 9.
-        Object thisModule = JavaCompilationUnitExtractor.class.getMethod("getModule").invoke(null);
+        Object thisModule =
+            Class.class.getMethod("getModule").invoke(JavaCompilationUnitExtractor.class);
         thisModule
             .getClass()
             .getMethod("addUses", Class.class)
@@ -955,7 +956,7 @@ public class JavaCompilationUnitExtractor {
             (ClassLoader) thisModule.getClass().getMethod("getClassLoader").invoke(thisModule);
         return ServiceLoader.load(JavaCompiler.class, loader).findFirst().orElse(null);
       } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-        logger.atWarning().log("Running on a pre-modular JDK; failing to find compiler.");
+        logger.atWarning().log("Running on a pre-modular JDK; failing to find compiler: %s", e);
       }
     }
     return compiler;

--- a/kythe/java/com/google/devtools/kythe/extractors/java/UsageAsInputReportingFileManager.java
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/UsageAsInputReportingFileManager.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -145,38 +146,87 @@ class UsageAsInputReportingFileManager extends ForwardingJavaFileManager<Standar
     return fileManager.getLocation(location);
   }
 
-  @Override
+  // TODO(shahms): @Override; added in JDK9
   public Location getLocationForModule(Location location, JavaFileObject fo) throws IOException {
-    return fileManager.getLocationForModule(location, unwrap(fo));
+    // TODO(shahms): return fileManager.getLocationForModule(location, unwrap(fo));
+    try {
+      return (Location)
+          StandardJavaFileManager.class
+              .getMethod("getLocationForModule", Location.class, JavaFileObject.class)
+              .invoke(fileManager, location, unwrap(fo));
+    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+      throw new IllegalStateException("getLocationForModule called by unsupported Java version", e);
+    }
   }
 
-  @Override
+  // TODO(shahms): @Override; added in JDK9
   public boolean contains(Location location, FileObject fo) throws IOException {
-    return fileManager.contains(location, unwrap(fo));
+    // TODO(shahms): return fileManager.contains(location, unwrap(fo));
+    try {
+      return (Boolean)
+          StandardJavaFileManager.class
+              .getMethod("contains", Location.class, FileObject.class)
+              .invoke(fileManager, location, unwrap(fo));
+    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+      throw new IllegalStateException("contains called by unsupported Java version", e);
+    }
   }
 
-  @Override
+  // TODO(shahms): @Override; added in JDK9
   public Iterable<? extends JavaFileObject> getJavaFileObjectsFromPaths(
       Iterable<? extends Path> paths) {
-    return Iterables.transform(
-        fileManager.getJavaFileObjectsFromPaths(paths), input -> map(input, null));
+    // TODO(shahms): return Iterables.transform(
+    //      fileManager.getJavaFileObjectsFromPaths(paths), input -> map(input, null));
+    try {
+      return Iterables.transform(
+          (Iterable<? extends JavaFileObject>)
+              StandardJavaFileManager.class
+                  .getMethod("getJavaFileObjectsFromPaths", Iterable.class)
+                  .invoke(fileManager, paths),
+          input -> map(input, null));
+    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+      throw new IllegalStateException(
+          "getJavaFileObjectsFromPaths called by unsupported Java version", e);
+    }
   }
 
-  @Override
+  // TODO(shahms): @Override; added in JDK9
   public void setLocationFromPaths(Location location, Collection<? extends Path> paths)
       throws IOException {
-    fileManager.setLocationFromPaths(location, paths);
+    // TODO(shahms): fileManager.setLocationFromPaths(location, paths);
+    try {
+      StandardJavaFileManager.class
+          .getMethod("setLocationFromPaths", Location.class, Collection.class)
+          .invoke(fileManager, location, paths);
+    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+      throw new IllegalStateException("setLocationFromPaths called by unsupported Java version", e);
+    }
   }
 
-  @Override
+  // TODO(shahms): @Override; added in JDK9
   public void setLocationForModule(
       Location location, String moduleName, Collection<? extends Path> paths) throws IOException {
-    fileManager.setLocationForModule(location, moduleName, paths);
+    // TODO(shahms): fileManager.setLocationForModule(location, moduleName, paths);
+    try {
+      StandardJavaFileManager.class
+          .getMethod("setLocationForModule", Location.class, String.class, Collection.class)
+          .invoke(fileManager, location, moduleName, paths);
+    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+      throw new IllegalStateException("setLocationForModule called by unsupported Java version", e);
+    }
   }
 
-  @Override
+  // TODO(shahms): @Override; added in JDK9
   public Path asPath(FileObject fo) {
-    return fileManager.asPath(unwrap(fo));
+    // TODO(shahms): return fileManager.asPath(unwrap(fo));
+    try {
+      return (Path)
+          StandardJavaFileManager.class
+              .getMethod("asPath", FileObject.class)
+              .invoke(fileManager, unwrap(fo));
+    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+      throw new IllegalStateException("asPath called by unsupported Java version", e);
+    }
   }
 
   // StandardJavaFileManager doesn't like it when it's asked about a JavaFileObject


### PR DESCRIPTION
Internally we still need to support JDK 8. Which is complainy when you try to call methods that don't exist ;-)