### PR TITLE
feature: Add a VName specification for TypeScript Indexer

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -36,3 +36,4 @@ Daniel Moy <danielmoy@google.com>
 Salvatore Guarnieri <salguarnieri@google.com>
 Jay Sachs <jsachs@google.com>
 Alexander Bezzubov <alex@sourced.tech>
+Ayaz Hafiz <ayaz.hafiz.1@gmail.com>

--- a/kythe/typescript/README.md
+++ b/kythe/typescript/README.md
@@ -79,6 +79,7 @@ describing the module.
 
 -   `NamespaceImport`
 -   `ClassDeclaration`
+-   `Constructor`
 -   `PropertyDeclaration`
 -   `MethodDeclaration`
 -   `EnumDeclaration`
@@ -94,35 +95,48 @@ describing the module.
 -   `TypeParameter`
 
 ```typescript
-//- @Klass defines/binding VName("Klass", _, _, _, _)
-//- @Klass defines/binding VName("Klass#type", _, _, _, _)
 export class Klass {
-  //- @property defines/binding VName("Klass.property", _, _, _, _)
-  property = {
-    //- @property defines/binding VName("Klass.property.key", _, _, _, _)
-    key: 0
+  //- @property defines/binding VName("Klass.method", _, _, _, _)
+  method() {
+    //- @property defines/binding VName("Klass.method.val", _, _, _, _)
+    let val;
   };
 }
 ```
 
-#### Constructor
+#### Class Declaration
 
-**Form**: `constructor`
+**Form**:
+- `$CLASS#type`
+- `$CLASS:ctor`
+
+**Notes**: Because a class is both a type and a value, it has to be labeled as
+such. The identifier of a class is always binded as the class type. If a class
+defines a constructor, the constructor is binded as the class value (`ctor`);
+otherwise, the class identifier is also bound as the value.
+
+This only applies to the class declarations. Signatures of identifiers within a
+class have a class component that is only `$CLASS`.
 
 **SyntaxKind**:
-
--   `Constructor`
+- ClassDeclaration
+- Constructor
 
 ```typescript
+//- @Klass defines/binding VName("Klass#type", _, _, _, _)
 class Klass {
-  //- @constructor defines/binding VName("Klass.constructor", _, _, _, _)
+  //- @constructor defines/binding VName("Klass:ctor", _, _, _, _)
   constructor() {}
 }
+
+//- @NoCtorKlass defines/binding VName("NoCtorKlass#type", _, _, _, _)
+//- @NoCtorKlass defines/binding VName("NoCtorKlass:ctor", _, _, _, _)
+class NoCtorKlass {}
 ```
 
 #### Getter
 
-**Form**: `$DECLARATION_NAME#getter`
+**Form**: `$DECLARATION_NAME:getter`
 
 **SyntaxKind**:
 
