### PR TITLE
fix(java_indexer): only emit MarkedSource for defined symbols

### DIFF
--- a/kythe/java/com/google/devtools/kythe/analyzers/java/JavaEntrySets.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/JavaEntrySets.java
@@ -151,7 +151,10 @@ public class JavaEntrySets extends KytheEntrySets {
 
       NodeKind kind = elementNodeKind(sym.getKind());
       NodeBuilder builder = kind != null ? newNode(kind) : newNode(sym.getKind().toString());
-      builder.setCorpusPath(CorpusPath.fromVName(v)).setProperty("code", markedSource);
+      builder.setCorpusPath(CorpusPath.fromVName(v));
+      if (markedSource != null) {
+        builder.setProperty("code", markedSource);
+      }
 
       if (signatureGenerator.getUseJvmSignatures()) {
         builder.setSignature(signature);

--- a/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
@@ -818,8 +818,7 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
             Arrays.asList(typeNode.getVName()),
             MarkedSources.ARRAY_TAPP);
     emitAnchor(ctx, EdgeKind.REF, node.getVName());
-    JavaNode arrayNode = new JavaNode(node);
-    return arrayNode;
+    return new JavaNode(node);
   }
 
   @Override
@@ -993,11 +992,10 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
 
   /** Returns the {@link JavaNode} associated with a {@link Symbol} or {@code null}. */
   private JavaNode getJavaNode(Symbol sym) {
-    Optional<String> signature = signatureGenerator.getSignature(sym);
-    if (!signature.isPresent()) {
-      return null;
-    }
-    return new JavaNode(entrySets.getNode(signatureGenerator, sym, signature.get(), null, null));
+    return signatureGenerator
+        .getSignature(sym)
+        .map(sig -> new JavaNode(entrySets.getNode(signatureGenerator, sym, sig, null)))
+        .orElse(null);
   }
 
   private void visitAnnotations(

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/CrossFile.java
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/CrossFile.java
@@ -25,7 +25,7 @@ public class CrossFile {
   //- @OtherDecl ref _ODecl
   OtherDecl f3;
 
-  //- @Inter ref _InterRaw
+  //- @Inter ref Inter
   Inter i;
 
   public static void main(String[] args) {

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Files.java
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Files.java
@@ -22,15 +22,17 @@ public class Files {
 
   // Ensure this private member does not affect the class node across compilations.
   private int PRIVATE_MEMBER = -42;
+
+  //- @OtherDecl defines/binding _ODecl
+  enum OtherDecl {}
+
+  //- @Inter defines/binding InterAbs
+  //- InterAbs.node/kind abs
+  //- Inter childof InterAbs
+  //- Inter.node/kind interface
+  interface Inter<T> {}
 }
 
 //- File=vname("","kythe","","kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Files.java","")
 //-   .node/kind file
 //- File.text/encoding "UTF-8"
-
-//- @OtherDecl defines/binding _ODecl
-enum OtherDecl {}
-
-//- @Inter defines/binding InterAbs
-//- _InterRaw childof InterAbs
-interface Inter<T> {}

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/MarkedSource.java
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/MarkedSource.java
@@ -386,14 +386,9 @@ public class MarkedSource {
   //- IntCode.kind "IDENTIFIER"
   //- IntCode.pre_text "int"
   static Object referencesArrayMember(int[][] arry) {
+    // No marked source emitted for node defined outside of compilation.
     //- @clone ref ArrayCloneMethod
-    //- ArrayCloneMethod.node/kind function
-    //- ArrayCloneMethod code ACMRoot
-    //- ACMRoot child.1 ACMContext
-    //- ACMContext.kind "CONTEXT"
-    //- ACMContext child.0 ACMContextIdent
-    //- ACMContextIdent.kind "IDENTIFIER"
-    //- ACMContextIdent.pre_text "int[][]"
+    //- !{ArrayCloneMethod code _}
     return arry.clone();
   }
 

--- a/tools/build_rules/verifier_test/java_verifier_test.bzl
+++ b/tools/build_rules/verifier_test/java_verifier_test.bzl
@@ -222,15 +222,18 @@ def java_verifier_test(
         visibility = visibility,
         deps = [kzip],
     )
+    goals = extra_goals
+    if len(goals) > 0:
+        goals += [entries] + [dep + "_entries" for dep in verifier_deps]
     return _invoke(
         verifier_test,
         name = name,
         size = size,
-        srcs = [entries] + extra_goals,
+        srcs = goals,
         opts = verifier_opts,
         tags = tags,
         visibility = visibility,
-        deps = [entries],
+        deps = [entries] + [dep + "_entries" for dep in verifier_deps],
     )
 
 def _generate_java_proto_impl(ctx):


### PR DESCRIPTION
Also, ensure cross-file tests actually check all source files.