### PR TITLE
build: update bitbucket.org/creachadair/shell to v0.0.5

### DIFF
--- a/external.bzl
+++ b/external.bzl
@@ -434,7 +434,7 @@ def _go_dependencies():
         custom = "shell",
         custom_git = "https://bitbucket.org/creachadair/shell.git",
         importpath = "bitbucket.org/creachadair/shell",
-        tag = "v0.0.4",
+        tag = "v0.0.5",
     )
 
     maybe(


### PR DESCRIPTION
Roughly 70% improvement in split performance over v0.0.4.

N.B.: This will require updating the internal version when you import, but that should be trivial as there are no API changes.