### PR TITLE
feat(typescript_indexer): add xrefs for declarations in objects

### DIFF
--- a/kythe/javatests/com/google/devtools/kythe/platform/kzip/KZipWriterTest.java
+++ b/kythe/javatests/com/google/devtools/kythe/platform/kzip/KZipWriterTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.google.devtools.kythe.platform.kzip;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -78,7 +79,8 @@ public final class KZipWriterTest {
     InMemoryKZip originalKZip = readKZip(TestDataUtil.getTestFile("stringset.kzip"));
 
     // Write out our kzip.
-    KZipWriter writer = new KZipWriter(new File(getTestTempDir(), "write_test.kzip"), encoding);
+    File tmpKZipFile = new File(getTestTempDir(), "write_test-" + encoding.toString() + ".kzip");
+    KZipWriter writer = new KZipWriter(tmpKZipFile, encoding);
 
     for (Analysis.IndexedCompilation compilation : originalKZip.compilations) {
       writer.writeUnit(compilation);
@@ -90,7 +92,7 @@ public final class KZipWriterTest {
     writer.close();
 
     // Read in the kzip we just wrote out.
-    InMemoryKZip writtenKZip = readKZip(new File(getTestTempDir(), "write_test.kzip"));
+    InMemoryKZip writtenKZip = readKZip(tmpKZipFile);
 
     // Compare the two kzips.
     assertThat(writtenKZip.compilations).containsExactlyElementsIn(originalKZip.compilations);

--- a/kythe/typescript/indexer.ts
+++ b/kythe/typescript/indexer.ts
@@ -968,6 +968,7 @@ class Visitor {
     let vname: VName|undefined;
     switch (decl.name.kind) {
       case ts.SyntaxKind.Identifier:
+      case ts.SyntaxKind.ComputedPropertyName:
         const sym = this.getSymbolAtLocation(decl.name);
         if (!sym) {
           this.todo(
@@ -978,15 +979,16 @@ class Visitor {
         this.emitNode(vname, 'variable');
 
         this.emitEdge(this.newAnchor(decl.name), 'defines/binding', vname);
+
+        if (ts.isComputedPropertyName(decl.name)) {
+          this.visit(decl.name.expression);
+        }
         break;
       case ts.SyntaxKind.ObjectBindingPattern:
       case ts.SyntaxKind.ArrayBindingPattern:
         for (const element of (decl.name as ts.BindingPattern).elements) {
           this.visit(element);
         }
-        break;
-      case ts.SyntaxKind.ComputedPropertyName:
-        this.visit(decl.name.expression);
         break;
       default:
         this.todo(

--- a/kythe/typescript/indexer.ts
+++ b/kythe/typescript/indexer.ts
@@ -983,12 +983,10 @@ class Visitor {
       case ts.SyntaxKind.ComputedPropertyName:
         this.visit(decl.name.expression);
         break;
-      // Nothing meaningful can be indexed about a literal expression.
-      case ts.SyntaxKind.StringLiteral:
-      case ts.SyntaxKind.NumericLiteral:
-        break;
       default:
-        break;
+        this.todo(
+            decl.name,
+            `handle variable declaration: ${ts.SyntaxKind[decl.name.kind]}`);
     }
     if (decl.type) this.visitType(decl.type);
     if (decl.initializer) this.visit(decl.initializer);

--- a/kythe/typescript/indexer.ts
+++ b/kythe/typescript/indexer.ts
@@ -980,9 +980,7 @@ class Visitor {
 
         this.emitEdge(this.newAnchor(decl.name), 'defines/binding', vname);
 
-        if (ts.isComputedPropertyName(decl.name)) {
-          this.visit(decl.name.expression);
-        }
+        decl.name.forEachChild(child => this.visit(child));
         break;
       case ts.SyntaxKind.ObjectBindingPattern:
       case ts.SyntaxKind.ArrayBindingPattern:

--- a/kythe/typescript/indexer.ts
+++ b/kythe/typescript/indexer.ts
@@ -423,6 +423,7 @@ class Visitor {
         case ts.SyntaxKind.VariableDeclaration:
         case ts.SyntaxKind.GetAccessor:
         case ts.SyntaxKind.SetAccessor:
+        case ts.SyntaxKind.ShorthandPropertyAssignment:
           const decl = node as ts.NamedDeclaration;
           if (decl.name && decl.name.kind === ts.SyntaxKind.Identifier) {
             let part = decl.name.text;
@@ -979,10 +980,15 @@ class Visitor {
           this.visit(element);
         }
         break;
+      case ts.SyntaxKind.ComputedPropertyName:
+        this.visit(decl.name.expression);
+        break;
+      // Nothing meaningful can be indexed about a literal expression.
+      case ts.SyntaxKind.StringLiteral:
+      case ts.SyntaxKind.NumericLiteral:
+        break;
       default:
-        this.todo(
-            decl.name,
-            `handle variable declaration: ${ts.SyntaxKind[decl.name.kind]}`);
+        break;
     }
     if (decl.type) this.visitType(decl.type);
     if (decl.initializer) this.visit(decl.initializer);
@@ -1259,6 +1265,7 @@ class Visitor {
       case ts.SyntaxKind.PropertyAssignment:  // property in object literal
       case ts.SyntaxKind.PropertyDeclaration:
       case ts.SyntaxKind.PropertySignature:
+      case ts.SyntaxKind.ShorthandPropertyAssignment:
         const vname =
             this.visitVariableDeclaration(node as ts.PropertyDeclaration);
         if (vname) this.visitJSDoc(node, vname);

--- a/kythe/typescript/testdata/object.ts
+++ b/kythe/typescript/testdata/object.ts
@@ -1,14 +1,25 @@
 export {}
 
+const shortProperty = 0;
+
+//- @#0"computed" defines/binding Computed
+const computed = 'computed';
+
 const Object = {
   //- @property defines/binding Property
   //- Property.node/kind variable
   property: 3,
 
+  //- @shortProperty defines/binding ShortProperty
+  //- ShortProperty.node/kind variable
+  shortProperty,
+
+  //- @computed ref Computed
+  [computed]: 0,
+
   //- @method defines/binding Method
   //- Method.node/kind function
-  method() {
-  }
+  method() {}
 };
 
 //- @property ref Property

--- a/kythe/typescript/testdata/object.ts
+++ b/kythe/typescript/testdata/object.ts
@@ -15,6 +15,7 @@ const Object = {
   shortProperty,
 
   //- @"[computed]" defines/binding ComputedProperty
+  //- ComputedProperty.node/kind variable
   //- @computed ref Computed
   [computed]: 0,
 

--- a/kythe/typescript/testdata/object.ts
+++ b/kythe/typescript/testdata/object.ts
@@ -14,6 +14,7 @@ const Object = {
   //- ShortProperty.node/kind variable
   shortProperty,
 
+  //- @"[computed]" defines/binding ComputedProperty
   //- @computed ref Computed
   [computed]: 0,
 
@@ -23,7 +24,9 @@ const Object = {
 };
 
 //- @property ref Property
-const x = Object.property;
+//- @shortProperty ref ShortProperty
+//- @computed ref ComputedProperty
+const x = Object.property || Object.shortProperty || Object.computed;
 
 //- @method ref Method
 Object.method();


### PR DESCRIPTION
Shorthand property assignments like foo in a = {foo,} were
previously not indexed at all. This emits edges for shorthand
assignments similar to other property assignments. Also adds xrefs for
computed properties in objects and ignores lvalue literals in a
declaration.

_edit_: new description