### PR TITLE
fixup: fail extraction after first failed command

### DIFF
--- a/kythe/extractors/bazel/extract.sh
+++ b/kythe/extractors/bazel/extract.sh
@@ -61,9 +61,7 @@ fi
 # It is ok if targets fail to build. We build using --keep_going and don't
 # care if some targets fail, but bazel will return a failure code if any
 # targets fail.
-set +e
-/kythe/bazelisk --bazelrc=/kythe/bazelrc "$@"
-set -e
+/kythe/bazelisk --bazelrc=/kythe/bazelrc "$@" || true
 
 # Collect any extracted compilations.
 mkdir -p "$KYTHE_OUTPUT_DIRECTORY"

--- a/kythe/extractors/bazel/extract.sh
+++ b/kythe/extractors/bazel/extract.sh
@@ -58,7 +58,12 @@ if [ -n "$KYTHE_SYSTEM_DEPS" ]; then
   apt-get clean
 fi
 
+# It is ok if targets fail to build. We build using --keep_going and don't
+# care if some targets fail, but bazel will return a failure code if any
+# targets fail.
+set +e
 /kythe/bazelisk --bazelrc=/kythe/bazelrc "$@"
+set -e
 
 # Collect any extracted compilations.
 mkdir -p "$KYTHE_OUTPUT_DIRECTORY"

--- a/kythe/extractors/bazel/extract.sh
+++ b/kythe/extractors/bazel/extract.sh
@@ -43,6 +43,10 @@
 # Also assumes you have extractors installed as per
 # kythe/extractors/bazel/extractors.bazelrc.
 
+# Print our commands for easier debugging and exit after our first failed
+# command so we avoid silent failures.
+set -ex
+
 : ${KYTHE_OUTPUT_DIRECTORY:?Missing output directory}
 
 if [ -n "$KYTHE_SYSTEM_DEPS" ]; then


### PR DESCRIPTION
Print out the executed commands and exit the script after the first failed
command to make debugging easier and to help avoid silent failures in an early
step that cause unexpected failures in a later step.