### PR TITLE
fix(KZipWriterTest.java): remove previous kzip before writing new one

### DIFF
--- a/kythe/javatests/com/google/devtools/kythe/platform/kzip/KZipWriterTest.java
+++ b/kythe/javatests/com/google/devtools/kythe/platform/kzip/KZipWriterTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.google.devtools.kythe.platform.kzip;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -77,11 +78,8 @@ public final class KZipWriterTest {
     // Read in the provided kzip.
     InMemoryKZip originalKZip = readKZip(TestDataUtil.getTestFile("stringset.kzip"));
 
-    // Delete old tmp kzip (if present).
-    File tmpKZipFile = new File(getTestTempDir(), "write_test.kzip");
-    tmpKZipFile.delete();
-
     // Write out our kzip.
+    File tmpKZipFile = new File(getTestTempDir(), "write_test-" + encoding.toString() + ".kzip");
     KZipWriter writer = new KZipWriter(tmpKZipFile, encoding);
 
     for (Analysis.IndexedCompilation compilation : originalKZip.compilations) {
@@ -94,7 +92,7 @@ public final class KZipWriterTest {
     writer.close();
 
     // Read in the kzip we just wrote out.
-    InMemoryKZip writtenKZip = readKZip(new File(getTestTempDir(), "write_test.kzip"));
+    InMemoryKZip writtenKZip = readKZip(tmpKZipFile);
 
     // Compare the two kzips.
     assertThat(writtenKZip.compilations).containsExactlyElementsIn(originalKZip.compilations);

--- a/kythe/javatests/com/google/devtools/kythe/platform/kzip/KZipWriterTest.java
+++ b/kythe/javatests/com/google/devtools/kythe/platform/kzip/KZipWriterTest.java
@@ -77,8 +77,12 @@ public final class KZipWriterTest {
     // Read in the provided kzip.
     InMemoryKZip originalKZip = readKZip(TestDataUtil.getTestFile("stringset.kzip"));
 
+    // Delete old tmp kzip (if present).
+    File tmpKZipFile = new File(getTestTempDir(), "write_test.kzip");
+    tmpKZipFile.delete();
+
     // Write out our kzip.
-    KZipWriter writer = new KZipWriter(new File(getTestTempDir(), "write_test.kzip"), encoding);
+    KZipWriter writer = new KZipWriter(tmpKZipFile, encoding);
 
     for (Analysis.IndexedCompilation compilation : originalKZip.compilations) {
       writer.writeUnit(compilation);


### PR DESCRIPTION
The test would occasionally fail due to interactions with the old file.
Error msg: "java.lang.IllegalArgumentException: MALFORMED" at java.util.zip.ZipCoder.toString(ZipCoder.java:65).

I'm not 100% sure why this is an issue. Does the kzip writer append to an existing file rather than replacing it? If so, maybe that should be changed instead.