### PR TITLE
Migrate Kythe for Bazel 0.27

### DIFF
--- a/kythe/cxx/tools/fyi/testdata/compile_commands.bzl
+++ b/kythe/cxx/tools/fyi/testdata/compile_commands.bzl
@@ -38,4 +38,5 @@ compile_commands = rule(
         "compile_commands": "compile_commands.json.in",
     },
     implementation = _compile_commands_impl,
+    toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
 )


### PR DESCRIPTION
This PR migrates Kythe for
https://github.com/bazelbuild/bazel/issues/7260, which we plan to flip in Bazel 0.27.