### PR TITLE
chore: use checkerframework @Nullable annotation

### DIFF
--- a/external.bzl
+++ b/external.bzl
@@ -219,6 +219,13 @@ def _java_dependencies():
 
     maybe(
         native.maven_jar,
+        name = "org_checkerframework_checker_qual",
+        artifact = "org.checkerframework:checker-qual:2.9.0",
+        sha1 = "8f783c7cdcda9f3639459d33cad5d5307b5512ba",
+    )
+
+    maybe(
+        native.maven_jar,
         name = "org_ow2_asm_asm",
         artifact = "org.ow2.asm:asm:7.0",
         sha1 = "d74d4ba0dee443f68fb2dcb7fcdb945a2cd89912",

--- a/kythe/java/com/google/devtools/kythe/analyzers/base/BUILD
+++ b/kythe/java/com/google/devtools/kythe/analyzers/base/BUILD
@@ -27,6 +27,7 @@ java_library(
         "//kythe/proto:schema_java_proto",
         "//third_party/guava",
         "@com_google_code_findbugs_jsr305//jar",
+        "@org_checkerframework_checker_qual//jar",
     ],
 )
 
@@ -50,6 +51,7 @@ java_library(
         "//third_party/guava",
         "@com_google_code_findbugs_jsr305//jar",
         "@com_google_protobuf//:protobuf_java",
+        "@org_checkerframework_checker_qual//jar",
     ],
 )
 

--- a/kythe/java/com/google/devtools/kythe/analyzers/base/KytheEntrySets.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/base/KytheEntrySets.java
@@ -33,7 +33,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Factory for Kythe-compliant node and edge {@link EntrySet}s. In general, this class provides two

--- a/kythe/java/com/google/devtools/kythe/analyzers/base/NodeKind.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/base/NodeKind.java
@@ -18,7 +18,7 @@ package com.google.devtools.kythe.analyzers.base;
 
 import com.google.devtools.kythe.util.schema.Schema;
 import java.util.Optional;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /** Schema-defined Kythe node kinds. */
 public enum NodeKind {

--- a/kythe/java/com/google/devtools/kythe/analyzers/java/BUILD
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/BUILD
@@ -40,6 +40,7 @@ java_library(
         "@com_beust_jcommander//jar",
         "@com_google_code_findbugs_jsr305//jar",
         "@com_google_protobuf//:protobuf_java",
+        "@org_checkerframework_checker_qual//jar",
     ],
 )
 

