### PR TITLE
chore(cxx_common): move memcached-related bits to a separate header

### DIFF
--- a/kythe/cxx/common/indexing/BUILD
+++ b/kythe/cxx/common/indexing/BUILD
@@ -29,9 +29,11 @@ cc_library(
     name = "caching_output",
     srcs = [
         "KytheCachingOutput.cc",
+        "MemcachedHashCache.cc",
     ],
     hdrs = [
         "KytheCachingOutput.h",
+        "MemcachedHashCache.h",
     ],
     visibility = [PUBLIC_VISIBILITY],
     deps = [

--- a/kythe/cxx/common/indexing/KytheCachingOutput.cc
+++ b/kythe/cxx/common/indexing/KytheCachingOutput.cc
@@ -25,58 +25,6 @@
 #include "absl/strings/str_format.h"
 
 namespace kythe {
-
-bool MemcachedHashCache::OpenMemcache(const std::string& spec) {
-  if (cache_) {
-    memcached_free(cache_);
-    cache_ = nullptr;
-  }
-  std::string spec_amend = spec;
-  spec_amend.append(" --BINARY-PROTOCOL");
-  cache_ = memcached(spec_amend.c_str(), spec_amend.size());
-  if (cache_ != nullptr) {
-    memcached_return_t remote_version = memcached_version(cache_);
-    return memcached_success(remote_version);
-  }
-  return false;
-}
-
-MemcachedHashCache::~MemcachedHashCache() {
-  if (cache_) {
-    memcached_free(cache_);
-    cache_ = nullptr;
-  }
-}
-
-void MemcachedHashCache::RegisterHash(const Hash& hash) {
-  if (!cache_) {
-    return;
-  }
-  char value = 1;
-  memcached_return_t add_result =
-      memcached_add(cache_, reinterpret_cast<const char*>(hash), kHashSize,
-                    &value, sizeof(value), 0, 0);
-  if (!memcached_success(add_result) && add_result != MEMCACHED_DATA_EXISTS) {
-    absl::FPrintF(stderr, "memcached add failed: %s\n",
-                  memcached_strerror(cache_, add_result));
-  }
-}
-
-bool MemcachedHashCache::SawHash(const Hash& hash) {
-  if (!cache_) {
-    return false;
-  }
-  memcached_return_t ex_result =
-      memcached_exist(cache_, reinterpret_cast<const char*>(hash), kHashSize);
-  if (ex_result == MEMCACHED_SUCCESS) {
-    return true;
-  } else if (ex_result != MEMCACHED_NOTFOUND) {
-    absl::FPrintF(stderr, "memcached exist failed: %s\n",
-                  memcached_strerror(cache_, ex_result));
-  }
-  return false;
-}
-
 std::string FileOutputStream::Stats::ToString() const {
   return absl::StrCat(
       buffers_merged_, " merged ", buffers_split_, " split ", buffers_retired_,

--- a/kythe/cxx/common/indexing/KytheCachingOutput.cc
+++ b/kythe/cxx/common/indexing/KytheCachingOutput.cc
@@ -16,8 +16,6 @@
 
 #include "kythe/cxx/common/indexing/KytheCachingOutput.h"
 
-#include <libmemcached/memcached.h>
-
 #include <algorithm>
 #include <sstream>
 

--- a/kythe/cxx/common/indexing/KytheCachingOutput.h
+++ b/kythe/cxx/common/indexing/KytheCachingOutput.h
@@ -29,10 +29,6 @@
 #include "kythe/proto/common.pb.h"
 #include "kythe/proto/storage.pb.h"
 
-extern "C" {
-struct memcached_st;
-}
-
 namespace kythe {
 /// \brief Keeps track of whether hashes have been seen before.
 class HashCache {
@@ -57,22 +53,6 @@ class HashCache {
  private:
   size_t min_size_ = 0;
   size_t max_size_ = 32 * 1024;
-};
-
-/// \brief A `HashCache` that uses a memcached server.
-class MemcachedHashCache : public HashCache {
- public:
-  ~MemcachedHashCache() override;
-
-  /// \brief Use a memcached instance (e.g. "--SERVER=foo:1234")
-  bool OpenMemcache(const std::string& spec);
-
-  void RegisterHash(const Hash& hash) override;
-
-  bool SawHash(const Hash& hash) override;
-
- private:
-  ::memcached_st* cache_ = nullptr;
 };
 
 // Interface for receiving Kythe data.

--- a/kythe/cxx/common/indexing/MemcachedHashCache.cc
+++ b/kythe/cxx/common/indexing/MemcachedHashCache.cc
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2019 The Kythe Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "kythe/cxx/common/indexing/MemcachedHashCache.h"
+
+#include <libmemcached/memcached.h>
+
+#include <iostream>
+
+namespace kythe {
+
+bool MemcachedHashCache::OpenMemcache(const std::string& spec) {
+  if (cache_) {
+    memcached_free(cache_);
+    cache_ = nullptr;
+  }
+  std::string spec_amend = spec;
+  spec_amend.append(" --BINARY-PROTOCOL");
+  cache_ = memcached(spec_amend.c_str(), spec_amend.size());
+  if (cache_ != nullptr) {
+    memcached_return_t remote_version = memcached_version(cache_);
+    return memcached_success(remote_version);
+  }
+  return false;
+}
+
+MemcachedHashCache::~MemcachedHashCache() {
+  if (cache_) {
+    memcached_free(cache_);
+    cache_ = nullptr;
+  }
+}
+
+void MemcachedHashCache::RegisterHash(const Hash& hash) {
+  if (!cache_) {
+    return;
+  }
+  char value = 1;
+  memcached_return_t add_result =
+      memcached_add(cache_, reinterpret_cast<const char*>(hash), kHashSize,
+                    &value, sizeof(value), 0, 0);
+  if (!memcached_success(add_result) && add_result != MEMCACHED_DATA_EXISTS) {
+    std::cerr << "memcached add failed: "
+              << memcached_strerror(cache_, add_result) << "\n";
+  }
+}
+
+bool MemcachedHashCache::SawHash(const Hash& hash) {
+  if (!cache_) {
+    return false;
+  }
+  memcached_return_t ex_result =
+      memcached_exist(cache_, reinterpret_cast<const char*>(hash), kHashSize);
+  if (ex_result == MEMCACHED_SUCCESS) {
+    return true;
+  } else if (ex_result != MEMCACHED_NOTFOUND) {
+    std::cerr << "memcached exist failed: "
+              << memcached_strerror(cache_, ex_result) << "\n";
+  }
+  return false;
+}
+
+}  // namespace kythe

--- a/kythe/cxx/common/indexing/MemcachedHashCache.h
+++ b/kythe/cxx/common/indexing/MemcachedHashCache.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 The Kythe Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef KYTHE_CXX_COMMON_INDEXING_MEMCACHEDHASHCACHE_H_
+#define KYTHE_CXX_COMMON_INDEXING_MEMCACHEDHASHCACHE_H_
+
+#include <string>
+
+#include "kythe/cxx/common/indexing/KytheCachingOutput.h"
+
+extern "C" {
+struct memcached_st;
+}
+
+namespace kythe {
+
+/// \brief A `HashCache` that uses a memcached server.
+class MemcachedHashCache : public HashCache {
+ public:
+  ~MemcachedHashCache() override;
+
+  /// \brief Use a memcached instance (e.g. "--SERVER=foo:1234")
+  bool OpenMemcache(const std::string& spec);
+
+  void RegisterHash(const Hash& hash) override;
+
+  bool SawHash(const Hash& hash) override;
+
+ private:
+  ::memcached_st* cache_ = nullptr;
+};
+
+}  // namespace kythe
+#endif  // KYTHE_CXX_COMMON_INDEXING_MEMCACHEDHASHCACHE_H_

--- a/kythe/cxx/indexer/cxx/frontend.cc
+++ b/kythe/cxx/indexer/cxx/frontend.cc
@@ -29,6 +29,7 @@
 #include "google/protobuf/io/gzip_stream.h"
 #include "google/protobuf/io/zero_copy_stream.h"
 #include "google/protobuf/io/zero_copy_stream_impl.h"
+#include "kythe/cxx/common/indexing/MemcachedHashCache.h"
 #include "kythe/cxx/common/kzip_reader.h"
 #include "kythe/cxx/common/path_utils.h"
 #include "kythe/cxx/indexer/cxx/proto_conversions.h"


### PR DESCRIPTION
At least for KytheCachingOutput, move the memcached parts to a separate header and implementation.  This makes it easier to remove them in environments where memcached isn't supported.