### PR TITLE
fix: update vulnerable outdated js-yaml NPM package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -661,9 +661,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",


### PR DESCRIPTION
A run of `npm audit` reported the following vulnerabilities:

```
$ npm audit
│ Moderate      │ Denial of Service
│ Package       │ js-yaml
│ Dependency of │ @commitlint/cli [dev]
│ Path          │ @commitlint/cli > @commitlint/load > cosmiconfig > js-yaml
│ More info     │ https://npmjs.com/advisories/788

│ High          │ Code Injection
│ Package       │ js-yaml
│ Dependency of │ @commitlint/cli [dev]
│ Path          │ @commitlint/cli > @commitlint/load > cosmiconfig > js-yaml
│ More info     │ https://npmjs.com/advisories/813
```

This change was proposed by `npm audit fix` to update the package lock.