### PR TITLE
fix: handle relative paths correctly in textproto and proto extractors

### DIFF
--- a/kythe/cxx/extractor/proto/proto_extractor.cc
+++ b/kythe/cxx/extractor/proto/proto_extractor.cc
@@ -31,6 +31,8 @@ namespace kythe {
 namespace lang_proto {
 namespace {
 
+using ::google::protobuf::compiler::DiskSourceTree;
+
 // Error "collector" that just writes messages to log output.
 class LoggingMultiFileErrorCollector
     : public google::protobuf::compiler::MultiFileErrorCollector {
@@ -48,8 +50,7 @@ class LoggingMultiFileErrorCollector
 
 // DiskSourceTree that records which proto files are opened while parsing the
 // toplevel proto(s), allowing us to get a list of transitive dependencies.
-class RecordingDiskSourceTree
-    : public google::protobuf::compiler::DiskSourceTree {
+class RecordingDiskSourceTree : public DiskSourceTree {
  public:
   google::protobuf::io::ZeroCopyInputStream* Open(
       const std::string& filename) override {
@@ -133,13 +134,18 @@ proto::CompilationUnit ProtoExtractor::ExtractProtos(
   }
 
   // Write each toplevel proto and its transitive dependencies into the kzip.
-  for (const std::string& filename : src_tree.opened_files()) {
+  for (const std::string& abspath : src_tree.opened_files()) {
+    // Resolve path relative to the proto compiler's search paths.
+    std::string relpath, shadow;
+    CHECK(DiskSourceTree::SUCCESS ==
+          src_tree.DiskFileToVirtualFile(abspath, &relpath, &shadow));
+    CHECK(shadow.empty()) << "Filepath shadows a real file: " << relpath;
     // Read file contents
     std::string file_contents;
     {
       std::unique_ptr<google::protobuf::io::ZeroCopyInputStream> in_stream(
-          src_tree.Open(filename));
-      CHECK(in_stream != nullptr) << "Can't open file: " << filename;
+          src_tree.Open(relpath));
+      CHECK(in_stream != nullptr) << "Can't open file: " << relpath;
 
       const void* data = nullptr;
       int size = 0;
@@ -148,12 +154,8 @@ proto::CompilationUnit ProtoExtractor::ExtractProtos(
       }
     }
 
-    // Resolve path relative to the proto compiler's search paths.
-    std::string full_path;
-    CHECK(src_tree.VirtualFileToDiskFile(filename, &full_path))
-        << "Error canonicalizing path: " << filename;
     // Make path relative to KYTHE_ROOT_DIRECTORY.
-    full_path = RelativizePath(full_path, root_directory);
+    const std::string final_path = RelativizePath(abspath, root_directory);
 
     // Write file to index.
     auto digest = index_writer->WriteFile(file_contents);
@@ -161,12 +163,12 @@ proto::CompilationUnit ProtoExtractor::ExtractProtos(
 
     // Record file info to compilation unit.
     proto::CompilationUnit::FileInput* file_input = unit.add_required_input();
-    proto::VName vname = vname_gen.LookupVName(full_path);
+    proto::VName vname = vname_gen.LookupVName(final_path);
     if (vname.corpus().empty()) {
       vname.set_corpus(std::string(corpus));
     }
     *file_input->mutable_v_name() = std::move(vname);
-    file_input->mutable_info()->set_path(full_path);
+    file_input->mutable_info()->set_path(final_path);
     file_input->mutable_info()->set_digest(*digest);
   }
 

--- a/kythe/cxx/extractor/textproto/BUILD
+++ b/kythe/cxx/extractor/textproto/BUILD
@@ -5,6 +5,7 @@ cc_binary(
     deps = [
         ":textproto_schema",
         "//kythe/cxx/common:kzip_writer",
+        "//kythe/cxx/common:path_utils",
         "//kythe/cxx/extractor/proto:lib",
         "//kythe/cxx/indexer/proto:search_path",
         "//kythe/proto:analysis_cc_proto",

--- a/kythe/cxx/extractor/textproto/testdata/BUILD
+++ b/kythe/cxx/extractor/textproto/testdata/BUILD
@@ -90,3 +90,18 @@ textproto_extractor_golden_test(
     ],
     deps = ["example.proto"],
 )
+
+# Test that KYTHE_ROOT_DIRECTORY environment variable works. File paths in the
+# output should be relative to KYTHE_ROOT_DIRECTORY, not the extractor's working
+# directory.
+textproto_extractor_golden_test(
+    name = "subdir",
+    srcs = ["subdir/subdir.pbtxt"],
+    extra_env = {"KYTHE_ROOT_DIRECTORY": "kythe/cxx/extractor/textproto/testdata/subdir"},
+    opts = [
+        "--",
+        "--proto_path",
+        "kythe/cxx/extractor/textproto/testdata/subdir",
+    ],
+    deps = ["subdir/subdir.proto"],
+)

--- a/kythe/cxx/extractor/textproto/testdata/subdir.UNIT
+++ b/kythe/cxx/extractor/textproto/testdata/subdir.UNIT
@@ -1,0 +1,26 @@
+required_input {
+  v_name {
+    path: "subdir.proto"
+  }
+  info {
+    path: "subdir.proto"
+    digest: "b51fdc6bd2a3b2cbb0c1609cb8d62dcc8940853d6dfd0147c26f73a402e4cc3a"
+  }
+}
+required_input {
+  v_name {
+    path: "subdir.pbtxt"
+  }
+  info {
+    path: "subdir.pbtxt"
+    digest: "f68ebecf9ed486124180fd0a25fb41200435b8bc0aee39f061c71f3d18dcaff6"
+  }
+}
+argument: "kythe/cxx/extractor/textproto/testdata/subdir/subdir.pbtxt"
+argument: "--proto_message"
+argument: "textproto_test.MyMessage"
+argument: "--"
+argument: "--proto_path"
+argument: "kythe/cxx/extractor/textproto/testdata/subdir"
+source_file: "subdir.pbtxt"
+entry_context: "hash0"

--- a/kythe/cxx/extractor/textproto/testdata/subdir/subdir.pbtxt
+++ b/kythe/cxx/extractor/textproto/testdata/subdir/subdir.pbtxt
@@ -1,0 +1,4 @@
+# proto-file: subdir.proto
+# proto-message: textproto_test.MyMessage
+
+str_field: "testing, testing..."

--- a/kythe/cxx/extractor/textproto/testdata/subdir/subdir.proto
+++ b/kythe/cxx/extractor/textproto/testdata/subdir/subdir.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package textproto_test;
+
+message MyMessage {
+    string str_field = 2;
+}


### PR DESCRIPTION
Previously there was an issue where proto file lookup failed if
KYTHE_ROOT_DIRECTORY was set to something other than the current
directory. Additionally, the textproto extractor did not respect
KYTHE_ROOT_DIRECTORY when recording the textproto file path.