### PR TITLE
chore(java_extractor): make test less brittle on JDK changes

### DIFF
--- a/kythe/javatests/com/google/devtools/kythe/extractors/java/JavaExtractorTest.java
+++ b/kythe/javatests/com/google/devtools/kythe/extractors/java/JavaExtractorTest.java
@@ -54,19 +54,14 @@ public class JavaExtractorTest extends TestCase {
 
   private static final ImmutableList<String> EMPTY = ImmutableList.of();
 
+  private static final String JDK_ANNOTATION_PATH = "!CLASS_PATH_JAR!";
   private static final FileInfo GENERATED_ANNOTATION_CLASS =
       FileInfo.newBuilder()
-          .setPath(join("!CLASS_PATH_JAR!", "javax/annotation/Generated.class"))
+          .setPath(join(JDK_ANNOTATION_PATH, "javax/annotation/Generated.class"))
           // This digest depends on the external javax_annotation_jsr250_api dependency.  If it is
           // updated, this will also need to change.
           .setDigest("e5ee743f5c6df4923a934cba33c73d3d73e19d277c8ddec5c4e7ac59788fc674")
           .build();
-
-  // Due to the nature of the jsr250 dependency, this class is incidentally
-  // included in some compilation environments but not others.
-  // In order to distinguish these dependencies from "true" dependencies, use this name.
-  private static final FileInfo JDK_ANNOTATION_CLASS = GENERATED_ANNOTATION_CLASS;
-  private static final String JDK_ANNOTATION_PATH = "!CLASS_PATH_JAR!";
 
   /** Tests the basic case of indexing a java compilation with two sources. */
   public void testJavaExtractorSimple() throws Exception {
@@ -99,12 +94,11 @@ public class JavaExtractorTest extends TestCase {
 
     // With the expected sources as required inputs.
     assertThat(getInfos(unit.getRequiredInputList()))
-        .containsExactlyElementsIn(getExpectedInfos(sources, JDK_ANNOTATION_CLASS));
+        .containsAtLeastElementsIn(getExpectedInfos(sources));
 
     // And the correct sourcepath set to replay the compilation.
     JavaDetails details = getJavaDetails(unit);
     assertThat(details.getSourcepathList()).containsExactly(TEST_DATA_DIR);
-    assertThat(details.getClasspathList()).containsExactly(JDK_ANNOTATION_PATH);
   }
 
   /** Tests that metadata is included when a file specifies it. */
@@ -140,12 +134,12 @@ public class JavaExtractorTest extends TestCase {
 
     // With the expected dependencies as required inputs.
     assertThat(getInfos(unit.getRequiredInputList()))
-        .containsExactlyElementsIn(getExpectedInfos(dependencies, GENERATED_ANNOTATION_CLASS));
+        .containsAtLeastElementsIn(getExpectedInfos(dependencies, GENERATED_ANNOTATION_CLASS));
 
     // And the correct sourcepath set to replay the compilation.
     JavaDetails details = getJavaDetails(unit);
     assertThat(details.getSourcepathList()).containsExactly(TEST_DATA_DIR);
-    assertThat(details.getClasspathList()).containsExactly("!CLASS_PATH_JAR!");
+    assertThat(details.getClasspathList()).contains(JDK_ANNOTATION_PATH);
   }
 
   /** Tests indexing within a symlink root. */
@@ -184,12 +178,11 @@ public class JavaExtractorTest extends TestCase {
 
     // With the expected sources as required inputs.
     assertThat(getInfos(unit.getRequiredInputList()))
-        .containsExactlyElementsIn(getExpectedInfos(sources, JDK_ANNOTATION_CLASS));
+        .containsAtLeastElementsIn(getExpectedInfos(sources));
 
     // And the correct sourcepath set to replay the compilation.
     JavaDetails details = getJavaDetails(unit);
     assertThat(details.getSourcepathList()).containsExactly(TEST_DATA_DIR);
-    assertThat(details.getClasspathList()).containsExactly(JDK_ANNOTATION_PATH);
   }
 
   /**
@@ -227,13 +220,12 @@ public class JavaExtractorTest extends TestCase {
     assertThat(unit.getSourceFileList()).containsExactly(sources.get(0), sources.get(1)).inOrder();
 
     assertThat(getInfos(unit.getRequiredInputList()))
-        .containsExactlyElementsIn(getExpectedInfos(sources, JDK_ANNOTATION_CLASS));
+        .containsAtLeastElementsIn(getExpectedInfos(sources));
 
     // And the correct sourcepath set to replay the compilation for both sources.
     JavaDetails details = getJavaDetails(unit);
     assertThat(details.getSourcepathList())
         .containsExactly(join(TEST_DATA_DIR, "one"), join(TEST_DATA_DIR, "two"));
-    assertThat(details.getClasspathList()).containsExactly(JDK_ANNOTATION_PATH);
   }
 
   /**
@@ -272,7 +264,7 @@ public class JavaExtractorTest extends TestCase {
 
     // Ensure the right class files are picked up from the classpath.
     assertThat(getInfos(unit.getRequiredInputList()))
-        .containsExactlyElementsIn(getExpectedInfos(Arrays.asList(sources.get(0), classFile)));
+        .containsAtLeastElementsIn(getExpectedInfos(Arrays.asList(sources.get(0), classFile)));
 
     JavaDetails details = getJavaDetails(unit);
     assertThat(details.getSourcepathList()).containsExactly(join(TEST_DATA_DIR, "child"));
@@ -312,12 +304,12 @@ public class JavaExtractorTest extends TestCase {
     assertThat(unit.getVName().getSignature()).isEqualTo(TARGET1);
     assertThat(unit.getSourceFileList()).containsExactlyElementsIn(sources).inOrder();
 
-    // The classpath is adjusted to start wit !CLASS_PATH_JAR!
+    // The classpath is adjusted to start with !CLASS_PATH_JAR!
     String classFile = join("!CLASS_PATH_JAR!", "base/A.class");
 
     // Ensure the right class files are picked up from the classpath from within the jar.
     assertThat(getInfos(unit.getRequiredInputList()))
-        .containsExactly(
+        .containsAtLeast(
             makeFileInfo(sources.get(0)),
             makeFileInfo(classFile, join(TEST_DATA_DIR, "parent/base/A.class")));
 
@@ -401,8 +393,7 @@ public class JavaExtractorTest extends TestCase {
 
     // With the expected sources as required inputs.
     assertThat(getInfos(unit.getRequiredInputList()))
-        .containsExactly(
-            JDK_ANNOTATION_CLASS,
+        .containsAtLeast(
             makeFileInfo(sources.get(0)),
             makeFileInfo(sources.get(2)),
             makeFileInfo(sources.get(1)))
@@ -442,13 +433,12 @@ public class JavaExtractorTest extends TestCase {
 
     // With the expected sources as required inputs.
     assertThat(getInfos(unit.getRequiredInputList()))
-        .containsExactlyElementsIn(getExpectedInfos(sources, JDK_ANNOTATION_CLASS));
+        .containsAtLeastElementsIn(getExpectedInfos(sources));
 
     // And the correct sourcepath set to replay the compilation.
     JavaDetails details = getJavaDetails(unit);
     assertThat(details.getSourcepathList()).hasSize(1);
     assertThat(details.getSourcepathList().get(0)).isEqualTo(TEST_DATA_DIR);
-    assertThat(details.getClasspathList()).containsExactly(JDK_ANNOTATION_PATH);
   }
 
   /**
@@ -484,12 +474,11 @@ public class JavaExtractorTest extends TestCase {
 
     // With the expected sources as required inputs.
     assertThat(getInfos(unit.getRequiredInputList()))
-        .containsExactlyElementsIn(getExpectedInfos(sources, JDK_ANNOTATION_CLASS));
+        .containsAtLeastElementsIn(getExpectedInfos(sources));
 
     // And the correct sourcepath set to replay the compilation.
     JavaDetails details = getJavaDetails(unit);
     assertThat(details.getSourcepathList()).containsExactly(TEST_DATA_DIR);
-    assertThat(details.getClasspathList()).containsExactly(JDK_ANNOTATION_PATH);
   }
 
   /**
@@ -621,18 +610,15 @@ public class JavaExtractorTest extends TestCase {
 
     // With the expected sources as required inputs.
     assertThat(getInfos(unit.getRequiredInputList()))
-        .containsExactly(
-            JDK_ANNOTATION_CLASS,
+        .containsAtLeast(
             makeFileInfo(origSources.get(0)),
             makeFileInfo(origSources.get(1)),
             makeFileInfo(sillyGenerated, Paths.get(testDir, sillyGenerated).toString()));
 
     // And the correct sourcepath set to replay the compilation.
     JavaDetails details = getJavaDetails(unit);
-    assertThat(details.getSourcepathList()).hasSize(2);
     assertThat(details.getSourcepathList())
         .containsExactly(TEST_DATA_DIR, "output-gensrc.jar.files");
-    assertThat(details.getClasspathList()).containsExactly(JDK_ANNOTATION_PATH);
   }
 
   /** Tests that the extractor doesn't fall over when it's provided with no sources. */
@@ -699,16 +685,12 @@ public class JavaExtractorTest extends TestCase {
     assertThat(unit.getSourceFileCount()).isEqualTo(1);
     assertThat(unit.getSourceFileList()).containsExactly(sources.get(0)).inOrder();
 
-    assertThat(unit.getRequiredInputCount()).isEqualTo(3);
     List<String> requiredPaths = new ArrayList<>();
     for (FileInput input : unit.getRequiredInputList()) {
       requiredPaths.add(input.getInfo().getPath());
     }
     assertThat(requiredPaths)
-        .containsExactly(
-            sources.get(0),
-            "!PLATFORM_CLASS_PATH_JAR!/java/lang/Fake.class",
-            "!CLASS_PATH_JAR!/javax/annotation/Generated.class");
+        .containsAtLeast(sources.get(0), "!PLATFORM_CLASS_PATH_JAR!/java/lang/Fake.class");
 
     assertThat(unit.getArgumentList())
         .containsNoneOf("-bootclasspath", "-sourcepath", "-cp", "-classpath");
@@ -716,7 +698,6 @@ public class JavaExtractorTest extends TestCase {
     // And the correct source/class locations set to replay the compilation.
     JavaDetails details = getJavaDetails(unit);
     assertThat(details.getSourcepathList()).isEmpty();
-    assertThat(details.getClasspathList()).containsExactly("!CLASS_PATH_JAR!");
     assertThat(details.getBootclasspathList()).containsExactly("!PLATFORM_CLASS_PATH_JAR!");
   }
 


### PR DESCRIPTION
Only test for those things which are necessary and expected by the test(s) in question. 

In particular, don't assert on the exact size of various required input lists and only expect that the elements known to the test are present.  Similarly, only test that the Generated annotation is included when the code-under-test actually uses Generated annotations.  When that's the case, we can test for exactly the expected annotation class, regardless of what the JDK uses.