### PR TITLE
fixup: Add jsr250 to our release proto toolchain

### DIFF
--- a/kythe/release/release.BUILD
+++ b/kythe/release/release.BUILD
@@ -29,11 +29,17 @@ proto_lang_toolchain(
     runtime = ":protobuf",
 )
 
+java_import(
+    name = "jsr250",
+    jars = [ "jsr250-api-1.0.jar"],
+)
+
 java_library(
     name = "protobuf",
     visibility = ["//visibility:private"],
     exports = [
         "@com_google_protobuf//:protobuf_java",
+        ":jsr250",
     ],
     runtime_deps = [
         "@com_google_protobuf//:protobuf_java",


### PR DESCRIPTION
This is the same change as #3910 but applied to our proto lang toolchain rule we expose in our release