@@ -130,7 +144,7 @@ class Klass {
 
 ```typescript
 class Klass {
-  //- @foo defines/binding VName("Klass.foo#getter", _, _, _, _)
+  //- @foo defines/binding VName("Klass.foo:getter", _, _, _, _)
   get foo() {}
 }
 ```
@@ -145,7 +159,7 @@ class Klass {
 
 ```typescript
 class Klass {
-  //- @foo defines/binding VName("Klass.foo#setter", _, _, _, _)
+  //- @foo defines/binding VName("Klass.foo:setter", _, _, _, _)
   set foo(newFoo) {}
 }
 ```

--- a/kythe/typescript/README.md
+++ b/kythe/typescript/README.md
@@ -75,6 +75,10 @@ describing the module.
 
 **Form**: `$DECLARATION_NAME`
 
+**Notes**: Every named declaration is guaranteed to have a signature of the form
+`$SCOPE[.$SCOPE]*` where `$SCOPE` is the name of each encompassing named
+declaration.
+
 **SyntaxKind**:
 
 -   `NamespaceImport`
@@ -107,7 +111,10 @@ export class Klass {
 
 #### Class Declaration
 
-**Form**: - `$CLASS#type` - `$CLASS:ctor`
+**Form**:
+
+-   `$CLASS#type`
+-   `$CLASS:ctor`
 
 **Notes**: Because a class is both a type and a value, it has to be labeled as
 such. The identifier of a class is always binded as the class type. If a class
@@ -117,7 +124,10 @@ otherwise, the class identifier is also bound as the value.
 This only applies to the class declarations. Signatures of identifiers within a
 class have a class component that is only `$CLASS`.
 
-**SyntaxKind**: - ClassDeclaration - Constructor
+**SyntaxKind**:
+
+-   ClassDeclaration
+-   Constructor
 
 ```typescript
 //- @Klass defines/binding VName("Klass#type", _, _, _, _)
@@ -133,7 +143,7 @@ class NoCtorKlass {}
 
 #### Setter
 
-**Form**: `$DECLARATION_NAME#setter`
+**Form**: `$DECLARATION_NAME:setter`
 
 **Notes**: This is to differentiate the setter from the getter, because the
 identifier for a getter and setter is the same and its symbol has multiple

--- a/kythe/typescript/README.md
+++ b/kythe/typescript/README.md
@@ -1,5 +1,171 @@
 # Kythe indexer for TypeScript
 
+## VName Specification
+
+This specification defines how indexer expresses TypeScript declarations as
+VNames. You may find this useful if you are developing an application that
+relies on TypeScript code you don't want to re-index.
+
+[spec tests](./testdata/declaration_spec.ts)
+
+### VName signature
+
+The signature of a TypeScript declaration is its enclosing scope and its name,
+joined by a delimiter of a dot (`.`). For example, in
+
+```typescript
+class A {
+  public foo: string;
+}
+```
+
+`foo` has the signature `A.foo`.
+
+The contribution of a scope to the signature name is defined below. Contribution
+forms are described with the following schema:
+
+- A substring starting with `$` is a variable up until its word boundary.
+  - e.g. `$DECLARATION_NAME` is a variable refering to the name of declaration.
+- All other substrings are literals.
+  - e.g. `get#$NAME` is really `get#foo` if `$NAME = foo`.
+
+#### Named Declaration
+
+**Form**: `$DECLARATION_NAME`
+
+**SyntaxKind**:
+
+- `NamespaceImport`
+- `ImportSpecifier`
+- `ExportSpecifier`
+- `ModuleDeclaration`
+- `ClassDeclaration`
+- `PropertyDeclaration`
+- `MethodDeclaration`
+- `EnumDeclaration`
+- `EnumMember`
+- `FunctionDeclaration`
+- `Parameter`
+- `InterfaceDeclaration`
+- `PropertySignature`
+- `MethodSignature`
+- `VariableDeclaration`
+- `PropertyAssignment`
+- `TypeAliasDeclaration`
+- `TypeParameter`
+
+```typescript
+//- @Klass defines/binding VName("Klass", _, _, _, _)
+export class Klass {
+  //- @property defines/binding VName("Klass.property", _, _, _, _)
+  property = {
+    //- @property defines/binding VName("Klass.property.key", _, _, _, _)
+    key: 0
+  };
+}
+```
+
+#### Constructor
+
+**Form**: `constructor`
+
+**SyntaxKind**:
+
+- `Constructor`
+
+```typescript
+class Klass {
+  //- @constructor defines/binding VName("Klass.constructor", _, _, _, _)
+  constructor() {}
+}
+```
+
+#### Getter
+
+**Form**: `$DECLARATION_NAME#getter`
+
+**SyntaxKind**:
+
+- GetAccessor
+
+```typescript
+class Klass {
+  //- @foo defines/binding VName("Klass.foo#getter", _, _, _, _)
+  get foo() {}
+}
+```
+
+#### Setter
+
+**Form**: `$DECLARATION_NAME#setter`
+
+**SyntaxKind**:
+
+- SetAccessor
+
+```typescript
+class Klass {
+  //- @foo defines/binding VName("Klass.foo#setter", _, _, _, _)
+  set foo(newFoo) {}
+}
+```
+
+#### Export Assignment
+
+**Form**: `default`
+
+**Notes**: Assignment to `export` is semantically equivalent to exporting a
+variable named `default`.
+
+**SyntaxKind**:
+
+- `ExportAssignment`
+
+```typescript
+//- @myExport defines/binding VName("default", _, _, _, _)
+export = myExport;
+```
+
+#### Anonymous Block
+
+**Form**: a unique, non-deterministic block name.
+
+**Notes**: The block name is not guaranteed, because declarations within an
+anonymous block cannot be accessed outside it.
+
+**SyntaxKind**:
+
+- `ArrowFunction`
+- `Block` that does not have a `FunctionDeclaration` or `MethodDeclaration`
+  parent
+
+```typescript
+let af = () => {
+  //- @decl defines/binding VName(_, _, _, _, _)
+  let decl;
+};
+```
+
+### VName corpus
+
+Project-specific, defined by the compilation unit you pass to the indexer.
+
+### VName root
+
+Project-specific, defined by the compilation unit you pass to the indexer.
+
+### VName path
+
+- For entire source code files
+  - the entire file path, relative to the corpus and root.
+- For declarations with a file
+  - the file path stripped of `.d.ts` or `.ts` extensions, relative to the
+    corpus and root.
+
+### VName language
+
+Always `'typescript'`.
+
 ## Development
 
 ### Dependencies
@@ -8,10 +174,10 @@ Install [yarn](https://yarnpkg.com/), then run it with no arguments to download
 dependencies.
 
 You also need an install of the kythe tools like `entrystream` and `verifier`,
-and point the `KYTHE` environment variable at the path to it.  You can either
-get these by [building Kythe](http://kythe.io/getting-started) or by downloading
-the Kythe binaries from the [Kythe
-releases](https://github.com/kythe/kythe/releases) page.
+and point the `KYTHE` environment variable at the path to it. You can either get
+these by [building Kythe](http://kythe.io/getting-started) or by downloading the
+Kythe binaries from the
+[Kythe releases](https://github.com/kythe/kythe/releases) page.
 
 ### Commands
 
@@ -63,7 +229,7 @@ function x() {}
 ```
 
 So the current approach instead starts from the `Symbol`, then from there jumps
-to the *declarations* of the `Symbol`, which then point to syntactic positions
+to the _declarations_ of the `Symbol`, which then point to syntactic positions
 (like the `function` above), and then from there maps the declaration back to
 the containing scopes to choose a unique name.
 
@@ -73,7 +239,7 @@ modules, for example.
 
 ### Module name
 
-A file `foo/bar.ts` has an associated *module name* `foo/bar`. This is distinct
+A file `foo/bar.ts` has an associated _module name_ `foo/bar`. This is distinct
 (without the extension) because it's also possible to define that module via
 other file names, such as `foo/bar.d.ts`, and all such files all define into the
 single extension-less namespace.

--- a/kythe/typescript/README.md
+++ b/kythe/typescript/README.md
@@ -2,24 +2,25 @@
 
 ## VName Specification
 
-This specification defines how indexer expresses TypeScript declarations as
-VNames. You may find this useful if you are developing an application that
+This specification defines how the indexer expresses VNames for TypeScript
+declarations. You may find this useful if you are developing an application that
 relies on TypeScript code you don't want to re-index.
 
 [spec tests](./testdata/declaration_spec.ts)
 
 ### VName signature
 
-The signature description language used in this document similar to regex.
+The signature description language used in this document is similar to regex.
 
-- A substring matching `\b\$.*\b` is a variable.
-  - e.g. `$DECLARATION_NAME` is a variable refering to the name of declaration.
-- A substring matching `\[.*\]\?` is matched 0 or 1 times.
-  - e.g. `(hidden)?` is really `hidden` or ``.
-- A substring matching `\[.*\]\*` is matched 0 or more times.
-  - e.g. `[a]*` is ``, or `a`, or `aa`, ...
-- All other substrings are literals.
-  - e.g. `get#$NAME` is really `get#foo` if `$NAME = foo`.
+-   A substring in `\b\$.*\b` is a variable.
+    -   e.g. `$DECLARATION_NAME` is a variable refering to the name of
+        declaration.
+-   A substring in `\[.*\]\?` is matched 0 or 1 times.
+    -   e.g. `(hidden)?` is really `hidden` or ``.
+-   A substring in `\[.*\]\*` is matched 0 or more times.
+    -   e.g. `[a]*` is ``, or`a`, or`aa`, ...
+-   All other substrings are literals.
+    -   e.g. `get#$NAME` is really `get#foo` if `$NAME = foo`.
 
 The signature of a TypeScript declaration is defined by the following schema:
 
@@ -31,11 +32,11 @@ where `$PART` is a component of the enclosing declaration scope and `#type` is
 appended to the signature of type declarations. `SyntaxKind`s that are type
 declarations are:
 
-- `ClassDeclaration` (also a value)
-- `EnumDeclaration` (also a value)
-- `InterfaceDeclaration`
-- `TypeAliasDeclaration`
-- `TypeParameter`
+-   `ClassDeclaration` (also a value)
+-   `EnumDeclaration` (also a value)
+-   `InterfaceDeclaration`
+-   `TypeAliasDeclaration`
+-   `TypeParameter`
 
 As an example of this schema, in
 
@@ -60,7 +61,7 @@ describing the module.
 
 **SyntaxKind**:
 
-- `SourceFile`
+-   `SourceFile`
 
 ```typescript
 //- FileModule=VName("module", _, _, _, _).node/kind record
@@ -72,28 +73,25 @@ describing the module.
 
 #### Named Declaration
 
-**Form**: `$DECLARATION_NAME(#type)?`
-
-**Notes**: Signatures for type declarations are appended with a `#type literal`.
-`SyntaxKind`s that are affected by this are annotated below.
+**Form**: `$DECLARATION_NAME`
 
 **SyntaxKind**:
 
-- `NamespaceImport`
-- `ClassDeclaration`
-- `PropertyDeclaration`
-- `MethodDeclaration`
-- `EnumDeclaration`
-- `EnumMember`
-- `FunctionDeclaration`
-- `Parameter`
-- `InterfaceDeclaration`
-- `PropertySignature`
-- `MethodSignature`
-- `VariableDeclaration`
-- `PropertyAssignment`
-- `TypeAliasDeclaration`
-- `TypeParameter`
+-   `NamespaceImport`
+-   `ClassDeclaration`
+-   `PropertyDeclaration`
+-   `MethodDeclaration`
+-   `EnumDeclaration`
+-   `EnumMember`
+-   `FunctionDeclaration`
+-   `Parameter`
+-   `InterfaceDeclaration`
+-   `PropertySignature`
+-   `MethodSignature`
+-   `VariableDeclaration`
+-   `PropertyAssignment`
+-   `TypeAliasDeclaration`
+-   `TypeParameter`
 
 ```typescript
 //- @Klass defines/binding VName("Klass", _, _, _, _)
@@ -113,7 +111,7 @@ export class Klass {
 
 **SyntaxKind**:
 
-- `Constructor`
+-   `Constructor`
 
 ```typescript
 class Klass {
@@ -128,7 +126,7 @@ class Klass {
 
 **SyntaxKind**:
 
-- GetAccessor
+-   GetAccessor
 
 ```typescript
 class Klass {
@@ -143,7 +141,7 @@ class Klass {
 
 **SyntaxKind**:
 
-- SetAccessor
+-   SetAccessor
 
 ```typescript
 class Klass {
@@ -161,11 +159,14 @@ variable named `default`.
 
 **SyntaxKind**:
 
-- `ExportAssignment`
+-   `ExportAssignment`
 
 ```typescript
-//- @myExport defines/binding VName("default", _, _, _, _)
+//- @"export =" defines/binding VName("default", _, _, _, _)
 export = myExport;
+
+//- @default defines/binding VName("default", _, _, _, _)
+export default myExport;
 ```
 
 #### Anonymous Block
@@ -177,9 +178,9 @@ anonymous block cannot be accessed outside it.
 
 **SyntaxKind**:
 
-- `ArrowFunction`
-- `Block` that does not have a `FunctionDeclaration` or `MethodDeclaration`
-  parent
+-   `ArrowFunction`
+-   `Block` that does not have a `FunctionDeclaration` or `MethodDeclaration`
+    parent
 
 ```typescript
 let af = () => {
@@ -198,15 +199,15 @@ Project-specific, defined by the compilation unit you pass to the indexer.
 
 ### VName path
 
-- For entire source code files
-  - the entire file path, relative to the corpus and root.
-- For declarations with a file
-  - the file path stripped of `.d.ts` or `.ts` extensions, relative to the
-    corpus and root.
+-   For entire source code files
+    -   the entire file path, relative to the corpus and root.
+-   For declarations with a file
+    -   the file path stripped of `.d.ts` or `.ts` extensions, relative to the
+        corpus and root.
 
 ### VName language
 
-Always `'typescript'`.
+Always `typescript`.
 
 ## Development
 

--- a/kythe/typescript/README.md
+++ b/kythe/typescript/README.md
@@ -82,6 +82,7 @@ describing the module.
 -   `Constructor`
 -   `PropertyDeclaration`
 -   `MethodDeclaration`
+-   `GetAccessor`
 -   `EnumDeclaration`
 -   `EnumMember`
 -   `FunctionDeclaration`
@@ -106,9 +107,7 @@ export class Klass {
 
 #### Class Declaration
 
-**Form**:
-- `$CLASS#type`
-- `$CLASS:ctor`
+**Form**: - `$CLASS#type` - `$CLASS:ctor`
 
 **Notes**: Because a class is both a type and a value, it has to be labeled as
 such. The identifier of a class is always binded as the class type. If a class
@@ -118,9 +117,7 @@ otherwise, the class identifier is also bound as the value.
 This only applies to the class declarations. Signatures of identifiers within a
 class have a class component that is only `$CLASS`.
 
-**SyntaxKind**:
-- ClassDeclaration
-- Constructor
+**SyntaxKind**: - ClassDeclaration - Constructor
 
 ```typescript
 //- @Klass defines/binding VName("Klass#type", _, _, _, _)
@@ -134,24 +131,13 @@ class Klass {
 class NoCtorKlass {}
 ```
 
-#### Getter
-
-**Form**: `$DECLARATION_NAME:getter`
-
-**SyntaxKind**:
-
--   GetAccessor
-
-```typescript
-class Klass {
-  //- @foo defines/binding VName("Klass.foo:getter", _, _, _, _)
-  get foo() {}
-}
-```
-
 #### Setter
 
 **Form**: `$DECLARATION_NAME#setter`
+
+**Notes**: This is to differentiate the setter from the getter, because the
+identifier for a getter and setter is the same and its symbol has multiple
+declarations.
 
 **SyntaxKind**:
 

--- a/kythe/typescript/indexer.ts
+++ b/kythe/typescript/indexer.ts
@@ -326,7 +326,18 @@ class Vistor {
           }
           break;
         case ts.SyntaxKind.Constructor:
-          parts.push('constructor');
+          // Class properties declared with the constructor shorthand:
+          //    constructor(private member: string)
+          // should be scoped to the class, not the constructor.
+          const isClassMember = startNode.kind === ts.SyntaxKind.Parameter &&
+              startNode.parent === node &&  // has to be in this ctor
+              startNode.modifiers &&
+              (startNode.modifiers.find(
+                  m => m.kind === ts.SyntaxKind.PrivateKeyword ||
+                      m.kind === ts.SyntaxKind.PublicKeyword));
+          if (!isClassMember) {
+            parts.push('constructor');
+          }
           break;
         case ts.SyntaxKind.ModuleDeclaration:
           const modDecl = node as ts.ModuleDeclaration;

--- a/kythe/typescript/indexer.ts
+++ b/kythe/typescript/indexer.ts
@@ -313,10 +313,8 @@ class Vistor {
           if (decl.name && decl.name.kind === ts.SyntaxKind.Identifier) {
             let part = decl.name.text;
             // Getters and setters semantically refer to the same entities but
-            // are declared differently, so they are differentiated.
-            if (ts.isGetAccessor(decl)) {
-              part += ':getter';
-            } else if (ts.isSetAccessor(decl)) {
+            // are declared differently, so setters are differentiated.
+            if (ts.isSetAccessor(decl)) {
               part += ':setter';
             }
             parts.push(part);

--- a/kythe/typescript/test.ts
+++ b/kythe/typescript/test.ts
@@ -80,6 +80,7 @@ function verify(
       });
 
   indexer.index(compilationUnit, new Map(), [test], program, (obj: {}) => {
+    // console.log(JSON.stringify(obj) + '\n');
     verifier.stdin.write(JSON.stringify(obj) + '\n');
   });
   verifier.stdin.end();

--- a/kythe/typescript/test.ts
+++ b/kythe/typescript/test.ts
@@ -80,7 +80,6 @@ function verify(
       });
 
   indexer.index(compilationUnit, new Map(), [test], program, (obj: {}) => {
-    // console.log(JSON.stringify(obj) + '\n');
     verifier.stdin.write(JSON.stringify(obj) + '\n');
   });
   verifier.stdin.end();

--- a/kythe/typescript/testdata/class.ts
+++ b/kythe/typescript/testdata/class.ts
@@ -44,6 +44,21 @@ class Class implements IFace {
     //- FakeMember.node/kind variable
     constructor(public otherMember: number, member: string) {}
 
+    //- @mem defines/binding GetMember
+    //- GetMember.node/kind function
+    //- GetMember childof Class
+    get mem() {
+      return this.mem;
+    }
+
+    //- @mem defines/binding SetMember
+    //- SetMember.node/kind function
+    //- SetMember childof Class
+    set mem(newMem) {
+      //- @member ref Member
+      this.member = newMem;
+    }
+
     //- @method defines/binding Method
     //- Method.node/kind function
     //- Method childof Class
@@ -52,6 +67,10 @@ class Class implements IFace {
         this.member;
         //- @method ref Method
         this.method();
+        //- @mem ref GetMember
+        this.mem;
+        //- @mem ref SetMember
+        this.mem = 0;
     }
 
     // TODO: ensure the method is linked to the interface too.

--- a/kythe/typescript/testdata/class.ts
+++ b/kythe/typescript/testdata/class.ts
@@ -19,9 +19,6 @@ interface IExtended extends IFace {}
 
 //- @Class defines/binding Class
 //- Class.node/kind record
-//- @Class defines/binding ClassCtor
-//- ClassCtor.node/kind function
-//- ClassCtor.subkind constructor
 //- @IFace ref IFace
 class Class implements IFace {
     //- @member defines/binding Member
@@ -33,11 +30,12 @@ class Class implements IFace {
     //- StaticMember.tag/static _
     static staticMember: number;
 
-    // TODO: ClassCtor should really point at this constructor, not at the
-    // top-level class declaration.
     // This ctor declares a new member var named 'otherMember', and also
     // declares an ordinary parameter named 'member' (to ensure we don't get
     // confused about params to the ctor vs true member variables).
+    //- @constructor defines/binding ClassCtor
+    //- ClassCtor.node/kind function
+    //- ClassCtor.subkind constructor
     //- @otherMember defines/binding OtherMember
     //- OtherMember.node/kind variable
     //- @member defines/binding FakeMember
@@ -78,11 +76,21 @@ class Class implements IFace {
     ifaceMethod(): void {}
 }
 
+// A class without a constructor binds the constructor to its declaration.
 //- @Class ref ClassCtor
+//- @Subclass defines/binding SubClassCtor
+//- SubClassCtor.node/kind function
+//- SubClassCtor.subkind constructor
 class Subclass extends Class {
     method() {
         //- @member ref Member
         this.member;
+
+        //- @Class ref ClassCtor
+        new Class(0, '');
+
+        //- @Class ref Class
+        type CC = Class;
     }
 }
 

--- a/kythe/typescript/testdata/declaration_spec.ts
+++ b/kythe/typescript/testdata/declaration_spec.ts
@@ -28,8 +28,10 @@ class C {
   method() {}
 
   // Constructor
-  //- @constructor defines/binding VName("C.constructor", _, _, "testdata/declaration_spec", "typescript")
-  constructor() {}
+  constructor() {
+    //- @a defines/binding VName("C.constructor.a", _, _, "testdata/declaration_spec", "typescript")
+    let a;
+  }
 
   // GetAccessor
   //- @prop defines/binding VName("C.prop#getter", _, _, "testdata/declaration_spec", "typescript")

--- a/kythe/typescript/testdata/declaration_spec.ts
+++ b/kythe/typescript/testdata/declaration_spec.ts
@@ -1,86 +1,103 @@
 // Tests the specification of VNames for symbol declarations
 
+// SourceFile
+//- FileModule=VName("module", _, _, "testdata/declaration_spec", "typescript").node/kind record
+//- FileModuleAnchor.node/kind anchor
+//- FileModuleAnchor./kythe/loc/start 0
+//- FileModuleAnchor./kythe/loc/end 1
+//- FileModuleAnchor defines/binding FileModule
+
 // NamespaceImport
-//- @NspI defines/binding VName("NspI", _, _, "testdata/spec", "typescript")
-import * as NspI from "./declaration";
+//- @NspI defines/binding VName("NspI", _, _, "testdata/declaration_spec", "typescript")
+import * as NspI from './declaration';
 
-// ImportSpecifier
-//- @I defines/binding VName("I", _, _, "testdata/spec", "typescript")
-import { decl as I } from "./declaration";
-
-// ExportSpecifier
-//- @exp define/binding VName("exp", _, _, "testdata/spec", "typescript")
-export { E as exp };
-
-// ModuleDeclaration
-//- @N define/binding VName("N", _, _, "testdata/spec", "typescript")
-namespace N {}
+// ExportAssignment
+//- @default defines/binding VName("default", _, _, "testdata/declaration_spec", "typescript")
+export default NspI;
 
 // ClassDeclaration
-//- @C defines/binding VName("C", _, _, "testdata/spec", "typescript")
+//- @C defines/binding VName("C", _, _, "testdata/declaration_spec", "typescript")
+//- @C defines/binding VName("C#type", _, _, "testdata/declaration_spec", "typescript")
 class C {
   // PropertyDeclaration
-  //- @method defines/binding VName("C.property", _, _, "testdata/spec", "typescript")
+  //- @property defines/binding VName("C.property", _, _, "testdata/declaration_spec", "typescript")
   property = 0;
 
   // MethodDeclaration
-  //- @method defines/binding VName("C.method", _, _, "testdata/spec", "typescript")
+  //- @method defines/binding VName("C.method", _, _, "testdata/declaration_spec", "typescript")
   method() {}
+
+  // Constructor
+  //- @constructor defines/binding VName("C.constructor", _, _, "testdata/declaration_spec", "typescript")
+  constructor() {}
+
+  // GetAccessor
+  //- @prop defines/binding VName("C.prop#getter", _, _, "testdata/declaration_spec", "typescript")
+  get prop() {
+    return this.property;
+  }
+
+  // SetAccessor
+  //- @prop defines/binding VName("C.prop#setter", _, _, "testdata/declaration_spec", "typescript")
+  set prop(nProp) {
+    this.property = nProp;
+  }
 }
 
 // EnumDeclaration
-//- @D defines/binding VName("E", _, _, "testdata/spec", "typescript")
+//- @E defines/binding VName("E", _, _, "testdata/declaration_spec", "typescript")
+//- @E defines/binding VName("E#type", _, _, "testdata/declaration_spec", "typescript")
 enum E {
   // EnumMember
-  //- @EnumMember defines/binding VName("E.EnumMember", _, _, "testdata/spec", "typescript")
+  //- @EnumMember defines/binding VName("E.EnumMember", _, _, "testdata/declaration_spec", "typescript")
   EnumMember = 0
 }
 
 // FunctionDeclaration
-//- @fun defines/binding VName("fun", _, _, "testdata/spec", "typescript")
+//- @#1"fun" defines/binding VName("fun", _, _, "testdata/declaration_spec", "typescript")
 function fun(
-  // Parameter
-  //- @param defines/binding VName("fun.param", _, _, "testdata/spec", "typescript")
-  param: number
-) {}
+    // Parameter
+    //- @param defines/binding VName("fun.param", _, _, "testdata/declaration_spec", "typescript")
+    param: number) {}
 
 // InterfaceDeclaration
-//- @B defines/binding VName("B", _, _, "testdata/spec", "typescript")
+//- @B defines/binding VName("B#type", _, _, "testdata/declaration_spec", "typescript")
 interface B {
   // PropertySignature
-  //- @pSig defines/binding VName("B.pSig", _, _, "testdata/spec", "typescript")
+  //- @pSig defines/binding VName("B.pSig", _, _, "testdata/declaration_spec", "typescript")
   pSig: number;
 
   // MethodSignature
-  //- @mSig defines/binding VName("B.mSig", _, _, "testdata/spec", "typescript")
+  //- @mSig defines/binding VName("B.mSig", _, _, "testdata/declaration_spec", "typescript")
   mSig(): void;
 }
 
 // VariableDeclaration
-//- @v defines/binding VName("v", _, _, "testdata/spec", "typescript")
+//- @v defines/binding VName("v", _, _, "testdata/declaration_spec", "typescript")
 let v = {
   // PropertyAssignment
-  //- @prop defines/binding VName("v.prop", _, _, "testdata/spec", "typescript")
+  // TODO: the signature here should be something like `block0.prop`, but
+  // anonymous block names are not well-defined by the spec yet.
+  //- @prop defines/binding VName(_, _, _, "testdata/declaration_spec", "typescript")
   prop: 0
 };
 
 // TypeAliasDeclaration
-//- @AliasArray defines/binding VName("AliasArray", _, _, "testdata/spec", "typescript")
+//- @AliasArray defines/binding VName("AliasArray#type", _, _, "testdata/declaration_spec", "typescript")
 type AliasArray<
-  // TypeParameter
-  //- @T defines/binding VName("AliasArray.T", _, _, "testdata/spec", "typescript")
-  T
-> = Array<T>;
+    // TypeParameter
+    //- @#0"T" defines/binding VName("AliasArray.T#type", _, _, "testdata/declaration_spec", "typescript")
+    T> = Array<T>;
 
-//- @decl defines/binding VName("aFun", _, _, "testdata/spec", "typescript")
-const aFun = () => {
+//- @arrowFun defines/binding VName("arrowFun", _, _, "testdata/declaration_spec", "typescript")
+const arrowFun = () => {
   // Arrow function scope name is not well-defined.
-  //- @decl defines/binding VName(_, _, _, "testdata/spec", "typescript")
+  //- @anonArrowFunDecl defines/binding VName(_, _, _, "testdata/declaration_spec", "typescript")
   let anonArrowFunDecl;
 };
 
 {
   // Anonymous block scope name is not well-defined.
-  //- @decl defines/binding VName(_, _, _, "testdata/spec", "typescript")
+  //- @anonBlockDecl defines/binding VName(_, _, _, "testdata/declaration_spec", "typescript")
   let anonBlockDecl;
 }

--- a/kythe/typescript/testdata/declaration_spec.ts
+++ b/kythe/typescript/testdata/declaration_spec.ts
@@ -16,7 +16,6 @@ import * as NspI from './declaration';
 export default NspI;
 
 // ClassDeclaration
-//- @C defines/binding VName("C", _, _, "testdata/declaration_spec", "typescript")
 //- @C defines/binding VName("C#type", _, _, "testdata/declaration_spec", "typescript")
 class C {
   // PropertyDeclaration
@@ -28,23 +27,29 @@ class C {
   method() {}
 
   // Constructor
-  constructor() {
+  //- @constructor defines/binding VName("C:ctor", _, _, "testdata/declaration_spec", "typescript")
+  //- @pProp defines/binding VName("C.pProp", _, _, "testdata/declaration_spec", "typescript")
+  constructor(private pProp: number) {
     //- @a defines/binding VName("C.constructor.a", _, _, "testdata/declaration_spec", "typescript")
     let a;
   }
 
   // GetAccessor
-  //- @prop defines/binding VName("C.prop#getter", _, _, "testdata/declaration_spec", "typescript")
+  //- @prop defines/binding VName("C.prop:getter", _, _, "testdata/declaration_spec", "typescript")
   get prop() {
     return this.property;
   }
 
   // SetAccessor
-  //- @prop defines/binding VName("C.prop#setter", _, _, "testdata/declaration_spec", "typescript")
+  //- @prop defines/binding VName("C.prop:setter", _, _, "testdata/declaration_spec", "typescript")
   set prop(nProp) {
     this.property = nProp;
   }
 }
+
+// ClassDeclaration with no constructor
+//- @CC defines/binding VName("CC:ctor", _, _, "testdata/declaration_spec", "typescript")
+class CC {}
 
 // EnumDeclaration
 //- @E defines/binding VName("E", _, _, "testdata/declaration_spec", "typescript")

--- a/kythe/typescript/testdata/declaration_spec.ts
+++ b/kythe/typescript/testdata/declaration_spec.ts
@@ -35,7 +35,7 @@ class C {
   }
 
   // GetAccessor
-  //- @prop defines/binding VName("C.prop:getter", _, _, "testdata/declaration_spec", "typescript")
+  //- @prop defines/binding VName("C.prop", _, _, "testdata/declaration_spec", "typescript")
   get prop() {
     return this.property;
   }

--- a/kythe/typescript/testdata/declaration_spec.ts
+++ b/kythe/typescript/testdata/declaration_spec.ts
@@ -1,0 +1,86 @@
+// Tests the specification of VNames for symbol declarations
+
+// NamespaceImport
+//- @NspI defines/binding VName("NspI", _, _, "testdata/spec", "typescript")
+import * as NspI from "./declaration";
+
+// ImportSpecifier
+//- @I defines/binding VName("I", _, _, "testdata/spec", "typescript")
+import { decl as I } from "./declaration";
+
+// ExportSpecifier
+//- @exp define/binding VName("exp", _, _, "testdata/spec", "typescript")
+export { E as exp };
+
+// ModuleDeclaration
+//- @N define/binding VName("N", _, _, "testdata/spec", "typescript")
+namespace N {}
+
+// ClassDeclaration
+//- @C defines/binding VName("C", _, _, "testdata/spec", "typescript")
+class C {
+  // PropertyDeclaration
+  //- @method defines/binding VName("C.property", _, _, "testdata/spec", "typescript")
+  property = 0;
+
+  // MethodDeclaration
+  //- @method defines/binding VName("C.method", _, _, "testdata/spec", "typescript")
+  method() {}
+}
+
+// EnumDeclaration
+//- @D defines/binding VName("E", _, _, "testdata/spec", "typescript")
+enum E {
+  // EnumMember
+  //- @EnumMember defines/binding VName("E.EnumMember", _, _, "testdata/spec", "typescript")
+  EnumMember = 0
+}
+
+// FunctionDeclaration
+//- @fun defines/binding VName("fun", _, _, "testdata/spec", "typescript")
+function fun(
+  // Parameter
+  //- @param defines/binding VName("fun.param", _, _, "testdata/spec", "typescript")
+  param: number
+) {}
+
+// InterfaceDeclaration
+//- @B defines/binding VName("B", _, _, "testdata/spec", "typescript")
+interface B {
+  // PropertySignature
+  //- @pSig defines/binding VName("B.pSig", _, _, "testdata/spec", "typescript")
+  pSig: number;
+
+  // MethodSignature
+  //- @mSig defines/binding VName("B.mSig", _, _, "testdata/spec", "typescript")
+  mSig(): void;
+}
+
+// VariableDeclaration
+//- @v defines/binding VName("v", _, _, "testdata/spec", "typescript")
+let v = {
+  // PropertyAssignment
+  //- @prop defines/binding VName("v.prop", _, _, "testdata/spec", "typescript")
+  prop: 0
+};
+
+// TypeAliasDeclaration
+//- @AliasArray defines/binding VName("AliasArray", _, _, "testdata/spec", "typescript")
+type AliasArray<
+  // TypeParameter
+  //- @T defines/binding VName("AliasArray.T", _, _, "testdata/spec", "typescript")
+  T
+> = Array<T>;
+
+//- @decl defines/binding VName("aFun", _, _, "testdata/spec", "typescript")
+const aFun = () => {
+  // Arrow function scope name is not well-defined.
+  //- @decl defines/binding VName(_, _, _, "testdata/spec", "typescript")
+  let anonArrowFunDecl;
+};
+
+{
+  // Anonymous block scope name is not well-defined.
+  //- @decl defines/binding VName(_, _, _, "testdata/spec", "typescript")
+  let anonBlockDecl;
+}

--- a/kythe/typescript/testdata/default_export.ts
+++ b/kythe/typescript/testdata/default_export.ts
@@ -2,6 +2,4 @@
 
 // An "export default" defines a variable named "default".
 //- @default defines/binding _Def=vname("default", _, _, _, _)
-export default {
-  key: 'value'
-};
+export default {key: 'value'};

--- a/kythe/typescript/testdata/default_export_assignment.ts
+++ b/kythe/typescript/testdata/default_export_assignment.ts
@@ -1,0 +1,5 @@
+// An "export =" defines a variable named "default".
+//- @"=" defines/binding _Def=vname("default", _, _, _, _)
+export = {
+  key: 'value'
+};


### PR DESCRIPTION
#3779

Discussion wanted.

In progress:
- [x] VName specification
  - [x] Signature format
    - [x] declarations
  - [x] Corpus format
  - [x] Root format
  - [x] Path format
  - [x] Language format
- [x] Specification tests
- [x] Extension of TypeScript indexer to support specification

TODO:
- [ ] Move specification to another file? Discussion wanted.
- [x] Import/export/better module specification