### PR TITLE
feat(typescript_indexer): add support for indexing literal properties

### DIFF
--- a/kythe/typescript/SCHEMA.md
+++ b/kythe/typescript/SCHEMA.md
@@ -73,11 +73,13 @@ Path__ for more.
 
 #### Named Declaration
 
-**Form**: `$DECLARATION_NAME`
+**Form**: `$DECLARATION_NAME | "$DECLARATION_NAME"`
 
 **Notes**: Every named declaration is guaranteed to have a signature of the form
 `$SCOPE[.$SCOPE]*` where `$SCOPE` is the name of each encompassing named
 declaration.
+
+If the declaration is a string literal, its name is wrapped in quotes.
 
 **SyntaxKind**:
 
@@ -103,6 +105,9 @@ export class Klass {
     //- @property defines/binding VName("Klass#type.method.val", _, _, _, _)
     let val;
   };
+
+  //- @"'propliteral'" defines/binding VName("Klass#type.\"propliteral\"", _, _, _, _)
+  'propliteral' = 0;
 }
 ```
 

--- a/kythe/typescript/indexer.ts
+++ b/kythe/typescript/indexer.ts
@@ -464,11 +464,11 @@ class Visitor {
                   part = decl.name.text;
                 }
                 // Wrap literals in quotes, so that characters used in other
-                // signatures do not interfere with the signature creates by a
+                // signatures do not interfere with the signature created by a
                 // literal. For instance, a literal
                 //   obj.prop
                 // may interefere with the signature of `prop` on an object
-                // `foo`. The literal receives a signature
+                // `obj`. The literal receives a signature
                 //   "obj.prop"
                 // to avoid this.
                 if (ts.isStringLiteral(decl.name)) {

--- a/kythe/typescript/indexer.ts
+++ b/kythe/typescript/indexer.ts
@@ -463,6 +463,17 @@ class Visitor {
                 } else {
                   part = decl.name.text;
                 }
+                // Wrap literals in quotes, so that characters used in other
+                // signatures do not interfere with the signature creates by a
+                // literal. For instance, a literal
+                //   obj.prop
+                // may interefere with the signature of `prop` on an object
+                // `foo`. The literal receives a signature
+                //   "obj.prop"
+                // to avoid this.
+                if (ts.isStringLiteral(decl.name)) {
+                  part = `"${part}"`;
+                }
                 // Instance members of a class are scoped to the type of the
                 // class.
                 if (ts.isClassDeclaration(decl) && lastNode !== undefined &&

--- a/kythe/typescript/indexer.ts
+++ b/kythe/typescript/indexer.ts
@@ -1053,7 +1053,8 @@ class Visitor {
         if (moduleName) {
           const kModule = this.newVName('module', moduleName);
           this.emitEdge(
-              this.newAnchor(decl.moduleSpecifier), EdgeKind.REF_IMPORTS, kModule);
+              this.newAnchor(decl.moduleSpecifier), EdgeKind.REF_IMPORTS,
+              kModule);
         }
       }
     }
@@ -1090,6 +1091,8 @@ class Visitor {
     switch (decl.name.kind) {
       case ts.SyntaxKind.Identifier:
       case ts.SyntaxKind.ComputedPropertyName:
+      case ts.SyntaxKind.StringLiteral:
+      case ts.SyntaxKind.NumericLiteral:
         const sym = this.getSymbolAtLocation(decl.name);
         if (!sym) {
           this.todo(
@@ -1109,10 +1112,6 @@ class Visitor {
         for (const element of (decl.name as ts.BindingPattern).elements) {
           this.visit(element);
         }
-        break;
-      case ts.SyntaxKind.StringLiteral:
-      case ts.SyntaxKind.NumericLiteral:
-        // Nothing meaningful can be recorded about literal expressions.
         break;
       default:
         break;
@@ -1531,6 +1530,8 @@ class Visitor {
         this.visitVariableDeclaration(node as ts.BindingElement);
         return;
       case ts.SyntaxKind.Identifier:
+      case ts.SyntaxKind.StringLiteral:
+      case ts.SyntaxKind.NumericLiteral:
         // Assume that this identifer is occurring as part of an
         // expression; we handle identifiers that occur in other
         // circumstances (e.g. in a type) separately in visitType.

--- a/kythe/typescript/testdata/object.ts
+++ b/kythe/typescript/testdata/object.ts
@@ -23,9 +23,9 @@ const Object = {
   //- Method.node/kind function
   method() {},
 
-  //- @"'sliteral'" defines/binding SLiteralProperty
+  //- @"'string#literal'" defines/binding SLiteralProperty
   //- SLiteralProperty.node/kind variable
-  'sliteral': 0,
+  'string#literal': 0,
 
   //- @"123" defines/binding NLiteralProperty
   //- NLiteralProperty.node/kind variable
@@ -37,8 +37,8 @@ const Object = {
 //- @computed ref ComputedProperty
 const x = Object.property || Object.shortProperty || Object.computed;
 
-//- @"'sliteral'" ref SLiteralProperty
-Object['sliteral'];
+//- @"'string#literal'" ref SLiteralProperty
+Object['string#literal'];
 
 //- @"123" ref NLiteralProperty
 Object[123];

--- a/kythe/typescript/testdata/object.ts
+++ b/kythe/typescript/testdata/object.ts
@@ -21,13 +21,27 @@ const Object = {
 
   //- @method defines/binding Method
   //- Method.node/kind function
-  method() {}
+  method() {},
+
+  //- @"'sliteral'" defines/binding SLiteralProperty
+  //- SLiteralProperty.node/kind variable
+  'sliteral': 0,
+
+  //- @"123" defines/binding NLiteralProperty
+  //- NLiteralProperty.node/kind variable
+  123: 'nliteral',
 };
 
 //- @property ref Property
 //- @shortProperty ref ShortProperty
 //- @computed ref ComputedProperty
 const x = Object.property || Object.shortProperty || Object.computed;
+
+//- @"'sliteral'" ref SLiteralProperty
+Object['sliteral'];
+
+//- @"123" ref NLiteralProperty
+Object[123];
 
 //- @method ref Method
 Object.method();

--- a/kythe/typescript/testdata/schema.ts
+++ b/kythe/typescript/testdata/schema.ts
@@ -23,6 +23,10 @@ class C {
   //- @property defines/binding VName("C#type.property", _, _, "testdata/schema", "typescript")
   property = 0;
 
+  // PropertyDeclarartion string literal
+  //- @"'propliteral'" defines/binding VName("C#type.\"propliteral\"", _, _, "testdata/schema", "typescript")
+  'propliteral' = 0;
+
   // PropertyDeclaration static member
   //- @property defines/binding VName("C.property", _, _, "testdata/schema", "typescript")
   static property = 0;


### PR DESCRIPTION
Add support for indexing string and numeric literals in property names,
and referencing string and numeric literals in a property access.