### PR TITLE
chore(java_indexer): add support and tests for JDK9 Generated annotation

### DIFF
--- a/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
@@ -20,6 +20,7 @@ import com.google.common.base.Ascii;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableList.Builder;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Streams;
 import com.google.common.flogger.FluentLogger;
@@ -106,6 +107,10 @@ import javax.tools.JavaFileObject;
 /** {@link JCTreeScanner} that emits Kythe nodes and edges. */
 public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();
+
+  /** Set of known class names used for annotating generated code. */
+  private static final ImmutableSet<String> GENERATED_ANNOTATIONS =
+      ImmutableSet.of("javax.annotation.Generated", "javax.annotation.processing.Generated");
 
   /** Maximum allowed text size for variable {@link MarkedSource.Kind.INITIALIZER}s */
   private static final int MAX_INITIALIZER_LENGTH = 80;
@@ -1339,7 +1344,7 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
         annotationSymbol = ((JCIdent) annotation.getAnnotationType()).sym;
       }
       if (annotationSymbol == null
-          || !annotationSymbol.toString().equals("javax.annotation.Generated")) {
+          || !GENERATED_ANNOTATIONS.contains(annotationSymbol.toString())) {
         continue;
       }
       for (JCExpression arg : annotation.getArguments()) {

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/BUILD
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/BUILD
@@ -8,6 +8,8 @@ filegroup(
             # Exclude meta-data tests
             "Metadata.java",
             "ProtobufMetadata.java",
+            "ProcessingMetadata.java",
+            "ProcessingProtobufMetadata.java",
         ],
     ),
     visibility = ["//kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata:__subpackages__"],
@@ -249,6 +251,16 @@ java_verifier_test(
 )
 
 java_verifier_test(
+    name = "processing_metadata_tests",
+    srcs = [
+        "ProcessingMetadata.java",
+    ],
+    meta = [
+        "ProcessingMetadata.java.meta",
+    ],
+)
+
+java_verifier_test(
     name = "protobuf_metadata_tests",
     srcs = [
         "ProtobufMetadata.java",
@@ -262,6 +274,21 @@ java_verifier_test(
     ],
     vnames_config = "protobuf_vnames.json",
     deps = ["@javax_annotation_jsr250_api//jar"],
+)
+
+java_verifier_test(
+    name = "processing_protobuf_metadata_tests",
+    srcs = [
+        "ProcessingProtobufMetadata.java",
+    ],
+    indexer_opts = [
+        "--verbose",
+        "--default_metadata_corpus=default",
+    ],
+    meta = [
+        "ProcessingProtobufMetadata.java.pb.meta",
+    ],
+    vnames_config = "protobuf_vnames.json",
 )
 
 java_verifier_test(

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/ProcessingMetadata.java
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/ProcessingMetadata.java
@@ -1,0 +1,8 @@
+package pkg;
+
+@javax.annotation.processing.Generated(value="kythe", comments="annotations:ProcessingMetadata.java.meta")
+//- @ProcessingMetadata defines/binding MetadataClass
+public class ProcessingMetadata {
+  
+}
+//- vname(gsig, gcorp, groot, gpath, glang) generates MetadataClass

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/ProcessingMetadata.java.meta
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/ProcessingMetadata.java.meta
@@ -1,0 +1,18 @@
+{
+  "type": "kythe0",
+  "meta": [
+    {
+      "type": "anchor_defines",
+      "begin": 188,
+      "end": 206,
+      "edge": "%/kythe/edge/generates",
+      "vname": {
+        "signature": "gsig",
+        "corpus": "gcorp",
+        "path": "gpath",
+        "language": "glang",
+        "root": "groot"
+      }
+    }
+  ]
+}

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/ProcessingProtobufMetadata.java
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/ProcessingProtobufMetadata.java
@@ -1,0 +1,7 @@
+package pkg;
+
+@javax.annotation.processing.Generated(value="protoc", comments="annotations:ProcessingProtobufMetadata.java.pb.meta")
+//- @ProcessingProtobufMetadata defines/binding ProtobufMetadata
+public class ProcessingProtobufMetadata {
+}
+//- vname("4.2",kythe,"","ProtobufMetadata.proto",protobuf) generates ProtobufMetadata

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/ProcessingProtobufMetadata.java.pb.meta
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/ProcessingProtobufMetadata.java.pb.meta
@@ -1,0 +1,2 @@
+
+"ProtobufMetadata.protoÓ í


### PR DESCRIPTION
Thankfully, the indexer itself doesn't reference `javax.annotation.Generated` directly so won't break in the same fashion as the extractor, but we might as well add support for the new package.