### PR TITLE
chore(java_extractor): rename build env jar in test

### DIFF
--- a/kythe/javatests/com/google/devtools/kythe/extractors/java/JavaExtractorTest.java
+++ b/kythe/javatests/com/google/devtools/kythe/extractors/java/JavaExtractorTest.java
@@ -62,6 +62,12 @@ public class JavaExtractorTest extends TestCase {
           .setDigest("e5ee743f5c6df4923a934cba33c73d3d73e19d277c8ddec5c4e7ac59788fc674")
           .build();
 
+  // Due to the nature of the jsr250 dependency, this class is incidentally
+  // included in some compilation environments but not others.
+  // In order to distinguish these dependencies from "true" dependencies, use this name.
+  private static final FileInfo JDK_ANNOTATION_CLASS = GENERATED_ANNOTATION_CLASS;
+  private static final String JDK_ANNOTATION_PATH = "!CLASS_PATH_JAR!";
+
   /** Tests the basic case of indexing a java compilation with two sources. */
   public void testJavaExtractorSimple() throws Exception {
     JavaCompilationUnitExtractor java = new JavaCompilationUnitExtractor(CORPUS);
@@ -93,12 +99,12 @@ public class JavaExtractorTest extends TestCase {
 
     // With the expected sources as required inputs.
     assertThat(getInfos(unit.getRequiredInputList()))
-        .containsExactlyElementsIn(getExpectedInfos(sources, GENERATED_ANNOTATION_CLASS));
+        .containsExactlyElementsIn(getExpectedInfos(sources, JDK_ANNOTATION_CLASS));
 
     // And the correct sourcepath set to replay the compilation.
     JavaDetails details = getJavaDetails(unit);
     assertThat(details.getSourcepathList()).containsExactly(TEST_DATA_DIR);
-    assertThat(details.getClasspathList()).containsExactly("!CLASS_PATH_JAR!");
+    assertThat(details.getClasspathList()).containsExactly(JDK_ANNOTATION_PATH);
   }
 
   /** Tests that metadata is included when a file specifies it. */
@@ -178,12 +184,12 @@ public class JavaExtractorTest extends TestCase {
 
     // With the expected sources as required inputs.
     assertThat(getInfos(unit.getRequiredInputList()))
-        .containsExactlyElementsIn(getExpectedInfos(sources, GENERATED_ANNOTATION_CLASS));
+        .containsExactlyElementsIn(getExpectedInfos(sources, JDK_ANNOTATION_CLASS));
 
     // And the correct sourcepath set to replay the compilation.
     JavaDetails details = getJavaDetails(unit);
     assertThat(details.getSourcepathList()).containsExactly(TEST_DATA_DIR);
-    assertThat(details.getClasspathList()).containsExactly("!CLASS_PATH_JAR!");
+    assertThat(details.getClasspathList()).containsExactly(JDK_ANNOTATION_PATH);
   }
 
   /**
@@ -221,13 +227,13 @@ public class JavaExtractorTest extends TestCase {
     assertThat(unit.getSourceFileList()).containsExactly(sources.get(0), sources.get(1)).inOrder();
 
     assertThat(getInfos(unit.getRequiredInputList()))
-        .containsExactlyElementsIn(getExpectedInfos(sources, GENERATED_ANNOTATION_CLASS));
+        .containsExactlyElementsIn(getExpectedInfos(sources, JDK_ANNOTATION_CLASS));
 
     // And the correct sourcepath set to replay the compilation for both sources.
     JavaDetails details = getJavaDetails(unit);
     assertThat(details.getSourcepathList())
         .containsExactly(join(TEST_DATA_DIR, "one"), join(TEST_DATA_DIR, "two"));
-    assertThat(details.getClasspathList()).containsExactly("!CLASS_PATH_JAR!");
+    assertThat(details.getClasspathList()).containsExactly(JDK_ANNOTATION_PATH);
   }
 
   /**
@@ -396,7 +402,7 @@ public class JavaExtractorTest extends TestCase {
     // With the expected sources as required inputs.
     assertThat(getInfos(unit.getRequiredInputList()))
         .containsExactly(
-            GENERATED_ANNOTATION_CLASS,
+            JDK_ANNOTATION_CLASS,
             makeFileInfo(sources.get(0)),
             makeFileInfo(sources.get(2)),
             makeFileInfo(sources.get(1)))
@@ -436,13 +442,13 @@ public class JavaExtractorTest extends TestCase {
 
     // With the expected sources as required inputs.
     assertThat(getInfos(unit.getRequiredInputList()))
-        .containsExactlyElementsIn(getExpectedInfos(sources, GENERATED_ANNOTATION_CLASS));
+        .containsExactlyElementsIn(getExpectedInfos(sources, JDK_ANNOTATION_CLASS));
 
     // And the correct sourcepath set to replay the compilation.
     JavaDetails details = getJavaDetails(unit);
     assertThat(details.getSourcepathList()).hasSize(1);
     assertThat(details.getSourcepathList().get(0)).isEqualTo(TEST_DATA_DIR);
-    assertThat(details.getClasspathList()).containsExactly("!CLASS_PATH_JAR!");
+    assertThat(details.getClasspathList()).containsExactly(JDK_ANNOTATION_PATH);
   }
 
   /**
@@ -478,12 +484,12 @@ public class JavaExtractorTest extends TestCase {
 
     // With the expected sources as required inputs.
     assertThat(getInfos(unit.getRequiredInputList()))
-        .containsExactlyElementsIn(getExpectedInfos(sources, GENERATED_ANNOTATION_CLASS));
+        .containsExactlyElementsIn(getExpectedInfos(sources, JDK_ANNOTATION_CLASS));
 
     // And the correct sourcepath set to replay the compilation.
     JavaDetails details = getJavaDetails(unit);
     assertThat(details.getSourcepathList()).containsExactly(TEST_DATA_DIR);
-    assertThat(details.getClasspathList()).containsExactly("!CLASS_PATH_JAR!");
+    assertThat(details.getClasspathList()).containsExactly(JDK_ANNOTATION_PATH);
   }
 
   /**


### PR DESCRIPTION
Be explicit about which annotations dependencies are explicit and intended and which are accidental artifacts of the build environment.  This makes it easier to replace the latter and, eventually, remove them.