### PR TITLE
fixup: Add jsr250 dep for Kythe annotated protos

### DIFF
--- a/kythe/extractors/BUILD
+++ b/kythe/extractors/BUILD
@@ -11,7 +11,17 @@ exports_files(["extractors.bzl"])
 proto_lang_toolchain(
     name = "java_proto_toolchain",
     command_line = "--java_out=annotate_code:$(OUT)",
-    runtime = "@com_google_protobuf//:protobuf_java",
+    runtime = ":protobuf_java",
+)
+
+# Clone of the java protobuf runtime that also exposes jsr250 so the generated
+# proto classes with our inserted annotations can be compiled.
+java_library(
+    name = "protobuf_java",
+    exports = [
+        "@com_google_protobuf//:protobuf_java",
+        "@javax_annotation_jsr250_api//jar",
+    ],
 )
 
 # Clone of default C++ proto toolchain with "annotate_headers" enabled for


### PR DESCRIPTION
When Kythe annotates protos, the resulting java code depends on jsr250. The
default proto runtime doesn't include this dep so we need to manually include
it in a custom runtime for our custom proto lang toolchain.