### PR TITLE
fix(typescript_indexer): add anon signature part for function expressions

### DIFF
--- a/kythe/typescript/indexer.ts
+++ b/kythe/typescript/indexer.ts
@@ -390,6 +390,12 @@ class Visitor {
           // Arrow functions are anonymous, so generate a unique id.
           parts.push(`arrow${this.anonId++}`);
           break;
+        case ts.SyntaxKind.FunctionExpression:
+          // Function expressions look like
+          //   (function() {})
+          // which have no name but introduce an anonymous scope.
+          parts.push(`func${this.anonId++}`);
+          break;
         case ts.SyntaxKind.Block:
           // Blocks need their own scopes for contained variable declarations.
           if (node.parent &&

--- a/kythe/typescript/testdata/function.ts
+++ b/kythe/typescript/testdata/function.ts
@@ -92,7 +92,7 @@ function bindingTest({aa, bb: {cc, dd}}, [ee, [ff]]: NestedArray) {
 //- @an defines/binding An
 let ev, an;
 (function() {
-//- !{ @ev ref Ev }
+//- !{ @ev defines/binding _Ev2=Ev }
 let ev;
 //- @an ref An
 an;

--- a/kythe/typescript/testdata/function.ts
+++ b/kythe/typescript/testdata/function.ts
@@ -30,7 +30,9 @@ function test(a: number, num: Num): Num {
 }
 
 //- @test ref F
-test(3, {num: 3});
+test(
+    3,
+    {num: 3});
 
 // Test computed function names by creating a constant string and checking that
 // a name computed from it is properly referenced to its computed definition.
@@ -84,3 +86,14 @@ function bindingTest({aa, bb: {cc, dd}}, [ee, [ff]]: NestedArray) {
   //- @ff ref FF
   dd = ff;
 }
+
+// Test function expressions introducing an anonymous scope
+//- @ev defines/binding Ev
+//- @an defines/binding An
+let ev, an;
+(function() {
+//- !{ @ev ref Ev }
+let ev;
+//- @an ref An
+an;
+})()


### PR DESCRIPTION
Function expressions like `(function())` have no name but introduce a
scope. Add an anonymous name for them when they are encountered in
generated a VName signature.