### PR TITLE
feat(go_indexer): overriding method type satisfies interface method type

### DIFF
--- a/kythe/docs/schema/schema.txt
+++ b/kythe/docs/schema/schema.txt
@@ -1281,11 +1281,11 @@ satisfies
 ~~~~~~~~~
 
 Brief description::
-  A *satisfies* T if A is a concrete type that satisfies an interface type T.
+  A *satisfies* T if A is a type that implicitly satisfies a type T.
 Points from::
-  type nodes (<<record>>)
+  type nodes (<<record>>, <<tapp>>, etc.)
 Points toward::
-  <<interface>>
+  type nodes (<<interface>>, <<tapp>>, etc.)
 Ordinals are used::
   never
 
@@ -1303,6 +1303,23 @@ type SB bool
 
 //- @HasBadge defines/binding HasBadge
 //- HasBadge childof StaticBadger
+func (s SB) HasBadge() bool { return bool(s) }
+--------------------------------------------------------------------------------
+
+[kythe,Go,"Types of overriding methods satisfy types of overridden interface methods."]
+--------------------------------------------------------------------------------
+package sat
+
+//- @HasBadge defines/binding HasBadgeI
+//- HasBadgeI typed HasBadgeIType
+type Badger interface { HasBadge() bool }
+
+type SB bool
+
+//- @HasBadge defines/binding HasBadge
+//- HasBadge typed HasBadgeType
+//- HasBadgeType satisfies HasBadgeIType
+//- ! { HasBadge typed HasBadgeIType }
 func (s SB) HasBadge() bool { return bool(s) }
 --------------------------------------------------------------------------------
 

--- a/kythe/go/indexer/testdata/override.go
+++ b/kythe/go/indexer/testdata/override.go
@@ -13,6 +13,7 @@ type Thinger interface {
 	//- @Thing defines/binding AbstractThing
 	//- Thing.node/kind function
 	//- Thing childof Thinger
+	//- AbstractThing typed AbstractThingType
 	Thing()
 }
 
@@ -25,6 +26,7 @@ type Stuffer interface {
 	//- @Stuff defines/binding AbstractStuff
 	//- Stuff.node/kind function
 	//- Stuff childof Stuffer
+	//- AbstractStuff typed AbstractStuffType
 	Stuff()
 }
 
@@ -38,6 +40,8 @@ type foo struct{}
 //- ConcreteThing.node/kind function
 //- ConcreteThing childof Foo
 //- ConcreteThing overrides AbstractThing
+//- ConcreteThing typed ConcreteThingType
+//- ConcreteThingType satisfies AbstractThingType
 //- !{ ConcreteThing overrides FoilThing }
 func (foo) Thing() {}
 
@@ -45,6 +49,8 @@ func (foo) Thing() {}
 //- ConcreteStuff.node/kind function
 //- ConcreteStuff childof Foo
 //- ConcreteStuff overrides AbstractStuff
+//- ConcreteStuff typed ConcreteStuffType
+//- ConcreteStuffType satisfies AbstractStuffType
 func (foo) Stuff() {}
 
 //- @bar defines/binding Bar

--- a/kythe/go/indexer/testdata/types.go
+++ b/kythe/go/indexer/testdata/types.go
@@ -336,7 +336,15 @@ func (s *S) PMethod() {}
 
 //- @Iter defines/binding Iter
 //- Iter.node/kind interface
-type Iter interface{}
+type Iter interface {
+	//- @Method defines/binding IMethod
+	//- IMethod typed IMethodType
+	//- IMethodType.node/kind tapp
+	//- IMethodType param.0 FnBuiltin
+	//- IMethodType param.1 IntBuiltin
+	//- IMethodType param.2 Iter
+	Method() int
+}
 
 //- @iv defines/binding IVar
 //- IVar.node/kind variable


### PR DESCRIPTION
The type of any method seen to override an interface method will now
have a `satisfies` edge to the interface method's type.

```
type I interface {
  //- @M defines/binding MI
  //- MI typed IType
  M()
}

type S struct {}

//- @M defines/binding MS
//- MS overrides MI
//- MS typed SType
//- SType satisfies IType    <------ new edge
func (S) M() {}
```