### PR TITLE
fix(java tests): apparently '_' is a keyword now

### DIFF
--- a/kythe/javatests/com/google/devtools/kythe/platform/kzip/KZipReaderTest.java
+++ b/kythe/javatests/com/google/devtools/kythe/platform/kzip/KZipReaderTest.java
@@ -95,7 +95,7 @@ public final class KZipReaderTest {
     try {
       KZipReader reader = new KZipReader(TestDataUtil.getTestFile("garbage_unit.kzip"));
       // Iterate over the units so we try to read in the garbage.
-      for (IndexedCompilation _: reader.scan()) {}
+      for (IndexedCompilation compilation: reader.scan()) {}
       fail();
     } catch (JsonParseException expected) {
     }


### PR DESCRIPTION
KZipReaderTest.java:98: error: as of release 9, '_' is a keyword, and may not be used as an identifier