### PR TITLE
refactor(typescript_indexer): emit "named" edges for imports

### DIFF
--- a/kythe/typescript/indexer.ts
+++ b/kythe/typescript/indexer.ts
@@ -906,20 +906,20 @@ class Visitor {
     // (including renaming imports) to the remote symbol.
     //
     // This is done by exploiting Kythe graph edges. A "name" node is defined
-    // for the local symbol which the remote symbol is said to "generates".
-    // "generates" is an edge between two semantic nodes that provides for
-    // folding references. That is, a graph like
+    // for the local symbol which is "named" by the remote symbol. The "named"
+    // edge between two semantic nodes provides a nice functionality of folding
+    // references. That is, a graph like
     //
-    //   LocalUsage    LocalSymbol  RemoteSymbol      RemoteAnchor
-    //        \___________/^ ^\_________/ ^\_______________/
-    //             ref         generates    defines/binding
+    //   LocalUsage    LocalSymbol  RemoteSymbol        RemoteAnchor
+    //        \___________/^ ^\_________/ ^\_________________/
+    //             ref           named       defines/binding
     //
     // will produce a UI cross-reference from LocalUsage to RemoteAnchor as if
     // the graph were
     //
-    //   LocalUsage    RemoteSymbol      RemoteAnchor
-    //        \___________/^ ^\_______________/
-    //             ref         defines/binding
+    //   LocalUsage    RemoteSymbol        RemoteAnchor
+    //        \___________/^ ^\_________________/
+    //             ref          defines/binding
 
     const localSym = this.host.getSymbolAtLocation(name);
     if (!localSym) {
@@ -931,20 +931,20 @@ class Visitor {
     const localImportAnchor = this.newAnchor(name);
 
     // The imported symbol can refer to a type, a value, or both. Attempt to
-    // create "name"s for the local symbol and "generates" edges to the remote
-    // symbol in both cases.
+    // create "name"s for the local symbol and "named" edges from the remote
+    // symbol to the local symbol in both cases.
     //
     // Also attempt to emit a "ref/imports" from the referencing node to the
-    // to the remote definition in both cases. If the referecning node is
-    // different not the local symbol node, skip emitting "name" nodes and
-    // "generates" edges, as this is already done for the local symbol node.
+    // to the remote definition in both cases. If the referencing node is
+    // different from the local symbol node, skip emitting "name" nodes and
+    // "named" edges, as this is already done for the local symbol node.
     let kRemoteValue, kRemoteType;
     if (remoteSym.flags & ts.SymbolFlags.Value) {
       kRemoteValue = this.host.getSymbolName(remoteSym, TSNamespace.VALUE);
       const kLocalValue = this.host.getSymbolName(localSym, TSNamespace.VALUE);
 
       this.emitNode(kLocalValue, NodeKind.NAME);
-      this.emitEdge(kRemoteValue, EdgeKind.GENERATES, kLocalValue);
+      this.emitEdge(kRemoteValue, EdgeKind.NAMED, kLocalValue);
 
       this.emitEdge(localImportAnchor, EdgeKind.REF_IMPORTS, kRemoteValue);
     }
@@ -953,7 +953,7 @@ class Visitor {
       const kLocalType = this.host.getSymbolName(localSym, TSNamespace.TYPE);
 
       this.emitNode(kLocalType, NodeKind.NAME);
-      this.emitEdge(kRemoteType, EdgeKind.GENERATES, kLocalType);
+      this.emitEdge(kRemoteType, EdgeKind.NAMED, kLocalType);
 
       this.emitEdge(localImportAnchor, EdgeKind.REF_IMPORTS, kRemoteType);
     }

--- a/kythe/typescript/indexer.ts
+++ b/kythe/typescript/indexer.ts
@@ -15,7 +15,6 @@
  */
 
 import 'source-map-support/register';
-
 import * as fs from 'fs';
 import * as path from 'path';
 import * as ts from 'typescript';
@@ -1053,9 +1052,6 @@ class Visitor {
           const kImport = this.visitImport(imp.name);
           if (imp.propertyName) {
             this.visitImport(imp.name, imp.propertyName);
-            // this.emitEdge(
-            //    this.newAnchor(imp.propertyName), EdgeKind.REF_IMPORTS,
-            //    kImport);
           }
         }
         break;

--- a/kythe/typescript/testdata/default_import.ts
+++ b/kythe/typescript/testdata/default_import.ts
@@ -2,10 +2,14 @@
 // a field named "default".
 
 //- @obj ref/imports Def=vname("default", _, _, "testdata/default_export", _)
+//- LocalObj=vname("obj", _, _, "testdata/default_import", _).node/kind name
+//- Def generates LocalObj
 import obj from './default_export';
 
-//- @obj ref Def
+//- @obj ref LocalObj
 obj.key;
 
 //- @obj2 ref/imports Def
+//- LocalObj2=vname("obj2", _, _, "testdata/default_import", _).node/kind name
+//- Def generates LocalObj2
 import {default as obj2} from './default_export';

--- a/kythe/typescript/testdata/default_import.ts
+++ b/kythe/typescript/testdata/default_import.ts
@@ -3,7 +3,7 @@
 
 //- @obj ref/imports Def=vname("default", _, _, "testdata/default_export", _)
 //- LocalObj=vname("obj", _, _, "testdata/default_import", _).node/kind name
-//- Def generates LocalObj
+//- Def named LocalObj
 import obj from './default_export';
 
 //- @obj ref LocalObj
@@ -11,5 +11,5 @@ obj.key;
 
 //- @obj2 ref/imports Def
 //- LocalObj2=vname("obj2", _, _, "testdata/default_import", _).node/kind name
-//- Def generates LocalObj2
+//- Def named LocalObj2
 import {default as obj2} from './default_export';

--- a/kythe/typescript/testdata/equals_import.ts
+++ b/kythe/typescript/testdata/equals_import.ts
@@ -3,7 +3,7 @@
 
 //- @obj ref/imports Def=vname("export=", _, _, "testdata/equals_export", _)
 //- LocalObj=vname("obj", _, _, "testdata/equals_import", _).node/kind name
-//- Def generates LocalObj
+//- Def named LocalObj
 import obj = require('./equals_export');
 
 //- @obj ref LocalObj

--- a/kythe/typescript/testdata/equals_import.ts
+++ b/kythe/typescript/testdata/equals_import.ts
@@ -2,7 +2,9 @@
 // export equals syntax.
 
 //- @obj ref/imports Def=vname("export=", _, _, "testdata/equals_export", _)
+//- LocalObj=vname("obj", _, _, "testdata/equals_import", _).node/kind name
+//- Def generates LocalObj
 import obj = require('./equals_export');
 
-//- @obj ref Def
+//- @obj ref LocalObj
 obj.key;

--- a/kythe/typescript/testdata/import.ts
+++ b/kythe/typescript/testdata/import.ts
@@ -11,23 +11,27 @@ import * as mod_imp from './module';
 // Importing from a module gets a VName that refers into the other module.
 //- @value ref/imports Val=VName(_, _, _, "testdata/module", _)
 //- @"'./module'" ref/imports ModRef
+//- LocalValue=VName("value", _, _, "testdata/import", _).node/kind name
+//- Val generates LocalValue
 import {value} from './module';
 
 // Importing from a module gets a VName that refers into the other module,.
 //- @value ref/imports Val
 //- @renamedValue ref/imports Val
+//- RenamedValue=VName("renamedValue", _, _, "testdata/import", _).node/kind name
+//- Val generates RenamedValue
 import {value as renamedValue} from './module';
 
 // Ensure the various names of the imported value link together.
 
-//- @value ref Val
+//- @value ref LocalValue
 value;
 
 //- @mod_imp ref ModLocal
 //- @value ref Val
 mod_imp.value;
 
-//- @renamedValue ref Val
+//- @renamedValue ref RenamedValue
 renamedValue;
 
 //- @value ref/imports Val
@@ -39,6 +43,8 @@ import {aliasedLocal} from './export';
 
 // Importing a type from another module.
 //- @MyType ref/imports MyType
+//- LocalMyType=VName("MyType#type", _, _, "testdata/import", _).node/kind name
+//- MyType generates LocalMyType
 import {MyType} from './module';
-//- @MyType ref MyType
+//- @MyType ref LocalMyType
 let x: MyType;

--- a/kythe/typescript/testdata/import.ts
+++ b/kythe/typescript/testdata/import.ts
@@ -12,14 +12,14 @@ import * as mod_imp from './module';
 //- @value ref/imports Val=VName(_, _, _, "testdata/module", _)
 //- @"'./module'" ref/imports ModRef
 //- LocalValue=VName("value", _, _, "testdata/import", _).node/kind name
-//- Val generates LocalValue
+//- Val named LocalValue
 import {value} from './module';
 
 // Importing from a module gets a VName that refers into the other module,.
 //- @value ref/imports Val
 //- @renamedValue ref/imports Val
 //- RenamedValue=VName("renamedValue", _, _, "testdata/import", _).node/kind name
-//- Val generates RenamedValue
+//- Val named RenamedValue
 import {value as renamedValue} from './module';
 
 // Ensure the various names of the imported value link together.
@@ -44,7 +44,7 @@ import {aliasedLocal} from './export';
 // Importing a type from another module.
 //- @MyType ref/imports MyType
 //- LocalMyType=VName("MyType#type", _, _, "testdata/import", _).node/kind name
-//- MyType generates LocalMyType
+//- MyType named LocalMyType
 import {MyType} from './module';
 //- @MyType ref LocalMyType
 let x: MyType;


### PR DESCRIPTION
Due to limitations in Kythe UIs, an anchor cannot be a definition and a
reference at the same time. For an import like

```typescript
import {foo} from './bar';
```

it would be nice to have local uses of `foo` "ref" `foo` in the import
statement and for `foo` in the import statement to "ref" the definition
of `foo` in './bar'. Since this is not possible, instead all local uses
of `foo` "ref" the definition of `foo` in './bar'.

The current way this is done is by having all Symbol VNames
corresponding to the external definition of `foo` also correspond to the
local definition of `foo`. This is somewhat unfavorable because it
breaks TypeScript semantics.

This PR introduces an alternate approach to achieving the same UI xref
functionality by exploiting Kythe "named" edges.

["named"](https://kythe.io/docs/schema/#named) edges connect a semantic node (i.e. a node that
represents a language entity and not a source code anchor) and an
external name for that node. They have a nice property of folding
cross-references for a UI; that is, given a graph like
  (1) `A -ref-> D <-named- B <-defines/binding- C`
a cross-reference between A and D is generated in a UI as if the graph
were
  (2) `A -ref-> B <-defines/binding- C`

For the TypeScript indexer, "D" in graph (1) is a local import VName.
Local usages can reference the local import, and such references will
later be folded to provide a UI xref from the local usage to the remote
definition.

Now that they are semantic nodes, local import symbols emit a ["name"](https://kythe.io/docs/schema/#name)
node because they are identifiers for a remote definition.

This commit introduces a change in the functionality of the indexer's
entry emissions but _not_ in its end result UI xrefs, so the change is
best classified as a refactoring.