### PR TITLE
java_verifier_tests: declare deps for annotations

### DIFF
--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/BUILD
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/BUILD
@@ -33,4 +33,5 @@ java_extract_kzip(
         "//kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/regression:regression_files",
     ],
     visibility = ["//visibility:public"],
+    deps = ["@com_google_code_findbugs_jsr305//jar"],  # needed for pkg/package-info.java
 )

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/BUILD
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/BUILD
@@ -149,7 +149,7 @@ java_verifier_test(
     name = "cross_file_tests",
     size = "small",
     srcs = ["CrossFile.java"],
-    deps = [":files_tests"],
+    verifier_deps = [":files_tests"],
 )
 
 java_verifier_test(
@@ -170,7 +170,7 @@ java_verifier_test(
         "--verbose",
         "--emit_jvm_signatures",
     ],
-    deps = [":jvm_files_tests"],
+    verifier_deps = [":jvm_files_tests"],
 )
 
 # TODO(#1501): This test currently fails
@@ -245,6 +245,7 @@ java_verifier_test(
     meta = [
         "Metadata.java.meta",
     ],
+    deps = ["@javax_annotation_jsr250_api//jar"],
 )
 
 java_verifier_test(
@@ -260,6 +261,7 @@ java_verifier_test(
         "ProtobufMetadata.java.pb.meta",
     ],
     vnames_config = "protobuf_vnames.json",
+    deps = ["@javax_annotation_jsr250_api//jar"],
 )
 
 java_verifier_test(
@@ -313,6 +315,7 @@ java_verifier_test(
         "Packages.java",
         "package-info.java",
     ],
+    deps = ["@com_google_code_findbugs_jsr305//jar"],
 )
 
 java_verifier_test(

--- a/tools/build_rules/verifier_test/java_verifier_test.bzl
+++ b/tools/build_rules/verifier_test/java_verifier_test.bzl
@@ -154,6 +154,7 @@ def java_verifier_test(
         name,
         srcs,
         meta = [],
+        verifier_deps = [],
         deps = [],
         size = "small",
         tags = [],
@@ -169,7 +170,8 @@ def java_verifier_test(
 
     Args:
       srcs: The compilation's source file inputs; each file's verifier goals will be checked
-      deps: Optional list of java_verifier_test targets to be used as Java compilation dependencies
+      verifier_deps: Optional list of java_verifier_test targets to be used as Java compilation dependencies
+      deps: Optional list of Java compilation dependencies
       meta: Optional list of Kythe metadata files
       extractor: Executable extractor tool to invoke (defaults to javac_extractor)
       extractor_opts: List of options passed to the extractor tool
@@ -191,7 +193,7 @@ def java_verifier_test(
         visibility = visibility,
         vnames_config = vnames_config,
         # This is a hack to depend on the .jar producer.
-        deps = [d + "_kzip" for d in deps],
+        deps = deps + [d + "_kzip" for d in verifier_deps],
     )
     indexer = "//kythe/java/com/google/devtools/kythe/analyzers/java:indexer"
     tools = []


### PR DESCRIPTION
Prior to this PR, importing kythe using the [intellij bazel plugin](https://github.com/bazelbuild/intellij) fails at sync time. The `java_extract_kzip` rule includes a `java_common.compile` action that will fail if the source requires any (non-jvt) deps. The failing targets used annotations that were not declared as deps, but the `java_common.compile` actions were getting pruned as the outputs were not used. The IntelliJ plugin tries to build them because the rule return a `JavaInfo` provider.

This PR renames the existing `deps` attribute to `java_verifier_test` to `verifier_deps` (as it is specifically only meant to be passed `java_verifier_test` targets) and introduces a new `deps` attribute that just gets passed through to the `java_common.compile` action.