### PR TITLE
docs: fix examples to use _CORPUS instead of _KYTHE_CORPUS

### DIFF
--- a/kythe/extractors/gcp/README.md
+++ b/kythe/extractors/gcp/README.md
@@ -110,21 +110,21 @@ gcloud builds submit --no-source --config kythe/extractors/gcp/bazel/bazel.yaml 
   --substitutions=_REPO=https://github.com/angular/angular.git,\
 _COMMIT=8accc98d28249628e84136d7306fdbbe1f4caaef,\
 _BUCKET_NAME=$BUCKET_NAME,\
-_KYTHE_CORPUS=github.com/angular/angular
+_CORPUS=github.com/angular/angular
 
 # Extract github.com/bazelbuild/bazel at commit 22d375b
 gcloud builds submit --no-source --config kythe/extractors/gcp/bazel/bazel.yaml \
   --substitutions=_REPO=https://github.com/bazelbuild/bazel.git,\
 _COMMIT=22d375bd532b04bb83f18a7770e5080e23a1d517,\
 _BUCKET_NAME=$BUCKET_NAME,\
-_KYTHE_CORPUS=github.com/bazelbuild/bazel
+_CORPUS=github.com/bazelbuild/bazel
 
 # Extract github.com/protocolbuffers/protobuf at commit e728325
 gcloud builds submit --no-source --config kythe/extractors/gcp/bazel/bazel.yaml \
   --substitutions=_REPO=https://github.com/protocolbuffers/protobuf.git,\
 _COMMIT=e7283254d6eb01ddfdb63cc3c89cd312e2d354d5,\
 _BUCKET_NAME=$BUCKET_NAME,\
-_KYTHE_CORPUS=github.com/protocolbuffers/protobuf
+_CORPUS=github.com/protocolbuffers/protobuf
 ```
 
 ## Cloud Build REST API


### PR DESCRIPTION
The yaml templates use _CORPUS as the variable name.