### PR TITLE
chore(cxx_common): update Abseil and use type-safe printf over libc

### DIFF
--- a/external.bzl
+++ b/external.bzl
@@ -60,9 +60,9 @@ def _cc_dependencies():
     maybe(
         http_archive,
         name = "com_google_absl",
-        sha256 = "77a39b7084b66582aaa18b42e4e4154df6bee29632875bbcc41d99502f784634",
-        strip_prefix = "abseil-cpp-2019e17a520575ab365b2b5134d71068182c70b8",
-        url = "https://github.com/abseil/abseil-cpp/archive/2019e17a520575ab365b2b5134d71068182c70b8.zip",
+        sha256 = "3601822b4d3c7cc62d891a2d0993b902ad1858e4faf41d895678d3a7749ec503",
+        strip_prefix = "abseil-cpp-ca3f87560a0eef716195cadf66dc6b938a579ec6",
+        url = "https://github.com/abseil/abseil-cpp/archive/ca3f87560a0eef716195cadf66dc6b938a579ec6.zip",
     )
 
     maybe(

--- a/kythe/cxx/common/indexing/BUILD
+++ b/kythe/cxx/common/indexing/BUILD
@@ -19,6 +19,7 @@ cc_library(
         "@com_github_gflags_gflags//:gflags",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
         "@com_google_absl//absl/types:optional",
         "@com_google_protobuf//:protobuf",
     ],

--- a/kythe/cxx/common/indexing/KytheCachingOutput.cc
+++ b/kythe/cxx/common/indexing/KytheCachingOutput.cc
@@ -21,6 +21,9 @@
 #include <algorithm>
 #include <sstream>
 
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
+
 namespace kythe {
 
 bool MemcachedHashCache::OpenMemcache(const std::string& spec) {
@@ -54,8 +57,8 @@ void MemcachedHashCache::RegisterHash(const Hash& hash) {
       memcached_add(cache_, reinterpret_cast<const char*>(hash), kHashSize,
                     &value, sizeof(value), 0, 0);
   if (!memcached_success(add_result) && add_result != MEMCACHED_DATA_EXISTS) {
-    fprintf(stderr, "memcached add failed: %s\n",
-            memcached_strerror(cache_, add_result));
+    absl::FPrintF(stderr, "memcached add failed: %s\n",
+                  memcached_strerror(cache_, add_result));
   }
 }
 
@@ -68,19 +71,18 @@ bool MemcachedHashCache::SawHash(const Hash& hash) {
   if (ex_result == MEMCACHED_SUCCESS) {
     return true;
   } else if (ex_result != MEMCACHED_NOTFOUND) {
-    fprintf(stderr, "memcached exist failed: %s\n",
-            memcached_strerror(cache_, ex_result));
+    absl::FPrintF(stderr, "memcached exist failed: %s\n",
+                  memcached_strerror(cache_, ex_result));
   }
   return false;
 }
 
 std::string FileOutputStream::Stats::ToString() const {
-  std::stringstream ostream;
-  ostream << buffers_merged_ << " merged " << buffers_split_ << " split "
-          << buffers_retired_ << " retired " << hashes_matched_ << " matches "
-          << (buffers_retired_ ? (total_bytes_ / buffers_retired_) : 0)
-          << " bytes/buffer";
-  return ostream.str();
+  return absl::StrCat(
+      buffers_merged_, " merged ", buffers_split_, " split ", buffers_retired_,
+      " retired ", hashes_matched_, " matches ",
+      (buffers_retired_ ? (total_bytes_ / buffers_retired_) : 0),
+      " bytes/buffer");
 }
 
 FileOutputStream::~FileOutputStream() {
@@ -89,7 +91,7 @@ FileOutputStream::~FileOutputStream() {
     EmitAndReleaseTopBuffer();
   }
   if (show_stats_) {
-    fprintf(stderr, "%s\n", stats_.ToString().c_str());
+    absl::FPrintF(stderr, "%s\n", stats_.ToString());
     fflush(stderr);
   }
 }

--- a/kythe/cxx/common/indexing/KytheOutputStream.h
+++ b/kythe/cxx/common/indexing/KytheOutputStream.h
@@ -17,6 +17,8 @@
 #ifndef KYTHE_CXX_COMMON_INDEXING_KYTHE_OUTPUT_STREAM_H_
 #define KYTHE_CXX_COMMON_INDEXING_KYTHE_OUTPUT_STREAM_H_
 
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
 #include "absl/strings/string_view.h"
 #include "kythe/proto/common.pb.h"
 #include "kythe/proto/storage.pb.h"
@@ -83,12 +85,7 @@ struct OrdinalEdgeRef {
   /// Overwrites all of the fields in `entry` that can differ between edges with
   /// ordinals.
   void Expand(proto::Entry* entry) const {
-    char digits[12];  // strlen("4294967295") + 2
-    int dot_ordinal_length = ::sprintf(digits, ".%u", ordinal);
-    entry->mutable_edge_kind()->clear();
-    entry->mutable_edge_kind()->reserve(dot_ordinal_length + edge_kind.size());
-    entry->mutable_edge_kind()->append(edge_kind.data(), edge_kind.size());
-    entry->mutable_edge_kind()->append(digits, dot_ordinal_length);
+    entry->set_edge_kind(absl::StrCat(edge_kind, ".", ordinal));
     source->Expand(entry->mutable_source());
     target->Expand(entry->mutable_target());
   }

--- a/kythe/cxx/doc/BUILD
+++ b/kythe/cxx/doc/BUILD
@@ -97,6 +97,7 @@ cc_library(
         "@com_github_gflags_gflags//:gflags",
         "@com_github_google_glog//:glog",
         "@com_google_absl//absl/memory",
+        "@com_google_absl//absl/strings:str_format",
     ],
 )
 

--- a/kythe/cxx/extractor/BUILD
+++ b/kythe/cxx/extractor/BUILD
@@ -80,6 +80,7 @@ cc_library(
     hdrs = ["path_utils.h"],
     deps = [
         "//kythe/cxx/common:lib",
+        "@com_google_absl//absl/strings:str_format",
         "@org_llvm//:LLVMSupport",
         "@org_llvm//:clangBasic",
         "@org_llvm//:clangLex",
@@ -109,6 +110,7 @@ cc_library(
     ],
     deps = [
         "@com_github_google_glog//:glog",
+        "@com_google_absl//absl/strings:str_format",
         "@org_llvm//:LLVMSupport",
     ],
 )

--- a/kythe/cxx/extractor/CommandLineUtils.cc
+++ b/kythe/cxx/extractor/CommandLineUtils.cc
@@ -26,6 +26,7 @@
 #include <string>
 #include <vector>
 
+#include "absl/strings/str_format.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Regex.h"
@@ -47,7 +48,7 @@ class FullMatchRegex {
       : InnerRegex("^(" + Regex.str() + ")$", llvm::Regex::NoFlags) {
     std::string st;
     if (!InnerRegex.isValid(st)) {
-      fprintf(stderr, "%s (regex was %s)\n", st.c_str(), Regex.str().c_str());
+      absl::FPrintF(stderr, "%s (regex was %s)\n", st, Regex.str());
       assert(0 && "!InnerRegex.isValid()");
     }
   }

--- a/kythe/cxx/extractor/cxx_extractor.cc
+++ b/kythe/cxx/extractor/cxx_extractor.cc
@@ -29,6 +29,7 @@
 #include "absl/memory/memory.h"
 #include "absl/strings/match.h"
 #include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
 #include "absl/strings/string_view.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Frontend/FrontendAction.h"
@@ -1192,7 +1193,7 @@ void MapCompilerResources(clang::tooling::ToolInvocation* invocation,
 
 void ExtractorConfiguration::SetVNameConfig(const std::string& path) {
   if (!index_writer_.SetVNameConfiguration(LoadFileOrDie(path))) {
-    fprintf(stderr, "Couldn't configure vnames from %s\n", path.c_str());
+    absl::FPrintF(stderr, "Couldn't configure vnames from %s\n", path);
     exit(1);
   }
 }

--- a/kythe/cxx/extractor/cxx_extractor_bazel_main.cc
+++ b/kythe/cxx/extractor/cxx_extractor_bazel_main.cc
@@ -20,6 +20,7 @@
 #include <fcntl.h>
 #include <sys/stat.h>
 
+#include "absl/strings/str_format.h"
 #include "cxx_extractor.h"
 #include "gflags/gflags.h"
 #include "glog/logging.h"
@@ -54,8 +55,9 @@ int main(int argc, char* argv[]) {
   gflags::SetVersionString("0.1");
   gflags::ParseCommandLineFlags(&argc, &argv, /*remove_flags=*/true);
   if (argc != 4) {
-    fprintf(stderr, "Call as %s extra-action-file output-file vname-config\n",
-            argv[0]);
+    absl::FPrintF(stderr,
+                  "Call as %s extra-action-file output-file vname-config\n",
+                  argv[0]);
     return 1;
   }
   std::string extra_action_file = argv[1];

--- a/kythe/cxx/extractor/objc_extractor_bazel_main.cc
+++ b/kythe/cxx/extractor/objc_extractor_bazel_main.cc
@@ -70,6 +70,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#include "absl/strings/str_format.h"
 #include "cxx_extractor.h"
 #include "gflags/gflags.h"
 #include "glog/logging.h"
@@ -201,10 +202,11 @@ int main(int argc, char* argv[]) {
   google::InitGoogleLogging(argv[0]);
   gflags::SetVersionString("0.2");
   if (argc != 4 && argc != 6) {
-    fprintf(stderr,
-            "Invalid number of arguments:\n\tCall as %s extra-action-file "
-            "output-file vname-config [devdir-script sdkroot-script]\n",
-            argv[0]);
+    absl::FPrintF(
+        stderr,
+        "Invalid number of arguments:\n\tCall as %s extra-action-file "
+        "output-file vname-config [devdir-script sdkroot-script]\n",
+        argv[0]);
     return 1;
   }
   XAState xa_state;

--- a/kythe/cxx/extractor/path_utils.cc
+++ b/kythe/cxx/extractor/path_utils.cc
@@ -16,6 +16,7 @@
 
 #include "path_utils.h"
 
+#include "absl/strings/str_format.h"
 #include "clang/Basic/FileManager.h"
 #include "clang/Lex/HeaderSearch.h"
 #include "clang/Lex/LexDiagnostic.h"
@@ -75,7 +76,7 @@ const clang::FileEntry* LookupFileForIncludePragma(
       nullptr /* IsMapped */, nullptr /* IsFrameworkFound */,
       false /* SkipCache */);
   if (file == nullptr) {
-    fprintf(stderr, "Missing required file %s.\n", filename.str().c_str());
+    absl::FPrintF(stderr, "Missing required file %s.\n", filename.str());
   }
   return file;
 }

--- a/kythe/cxx/indexer/cxx/BUILD
+++ b/kythe/cxx/indexer/cxx/BUILD
@@ -378,6 +378,7 @@ cc_library(
         "//kythe/proto:common_cc_proto",
         "//kythe/proto:storage_cc_proto",
         "@com_google_absl//absl/memory",
+        "@com_google_absl//absl/strings:str_format",
         "@com_google_absl//absl/types:optional",
         "@com_google_protobuf//:protobuf",
         "@org_llvm//:LLVMSupport",

--- a/kythe/cxx/indexer/cxx/IndexerFrontendAction.cc
+++ b/kythe/cxx/indexer/cxx/IndexerFrontendAction.cc
@@ -22,6 +22,7 @@
 
 #include "KytheGraphObserver.h"
 #include "absl/memory/memory.h"
+#include "absl/strings/str_format.h"
 #include "clang/Frontend/FrontendAction.h"
 #include "clang/Tooling/Tooling.h"
 #include "kythe/cxx/common/indexing/KytheGraphRecorder.h"
@@ -101,8 +102,9 @@ bool DecodeHeaderSearchInfo(const proto::CxxCompilationUnitDetails& Details,
     return false;
   }
   if (!Info.CopyFrom(Details)) {
-    fprintf(stderr,
-            "Warning: unit has header search info, but it is ill-formed.\n");
+    absl::FPrintF(
+        stderr,
+        "Warning: unit has header search info, but it is ill-formed.\n");
     return false;
   }
   return true;

--- a/kythe/cxx/indexer/cxx/IndexerPPCallbacks.cc
+++ b/kythe/cxx/indexer/cxx/IndexerPPCallbacks.cc
@@ -19,6 +19,7 @@
 #include "IndexerPPCallbacks.h"
 
 #include "GraphObserver.h"
+#include "absl/strings/str_format.h"
 #include "clang/Basic/FileManager.h"
 #include "clang/Basic/SourceManager.h"
 #include "clang/Lex/PPCallbacks.h"
@@ -326,7 +327,7 @@ void IndexerPPCallbacks::HandleKytheMetadataPragma(
   const auto* file = cxx_extractor::LookupFileForIncludePragma(
       &preprocessor, &search_path, &relative_path, &filename);
   if (!file) {
-    fprintf(stderr, "Missing metadata file: %s\n", filename.c_str());
+    absl::FPrintF(stderr, "Missing metadata file: %s\n", filename.str());
     return;
   }
   clang::FileID pragma_file_id =
@@ -334,7 +335,7 @@ void IndexerPPCallbacks::HandleKytheMetadataPragma(
   if (!pragma_file_id.isInvalid()) {
     Observer.applyMetadataFile(pragma_file_id, file, "");
   } else {
-    fprintf(stderr, "Metadata pragma was in an impossible place\n");
+    absl::FPrintF(stderr, "Metadata pragma was in an impossible place\n");
   }
 }
 

--- a/kythe/cxx/indexer/cxx/KytheClaimClient.cc
+++ b/kythe/cxx/indexer/cxx/KytheClaimClient.cc
@@ -19,6 +19,8 @@
 #include <libmemcached/memcached.h>
 #include <openssl/sha.h>
 
+#include "absl/strings/str_format.h"
+
 namespace kythe {
 namespace {
 constexpr char kArbitraryClaimantRoot[] = "KytheClaimClient";
@@ -58,7 +60,7 @@ DynamicClaimClient::~DynamicClaimClient() {
     memcached_free(cache_);
     cache_ = nullptr;
   }
-  fprintf(
+  absl::FPrintF(
       stderr, "%8lu  %8lu claims approved/rejected (%f reject fraction)\n",
       request_count_ - rejected_requests_, rejected_requests_,
       request_count_ == 0 ? 0.0 : (double)rejected_requests_ / request_count_);
@@ -118,8 +120,8 @@ bool DynamicClaimClient::Claim(const kythe::proto::VName& claimant,
       if (!memcached_success(add_result) &&
           add_result != MEMCACHED_DATA_EXISTS) {
         // We'll also pass the check below and assume we claimed the vname.
-        fprintf(stderr, "memcached add failed: %s\n",
-                memcached_strerror(cache_, add_result));
+        absl::FPrintF(stderr, "memcached add failed: %s\n",
+                      memcached_strerror(cache_, add_result));
       }
       if (add_result != MEMCACHED_DATA_EXISTS) {
         claim_table_[vname] = claimant;

--- a/kythe/cxx/indexer/cxx/KytheGraphObserver.cc
+++ b/kythe/cxx/indexer/cxx/KytheGraphObserver.cc
@@ -18,6 +18,7 @@
 
 #include "IndexerASTHooks.h"
 #include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
 #include "absl/strings/str_join.h"
 #include "clang/AST/Attr.h"
 #include "clang/AST/Decl.h"
@@ -424,8 +425,8 @@ void KytheGraphObserver::MetaHookDefines(const MetadataFile& meta,
           recorder_->AddEdge(decl, edge_kind, remote);
         }
       } else {
-        fprintf(stderr, "Unknown edge kind %s from metadata\n",
-                rule->second.edge_out.c_str());
+        absl::FPrintF(stderr, "Unknown edge kind %s from metadata\n",
+                      rule->second.edge_out);
       }
     }
   }
@@ -1072,8 +1073,8 @@ void KytheGraphObserver::applyMetadataFile(clang::FileID id,
   const llvm::MemoryBuffer* buffer =
       SourceManager->getMemoryBufferForFile(file);
   if (!buffer) {
-    fprintf(stderr, "Couldn't get content for %s\n",
-            file->getName().str().c_str());
+    absl::FPrintF(stderr, "Couldn't get content for %s\n",
+                  file->getName().str());
     return;
   }
   if (auto metadata = meta_supports_->ParseFile(
@@ -1184,25 +1185,27 @@ void KytheGraphObserver::pushFile(clang::SourceLocation blame_location,
               if (offset_info != context_info->second.end()) {
                 state.context = offset_info->second;
               } else {
-                fprintf(stderr,
-                        "Warning: when looking for %s[%s]:%u: missing source "
-                        "offset\n",
-                        vfs_->get_debug_uid_string(previous_uid).c_str(),
-                        previous_context.c_str(), offset);
+                absl::FPrintF(
+                    stderr,
+                    "Warning: when looking for %s[%s]:%u: missing source "
+                    "offset\n",
+                    vfs_->get_debug_uid_string(previous_uid), previous_context,
+                    offset);
               }
             } else {
-              fprintf(stderr,
-                      "Warning: when looking for %s[%s]:%u: missing source "
-                      "context\n",
-                      vfs_->get_debug_uid_string(previous_uid).c_str(),
-                      previous_context.c_str(), offset);
+              absl::FPrintF(
+                  stderr,
+                  "Warning: when looking for %s[%s]:%u: missing source "
+                  "context\n",
+                  vfs_->get_debug_uid_string(previous_uid), previous_context,
+                  offset);
             }
           } else {
-            fprintf(
+            absl::FPrintF(
                 stderr,
                 "Warning: when looking for %s[%s]:%u: missing source path\n",
-                vfs_->get_debug_uid_string(previous_uid).c_str(),
-                previous_context.c_str(), offset);
+                vfs_->get_debug_uid_string(previous_uid), previous_context,
+                offset);
           }
         }
         state.vname.set_signature(absl::StrCat(
@@ -1293,8 +1296,9 @@ void KytheGraphObserver::AddContextInformation(
     path_to_context_data_[found_file->getUniqueID()][context][offset] =
         dest_context;
   } else {
-    fprintf(stderr, "WARNING: Path %s could not be mapped to a VFS record.\n",
-            path.c_str());
+    absl::FPrintF(stderr,
+                  "WARNING: Path %s could not be mapped to a VFS record.\n",
+                  path);
   }
 }
 

--- a/kythe/cxx/indexer/cxx/KytheIndexerMain.cc
+++ b/kythe/cxx/indexer/cxx/KytheIndexerMain.cc
@@ -23,6 +23,7 @@
 //       indexer -i foo.cc | verifier foo.cc
 //       indexer some/index.kindex
 
+#include "absl/strings/str_format.h"
 #include "gflags/gflags.h"
 #include "google/protobuf/stubs/common.h"
 #include "kythe/cxx/common/protobuf_metadata_file.h"
@@ -83,8 +84,8 @@ int main(int argc, char* argv[]) {
   options.AllowFSAccess = context.allow_filesystem_access();
   if (FLAGS_report_profiling_events) {
     options.ReportProfileEvent = [](const char* counter, ProfilingEvent event) {
-      fprintf(stderr, "%s: %s\n", counter,
-              event == ProfilingEvent::Enter ? "enter" : "exit");
+      absl::FPrintF(stderr, "%s: %s\n", counter,
+                    event == ProfilingEvent::Enter ? "enter" : "exit");
     };
   }
 
@@ -114,7 +115,7 @@ int main(int argc, char* argv[]) {
         });
 
     if (!result.empty()) {
-      fprintf(stderr, "Error: %s\n", result.c_str());
+      absl::FPrintF(stderr, "Error: %s\n", result);
       had_errors = true;
     }
   });

--- a/kythe/cxx/indexer/cxx/KytheVFS.cc
+++ b/kythe/cxx/indexer/cxx/KytheVFS.cc
@@ -17,6 +17,7 @@
 #include "KytheVFS.h"
 
 #include "absl/memory/memory.h"
+#include "absl/strings/str_format.h"
 #include "kythe/cxx/indexer/cxx/proto_conversions.h"
 #include "llvm/Support/Errc.h"
 #include "llvm/Support/FileSystem.h"
@@ -254,9 +255,12 @@ IndexVFS::FileRecord* IndexVFS::AllocOrReturnFileRecord(
     if (record->label == label) {
       if (create_if_missing && (record->status.getSize() != size ||
                                 record->status.getType() != type)) {
-        fprintf(stderr, "Warning: path %s/%s: defined inconsistently (%s/%s)\n",
-                parent->status.getName().str().c_str(), label.str().c_str(),
-                NameOfFileType(type), NameOfFileType(record->status.getType()));
+        absl::FPrintF(
+            stderr,
+            "Warning: path %s/%s: defined inconsistently (%s:%d/%s:%d)\n",
+            parent->status.getName().str(), label.str(), NameOfFileType(type),
+            size, NameOfFileType(record->status.getType()),
+            record->status.getSize());
         return nullptr;
       }
       return record;

--- a/kythe/cxx/indexer/cxx/frontend.cc
+++ b/kythe/cxx/indexer/cxx/frontend.cc
@@ -23,6 +23,7 @@
 #include <string>
 
 #include "absl/memory/memory.h"
+#include "absl/strings/str_format.h"
 #include "gflags/gflags.h"
 #include "google/protobuf/io/coded_stream.h"
 #include "google/protobuf/io/gzip_stream.h"
@@ -316,7 +317,7 @@ void IndexerContext::InitializeClaimClient() {
     dynamic_claims->set_max_redundant_claims(
         FLAGS_experimental_dynamic_overclaim);
     if (!dynamic_claims->OpenMemcache(FLAGS_experimental_dynamic_claim_cache)) {
-      fprintf(stderr, "Can't open memcached\n");
+      absl::FPrintF(stderr, "Can't open memcached\n");
       exit(1);
     }
     claim_client_ = std::move(dynamic_claims);

--- a/kythe/cxx/tools/BUILD
+++ b/kythe/cxx/tools/BUILD
@@ -23,6 +23,7 @@ cc_library(
         "@com_github_google_glog//:glog",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
         "@com_google_protobuf//:protobuf",
         "@com_googlesource_code_re2//:re2",
     ],
@@ -47,6 +48,7 @@ cc_library(
         "//kythe/proto:filecontext_cc_proto",
         "@com_github_gflags_gflags//:gflags",
         "@com_github_google_glog//:glog",
+        "@com_google_absl//absl/strings:str_format",
         "@com_google_protobuf//:protobuf",
     ],
 )
@@ -68,6 +70,7 @@ cc_library(
         "//kythe/proto:claim_cc_proto",
         "@com_github_gflags_gflags//:gflags",
         "@com_github_google_glog//:glog",
+        "@com_google_absl//absl/strings:str_format",
         "@com_google_protobuf//:protobuf",
     ],
 )

--- a/kythe/cxx/tools/fyi/BUILD
+++ b/kythe/cxx/tools/fyi/BUILD
@@ -25,6 +25,7 @@ cc_library(
         "@com_github_gflags_gflags//:gflags",
         "@com_github_google_glog//:glog",
         "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
         "@com_google_protobuf//:protobuf",
         "@org_llvm//:LLVMSupport",
         "@org_llvm//:clangFrontend",

--- a/kythe/cxx/tools/fyi/fyi.cc
+++ b/kythe/cxx/tools/fyi/fyi.cc
@@ -17,6 +17,7 @@
 #include "kythe/cxx/tools/fyi/fyi.h"
 
 #include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
 #include "clang/Frontend/ASTUnit.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Frontend/TextDiagnosticPrinter.h"
@@ -414,7 +415,7 @@ class Action : public clang::ASTFrontendAction,
     std::string error_text;
     if (!factory_.xrefs_->Edges(named_edges_request, &named_edges_reply,
                                 &error_text)) {
-      fprintf(stderr, "Xrefs error (named): %s\n", error_text.c_str());
+      absl::FPrintF(stderr, "Xrefs error (named): %s\n", error_text);
       return clang::TypoCorrection();
     }
     // Get information about the places where those nodes were defined.
@@ -427,7 +428,7 @@ class Action : public clang::ASTFrontendAction,
         ToStringRef(absl::StrCat("%", kythe::common::schema::kDefines)));
     if (!factory_.xrefs_->Edges(defined_edges_request, &defined_edges_reply,
                                 &error_text)) {
-      fprintf(stderr, "Xrefs error (defines): %s\n", error_text.c_str());
+      absl::FPrintF(stderr, "Xrefs error (defines): %s\n", error_text);
       return clang::TypoCorrection();
     }
     // Finally, figure out whether we can make those definition sites visible
@@ -440,7 +441,7 @@ class Action : public clang::ASTFrontendAction,
     childof_request.add_filter(kythe::common::schema::kFactNodeKind);
     childof_request.add_kind(kythe::common::schema::kChildOf);
     if (!factory_.xrefs_->Edges(childof_request, &childof_reply, &error_text)) {
-      fprintf(stderr, "Xrefs error (childof): %s\n", error_text.c_str());
+      absl::FPrintF(stderr, "Xrefs error (childof): %s\n", error_text);
       return clang::TypoCorrection();
     }
     // Add those files to the set of includes to try out.
@@ -602,7 +603,7 @@ bool ActionFactory::runInvocation(
           /*ErrAST*/ nullptr);
       // The preprocessor hooks must have configured the FileTracker.
       if (action->tracker() == nullptr) {
-        fprintf(stderr, "Error: Never entered input file.\n");
+        absl::FPrintF(stderr, "Error: Never entered input file.\n");
         return false;
       }
     } else {
@@ -654,7 +655,7 @@ bool ActionFactory::runInvocation(
   if (action->tracker()->state() != FileTracker::State::kFailure) {
     const auto buffer = action->tracker()->backing_store();
     if (!buffer.empty()) {
-      printf("%s", buffer.str().c_str());
+      absl::PrintF("%s", buffer.str());
     }
   }
   return action->tracker()->state() == FileTracker::State::kSuccess;

--- a/kythe/cxx/tools/generate_compile_commands/BUILD
+++ b/kythe/cxx/tools/generate_compile_commands/BUILD
@@ -9,6 +9,7 @@ cc_binary(
         "@com_github_gflags_gflags//:gflags",
         "@com_github_google_glog//:glog",
         "@com_github_tencent_rapidjson//:rapidjson",
+        "@com_google_absl//absl/strings:str_format",
         "@com_google_protobuf//:protobuf",
     ],
 )

--- a/kythe/cxx/tools/generate_compile_commands/extract_compile_command.cc
+++ b/kythe/cxx/tools/generate_compile_commands/extract_compile_command.cc
@@ -22,6 +22,7 @@
 #include <string>
 #include <vector>
 
+#include "absl/strings/str_format.h"
 #include "glog/logging.h"
 #include "google/protobuf/io/coded_stream.h"
 #include "google/protobuf/io/zero_copy_stream.h"
@@ -100,7 +101,7 @@ int main(int argc, char** argv) {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
   google::InitGoogleLogging(argv[0]);
   if (argc != 3) {
-    fprintf(stderr, "usage: %s extra-action-file output-file\n", argv[0]);
+    absl::FPrintF(stderr, "usage: %s extra-action-file output-file\n", argv[0]);
     return 1;
   }
   std::string extra_action_file = argv[1];

--- a/kythe/cxx/tools/kindex_tool_main.cc
+++ b/kythe/cxx/tools/kindex_tool_main.cc
@@ -27,6 +27,7 @@
 #include <sys/stat.h>
 
 #include "absl/container/flat_hash_map.h"
+#include "absl/strings/str_format.h"
 #include "absl/strings/match.h"
 #include "gflags/gflags.h"
 #include "glog/logging.h"
@@ -277,7 +278,7 @@ kindex_tool -assemble some/file.kindex some/unit some/content...
     std::vector<std::string> constituent_parts(argv + 1, argv + argc);
     BuildIndexFile(FLAGS_assemble, constituent_parts);
   } else {
-    fprintf(stderr, "Specify either -assemble or -explode.\n");
+    absl::FPrintF(stderr, "Specify either -assemble or -explode.\n");
     return -1;
   }
   return 0;

--- a/kythe/cxx/tools/shuck_main.cc
+++ b/kythe/cxx/tools/shuck_main.cc
@@ -37,6 +37,7 @@
 
 #include <set>
 
+#include "absl/strings/str_format.h"
 #include "gflags/gflags.h"
 #include "glog/logging.h"
 #include "google/protobuf/io/coded_stream.h"
@@ -97,7 +98,7 @@ int main(int argc, char* argv[]) {
       FLAGS_index_pack, kythe::IndexPackFilesystem::OpenMode::kReadOnly,
       &error_text);
   if (!filesystem) {
-    ::fprintf(stderr, "Error reading index pack: %s\n", error_text.c_str());
+    absl::FPrintF(stderr, "Error reading index pack: %s\n", error_text);
     return 1;
   }
   kythe::IndexPack pack(std::move(filesystem));
@@ -112,24 +113,24 @@ int main(int argc, char* argv[]) {
             for (const auto& input : unit.required_input()) {
               if (paths.count(input.v_name().path())) {
                 if (!FLAGS_slice_dependencies || claimed) {
-                  ::printf("units/%s.unit\n", file_id.c_str());
+                  absl::PrintF("units/%s.unit\n", file_id);
                   if (!FLAGS_slice_dependencies && claimed) {
-                    ::printf("# prev claim contains");
+                    absl::PrintF("# prev claim contains");
                     for (const auto& arg : unit.source_file()) {
-                      ::printf(" %s", arg.c_str());
+                      absl::PrintF(" %s", arg);
                     }
-                    ::printf("\n");
+                    absl::PrintF("\n");
                   }
                 }
               }
               if (FLAGS_slice_dependencies && claimed) {
-                ::printf("files/%s.data\n", input.info().digest().c_str());
+                absl::PrintF("files/%s.data\n", input.info().digest());
               }
             }
             return true;
           },
           &error_text)) {
-    ::fprintf(stderr, "Error scanning index pack: %s\n", error_text.c_str());
+    absl::FPrintF(stderr, "Error scanning index pack: %s\n", error_text);
   }
   return 0;
 }

--- a/kythe/cxx/tools/static_claim_main.cc
+++ b/kythe/cxx/tools/static_claim_main.cc
@@ -26,6 +26,7 @@
 #include <map>
 #include <set>
 
+#include "absl/strings/str_format.h"
 #include "gflags/gflags.h"
 #include "glog/logging.h"
 #include "google/protobuf/io/coded_stream.h"
@@ -162,7 +163,7 @@ class ClaimTool {
           claim.mutable_compilation_v_name()->CopyFrom(
               claimable.second.elected_claimant->vname);
           claim.mutable_dependency_v_name()->CopyFrom(claimable.second.vname);
-          ::printf("%s", claim.DebugString().c_str());
+          absl::PrintF("%s", claim.DebugString());
         }
       }
       return;
@@ -270,7 +271,7 @@ int main(int argc, char* argv[]) {
       tool.HandleCompilationUnit(unit);
     }
     if (!std::cin.eof()) {
-      ::fprintf(stderr, "Error reading from standard input.\n");
+      absl::FPrintF(stderr, "Error reading from standard input.\n");
       return 1;
     }
   } else {
@@ -279,7 +280,7 @@ int main(int argc, char* argv[]) {
         FLAGS_index_pack, kythe::IndexPackFilesystem::OpenMode::kReadOnly,
         &error_text);
     if (!filesystem) {
-      ::fprintf(stderr, "Error reading index pack: %s\n", error_text.c_str());
+      absl::FPrintF(stderr, "Error reading index pack: %s\n", error_text);
       return 1;
     }
     kythe::IndexPack pack(std::move(filesystem));
@@ -294,19 +295,19 @@ int main(int argc, char* argv[]) {
               return true;
             },
             &error_text)) {
-      ::fprintf(stderr, "Error scanning index pack: %s\n", error_text.c_str());
+      absl::FPrintF(stderr, "Error scanning index pack: %s\n", error_text);
       return 1;
     }
   }
   tool.AssignClaims();
   tool.WriteClaimFile(STDOUT_FILENO);
   if (FLAGS_show_stats) {
-    ::printf("Number of claimables: %lu\n", tool.claimables().size());
-    ::printf(" Number of claimants: %lu\n", tool.claimants().size());
-    ::printf("   Total input count: %lu\n", tool.total_input_count());
-    ::printf(" Total include count: %lu\n", tool.total_include_count());
-    ::printf("%%claimables/includes: %f\n",
-             tool.claimables().size() * 100.0 / tool.total_include_count());
+    absl::PrintF("Number of claimables: %lu\n", tool.claimables().size());
+    absl::PrintF(" Number of claimants: %lu\n", tool.claimants().size());
+    absl::PrintF("   Total input count: %lu\n", tool.total_input_count());
+    absl::PrintF(" Total include count: %lu\n", tool.total_include_count());
+    absl::PrintF("%%claimables/includes: %f\n",
+                 tool.claimables().size() * 100.0 / tool.total_include_count());
   }
   return 0;
 }

--- a/kythe/cxx/verifier/BUILD
+++ b/kythe/cxx/verifier/BUILD
@@ -75,6 +75,7 @@ cc_library(
         "@com_github_gflags_gflags//:gflags",
         "@com_github_google_glog//:glog",
         "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/strings:str_format",
         "@com_google_protobuf//:protobuf",
         "@com_googlesource_code_re2//:re2",
     ],
@@ -95,6 +96,7 @@ cc_library(
         "//kythe/proto:storage_cc_proto",
         "@com_github_gflags_gflags//:gflags",
         "@com_github_google_glog//:glog",
+        "@com_google_absl//absl/strings:str_format",
         "@com_google_protobuf//:protobuf",
     ],
 )

--- a/kythe/cxx/verifier/pretty_printer.cc
+++ b/kythe/cxx/verifier/pretty_printer.cc
@@ -18,6 +18,8 @@
 
 #include <bitset>
 
+#include "absl/strings/str_format.h"
+
 namespace kythe {
 namespace verifier {
 
@@ -36,15 +38,15 @@ void StringPrettyPrinter::Print(const void* ptr) {
 }
 
 void FileHandlePrettyPrinter::Print(const std::string& string) {
-  fprintf(file_, "%s", string.c_str());
+  absl::FPrintF(file_, "%s", string);
 }
 
 void FileHandlePrettyPrinter::Print(const char* string) {
-  fprintf(file_, "%s", string);
+  absl::FPrintF(file_, "%s", string);
 }
 
 void FileHandlePrettyPrinter::Print(const void* ptr) {
-  fprintf(file_, "0x%016llx", reinterpret_cast<unsigned long long>(ptr));
+  absl::FPrintF(file_, "0x%016llx", reinterpret_cast<unsigned long long>(ptr));
 }
 
 void QuoteEscapingPrettyPrinter::Print(const std::string& string) {

--- a/kythe/cxx/verifier/verifier_main.cc
+++ b/kythe/cxx/verifier/verifier_main.cc
@@ -19,6 +19,7 @@
 
 #include <string>
 
+#include "absl/strings/str_format.h"
 #include "assertion_ast.h"
 #include "gflags/gflags.h"
 #include "glog/logging.h"
@@ -67,7 +68,7 @@ Example:
   } else {
     std::string error;
     if (!v.SetGoalCommentRegex(FLAGS_goal_regex, &error)) {
-      fprintf(stderr, "While parsing goal regex: %s\n", error.c_str());
+      absl::FPrintF(stderr, "While parsing goal regex: %s\n", error);
       return 1;
     }
   }
@@ -109,7 +110,7 @@ Example:
     }
     auto limit = coded_input.PushLimit(byte_size);
     if (!entry.ParseFromCodedStream(&coded_input)) {
-      fprintf(stderr, "Error reading around fact %zu\n", facts);
+      absl::FPrintF(stderr, "Error reading around fact %zu\n", facts);
       return 1;
     }
     if (FLAGS_show_protos) {
@@ -117,7 +118,7 @@ Example:
       putchar('\n');
     }
     if (!v.AssertSingleFact(&dbname, facts, entry)) {
-      fprintf(stderr, "Error asserting fact %zu\n", facts);
+      absl::FPrintF(stderr, "Error asserting fact %zu\n", facts);
       return 1;
     }
     ++facts;
@@ -130,7 +131,7 @@ Example:
   if (!FLAGS_graphviz) {
     std::vector<std::string> rule_files(argv + 1, argv + argc);
     if (rule_files.empty() && !FLAGS_use_file_nodes) {
-      fprintf(stderr, "No rule files specified\n");
+      absl::FPrintF(stderr, "No rule files specified\n");
       return 1;
     }
 
@@ -139,7 +140,7 @@ Example:
         continue;
       }
       if (!v.LoadInlineRuleFile(rule_file)) {
-        fprintf(stderr, "Failed loading %s.\n", rule_file.c_str());
+        absl::FPrintF(stderr, "Failed loading %s.\n", rule_file);
         return 2;
       }
     }
@@ -156,8 +157,8 @@ Example:
   int result = 0;
 
   if (!v.VerifyAllGoals()) {
-    fprintf(stderr,
-            "Could not verify all goals. The furthest we reached was:\n  ");
+    absl::FPrintF(
+        stderr, "Could not verify all goals. The furthest we reached was:\n  ");
     v.DumpErrorGoal(v.highest_group_reached(), v.highest_goal_reached());
     result = 1;
   }


### PR DESCRIPTION
libc's printf-family of formatting routines are not typesafe and require the use of unportable length prefixes or awkward macros when printing standard integer typedefs and null-terminated strings.  Switch to using the equivalent routines provided by Abseil which are typesafe and print a wider variety of string-like things directly.