### PR TITLE
release: change buildbot config to use secrets directly

### DIFF
--- a/kythe/release/appengine/buildbot/.gitignore
+++ b/kythe/release/appengine/buildbot/.gitignore
@@ -1,3 +1,2 @@
-master/master.cfg
 twistd.log
 secret*

--- a/kythe/release/appengine/buildbot/Dockerfile
+++ b/kythe/release/appengine/buildbot/Dockerfile
@@ -65,8 +65,7 @@ ADD start.sh /buildbot/
 ADD worker /buildbot/worker
 ADD master /buildbot/master
 ADD secrets.tar /buildbot
-RUN chmod 400 /buildbot/secrets/kythe-bazel-remote-cache.json && \
-    buildbot checkconfig /buildbot/master/master.cfg
+RUN buildbot checkconfig /buildbot/master/master.cfg
 
 EXPOSE 8080
 CMD /buildbot/start.sh

--- a/kythe/release/appengine/buildbot/Dockerfile
+++ b/kythe/release/appengine/buildbot/Dockerfile
@@ -64,7 +64,9 @@ ADD bazelrc /root/.bazelrc
 ADD start.sh /buildbot/
 ADD worker /buildbot/worker
 ADD master /buildbot/master
-ADD secrets/kythe-bazel-remote-cache.json /buildbot/
+ADD secrets.tar /buildbot
+RUN chmod 400 /buildbot/secrets/kythe-bazel-remote-cache.json && \
+    buildbot checkconfig /buildbot/master/master.cfg
 
 EXPOSE 8080
 CMD /buildbot/start.sh

--- a/kythe/release/appengine/buildbot/bazelrc
+++ b/kythe/release/appengine/buildbot/bazelrc
@@ -4,4 +4,4 @@ test --test_tag_filters=-flaky
 
 # TODO(schroederc): enable remote cache between builders and devs
 # build --remote_http_cache=https://storage.googleapis.com/kythe-bazel-remote-cache
-# build --google_credentials=/buildbot/kythe-bazel-remote-cache.json
+# build --google_credentials=/buildbot/secrets/kythe-bazel-remote-cache.json

--- a/kythe/release/appengine/buildbot/cloudbuild.yaml
+++ b/kythe/release/appengine/buildbot/cloudbuild.yaml
@@ -29,7 +29,7 @@ steps:
   args:
   - push
   - gcr.io/$PROJECT_ID/buildbot.$_VERSION
-timeout: 30m
+timeout: 1800s # 30 minute timeout
 images:
   - gcr.io/$PROJECT_ID/buildbot.$_VERSION
 substitutions:

--- a/kythe/release/appengine/buildbot/cloudbuild.yaml
+++ b/kythe/release/appengine/buildbot/cloudbuild.yaml
@@ -5,6 +5,8 @@ steps:
   - cp
   - gs://kythe-buildbot/secrets.tar.enc
   - secrets.tar.enc
+# Decrypt retrieved credentials.
+# https://cloud.google.com/cloud-build/docs/securing-builds/use-encrypted-secrets-credentials
 - name: gcr.io/cloud-builders/gcloud
   id: 'Decrypt secrets'
   args:
@@ -22,6 +24,11 @@ steps:
   - -t
   - gcr.io/$PROJECT_ID/buildbot.$_VERSION
   - .
+- name: gcr.io/cloud-builders/docker
+  id: 'Push image'
+  args:
+  - push
+  - gcr.io/$PROJECT_ID/buildbot.$_VERSION
 timeout: 1800s # 30 minute timeout
 images:
   - gcr.io/$PROJECT_ID/buildbot.$_VERSION

--- a/kythe/release/appengine/buildbot/cloudbuild.yaml
+++ b/kythe/release/appengine/buildbot/cloudbuild.yaml
@@ -29,7 +29,7 @@ steps:
   args:
   - push
   - gcr.io/$PROJECT_ID/buildbot.$_VERSION
-timeout: 1800s # 30 minute timeout
+timeout: 30m
 images:
   - gcr.io/$PROJECT_ID/buildbot.$_VERSION
 substitutions:

