### PR TITLE
fixup(c++): Don't build manual targets

### DIFF
--- a/tools/cpp/generate_compilation_database.sh
+++ b/tools/cpp/generate_compilation_database.sh
@@ -9,7 +9,7 @@ bazel build \
   --experimental_action_listener=//kythe/cxx/tools/generate_compile_commands:extract_json \
   --noshow_progress \
   --noshow_loading_progress \
-  $(bazel query 'kind(cc_.*, //...)') > /dev/null
+  $(bazel query 'kind(cc_.*, //...) - attr(tags, manual, //...)') > /dev/null
 
 pushd $(bazel info execution_root) > /dev/null
 echo "[" > compile_commands.json


### PR DESCRIPTION
Don't try to build manual targets when using the generate compilation database script.