### PR TITLE
docs: remove obsolete readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,0 @@
-# Support for Kythe extraction and indexing of protobuf. https://kythe.io


### PR DESCRIPTION
this accidentally got pulled in when the kythe/lang-proto repo got merged.
The actual readme for kythe is README.adoc.