### PR TITLE
revert: "fix(java_indexer): only emit MarkedSource for defined symbols (#3788)

### DIFF
--- a/kythe/java/com/google/devtools/kythe/analyzers/java/JavaEntrySets.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/JavaEntrySets.java
@@ -151,10 +151,7 @@ public class JavaEntrySets extends KytheEntrySets {
 
       NodeKind kind = elementNodeKind(sym.getKind());
       NodeBuilder builder = kind != null ? newNode(kind) : newNode(sym.getKind().toString());
-      builder.setCorpusPath(CorpusPath.fromVName(v));
-      if (markedSource != null) {
-        builder.setProperty("code", markedSource);
-      }
+      builder.setCorpusPath(CorpusPath.fromVName(v)).setProperty("code", markedSource);
 
       if (signatureGenerator.getUseJvmSignatures()) {
         builder.setSignature(signature);

--- a/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
@@ -818,7 +818,8 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
             Arrays.asList(typeNode.getVName()),
             MarkedSources.ARRAY_TAPP);
     emitAnchor(ctx, EdgeKind.REF, node.getVName());
-    return new JavaNode(node);
+    JavaNode arrayNode = new JavaNode(node);
+    return arrayNode;
   }
 
   @Override
@@ -992,10 +993,11 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
 
   /** Returns the {@link JavaNode} associated with a {@link Symbol} or {@code null}. */
   private JavaNode getJavaNode(Symbol sym) {
-    return signatureGenerator
-        .getSignature(sym)
-        .map(sig -> new JavaNode(entrySets.getNode(signatureGenerator, sym, sig, null)))
-        .orElse(null);
+    Optional<String> signature = signatureGenerator.getSignature(sym);
+    if (!signature.isPresent()) {
+      return null;
+    }
+    return new JavaNode(entrySets.getNode(signatureGenerator, sym, signature.get(), null, null));
   }
 
   private void visitAnnotations(

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/MarkedSource.java
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/MarkedSource.java
@@ -386,9 +386,14 @@ public class MarkedSource {
   //- IntCode.kind "IDENTIFIER"
   //- IntCode.pre_text "int"
   static Object referencesArrayMember(int[][] arry) {
-    // No marked source emitted for node defined outside of compilation.
     //- @clone ref ArrayCloneMethod
-    //- !{ArrayCloneMethod code _}
+    //- ArrayCloneMethod.node/kind function
+    //- ArrayCloneMethod code ACMRoot
+    //- ACMRoot child.1 ACMContext
+    //- ACMContext.kind "CONTEXT"
+    //- ACMContext child.0 ACMContextIdent
+    //- ACMContextIdent.kind "IDENTIFIER"
+    //- ACMContextIdent.pre_text "int[][]"
     return arry.clone();
   }
 


### PR DESCRIPTION
This reverts commit 6bfb2f7a46e7704f25073b7f419c34062218765a.

It breaks cross-file references.