### PR TITLE
chore(doc): remove cmake/ssl from deps and docs

### DIFF
--- a/kythe/release/appengine/buildbot/Dockerfile
+++ b/kythe/release/appengine/buildbot/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update && \
       # Bazel dependencies
       pkg-config zip g++ zlib1g-dev unzip \
       # Kythe C++ dependencies
-      cmake gcc libssl-dev uuid-dev libcurl4-openssl-dev flex clang-3.8 bison \
+      gcc uuid-dev flex clang-3.8 bison \
       # Kythe misc dependencies
       asciidoc source-highlight graphviz curl parallel && \
     apt-get clean

--- a/kythe/web/site/getting-started-macos.md
+++ b/kythe/web/site/getting-started-macos.md
@@ -59,7 +59,7 @@ rest of these instructions assume you have it.
 To install most of the [external dependencies][ext], run
 
 {% highlight bash %}
-for pkg in asciidoc bison brotli cmake go graphviz leveldb node parallel source-highlight wget ; do
+for pkg in asciidoc bison brotli go graphviz leveldb node parallel source-highlight wget ; do
    brew install $pkg
 done
 

--- a/kythe/web/site/getting-started.md
+++ b/kythe/web/site/getting-started.md
@@ -31,16 +31,13 @@ Kythe relies on the following external dependencies:
 
 * asciidoc
 * bison-3.0.4
-* clang >= 3.6
-* cmake >= 3.4.3
+* clang >= 3.8
 * [docker](https://www.docker.com/) (for release images `//kythe/release/...` and `//buildtools/docker`)
 * flex-2.5
 * go >= 1.7
 * graphviz
 * jdk >= 8
 * [leiningen](http://leiningen.org/) (used to build `//kythe/web/ui`)
-* libcurl4-openssl-dev
-* libssl-dev
 * node.js
 * parallel
 * source-highlight
@@ -60,7 +57,7 @@ apt-get update
 
 apt-get install \
     asciidoc asciidoctor source-highlight graphviz \
-    gcc libssl-dev uuid-dev libncurses-dev libcurl4-openssl-dev flex clang-3.6 bison \
+    gcc uuid-dev libncurses-dev flex clang-3.8 bison \
     openjdk-8-jdk \
     parallel \
     wget
@@ -74,14 +71,14 @@ You must either have `/usr/bin/clang` aliased properly, or the `CC` env var set
 for Bazel:
 
 {% highlight bash %}
-echo 'build --client_env=CC=/usr/bin/clang-3.6' >>~/.bazelrc
+echo 'build --client_env=CC=/usr/bin/clang-3.8' >>~/.bazelrc
 {% endhighlight %}
 
 OR:
 
 {% highlight bash %}
-sudo ln -s /usr/bin/clang-3.6 /usr/bin/clang
-sudo ln -s /usr/bin/clang++-3.6 /usr/bin/clang++
+sudo ln -s /usr/bin/clang-3.8 /usr/bin/clang
+sudo ln -s /usr/bin/clang++-3.8 /usr/bin/clang++
 {% endhighlight %}
 
 OR:

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -29,8 +29,8 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       git pkg-config zip unzip rsync patch zsh wget net-tools less parallel locales make \
       g++ gcc openjdk-8-jdk openjdk-8-source clang-3.6 flex asciidoc source-highlight graphviz \
-      zlib1g-dev libarchive-dev uuid-dev libssl-dev bazel cmake \
-      ca-certificates-java libcurl4-openssl-dev libsasl2-dev && \
+      zlib1g-dev libarchive-dev uuid-dev bazel \
+      ca-certificates-java libsasl2-dev && \
     apt-get clean
 
 RUN update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java

--- a/tools/platforms/Dockerfile
+++ b/tools/platforms/Dockerfile
@@ -18,7 +18,7 @@ FROM gcr.io/cloud-marketplace/google/rbe-ubuntu16-04@sha256:9bd8ba020af33edb5f11
 RUN apt-get update && \
     apt-get install -y \
       # Kythe C++ dependencies
-      cmake libssl-dev uuid-dev libcurl4-openssl-dev flex bison g++ \
+      uuid-dev flex bison g++ \
       # Kythe misc dependencies
       asciidoc source-highlight graphviz && \
     apt-get clean


### PR DESCRIPTION
We haven't needed CMake or SSL libraries to build anything for a while now, remove them from the docs and Dockerfiles.

Document the long-standing requirement for clang >= 3.8