### PR TITLE
fix(go_indexer): use only name for a named type's MarkedSource

### DIFF
--- a/kythe/go/indexer/markedsource.go
+++ b/kythe/go/indexer/markedsource.go
@@ -145,19 +145,6 @@ func (pi *PackageInfo) MarkedSource(obj types.Object) *cpb.MarkedSource {
 		}
 		ms = repl
 
-	case *types.TypeName:
-		// For named types, include the underlying type.
-		repl := &cpb.MarkedSource{
-			Kind:          cpb.MarkedSource_BOX,
-			PostChildText: " ",
-			Child: []*cpb.MarkedSource{
-				{PreText: "type"},
-				ms,
-				{Kind: cpb.MarkedSource_TYPE, PreText: typeName(t.Type().Underlying())},
-			},
-		}
-		ms = repl
-
 	default:
 		// TODO(fromberger): Handle other variations from go/types.
 	}

--- a/kythe/go/indexer/testdata/code/interface.go
+++ b/kythe/go/indexer/testdata/code/interface.go
@@ -2,19 +2,14 @@
 package iface
 
 //- @Thinger defines/binding Thinger
-//- Thinger code TCode
+//- Thinger code TName
 //-
-//- TCode.kind "BOX"
-//- TCode child.0 TType
-//- TCode child.1 TName
-//- TCode child.2 TInterface
+//- TName child.0 TContext
+//- TContext.kind "CONTEXT"
 //-
-//- TType.pre_text "type"
-//-
-//- TName child.0 _TContext
-//- TName child.1 _TIdent
-//-
-//- TInterface.pre_text "interface {...}"
+//- TName child.1 TIdent
+//- TIdent.kind "IDENTIFIER"
+//- TIdent.pre_text "Thinger"
 type Thinger interface {
 	//- @Thing defines/binding Thing
 	//- Thing code MCode

--- a/kythe/go/indexer/testdata/code/structtype.go
+++ b/kythe/go/indexer/testdata/code/structtype.go
@@ -2,21 +2,10 @@
 package structtype
 
 //- @T defines/binding Type
-//- Type code TypeCode
-//-
-//- TypeCode.kind "BOX"
-//- TypeCode.post_child_text " "
-//- TypeCode child.0 TType
-//- TypeCode child.1 TName
-//- TypeCode child.2 TStruct
-//-
-//- TType.pre_text "type"
+//- Type code TName
 //-
 //- TName child.0 TContext
 //- TName child.1 TIdent
-//-
-//- TStruct.pre_text "struct {...}"
-//- TStruct.kind "TYPE"
 //-
 //- TContext.kind "CONTEXT"
 //- TContext child.0 TPkg


### PR DESCRIPTION
```
type S struct {}

func f(s *S) {}
```

The MarkedSource for `S` can now be rendered as simply "S" (versus "type S struct {...}") and `f` can be rendered as "f(s *S)" instead of "f(S *type S struct {...})".