### PR TITLE
feat(kzip tool): add more details and json output mode to `kzip info`

### DIFF
--- a/kythe/go/platform/tools/kzip/infocmd/infocmd.go
+++ b/kythe/go/platform/tools/kzip/infocmd/infocmd.go
@@ -34,8 +34,7 @@ import (
 type infoCommand struct {
 	cmdutil.Info
 
-	input       string
-	writeFormat string
+	input string
 }
 
 // New creates a new subcommand for obtaining info on a kzip file.


### PR DESCRIPTION
The motivation for this change is to make `kzip info` more useful for validating kzips. A few things we can check using this new info:

* compare counts between different versions of a kzip from the same repo to detect large changes.
* check that a kzip contains compilation units only from the corpus it has been assigned. 
* the corpora of other input files in the kzip can be different, but are something we're interested in keeping track of

TODO:
* is there any other info we want to record?
* naming of keys in the json output?

Example usage:

```
$ kzip info --input github.com_knative_pkg.kzip                            
57 compilation units, 828 input files, corpora: {"github.com/knative/pkg", "golang.org"}
Unit Counts (by corpus, language):
  github.com/knative/pkg
    go: 57
File Counts (by corpus, language):
  github.com/knative/pkg
    <empty lang>: 256
    go: 340
  golang.org
    go: 232

#########################################

$ kzip info --input github.com_knative_pkg.kzip  --write_format json | jq .
{                                                                                                                                                                                                     
  "file_counts": {
    "github.com/knative/pkg": {
      "": 256,
      "go": 340
    },
    "golang.org": {
      "go": 232
    }
  },
  "total_files": 828,
  "total_units": 57,
  "unit_counts": {
    "github.com/knative/pkg": {
      "go": 57
    }
  }
}
```