### PR TITLE
fix(leiningen): ensure wrapper script uses /bin/bash rather than /bin/sh

### DIFF
--- a/third_party/leiningen/lein_repo.bzl
+++ b/third_party/leiningen/lein_repo.bzl
@@ -10,7 +10,7 @@ def _lein_repository(repository_ctx):
     repository_ctx.template("home/lein.sh", "home/lein.sh.in", {"LEIN_JVM_OPTS": "JVM_OPTS"})
     repository_ctx.file(
         "leinbuild.sh",
-        """#!/bin/sh
+        """#!/bin/bash
 abspath() {{
   # Compatibility script for OS X which lacks realpath
   if [ ! -z "$(which realpath)" ]; then


### PR DESCRIPTION
(because /bin/sh doesn't always understand pipefail)