### PR TITLE
fix(typescript_indexer): log missing signature only if name is defined

### DIFF
--- a/kythe/typescript/indexer.ts
+++ b/kythe/typescript/indexer.ts
@@ -521,7 +521,7 @@ class Visitor {
           // If the node is actually some subtype that has a 'name' attribute
           // it's likely this function should have handled it.  Dynamically
           // probe for this case and warn if we missed one.
-          if ('name' in (node as any)) {
+          if ((node as any).name) {
             this.todo(
                 node,
                 `scopedSignature: ${ts.SyntaxKind[node.kind]} ` +


### PR DESCRIPTION
We currently log an error message for nodes not included in a VName
signature but that have a "name" attribute. What we really care about,
though, is if the node has a name value; for instance, function
expressions like `(function())` have a name attribute, but it is always
`undefined`.

This reduces superfluous error logging.