--- a/kythe/release/appengine/buildbot/cloudbuild.yaml
+++ b/kythe/release/appengine/buildbot/cloudbuild.yaml
@@ -1,0 +1,42 @@
+steps:
+- name: gcr.io/cloud-builders/gsutil
+  id: 'Fetch secrets'
+  args:
+  - cp
+  - gs://kythe-buildbot/secrets.tar.enc
+  - secrets.tar.enc
+- name: gcr.io/cloud-builders/gcloud
+  id: 'Decrypt secrets'
+  args:
+  - kms
+  - decrypt
+  - --location=global
+  - --keyring=Buildbot
+  - --key=secrets
+  - --ciphertext-file=secrets.tar.enc
+  - --plaintext-file=secrets.tar
+- name: gcr.io/cloud-builders/docker
+  id: 'Build image'
+  args:
+  - build
+  - -t
+  - 'gcr.io/$PROJECT_ID/buildbot.$_VERSION'
+  - .
+- name: gcr.io/cloud-builders/docker
+  id: 'Push image'
+  args:
+  - push
+  - 'gcr.io/$PROJECT_ID/buildbot.$_VERSION'
+- name: gcr.io/cloud-builders/gcloud
+  id: 'Deploy $_VERSION'
+  args:
+  - app
+  - deploy
+  - '--image_url=gcr.io/kythe-repo/buildbot.$_VERSION'
+  - --stop-previous-version
+  - '--version=$_VERSION'
+timeout: 1800s # 30 minute timeout
+images:
+  - 'gcr.io/$PROJECT_ID/buildbot.$_VERSION'
+substitutions:
+  _VERSION: v1

--- a/kythe/release/appengine/buildbot/cloudbuild.yaml
+++ b/kythe/release/appengine/buildbot/cloudbuild.yaml
@@ -20,23 +20,23 @@ steps:
   args:
   - build
   - -t
-  - 'gcr.io/$PROJECT_ID/buildbot.$_VERSION'
+  - gcr.io/$PROJECT_ID/buildbot.$_VERSION
   - .
 - name: gcr.io/cloud-builders/docker
   id: 'Push image'
   args:
   - push
-  - 'gcr.io/$PROJECT_ID/buildbot.$_VERSION'
+  - gcr.io/$PROJECT_ID/buildbot.$_VERSION
 - name: gcr.io/cloud-builders/gcloud
-  id: 'Deploy $_VERSION'
+  id: 'Deploy'
   args:
   - app
   - deploy
-  - '--image_url=gcr.io/kythe-repo/buildbot.$_VERSION'
+  - --image-url=gcr.io/kythe-repo/buildbot.$_VERSION
   - --stop-previous-version
-  - '--version=$_VERSION'
+  - --version=$_VERSION
 timeout: 1800s # 30 minute timeout
 images:
-  - 'gcr.io/$PROJECT_ID/buildbot.$_VERSION'
+  - gcr.io/$PROJECT_ID/buildbot.$_VERSION
 substitutions:
   _VERSION: v1

--- a/kythe/release/appengine/buildbot/cloudbuild.yaml
+++ b/kythe/release/appengine/buildbot/cloudbuild.yaml
@@ -22,19 +22,6 @@ steps:
   - -t
   - gcr.io/$PROJECT_ID/buildbot.$_VERSION
   - .
-- name: gcr.io/cloud-builders/docker
-  id: 'Push image'
-  args:
-  - push
-  - gcr.io/$PROJECT_ID/buildbot.$_VERSION
-- name: gcr.io/cloud-builders/gcloud
-  id: 'Deploy'
-  args:
-  - app
-  - deploy
-  - --image-url=gcr.io/kythe-repo/buildbot.$_VERSION
-  - --stop-previous-version
-  - --version=$_VERSION
 timeout: 1800s # 30 minute timeout
 images:
   - gcr.io/$PROJECT_ID/buildbot.$_VERSION

