### PR TITLE
chore(zlib): only export actual public headers from zlib

### DIFF
--- a/third_party/zlib.BUILD
+++ b/third_party/zlib.BUILD
@@ -2,28 +2,20 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # BSD/MIT-like license (for zlib)
 
-_ZLIB_HEADERS = [
-    "crc32.h",
-    "deflate.h",
-    "gzguts.h",
-    "inffast.h",
-    "inffixed.h",
-    "inflate.h",
-    "inftrees.h",
-    "trees.h",
+# From zlib/README
+_ZLIB_PUBLIC_HEADERS = [
     "zconf.h",
     "zlib.h",
-    "zutil.h",
 ]
 
-_ZLIB_PREFIXED_HEADERS = ["zlib/include/" + hdr for hdr in _ZLIB_HEADERS]
+_ZLIB_PREFIXED_HEADERS = ["zlib/include/" + hdr for hdr in _ZLIB_PUBLIC_HEADERS]
 
 # In order to limit the damage from the `includes` propagation
 # via `:zlib`, copy the public headers to a subdirectory and
 # expose those.
 genrule(
     name = "copy_public_headers",
-    srcs = _ZLIB_HEADERS,
+    srcs = _ZLIB_PUBLIC_HEADERS,
     outs = _ZLIB_PREFIXED_HEADERS,
     cmd = "cp $(SRCS) $(@D)/zlib/include/",
     visibility = ["//visibility:private"],
@@ -47,10 +39,19 @@ cc_library(
         "trees.c",
         "uncompr.c",
         "zutil.c",
+        "crc32.h",
+        "deflate.h",
+        "gzguts.h",
+        "inffast.h",
+        "inffixed.h",
+        "inflate.h",
+        "inftrees.h",
+        "trees.h",
+        "zutil.h",
         # Include the un-prefixed headers in srcs to work
-        # around the fact that zlib isn't consistent in its
-        # choice of <> or "" delimiter when including itself.
-    ] + _ZLIB_HEADERS,
+        # around the fact that zlib uses "" when including itself,
+        # but clients generally use <>.
+    ] + _ZLIB_PUBLIC_HEADERS,
     hdrs = _ZLIB_PREFIXED_HEADERS,
     copts = [
         "-Wno-unused-variable",


### PR DESCRIPTION
Minor cleanup to only export the actually public headers from zlib (after looking at the README) instead of all of them.