### PR TITLE
fix(cxx_indexer): insist that compilation units have working directories

### DIFF
--- a/kythe/cxx/indexer/cxx/frontend.cc
+++ b/kythe/cxx/indexer/cxx/frontend.cc
@@ -123,11 +123,10 @@ void MaybeNormalizeFileVNames(IndexerJob* job) {
 
 void UpdateJobWdirFromUnit(IndexerJob* job) {
   job->working_directory = job->unit.working_directory();
-  if (!llvm::sys::path::is_absolute(job->working_directory)) {
-    llvm::SmallString<1024> stored_wd;
-    CHECK(!llvm::sys::fs::make_absolute(stored_wd));
-    job->working_directory = stored_wd.str();
-  }
+  CHECK(!job->working_directory.empty())
+      << "Indexer jobs must have their absolute working directory set.";
+  CHECK(llvm::sys::path::is_absolute(job->working_directory))
+      << "Indexer jobs must have their absolute working directory set.";
 }
 
 /// \brief Reads data from a .kindex file into memory.

--- a/kythe/cxx/indexer/cxx/testdata/kindex_test.unit
+++ b/kythe/cxx/indexer/cxx/testdata/kindex_test.unit
@@ -31,3 +31,4 @@ argument: "/fake/test.cc"
 has_compile_errors: false
 source_file: "/fake/test.cc"
 output_key: "/fake-out/test.o"
+working_directory: "/"


### PR DESCRIPTION
The C++ (+ friends) indexer should be hermetic modulo claiming when
reading from extracted compilation units. Currently, it will use the
indexing environment's working directory when one is not set in the
compilation unit (or if the value that was set is not an absolute path).
This PR turns this into an error condition.