### PR TITLE
chore(build): add blacklist for known-bad releases (currently 0.25.0)

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,10 +2,15 @@ workspace(name = "io_kythe")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository", "new_git_repository")
-load("//:version.bzl", "check_version")
+load("//:version.bzl", "check_version", "blacklist_version")
 
 # Check that the user has a version between our minimum supported version of
-# Bazel and our maximum supported version of Bazel.
+# Bazel and our maximum supported version of Bazel, and not one of the known-bad releases.
+blacklist_version(
+    reason = "Broken cc_common.compile API: https://github.com/bazelbuild/bazel/issues/8226",
+    version = "0.25.0",
+)
+
 check_version("0.22", "0.24")
 
 http_archive(

--- a/version.bzl
+++ b/version.bzl
@@ -32,3 +32,13 @@ def check_version(min_required, max_supported):
     max = _parse_version(max_supported)
     if max < _bound_size(found_version, len(max)):
         fail("Your bazel is too new. Maximum supported version {} of bazel, found {}".format(max_supported, found))
+
+def blacklist_version(version, reason):
+    found = _parse_version(native.bazel_version)
+    if found == _parse_version(version):
+        fail("\n".join([
+            "You're using a blacklisted version of Bazel ({}).".format(native.bazel_version),
+            "Please upgrade or downgrade to a supported release.",
+            "The version of Bazel you're using is incompatible with Kythe because:",
+            reason,
+        ]))


### PR DESCRIPTION
Seeing as we have a specific reason we're avoiding 0.25, document that the reason is known and warn users against it for now.