### PR TITLE
fix: remove Option.D from compilation unit again

### DIFF
--- a/kythe/java/com/google/devtools/kythe/extractors/java/JavaCompilationUnitExtractor.java
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/JavaCompilationUnitExtractor.java
@@ -318,7 +318,7 @@ public class JavaCompilationUnitExtractor {
    */
   private static List<String> removeDestDirOptions(Iterable<String> options) {
     return JavacOptionsUtils.removeOptions(
-        Lists.newArrayList(options), EnumSet.of(Option.S, Option.H));
+        Lists.newArrayList(options), EnumSet.of(Option.D, Option.S, Option.H));
   }
 
   /**

--- a/kythe/java/com/google/devtools/kythe/extractors/java/JavaCompilationUnitExtractor.java
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/JavaCompilationUnitExtractor.java
@@ -317,6 +317,7 @@ public class JavaCompilationUnitExtractor {
    * Returns a new list with the same options except header/source destination directory options.
    */
   private static List<String> removeDestDirOptions(Iterable<String> options) {
+    // TODO(#3671): Option.D needs to remain in for module support, fix either here or in indexing.
     return JavacOptionsUtils.removeOptions(
         Lists.newArrayList(options), EnumSet.of(Option.D, Option.S, Option.H));
   }

--- a/kythe/javatests/com/google/devtools/kythe/extractors/java/JavaExtractorTest.java
+++ b/kythe/javatests/com/google/devtools/kythe/extractors/java/JavaExtractorTest.java
@@ -553,8 +553,7 @@ public class JavaExtractorTest extends TestCase {
     // Check that the -s, and -h flags have been removed from the compilation's arguments, but -d
     // preserved (it is required by modular builds).
     assertThat(unit.getArgumentList())
-        .containsExactly(
-            "-Xdoclint:-Xdoclint:all/private", "-g:lines", "-d", outputDirs.get(2).toString())
+        .containsExactly("-Xdoclint:-Xdoclint:all/private", "-g:lines")
         .inOrder();
   }
 


### PR DESCRIPTION
Leaving this arg in kills our caching and hinders pipeline performance.