--- a/kythe/release/appengine/buildbot/deploy.sh
+++ b/kythe/release/appengine/buildbot/deploy.sh
@@ -18,25 +18,4 @@
 
 cd "$(dirname "$0")"
 
-# Cleanup secrets on exit
-trap "rm -rf '$PWD/secrets'* '$PWD/master/master.cfg'" EXIT ERR INT
-
-gsutil cp gs://kythe-buildbot/secrets.tar.enc secrets.tar.enc
-gcloud kms decrypt --location=global --keyring=Buildbot --key=secrets \
-  --plaintext-file=secrets.tar --ciphertext-file=secrets.tar.enc
-tar xf secrets.tar
-
-SECRETS_SED=
-for secret in secrets/*; do
-  name="$(basename "$secret")"
-  SECRETS_SED="$SECRETS_SED
-s/@secret{$name}/$(cat "$secret" | tr -d '\n' | sed 's#/#\\/#g')/g"
-done
-
-sed "$SECRETS_SED" master/master.cfg.template >master/master.cfg
-buildbot checkconfig master
-
-VERSION=v1
-docker build -t gcr.io/kythe-repo/buildbot.$VERSION .
-docker push gcr.io/kythe-repo/buildbot.$VERSION
-gcloud app deploy --image-url=gcr.io/kythe-repo/buildbot.$VERSION --stop-previous-version --version $VERSION
+gcloud builds submit .

--- a/kythe/release/appengine/buildbot/master/master.cfg
+++ b/kythe/release/appengine/buildbot/master/master.cfg
@@ -40,7 +40,7 @@ c['secretsProviders'] = [secrets.SecretInAFile(dirname=secrets_dir)]
 # a Worker object, specifying a unique worker name and password.  The same
 # worker name and password must be configured on the worker.
 c['workers'] = [
-    worker.Worker("local-worker", util.Secret("worker_password")),
+    worker.Worker("local-worker", secrets_dict["worker_password"]),
 ]
 
 # 'protocols' contains information about protocols which master will use for
@@ -99,7 +99,7 @@ def add_github_change_sources(repo, owner='kythe'):
       pullrequest_filter=pullRequestFilter,
       category='pull', magic_link=True,
       pollAtLaunch=True, pollInterval=60,
-      token=util.Secret('github_token')))
+      token=secrets_dict['github_token']))
 
 add_github_change_sources('kythe')
 add_github_change_sources('lang-proto')
@@ -262,7 +262,7 @@ def renderBuildState(props):
 
 # Push GitHub status messages for every build start/end.
 c['services'] = []
-c['services'].append(reporters.GitHubStatusPush(token=util.Secret('github_token'),
+c['services'].append(reporters.GitHubStatusPush(token=secrets_dict['github_token'],
                                                 startDescription=renderBuildState,
                                                 endDescription=renderBuildState))
 
@@ -274,7 +274,7 @@ c['buildbotURL'] = "https://buildbot-dot-kythe-repo.appspot.com/"
 c['www'] = {
     'port': 8080, # AppEngine web port
     'plugins': dict(waterfall_view={}, console_view={}, grid_view={}),
-    'auth': util.GitHubAuth(util.Secret("github_auth_id"), util.Secret("github_auth_secret")),
+    'auth': util.GitHubAuth(secrets_dict["github_auth_id"], secrets_dict["github_auth_secret"]),
     'authz': util.Authz(
 	# restrict control access to users in the 'google' org
 	allowRules=[util.AnyControlEndpointMatcher(role="google")],

--- a/kythe/release/appengine/buildbot/master/master.cfg
+++ b/kythe/release/appengine/buildbot/master/master.cfg
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from os import path
+from os import path, listdir
 import json
 import urllib.request
 
@@ -26,13 +26,20 @@ from twisted.internet import defer
 c = BuildmasterConfig = {}
 c['buildbotNetUsageData'] = None
 
+# https://github.com/buildbot/buildbot/issues/3627
+# db_url and a few other places don't support Interpolate, so do it manually.
+secrets_dir = path.join(path.dirname(__file__), "../secrets")
+secrets_dict = {p: open(path.join(secrets_dir, p)).read() for p in listdir(secrets_dir)}
+
+c['secretsProviders'] = [secrets.SecretInAFile(dirname=secrets_dir)]
+
 ####### WORKERS
 
 # The 'workers' list defines the set of recognized workers. Each element is
 # a Worker object, specifying a unique worker name and password.  The same
 # worker name and password must be configured on the worker.
 c['workers'] = [
-    worker.Worker("local-worker", "@secret{worker_password}"),
+    worker.Worker("local-worker", util.Secret("worker_password")),
 ]
 
 # 'protocols' contains information about protocols which master will use for
@@ -53,7 +60,10 @@ def pullRequestFilter(pr):
   # Allow all Kythe maintainer Pull Requests
   url = 'https://api.github.com/teams/2988296/memberships/'+pr['user']['login']
   req = urllib.request.Request(
-      url, headers={'User-Agent': 'Buildbot', 'Authorization': 'token @secret{github_token}'})
+      url, headers={
+          'User-Agent': 'Buildbot',
+          'Authorization': 'token {github_token}'.format(**secrets_dict)
+      })
   try:
     with urllib.request.urlopen(req) as f:
       userMembership = json.loads(f.read().decode('utf-8'))
@@ -88,7 +98,7 @@ def add_github_change_sources(repo, owner='kythe'):
       pullrequest_filter=pullRequestFilter,
       category='pull', magic_link=True,
       pollAtLaunch=True, pollInterval=60,
-      token='@secret{github_token}'))
+      token=util.Secret('github_token')))
 
 add_github_change_sources('kythe')
 add_github_change_sources('lang-proto')
@@ -251,7 +261,7 @@ def renderBuildState(props):
 
 # Push GitHub status messages for every build start/end.
 c['services'] = []
-c['services'].append(reporters.GitHubStatusPush(token='@secret{github_token}',
+c['services'].append(reporters.GitHubStatusPush(token=util.Secret('github_token'),
                                                 startDescription=renderBuildState,
                                                 endDescription=renderBuildState))
 
@@ -263,7 +273,7 @@ c['buildbotURL'] = "https://buildbot-dot-kythe-repo.appspot.com/"
 c['www'] = {
     'port': 8080, # AppEngine web port
     'plugins': dict(waterfall_view={}, console_view={}, grid_view={}),
-    'auth': util.GitHubAuth("@secret{github_auth_id}", "@secret{github_auth_secret}"),
+    'auth': util.GitHubAuth(util.Secret("github_auth_id"), util.Secret("github_auth_secret")),
     'authz': util.Authz(
 	# restrict control access to users in the 'google' org
 	allowRules=[util.AnyControlEndpointMatcher(role="google")],
@@ -274,5 +284,5 @@ c['www'] = {
 ####### DB URL
 
 c['db'] = {
-    'db_url': "postgresql+psycopg2://@secret{db_userpass}@/buildbot?host=@secret{db_host}",
+    'db_url': "postgresql+psycopg2://{db_userpass}@/buildbot?host={db_host}".format(**secrets_dict),
 }

--- a/kythe/release/appengine/buildbot/master/master.cfg
+++ b/kythe/release/appengine/buildbot/master/master.cfg
@@ -29,7 +29,8 @@ c['buildbotNetUsageData'] = None
 # https://github.com/buildbot/buildbot/issues/3627
 # db_url and a few other places don't support Interpolate, so do it manually.
 secrets_dir = path.join(path.dirname(__file__), "../secrets")
-secrets_dict = {p: open(path.join(secrets_dir, p)).read() for p in listdir(secrets_dir)}
+secrets_dict = {p: open(path.join(secrets_dir, p)).read().rstrip("\n")
+                for p in listdir(secrets_dir)}
 
 c['secretsProviders'] = [secrets.SecretInAFile(dirname=secrets_dir)]
 


### PR DESCRIPTION
Rather than include the sed shenanigans in the deploy.sh script, read them from master.cfg directly.  Also and a cloudbuild.yaml file to allow building buildbot images using GCB.