### PR TITLE
feat(tools): kzip merge can optional read input files from file

### DIFF
--- a/kythe/extractors/bazel/extract.sh
+++ b/kythe/extractors/bazel/extract.sh
@@ -59,6 +59,7 @@ fi
 # Collect any extracted compilations.
 mkdir -p "$KYTHE_OUTPUT_DIRECTORY"
 find bazel-out/*/extra_actions/external/kythe_release -name '*.kzip' | \
-  /kythe/tools/kzip merge --output "$KYTHE_OUTPUT_DIRECTORY/compilations.kzip"
+  /kythe/tools/kzip merge --inputs_from_stdin \
+                          --output "$KYTHE_OUTPUT_DIRECTORY/compilations.kzip"
 /kythe/fix_permissions.sh "$KYTHE_OUTPUT_DIRECTORY"
 test -f "$KYTHE_OUTPUT_DIRECTORY/compilations.kzip"

--- a/kythe/extractors/bazel/extract.sh
+++ b/kythe/extractors/bazel/extract.sh
@@ -59,7 +59,7 @@ fi
 # Collect any extracted compilations.
 mkdir -p "$KYTHE_OUTPUT_DIRECTORY"
 find bazel-out/*/extra_actions/external/kythe_release -name '*.kzip' | \
-  /kythe/tools/kzip merge --inputs_from_stdin \
+  /kythe/tools/kzip merge --inputs_list_file - \
                           --output "$KYTHE_OUTPUT_DIRECTORY/compilations.kzip"
 /kythe/fix_permissions.sh "$KYTHE_OUTPUT_DIRECTORY"
 test -f "$KYTHE_OUTPUT_DIRECTORY/compilations.kzip"

