### PR TITLE
fix(bazel extractor): better handling of bazel exit code

### DIFF
--- a/kythe/extractors/bazel/BUILD
+++ b/kythe/extractors/bazel/BUILD
@@ -11,7 +11,7 @@ docker_build(
         "@com_github_philwo_bazelisk//:bazelisk",
         "@javax_annotation_jsr250_api//jar",
     ],
-    image_name = "local_bazel_extractor",
+    image_name = "gcr.io/kythe-public/bazel-extractor",
     tags = ["manual"],
     use_cache = True,
 )

--- a/kythe/extractors/bazel/BUILD
+++ b/kythe/extractors/bazel/BUILD
@@ -11,7 +11,7 @@ docker_build(
         "@com_github_philwo_bazelisk//:bazelisk",
         "@javax_annotation_jsr250_api//jar",
     ],
-    image_name = "gcr.io/kythe-public/bazel-extractor",
+    image_name = "local_bazel_extractor",
     tags = ["manual"],
     use_cache = True,
 )

--- a/kythe/extractors/bazel/extract.sh
+++ b/kythe/extractors/bazel/extract.sh
@@ -67,9 +67,9 @@ fi
 # targets fail.
 /kythe/bazelisk --bazelrc=/kythe/bazelrc "$@" || true
 retval=$?
-if [ $retval -eq 1 ]; then
+if [[ $retval -eq 1 ]]; then
     echo "Not all bazel targets built successfully, but continuing anyways."
-else if [ $retval -ne 0 ];
+else if [[ $retval -ne 0 ]];
     echo "Bazel build failed with exit code: $retval"
     exit 1
 fi

--- a/kythe/extractors/bazel/extract.sh
+++ b/kythe/extractors/bazel/extract.sh
@@ -66,6 +66,13 @@ fi
 # care if some targets fail, but bazel will return a failure code if any
 # targets fail.
 /kythe/bazelisk --bazelrc=/kythe/bazelrc "$@" || true
+retval=$?
+if [ $retval -eq 1 ]; then
+    echo "Not all bazel targets built successfully, but continuing anyways."
+else if [ $retval -ne 0 ];
+    echo "Bazel build failed with exit code: $retval"
+    exit 1
+fi
 
 # Collect any extracted compilations.
 mkdir -p "$KYTHE_OUTPUT_DIRECTORY"

--- a/kythe/extractors/bazel/extract.sh
+++ b/kythe/extractors/bazel/extract.sh
@@ -65,11 +65,11 @@ fi
 # It is ok if targets fail to build. We build using --keep_going and don't
 # care if some targets fail, but bazel will return a failure code if any
 # targets fail.
-/kythe/bazelisk --bazelrc=/kythe/bazelrc "$@" || true
-retval=$?
+retval=0
+/kythe/bazelisk --bazelrc=/kythe/bazelrc "$@" || retval=$?
 if [[ $retval -eq 1 ]]; then
     echo "Not all bazel targets built successfully, but continuing anyways."
-else if [[ $retval -ne 0 ]];
+elif [[ $retval -ne 0 ]]; then
     echo "Bazel build failed with exit code: $retval"
     exit 1
 fi


### PR DESCRIPTION
We use the `--keep_going` flag so that we can extract all buildable targets even if some other targets fail.
If bazel fails to build some packages, but otherwise succeeds in extracting, the exit code is 1. Other
errors like "bazel server died unexpectedly" give other exit codes and will now cause the
extractor script to fail.