### PR TITLE
feat(java_indexer): emit refs to JVM graph for externally defined nodes

### DIFF
--- a/kythe/java/com/google/devtools/kythe/analyzers/java/JavaEntrySets.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/JavaEntrySets.java
@@ -345,7 +345,7 @@ public class JavaEntrySets extends KytheEntrySets {
     return sourceFile.toUri().getHost();
   }
 
-  private static boolean fromJDK(@Nullable Symbol sym) {
+  static boolean fromJDK(@Nullable Symbol sym) {
     if (sym == null || sym.enclClass() == null) {
       return false;
     }

--- a/kythe/java/com/google/devtools/kythe/analyzers/java/JavaIndexerConfig.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/JavaIndexerConfig.java
@@ -60,6 +60,13 @@ public class JavaIndexerConfig extends IndexerConfig {
   private JvmMode jvmMode = JvmMode.SEMANTIC;
 
   @Parameter(
+      names = "--emit_jvm_references",
+      description =
+          "Whether to reference the JVM graph when encountering nodes from outside the analyzed"
+              + " compilation unit")
+  private boolean jvmReferences = false;
+
+  @Parameter(
       names = "--emit_anchor_scopes",
       description =
           "Whether to emit childof edges from anchors to their lexical scope's semantic node")
@@ -94,6 +101,10 @@ public class JavaIndexerConfig extends IndexerConfig {
     return jvmMode;
   }
 
+  public boolean getEmitJvmReferences() {
+    return jvmReferences;
+  }
+
   public boolean getEmitAnchorScopes() {
     return emitAnchorScopes;
   }
@@ -115,6 +126,11 @@ public class JavaIndexerConfig extends IndexerConfig {
 
   public JavaIndexerConfig setJvmMode(JvmMode jvmMode) {
     this.jvmMode = jvmMode;
+    return this;
+  }
+
+  public JavaIndexerConfig setEmitJvmReferences(boolean jvmReferences) {
+    this.jvmReferences = jvmReferences;
     return this;
   }
 

--- a/kythe/java/com/google/devtools/kythe/common/BUILD
+++ b/kythe/java/com/google/devtools/kythe/common/BUILD
@@ -18,7 +18,10 @@ java_plugin(
 java_library(
     name = "autovalue",
     exported_plugins = [":auto_plugin"],
-    exports = ["@com_google_auto_value_auto_value//jar"],
+    exports = [
+        "@com_google_auto_value_auto_value//jar",
+        "@javax_annotation_jsr250_api//jar",
+    ],
 )
 
 java_plugin(
@@ -34,5 +37,8 @@ java_plugin(
 java_library(
     name = "autoservice",
     exported_plugins = [":auto_service_plugin"],
-    exports = ["@com_google_auto_service_auto_service//jar"],
+    exports = [
+        "@com_google_auto_service_auto_service//jar",
+        "@javax_annotation_jsr250_api//jar",
+    ],
 )

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/BUILD
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/BUILD
@@ -323,13 +323,20 @@ java_verifier_test(
     size = "small",
     srcs = ["Jvm.java"],
     extra_goals = ["//kythe/javatests/com/google/devtools/kythe/analyzers/jvm/testdata:jvm_nodes.kythe_verifier.txt"],
-    indexer_opts = ["--emit_jvm=semantic"],
     verifier_opts = [
         "--ignore_dups",
         "--convert_marked_source",
         "--nofile_vnames",
     ],
     visibility = ["//kythe/javatests/com/google/devtools/kythe/analyzers/jvm/testdata:__pkg__"],
+)
+
+java_verifier_test(
+    name = "jvm_reference_tests",
+    size = "small",
+    srcs = ["JvmCrossFile.java"],
+    indexer_opts = ["--emit_jvm_references"],
+    verifier_deps = [":files_tests"],
 )
 
 java_verifier_test(

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/JvmCrossFile.java
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/JvmCrossFile.java
@@ -1,0 +1,49 @@
+package pkg;
+
+// Check that nodes unify across file/compilation boundaries
+
+//- @CONSTANT ref/imports JvmConstantMember
+import static pkg.Files.CONSTANT;
+//- @Inner ref/imports JvmInnerClass
+import static pkg.Files.Inner;
+//- @staticMethod ref/imports JvmStaticMethod
+import static pkg.Files.staticMethod;
+
+import pkg.Files.Inter;
+import pkg.Files.OtherDecl;
+
+//- ConstantMember generates JvmConstantMember
+//- FilesClass generates JvmFilesClass
+//- InnerClass generates JvmInnerClass
+//- Inter generates JvmInter
+//- ODecl generates JvmODecl
+//- StaticMethod generates JvmStaticMethod
+
+public class JvmCrossFile {
+  //- @Files ref JvmFilesClass
+  Files f1;
+
+  //- @Files ref JvmFilesClass
+  //- @Inner ref JvmInnerClass
+  Files.Inner f2;
+
+  //- @OtherDecl ref JvmODecl
+  OtherDecl f3;
+
+  //- @Inter ref JvmInter
+  Inter i;
+
+  //- @InterSub defines/binding InterSub
+  //- InterSub.node/kind interface
+  //- InterSub extends JvmInter
+  interface InterSub extends Inter {}
+
+  public static void main(String[] args) {
+    //- @staticMethod ref JvmStaticMethod
+    Files.staticMethod();
+    //- @staticMethod ref JvmStaticMethod
+    staticMethod();
+    //- @CONSTANT ref JvmConstantMember
+    System.out.println(Files.CONSTANT);
+  }
+}


### PR DESCRIPTION
Experimental feature to support cross-language references for JVM-based
languages.  Currently, the indexer will be highly conservative when
deciding whether to emit references to the JVM language vs Java-native
nodes.  Only nodes within the same source file as the enclosing class
and JDK symbols will be considered Java-native when
--emit_jvm_references is enabled.

See: https://github.com/kythe/kythe/blob/master/kythe/java/com/google/devtools/kythe/analyzers/jvm/DESIGN.md#relations-with-higher-level-jvm-languages