### PR TITLE
fix(java_extractor): replace JDK9 findFirst with loop

### DIFF
--- a/kythe/java/com/google/devtools/kythe/extractors/java/JavaCompilationUnitExtractor.java
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/JavaCompilationUnitExtractor.java
@@ -963,7 +963,9 @@ public class JavaCompilationUnitExtractor {
       // resides in jdk.compiler.iterim.  Rather than hard-code this, just fall back to the first
       // JavaCompiler we can find.
       logger.atWarning().log("Unable to find system compiler, using first available.");
-      return ServiceLoader.load(JavaCompiler.class, moduleClassLoader).findFirst().orElse(null);
+      for (JavaCompiler found : ServiceLoader.load(JavaCompiler.class, moduleClassLoader)) {
+        return found;
+      }
     }
     return compiler;
   }


### PR DESCRIPTION
All the accidental JDK 9 should be gone now...