### PR TITLE
fix: Properly handle target expressions

### DIFF
--- a/kythe/extractors/bazel/extract.sh
+++ b/kythe/extractors/bazel/extract.sh
@@ -63,7 +63,7 @@ if [ -n "$KYTHE_PRE_BUILD_STEP" ]; then
 fi
 
 if [[ -n "$KYTHE_BAZEL_TARGET" ]]; then
-  sh /kythe/bazel_wrapper.sh --bazelrc=/kythe/bazelrc "$@" -- "$KYTHE_BAZEL_TARGET"
+  sh /kythe/bazel_wrapper.sh --bazelrc=/kythe/bazelrc "$@" -- $KYTHE_BAZEL_TARGET
 else
   # If the user supplied a bazel query, execute it and run bazel, but we have to
   # shard the results to different bazel runs because the bazel command line

--- a/kythe/extractors/bazel/extract.sh
+++ b/kythe/extractors/bazel/extract.sh
@@ -63,6 +63,12 @@ if [ -n "$KYTHE_PRE_BUILD_STEP" ]; then
 fi
 
 if [[ -n "$KYTHE_BAZEL_TARGET" ]]; then
+  # $KYTHE_BAZEL_TARGET is unquoted because bazel_wrapper needs to see each
+  # target expression in KYTHE_BAZEL_WRAPPER as individual arguments. For
+  # example, if KYTHE_BAZEL_TARGET=//foo/... -//foo/test/..., bazel_wrapper
+  # needs to see two valid target expressions (//foo/... and -//foo/test/...)
+  # not one invalid target expression with white space
+  # ("//foo/... -//foo/test/...").
   sh /kythe/bazel_wrapper.sh --bazelrc=/kythe/bazelrc "$@" -- $KYTHE_BAZEL_TARGET
 else
   # If the user supplied a bazel query, execute it and run bazel, but we have to


### PR DESCRIPTION
We shouldn't quote the target expression variable because we want the underlying
script/program to interpret each target expression individually, we don't want
the program to get a single target expression that contains white space.