### PR TITLE
feat(typescript_indexer): reference modules in export statements

### DIFF
--- a/kythe/typescript/indexer.ts
+++ b/kythe/typescript/indexer.ts
@@ -929,8 +929,13 @@ class Visitor {
       }
     }
     if (decl.moduleSpecifier) {
-      this.todo(
-          decl.moduleSpecifier, `handle module specifier in ${decl.getText()}`);
+      const moduleSym = this.getSymbolAtLocation(decl.moduleSpecifier);
+      if (moduleSym) {
+        const kModule = this.newVName(
+            'module', this.getModulePathFromModuleReference(moduleSym));
+        this.emitEdge(
+            this.newAnchor(decl.moduleSpecifier), 'ref/imports', kModule);
+      }
     }
   }
 

--- a/kythe/typescript/testdata/export.ts
+++ b/kythe/typescript/testdata/export.ts
@@ -1,4 +1,5 @@
 // Syntax 1: exporting a value from another module.
+//- @"'./module'" ref/imports vname("module", _, _, "testdata/module", _)
 export {value} from './module';
 
 // Syntax 2: a bare "export" statement.


### PR DESCRIPTION
Fix a long-standing todo where module names in export statements are not
referenced to the modules they refer to. Same approach as referencing
modules in import statements.