### PR TITLE
fix(cxx_indexer): always add . to the VFS

### DIFF
--- a/kythe/cxx/indexer/cxx/KytheVFS.cc
+++ b/kythe/cxx/indexer/cxx/KytheVFS.cc
@@ -46,6 +46,8 @@ IndexVFS::IndexVFS(const std::string& working_directory,
   for (llvm::StringRef dir : virtual_dirs) {
     FileRecordForPath(dir, BehaviorOnMissing::kCreateDirectory, 0);
   }
+  // Clang always expects to be able to find a directory at .
+  FileRecordForPath(".", BehaviorOnMissing::kCreateDirectory, 0);
 }
 
 IndexVFS::~IndexVFS() {


### PR DESCRIPTION
clang's Preprocessor::LookupFile always expects FileMgr.getDirectory(".")
to succeed, so we should make sure there's a directory there.