### PR TITLE
fix(cxx): remove dependency on ncurses/terminfo

### DIFF
--- a/tools/build_rules/llvm/cmake_defines.bzl
+++ b/tools/build_rules/llvm/cmake_defines.bzl
@@ -52,7 +52,6 @@ _CMAKE_DEFINES = {
     "HAVE_SYS_STAT_H": "1",
     "HAVE_SYS_TIME_H": "1",
     "HAVE_SYS_TYPES_H": "1",
-    "HAVE_TERMINFO": "1",
     "HAVE_TERMIOS_H": "1",
     "HAVE_UNISTD_H": "1",
     "HAVE__UNWIND_BACKTRACE": "1",

--- a/tools/build_rules/llvm/llvm.BUILD
+++ b/tools/build_rules/llvm/llvm.BUILD
@@ -6,7 +6,6 @@ TARGET_DEFAULTS = {
     "LLVMSupport": {
         "linkopts": [
             "-pthread",
-            "-lncurses",
             "-ldl",
         ],
         "deps": [


### PR DESCRIPTION
LLVM uses ncurses for terminfo support and even then only to determine if the terminal supports color.  Barring that it false back to a hard-coded list of TERM values.  We don't really care about this feature anyway so remove the dependency.