--- a/kythe/java/com/google/devtools/kythe/analyzers/java/JavaEntrySets.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/JavaEntrySets.java
@@ -48,10 +48,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import javax.annotation.Nullable;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.Name;
 import javax.tools.JavaFileObject;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /** Specialization of {@link KytheEntrySets} for Java. */
 public class JavaEntrySets extends KytheEntrySets {
@@ -89,7 +89,7 @@ public class JavaEntrySets extends KytheEntrySets {
       Symbol sym,
       String signature,
       // TODO(schroederc): separate MarkedSource generation from JavaEntrySets
-      @Nullable MarkedSource.Builder msBuilder,
+       MarkedSource.@Nullable Builder msBuilder,
       @Nullable Iterable<MarkedSource> postChildren) {
     return getNode(
         signatureGenerator,

--- a/kythe/java/com/google/devtools/kythe/analyzers/java/MarkedSources.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/MarkedSources.java
@@ -28,8 +28,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
-import javax.annotation.Nullable;
 import javax.lang.model.element.ElementKind;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /** {@link MarkedSource} utility class. */
 public final class MarkedSources {
@@ -116,7 +116,7 @@ public final class MarkedSources {
   static MarkedSource construct(
       SignatureGenerator signatureGenerator,
       Symbol sym,
-      @Nullable MarkedSource.Builder msBuilder,
+      MarkedSource.@Nullable Builder msBuilder,
       @Nullable Iterable<MarkedSource> postChildren,
       Function<Symbol, Optional<VName>> symNames) {
     MarkedSource markedType = markType(signatureGenerator, sym, symNames);
@@ -126,7 +126,7 @@ public final class MarkedSources {
   private static MarkedSource construct(
       SignatureGenerator signatureGenerator,
       Symbol sym,
-      @Nullable MarkedSource.Builder msBuilder,
+      MarkedSource.@Nullable Builder msBuilder,
       @Nullable Iterable<MarkedSource> postChildren,
       @Nullable MarkedSource markedType) {
     MarkedSource.Builder markedSource = msBuilder == null ? MarkedSource.newBuilder() : msBuilder;

--- a/kythe/java/com/google/devtools/kythe/extractors/java/BUILD
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/BUILD
@@ -29,5 +29,6 @@ java_library(
         "@com_google_protobuf//:protobuf_java",
         "@com_google_protobuf//:protobuf_java_util",
         "@javax_annotation_jsr250_api//jar",
+        "@org_checkerframework_checker_qual//jar",
     ],
 )

--- a/kythe/java/com/google/devtools/kythe/extractors/java/InputUsageRecord.java
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/InputUsageRecord.java
@@ -18,9 +18,9 @@ package com.google.devtools.kythe.extractors.java;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import javax.annotation.Nullable;
 import javax.tools.JavaFileManager.Location;
 import javax.tools.JavaFileObject;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * A compilation with multiple rounds of annotation processing will create new file objects for each

--- a/kythe/java/com/google/devtools/kythe/platform/java/BUILD
+++ b/kythe/java/com/google/devtools/kythe/platform/java/BUILD
@@ -34,5 +34,6 @@ java_library(
         "@com_google_code_findbugs_jsr305//jar",
         "@com_google_protobuf//:any_proto",
         "@com_google_protobuf//:protobuf_java",
+        "@org_checkerframework_checker_qual//jar",
     ],
 )

--- a/kythe/java/com/google/devtools/kythe/platform/java/JavacOptionsUtils.java
+++ b/kythe/java/com/google/devtools/kythe/platform/java/JavacOptionsUtils.java
@@ -42,8 +42,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
-import javax.annotation.Nullable;
 import javax.tools.OptionChecker;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * A utility class for dealing with javac command-line options.

--- a/kythe/java/com/google/devtools/kythe/platform/shared/BUILD
+++ b/kythe/java/com/google/devtools/kythe/platform/shared/BUILD
@@ -49,5 +49,6 @@ java_library(
         "@com_google_code_findbugs_jsr305//jar",
         "@com_google_code_gson_gson//jar",
         "@com_google_protobuf//:protobuf_java",
+        "@org_checkerframework_checker_qual//jar",
     ],
 )

--- a/kythe/java/com/google/devtools/kythe/platform/shared/KytheMetadataLoader.java
+++ b/kythe/java/com/google/devtools/kythe/platform/shared/KytheMetadataLoader.java
@@ -32,7 +32,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /** Loads Kythe JSON-formatted metadata (with the .meta extension). */
 public class KytheMetadataLoader implements MetadataLoader {
@@ -65,8 +65,7 @@ public class KytheMetadataLoader implements MetadataLoader {
       return new AutoValue_KytheMetadataLoader_RuleXorError(null, error);
     }
 
-    @Nullable
-    abstract Metadata.Rule rule();
+    abstract Metadata.@Nullable Rule rule();
 
     @Nullable
     abstract String error();

--- a/kythe/java/com/google/devtools/kythe/platform/shared/ProtobufMetadataLoader.java
+++ b/kythe/java/com/google/devtools/kythe/platform/shared/ProtobufMetadataLoader.java
@@ -25,7 +25,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.function.Function;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /** Loads protobuf metadata (stored as GeneratedCodeInfo messages). */
 public class ProtobufMetadataLoader implements MetadataLoader {


### PR DESCRIPTION
This version of `@Nullable` is usable in TYPE_USE and TYPE_PARAMETER contexts (e.g. it permits declaring `List<@Nullable String>`); it also is used by the [checker framework](https://checkerframework.org) nullness analysis. .