### PR TITLE
feat: add KYTHE_PRE_BUILD_STEP handling to go extractor image

### DIFF
--- a/kythe/go/extractors/cmd/gotool/analyze_packages.sh
+++ b/kythe/go/extractors/cmd/gotool/analyze_packages.sh
@@ -37,6 +37,10 @@ if [ ! -z "$KYTHE_GO_BUILD_TAGS" ]; then
   FLAGS+=( "--buildtags=$KYTHE_GO_BUILD_TAGS" )
 fi
 
+if [ -n "$KYTHE_PRE_BUILD_STEP" ]; then
+  eval "$KYTHE_PRE_BUILD_STEP"
+fi
+
 echo "Downloading ${PACKAGES[*]}" >&2
 go get -d "${PACKAGES[@]}" || true
 


### PR DESCRIPTION
Followup to https://github.com/kythe/kythe/pull/3890 that adds the same pre-build step to the go extractor image.