### PR TITLE
refactor(cxx): move LoadFileOrDie() into a new file_utils library

### DIFF
--- a/kythe/cxx/common/BUILD
+++ b/kythe/cxx/common/BUILD
@@ -68,6 +68,15 @@ cc_test(
 )
 
 cc_library(
+    name = "file_utils",
+    srcs = ["file_utils.cc"],
+    hdrs = ["file_utils.h"],
+    deps = [
+        "@com_github_google_glog//:glog",
+    ],
+)
+
+cc_library(
     name = "vname_ordering",
     hdrs = ["vname_ordering.h"],
     visibility = [PUBLIC_VISIBILITY],

--- a/kythe/cxx/common/file_utils.cc
+++ b/kythe/cxx/common/file_utils.cc
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 The Kythe Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "file_utils.h"
+
+#include "glog/logging.h"
+
+namespace kythe {
+
+std::string LoadFileOrDie(const std::string& file) {
+  FILE* handle = fopen(file.c_str(), "rb");
+  CHECK(handle != nullptr) << "Couldn't open input file " << file;
+  CHECK_EQ(fseek(handle, 0, SEEK_END), 0) << "Couldn't seek " << file;
+  long size = ftell(handle);
+  CHECK_GE(size, 0) << "Bad size for " << file;
+  CHECK_EQ(fseek(handle, 0, SEEK_SET), 0) << "Couldn't seek " << file;
+  std::string content;
+  content.resize(size);
+  CHECK_EQ(fread(&content[0], size, 1, handle), 1) << "Couldn't read " << file;
+  CHECK_NE(fclose(handle), EOF) << "Couldn't close " << file;
+  return content;
+}
+
+}  // namespace kythe

--- a/kythe/cxx/common/file_utils.h
+++ b/kythe/cxx/common/file_utils.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 The Kythe Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef KYTHE_CXX_COMMON_FILE_UTILS_H_
+#define KYTHE_CXX_COMMON_FILE_UTILS_H_
+
+#include <string>
+
+namespace kythe {
+
+/// \brief Loads all data from a file or terminates the process.
+std::string LoadFileOrDie(const std::string& file);
+
+}  // namespace kythe
+
+#endif  // KYTHE_CXX_COMMON_FILE_UTILS_H_

--- a/kythe/cxx/extractor/BUILD
+++ b/kythe/cxx/extractor/BUILD
@@ -157,6 +157,7 @@ cc_library(
         ":path_utils",
         ":supported_language",
         "//external:zlib",
+        "//kythe/cxx/common:file_utils",
         "//kythe/cxx/common:index_writer",
         "//kythe/cxx/common:json_proto",
         "//kythe/cxx/common:kzip_writer",

--- a/kythe/cxx/extractor/cxx_extractor.cc
+++ b/kythe/cxx/extractor/cxx_extractor.cc
@@ -38,6 +38,7 @@
 #include "clang/Tooling/Tooling.h"
 #include "gflags/gflags.h"
 #include "glog/logging.h"
+#include "kythe/cxx/common/file_utils.h"
 #include "kythe/cxx/common/json_proto.h"
 #include "kythe/cxx/common/kzip_writer.h"
 #include "kythe/cxx/common/path_utils.h"
@@ -1187,21 +1188,6 @@ void MapCompilerResources(clang::tooling::ToolInvocation* invocation,
     llvm::sys::path::append(out_path, file->name);
     invocation->mapVirtualFile(out_path, file->data);
   }
-}
-
-/// \brief Loads all data from a file or terminates the process.
-static std::string LoadFileOrDie(const std::string& file) {
-  FILE* handle = fopen(file.c_str(), "rb");
-  CHECK(handle != nullptr) << "Couldn't open input file " << file;
-  CHECK_EQ(fseek(handle, 0, SEEK_END), 0) << "Couldn't seek " << file;
-  long size = ftell(handle);
-  CHECK_GE(size, 0) << "Bad size for " << file;
-  CHECK_EQ(fseek(handle, 0, SEEK_SET), 0) << "Couldn't seek " << file;
-  std::string content;
-  content.resize(size);
-  CHECK_EQ(fread(&content[0], size, 1, handle), 1) << "Couldn't read " << file;
-  CHECK_NE(fclose(handle), EOF) << "Couldn't close " << file;
-  return content;
 }
 
 void ExtractorConfiguration::SetVNameConfig(const std::string& path) {

--- a/kythe/cxx/extractor/proto/BUILD
+++ b/kythe/cxx/extractor/proto/BUILD
@@ -21,6 +21,7 @@ cc_library(
     hdrs = ["proto_extractor.h"],
     visibility = ["//kythe/cxx/extractor/textproto:__subpackages__"],
     deps = [
+        "//kythe/cxx/common:file_utils",
         "//kythe/cxx/common:index_writer",
         "//kythe/cxx/common:lib",
         "//kythe/cxx/common:path_utils",

--- a/kythe/cxx/extractor/proto/proto_extractor.cc
+++ b/kythe/cxx/extractor/proto/proto_extractor.cc
@@ -22,6 +22,7 @@
 #include "glog/logging.h"
 #include "google/protobuf/compiler/importer.h"
 #include "google/protobuf/io/zero_copy_stream_impl.h"
+#include "kythe/cxx/common/file_utils.h"
 #include "kythe/cxx/common/file_vname_generator.h"
 #include "kythe/cxx/common/path_utils.h"
 #include "kythe/cxx/indexer/proto/search_path.h"
@@ -73,21 +74,6 @@ class RecordingDiskSourceTree : public DiskSourceTree {
  private:
   std::set<std::string> opened_files_;
 };
-
-// Loads all data from a file or terminates the process.
-static std::string LoadFileOrDie(const std::string& file) {
-  FILE* handle = fopen(file.c_str(), "rb");
-  CHECK(handle != nullptr) << "Couldn't open input file " << file;
-  CHECK_EQ(fseek(handle, 0, SEEK_END), 0) << "Couldn't seek " << file;
-  long size = ftell(handle);
-  CHECK_GE(size, 0) << "Bad size for " << file;
-  CHECK_EQ(fseek(handle, 0, SEEK_SET), 0) << "Couldn't seek " << file;
-  std::string content;
-  content.resize(size);
-  CHECK_EQ(fread(&content[0], size, 1, handle), 1) << "Couldn't read " << file;
-  CHECK_NE(fclose(handle), EOF) << "Couldn't close " << file;
-  return content;
-}
 
 }  // namespace
 

--- a/kythe/cxx/extractor/textproto/BUILD
+++ b/kythe/cxx/extractor/textproto/BUILD
@@ -4,6 +4,7 @@ cc_binary(
     visibility = ["//visibility:public"],
     deps = [
         ":textproto_schema",
+        "//kythe/cxx/common:file_utils",
         "//kythe/cxx/common:kzip_writer",
         "//kythe/cxx/common:path_utils",
         "//kythe/cxx/extractor/proto:lib",

--- a/kythe/cxx/extractor/textproto/textproto_extractor.cc
+++ b/kythe/cxx/extractor/textproto/textproto_extractor.cc
@@ -30,6 +30,7 @@
 #include "absl/strings/str_split.h"
 #include "gflags/gflags.h"
 #include "glog/logging.h"
+#include "kythe/cxx/common/file_utils.h"
 #include "kythe/cxx/common/kzip_writer.h"
 #include "kythe/cxx/common/path_utils.h"
 #include "kythe/cxx/extractor/proto/proto_extractor.h"
@@ -52,21 +53,6 @@ IndexWriter OpenKzipWriterOrDie(absl::string_view path) {
   auto writer = KzipWriter::Create(path);
   CHECK(writer.ok()) << "Failed to open KzipWriter: " << writer.status();
   return std::move(*writer);
-}
-
-// Loads all data from a file or terminates the process.
-std::string LoadFileOrDie(const std::string& file) {
-  FILE* handle = fopen(file.c_str(), "rb");
-  CHECK(handle != nullptr) << "Couldn't open input file " << file;
-  CHECK_EQ(fseek(handle, 0, SEEK_END), 0) << "Couldn't seek " << file;
-  long size = ftell(handle);
-  CHECK_GE(size, 0) << "Bad size for " << file;
-  CHECK_EQ(fseek(handle, 0, SEEK_SET), 0) << "Couldn't seek " << file;
-  std::string content;
-  content.resize(size);
-  CHECK_EQ(fread(&content[0], size, 1, handle), 1) << "Couldn't read " << file;
-  CHECK_NE(fclose(handle), EOF) << "Couldn't close " << file;
-  return content;
 }
 
 }  // namespace
@@ -107,7 +93,7 @@ Examples:
   CHECK(textproto_args.size() == 1)
       << "Expected 1 textproto file, got " << textproto_args.size();
   std::string textproto_filename = textproto_args[0];
-  const std::string textproto = LoadFileOrDie(textproto_filename);
+  const std::string textproto = ::kythe::LoadFileOrDie(textproto_filename);
 
   const char* output_file = getenv("KYTHE_OUTPUT_FILE");
   CHECK(output_file != nullptr)

--- a/kythe/cxx/verifier/BUILD
+++ b/kythe/cxx/verifier/BUILD
@@ -67,6 +67,7 @@ cc_library(
     ],
     deps = [
         ":lexparse",
+        "//kythe/cxx/common:file_utils",
         "//kythe/cxx/common:kythe_uri",
         "//kythe/cxx/common:scope_guard",
         "//kythe/proto:common_cc_proto",

--- a/kythe/cxx/verifier/assertions.cc
+++ b/kythe/cxx/verifier/assertions.cc
@@ -18,6 +18,7 @@
 
 #include <sstream>
 
+#include "kythe/cxx/common/file_utils.h"
 #include "verifier.h"
 
 namespace kythe {
@@ -559,21 +560,11 @@ void AssertionParser::ScanBeginString(const RE2& goal_comment_regex,
 
 void AssertionParser::ScanBeginFile(const RE2& goal_comment_regex,
                                     bool trace_scanning) {
-  std::string buffer;
   if (file().empty() || file() == "-") {
     Error("will not read goals from stdin");
     exit(EXIT_FAILURE);
   }
-  FILE* input = ::fopen(file().c_str(), "r");
-  CHECK(input != nullptr) << "Couldn't open " << file();
-  CHECK(!::fseek(input, 0, SEEK_END));
-  auto file_len = ::ftell(input);
-  CHECK(file_len >= 0);
-  CHECK(!::fseek(input, 0, SEEK_SET));
-  buffer.resize(file_len);
-  CHECK(::fread(const_cast<char*>(buffer.data()), 1, file_len, input) ==
-        file_len);
-  ::fclose(input);
+  std::string buffer = LoadFileOrDie(file());
   ScanBeginString(goal_comment_regex, buffer, trace_scanning);
 }
 


### PR DESCRIPTION
I think this is a worthwhile refactor on its own, but the reason I'm doing this is so I can easily swap the implementation when in google3. I need to read some files from google-specific filesystems that don't work with `fopen()`.