--- a/kythe/extractors/bazel/extract.sh
+++ b/kythe/extractors/bazel/extract.sh
@@ -59,6 +59,6 @@ fi
 # Collect any extracted compilations.
 mkdir -p "$KYTHE_OUTPUT_DIRECTORY"
 find bazel-out/*/extra_actions/external/kythe_release -name '*.kzip' | \
-  xargs -r /kythe/tools/kzip merge --output "$KYTHE_OUTPUT_DIRECTORY/compilations.kzip"
+  /kythe/tools/kzip merge --output "$KYTHE_OUTPUT_DIRECTORY/compilations.kzip"
 /kythe/fix_permissions.sh "$KYTHE_OUTPUT_DIRECTORY"
 test -f "$KYTHE_OUTPUT_DIRECTORY/compilations.kzip"

--- a/kythe/go/platform/tools/kzip/mergecmd/mergecmd.go
+++ b/kythe/go/platform/tools/kzip/mergecmd/mergecmd.go
@@ -18,6 +18,7 @@
 package mergecmd
 
 import (
+	"bufio"
 	"context"
 	"flag"
 	"fmt"
@@ -57,7 +58,14 @@ func (c *mergeCommand) Execute(ctx context.Context, fs *flag.FlagSet, _ ...inter
 	if c.output == "" {
 		return c.Fail("required --output path missing")
 	}
-	if err := mergeArchives(ctx, c.output, fs.Args()); err != nil {
+	archives := fs.Args()
+	if len(archives) == 0 {
+		scanner := bufio.NewScanner(os.Stdin)
+		for scanner.Scan() {
+			archives = append(archives, scanner.Text())
+		}
+	}
+	if err := mergeArchives(ctx, c.output, archives); err != nil {
 		return c.Fail("Error merging archives: ", err)
 	}
 	return subcommands.ExitSuccess

--- a/kythe/go/platform/tools/kzip/mergecmd/mergecmd.go
+++ b/kythe/go/platform/tools/kzip/mergecmd/mergecmd.go
@@ -37,8 +37,8 @@ import (
 type mergeCommand struct {
 	cmdutil.Info
 
-	output    string
-	xargsMode bool
+	output          string
+	inputsFromStdin bool
 }
 
 // New creates a new subcommand for merging kzip files.
@@ -52,7 +52,7 @@ func New() subcommands.Command {
 // for merging kzip files.
 func (c *mergeCommand) SetFlags(fs *flag.FlagSet) {
 	fs.StringVar(&c.output, "output", "", "Path to output kzip file")
-	fs.BoolVar(&c.xargsMode, "xargs_mode", false, "Whether input files should be read from stdin like xargs")
+	fs.BoolVar(&c.inputsFromStdin, "inputs_from_stdin", false, "Whether input file paths should be read from stdin")
 }
 
 // Execute implements the subcommands interface and merges the provided files.
@@ -61,7 +61,7 @@ func (c *mergeCommand) Execute(ctx context.Context, fs *flag.FlagSet, _ ...inter
 		return c.Fail("required --output path missing")
 	}
 	archives := fs.Args()
-	if c.xargsMode {
+	if c.inputsFromStdin {
 		scanner := bufio.NewScanner(os.Stdin)
 		for scanner.Scan() {
 			archives = append(archives, scanner.Text())

--- a/kythe/go/platform/tools/kzip/mergecmd/mergecmd.go
+++ b/kythe/go/platform/tools/kzip/mergecmd/mergecmd.go
@@ -59,10 +59,15 @@ func (c *mergeCommand) Execute(ctx context.Context, fs *flag.FlagSet, _ ...inter
 		return c.Fail("required --output path missing")
 	}
 	archives := fs.Args()
+	scanner := bufio.NewScanner(os.Stdin)
 	if len(archives) == 0 {
-		scanner := bufio.NewScanner(os.Stdin)
 		for scanner.Scan() {
 			archives = append(archives, scanner.Text())
+		}
+	} else {
+		stat, _ := os.Stdin.Stat()
+		if (stat.Mode() & os.ModeCharDevice) == 0 && scanner.Scan() {
+			return c.Fail("stdin not empty but input files specified as args")
 		}
 	}
 	if err := mergeArchives(ctx, c.output, archives); err != nil {

--- a/kythe/go/platform/tools/kzip/mergecmd/mergecmd.go
+++ b/kythe/go/platform/tools/kzip/mergecmd/mergecmd.go
@@ -37,8 +37,8 @@ import (
 type mergeCommand struct {
 	cmdutil.Info
 
-	output          string
-	inputsFromStdin bool
+	output     string
+	inputsFile string
 }
 
 // New creates a new subcommand for merging kzip files.
@@ -52,7 +52,7 @@ func New() subcommands.Command {
 // for merging kzip files.
 func (c *mergeCommand) SetFlags(fs *flag.FlagSet) {
 	fs.StringVar(&c.output, "output", "", "Path to output kzip file")
-	fs.BoolVar(&c.inputsFromStdin, "inputs_from_stdin", false, "Whether input file paths should be read from stdin")
+	fs.StringVar(&c.inputsFile, "inputs_list_file", "", "A file from which to read input kzip file names")
 }
 
 // Execute implements the subcommands interface and merges the provided files.
@@ -61,7 +61,10 @@ func (c *mergeCommand) Execute(ctx context.Context, fs *flag.FlagSet, _ ...inter
 		return c.Fail("required --output path missing")
 	}
 	archives := fs.Args()
-	if c.inputsFromStdin {
+	if c.inputsFile != "" {
+		if len(archives) != 0 {
+			return c.Fail("--inputs_list_file cannot be combined with command line inputs")
+		}
 		scanner := bufio.NewScanner(os.Stdin)
 		for scanner.Scan() {
 			archives = append(archives, scanner.Text())


### PR DESCRIPTION
This is more efficient than extending merge to also merge in the contents of the existing output file, which would be required for kzip to work in general with xargs (which currently is very dependent on ensuring both -n and -s are set correctly to ensure exactly one invocation of kzip).

More explicitly, we currently do

`find bazel-out/stuff -name '*.kzip' | xargs -r kzip merge --output-file output.kzip`

but that fails when the cardinality (in input file count or input file path lengths) is too large. We could choose a `-n` and `-s` argument to `xargs` that covered "most".  A more general change would be to have `kzip merge` merge in the contents of the existing output file, if any. That would be a more intrusive change. This PR simply gives kzip merge the same functionality as xargs if no input files are specified.