### PR TITLE
fix(kzip): ensure the EncodingFlag has a suitable default.

### DIFF
--- a/kythe/go/platform/tools/kzip/createcmd/createcmd.go
+++ b/kythe/go/platform/tools/kzip/createcmd/createcmd.go
@@ -65,6 +65,7 @@ occurrence of the flag being appended to the corresponding field in the compilat
 
 Any additional positional arguments are included as arguments in the compilation unit.
 `),
+		encoding: flags.EncodingFlag{Encoding: kzip.EncodingJSON},
 	}
 }
 

--- a/kythe/go/platform/tools/kzip/mergecmd/mergecmd.go
+++ b/kythe/go/platform/tools/kzip/mergecmd/mergecmd.go
@@ -46,7 +46,8 @@ type mergeCommand struct {
 // New creates a new subcommand for merging kzip files.
 func New() subcommands.Command {
 	return &mergeCommand{
-		Info: cmdutil.NewInfo("merge", "merge kzip files", "--output path kzip-file*"),
+		Info:     cmdutil.NewInfo("merge", "merge kzip files", "--output path kzip-file*"),
+		encoding: flags.EncodingFlag{Encoding: kzip.EncodingJSON},
 	}
 }
 


### PR DESCRIPTION
I couldn't decide if it was better to make a EncodingDefault constant = 0, and treat that specially, or do this.