### PR TITLE
docs(go extractor): remove mention of kindex and indexpack

### DIFF
--- a/kythe/go/extractors/cmd/gotool/gotool.go
+++ b/kythe/go/extractors/cmd/gotool/gotool.go
@@ -42,7 +42,7 @@ var (
 
 	corpus     = flag.String("corpus", "", "Default corpus name to use")
 	localPath  = flag.String("local_path", "", "Directory where relative imports are resolved")
-	outputPath = flag.String("output", "", "Output path (indexpack directory or .kzip filename)")
+	outputPath = flag.String("output", "", "KZip output path")
 	extraFiles = flag.String("extra_files", "", "Additional files to include in each compilation (CSV)")
 	byDir      = flag.Bool("bydir", false, "Import by directory rather than import path")
 	keepGoing  = flag.Bool("continue", false, "Continue past errors")
@@ -57,8 +57,7 @@ func init() {
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, `Usage: %s [options] <import-path>...
 Extract Kythe compilation records from Go import paths specified on the command line.
-Outputs are written to an index pack unless --kindex is set, in which case they
-are written to individual .kindex files in the output directory.
+Output is written to a .kzip file specified by --output.
 
 Options:
 `, filepath.Base(os.Args[0]))


### PR DESCRIPTION
the extractor only handles kzip