### PR TITLE
fix(cxx_indexer): properly reference C++17 deduced templates

### DIFF
--- a/kythe/cxx/indexer/cxx/IndexerASTHooks.h
+++ b/kythe/cxx/indexer/cxx/IndexerASTHooks.h
@@ -132,10 +132,15 @@ class IndexerASTVisitor : public clang::RecursiveASTVisitor<IndexerASTVisitor> {
   bool VisitTemplateTypeParmTypeLoc(clang::TemplateTypeParmTypeLoc TL);
   bool VisitSubstTemplateTypeParmTypeLoc(
       clang::SubstTemplateTypeParmTypeLoc TL);
+
+  template <typename T>
+  bool VisitTemplateSpecializationTypeLocHelper(T TL);
   bool VisitTemplateSpecializationTypeLoc(
       clang::TemplateSpecializationTypeLoc TL);
-  // Handles AutoTypeLoc and DeducedTemplateSpecializationTypeLoc
-  bool VisitDeducedTypeLoc(clang::DeducedTypeLoc TL);
+  bool VisitDeducedTemplateSpecializationTypeLoc(
+      clang::DeducedTemplateSpecializationTypeLoc TL);
+
+  bool VisitAutoTypeLoc(clang::AutoTypeLoc TL);
   bool VisitDecltypeTypeLoc(clang::DecltypeTypeLoc TL);
   bool VisitElaboratedTypeLoc(clang::ElaboratedTypeLoc TL);
   bool VisitTypedefTypeLoc(clang::TypedefTypeLoc TL);

--- a/kythe/cxx/indexer/cxx/testdata/BUILD
+++ b/kythe/cxx/indexer/cxx/testdata/BUILD
@@ -1727,10 +1727,7 @@ cc_indexer_test(
     srcs = ["rec/rec_implicit_ctor_calls_conversion.cc"],
     check_for_singletons = True,
     ignore_dups = True,
-    tags = [
-        "manual",  # https://github.com/kythe/kythe/issues/2894
-        "rec",
-    ],
+    tags = ["rec"],
 )
 
 cc_indexer_test(

--- a/kythe/cxx/indexer/cxx/testdata/template/template_class_ctor_deduction.cc
+++ b/kythe/cxx/indexer/cxx/testdata/template/template_class_ctor_deduction.cc
@@ -23,14 +23,21 @@ struct C {
 //- @S ref StructS
 C() -> C<S>;
 
+// TODO(shahms): This should not be considered an implicit ref.
 //- @#1C ref/implicit TemplC
 template <typename U> C(U, U) -> C<U>;
 
 void f() {
-  // TODO(shahms): Uncomment this test when Clang supports class template
-  // argument deduction for default construction.
-  // See: https://bugs.llvm.org/show_bug.cgi?id=32443
-  // C cz;
+  //- @C ref TemplC
+  //- @cz ref/call Ctor0App
+  //- Ctor0App param.0 Ctor0
+  C cz;
+  //- @C ref TemplC
+  //- @"ct(S{})" ref/call CtorTApp
+  //- CtorTApp param.0 CtorT
   C ct(S{});
+  //- @C ref TemplC
+  //- @"cu(S{}, S{})" ref/call CtorUApp
+  //- CtorUApp param.0 CtorU
   C cu(S{}, S{});
 }


### PR DESCRIPTION
Incidentally fixes and enables the test for #2894