### PR TITLE
feat(typescript_indexer): pass module name creation logic to plugins

### DIFF
--- a/kythe/typescript/indexer.ts
+++ b/kythe/typescript/indexer.ts
@@ -71,7 +71,7 @@ export interface Plugin {
    * Takes a plugin host, which provides useful properties and methods that the
    * plugin can defer to rather than reimplementing.
    */
-  index: (host: PluginHost) => void;
+  index(host: PluginHost): void;
 }
 
 /**

--- a/kythe/typescript/test.ts
+++ b/kythe/typescript/test.ts
@@ -136,14 +136,14 @@ async function testIndexer(args: string[], plugins?: indexer.Plugin[]) {
 async function testPlugin() {
   const plugin: indexer.Plugin = {
     name: 'TestPlugin',
-    index(host: indexer.IndexerHost) {
-      for (const testPath of host.paths) {
+    index(context: indexer.IndexerContext) {
+      for (const testPath of context.paths) {
         const pluginMod = {
-          ...host.pathToVName(host.moduleName(testPath)),
+          ...context.pathToVName(context.moduleName(testPath)),
           signature: 'plugin-module',
           language: 'plugin-language',
         };
-        host.emit({
+        context.emit({
           source: pluginMod,
           fact_name: '/kythe/node/pluginKind',
           fact_value: Buffer.from('pluginRecord').toString('base64'),

--- a/kythe/typescript/test.ts
+++ b/kythe/typescript/test.ts
@@ -136,7 +136,7 @@ async function testIndexer(args: string[], plugins?: indexer.Plugin[]) {
 async function testPlugin() {
   const plugin: indexer.Plugin = {
     name: 'TestPlugin',
-    index(context: indexer.IndexerContext) {
+    index(context: indexer.IndexerHost) {
       for (const testPath of context.paths) {
         const pluginMod = {
           ...context.pathToVName(context.moduleName(testPath)),

--- a/kythe/typescript/test.ts
+++ b/kythe/typescript/test.ts
@@ -136,17 +136,14 @@ async function testIndexer(args: string[], plugins?: indexer.Plugin[]) {
 async function testPlugin() {
   const plugin: indexer.Plugin = {
     name: 'TestPlugin',
-    index(
-        pathToVName: (path: string) => indexer.VName,
-        moduleName: (path: string) => string, paths: string[],
-        program: ts.Program, emit?: (obj: {}) => void) {
-      for (const testPath of paths) {
+    index(host: indexer.PluginHost) {
+      for (const testPath of host.paths) {
         const pluginMod = {
-          ...pathToVName(moduleName(testPath)),
+          ...host.pathToVName(host.moduleName(testPath)),
           signature: 'plugin-module',
           language: 'plugin-language',
         };
-        emit!({
+        host.emit({
           source: pluginMod,
           fact_name: '/kythe/node/pluginKind',
           fact_value: Buffer.from('pluginRecord').toString('base64'),

--- a/kythe/typescript/test.ts
+++ b/kythe/typescript/test.ts
@@ -136,7 +136,7 @@ async function testIndexer(args: string[], plugins?: indexer.Plugin[]) {
 async function testPlugin() {
   const plugin: indexer.Plugin = {
     name: 'TestPlugin',
-    index(host: indexer.PluginHost) {
+    index(host: indexer.IndexerHost) {
       for (const testPath of host.paths) {
         const pluginMod = {
           ...host.pathToVName(host.moduleName(testPath)),

--- a/kythe/typescript/test.ts
+++ b/kythe/typescript/test.ts
@@ -137,16 +137,12 @@ async function testPlugin() {
   const plugin: indexer.Plugin = {
     name: 'TestPlugin',
     index(
-        pathToVName: (path: string) => indexer.VName, paths: string[],
+        pathToVName: (path: string) => indexer.VName,
+        moduleName: (path: string) => string, paths: string[],
         program: ts.Program, emit?: (obj: {}) => void) {
       for (const testPath of paths) {
-        const relPath = path.relative(
-                                program.getCompilerOptions().rootDir!,
-                                program.getSourceFile(testPath)!.fileName)
-                            .replace(/\.(d\.)?ts$/, '');
-
         const pluginMod = {
-          ...pathToVName(relPath),
+          ...pathToVName(moduleName(testPath)),
           signature: 'plugin-module',
           language: 'plugin-language',
         };


### PR DESCRIPTION
Plugins would benefit from determining the name of TypeScript modules in the same manner that the TypeScript indexer does, to ensure compatibility between the TS indexer and its plugins. This PR adds this feature.