### PR TITLE
fix(compdb_test): ignore log files intead of treating as kzip

### DIFF
--- a/kythe/go/extractors/config/runextractor/compdb/compdb_test.go
+++ b/kythe/go/extractors/config/runextractor/compdb/compdb_test.go
@@ -71,6 +71,9 @@ func TestExtractCompilationsEndToEnd(t *testing.T) {
 			return err
 		} else if info.IsDir() {
 			return nil
+		} else if filepath.Ext(path) != ".kzip" {
+			t.Logf("Ignoring non-kzip file: %v", path)
+			return nil
 		}
 		reader, err := os.Open(path)
 		if err != nil {


### PR DESCRIPTION
In google3, the c++ extractor calls InitGoogle(), which causes log files
to be written to disk. This commit changes the compdb test to ignore
them instead of trying and failing to extract them as kzips.

Related to https://github.com/kythe/kythe/pull/3695.