### PR TITLE
build: update min/max bazel version to 0.22/0.24

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -43,8 +43,9 @@ build:remote --host_platform=//tools/platforms:rbe
 build:remote --platforms=//tools/platforms:rbe
 
 build:remote --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
-build:remote --crosstool_top=@bazel_toolchains//configs/ubuntu16_04_clang/1.1/bazel_0.20.0/default:toolchain
-build:remote --extra_toolchains=@bazel_toolchains//configs/ubuntu16_04_clang/1.1/bazel_0.20.0/cpp:cc-toolchain-clang-x86_64-default
+build:remote --crosstool_top=@bazel_toolchains//configs/ubuntu16_04_clang/1.1/bazel_0.22.0/default:toolchain
+build:remote --extra_toolchains=@bazel_toolchains//configs/ubuntu16_04_clang/1.1/bazel_0.22.0/cpp:cc-toolchain-clang-x86_64-default
+
 build:remote --extra_toolchains=@io_kythe//tools/build_rules/lexyacc:lexyacc_remote_toolchain
 
 build:remote --javabase=@bazel_toolchains//configs/ubuntu16_04_clang/1.1:jdk10

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -6,15 +6,15 @@ load("//:version.bzl", "check_version")
 
 # Check that the user has a version between our minimum supported version of
 # Bazel and our maximum supported version of Bazel.
-check_version("0.20", "0.23")
+check_version("0.22", "0.24")
 
 http_archive(
     name = "bazel_toolchains",
-    sha256 = "0ffaab86bed3a0c8463dd63b1fe2218d8cad09e7f877075bf028f202f8df1ddc",
-    strip_prefix = "bazel-toolchains-5ce127aee3b4c22ab76071de972b71190f29be6e",
+    sha256 = "3296270c89ad23d1cde1a9cea54873c33d894fe7e8e1b2a44589db5da7f4a9ba",
+    strip_prefix = "bazel-toolchains-bdcb59618ced1fc1a749669fc1fe7b7d98b0239f",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/5ce127aee3b4c22ab76071de972b71190f29be6e.tar.gz",
-        "https://github.com/bazelbuild/bazel-toolchains/archive/5ce127aee3b4c22ab76071de972b71190f29be6e.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/bdcb59618ced1fc1a749669fc1fe7b7d98b0239f.tar.gz",
+        "https://github.com/bazelbuild/bazel-toolchains/archive/bdcb59618ced1fc1a749669fc1fe7b7d98b0239f.tar.gz",
     ],
 )
 

--- a/kythe/release/appengine/buildbot/Dockerfile
+++ b/kythe/release/appengine/buildbot/Dockerfile
@@ -57,7 +57,7 @@ RUN curl -L -o /usr/bin/bazel-0.22.0 https://github.com/bazelbuild/bazel/release
 ADD bazel /usr/bin/bazel
 
 # Install latest supported Bazel version
-RUN curl -L -o /usr/bin/bazel-0.23.1 https://github.com/bazelbuild/bazel/releases/download/0.23.1/bazel-0.23.1-linux-x86_64 && chmod +x /usr/bin/bazel-0.23.1
+RUN curl -L -o /usr/bin/bazel-0.24.0 https://github.com/bazelbuild/bazel/releases/download/0.24.0/bazel-0.24.0-linux-x86_64 && chmod +x /usr/bin/bazel-0.24.0
 
 # Buildbot configuration
 ADD bazelrc /root/.bazelrc

--- a/kythe/release/appengine/buildbot/master/master.cfg.template
+++ b/kythe/release/appengine/buildbot/master/master.cfg.template
@@ -96,7 +96,7 @@ add_github_change_sources('lang-proto')
 ####### SCHEDULERS
 
 bazelMinVersion = '0.22.0'
-bazelMaxVersion = '0.23.1'
+bazelMaxVersion = '0.24.0'
 
 bazelBuilders = [
     'bazel-'+bazelMaxVersion,


### PR DESCRIPTION
Update .bazelrc to use a remote toolchain corresponding to the minimum supported version, update WORKSPACE to correspond to the minimum tested version and bump the buildbot maximum supported version to reflect the new limit.  Fixes #3650