### PR TITLE
build: migrate to Starlark Java rules

### DIFF
--- a/external.bzl
+++ b/external.bzl
@@ -2,6 +2,7 @@ load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+load("@io_bazel_rules_java//java:repositories.bzl", "rules_java_dependencies")
 load("@io_kythe//:setup.bzl", "maybe")
 load("@io_kythe//tools:build_rules/shims.bzl", "go_repository")
 load("@io_kythe//tools/build_rules/llvm:repo.bzl", "git_llvm_repository")
@@ -12,6 +13,7 @@ def _rule_dependencies():
     gazelle_dependencies()
     go_rules_dependencies()
     go_register_toolchains()
+    rules_java_dependencies()
 
 def _cc_dependencies():
     maybe(

--- a/kythe/extractors/BUILD
+++ b/kythe/extractors/BUILD
@@ -1,3 +1,5 @@
+load("@io_bazel_rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//visibility:public"])
 
 load(":extractors.bzl", "extractor_action")

--- a/kythe/java/com/google/devtools/kythe/analyzers/base/BUILD
+++ b/kythe/java/com/google/devtools/kythe/analyzers/base/BUILD
@@ -1,3 +1,5 @@
+load("@io_bazel_rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//visibility:public"])
 
 java_library(

--- a/kythe/java/com/google/devtools/kythe/analyzers/java/BUILD
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/BUILD
@@ -1,3 +1,5 @@
+load("@io_bazel_rules_java//java:defs.bzl", "java_library", "java_binary")
+
 package(default_visibility = ["//kythe:default_visibility"])
 
 java_library(

--- a/kythe/java/com/google/devtools/kythe/analyzers/jvm/BUILD
+++ b/kythe/java/com/google/devtools/kythe/analyzers/jvm/BUILD
@@ -1,3 +1,5 @@
+load("@io_bazel_rules_java//java:defs.bzl", "java_library", "java_binary")
+
 package(
     default_visibility = ["//kythe:default_visibility"],
     licenses = ["notice"],

--- a/kythe/java/com/google/devtools/kythe/common/BUILD
+++ b/kythe/java/com/google/devtools/kythe/common/BUILD
@@ -1,3 +1,5 @@
+load("@io_bazel_rules_java//java:defs.bzl", "java_library", "java_plugin")
+
 package(default_visibility = ["//kythe:default_visibility"])
 
 java_library(

--- a/kythe/java/com/google/devtools/kythe/doc/BUILD
+++ b/kythe/java/com/google/devtools/kythe/doc/BUILD
@@ -1,3 +1,5 @@
+load("@io_bazel_rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//kythe:default_visibility"])
 
 java_library(

--- a/kythe/java/com/google/devtools/kythe/extractors/java/BUILD
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/BUILD
@@ -1,3 +1,5 @@
+load("@io_bazel_rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//kythe:default_visibility"])
 
 java_library(

--- a/kythe/java/com/google/devtools/kythe/extractors/java/bazel/BUILD
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/bazel/BUILD
@@ -1,3 +1,5 @@
+load("@io_bazel_rules_java//java:defs.bzl", "java_binary")
+
 package(default_visibility = ["//visibility:public"])
 
 java_binary(

--- a/kythe/java/com/google/devtools/kythe/extractors/java/standalone/BUILD
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/standalone/BUILD
@@ -1,3 +1,5 @@
+load("@io_bazel_rules_java//java:defs.bzl", "java_library", "java_binary")
+
 package(default_visibility = ["//kythe:default_visibility"])
 
 exports_files(["javac-wrapper.sh"])

--- a/kythe/java/com/google/devtools/kythe/extractors/jvm/BUILD
+++ b/kythe/java/com/google/devtools/kythe/extractors/jvm/BUILD
@@ -1,3 +1,5 @@
+load("@io_bazel_rules_java//java:defs.bzl", "java_library", "java_binary")
+
 package(default_visibility = ["//kythe:default_visibility"])
 
 java_binary(

--- a/kythe/java/com/google/devtools/kythe/extractors/jvm/bazel/BUILD
+++ b/kythe/java/com/google/devtools/kythe/extractors/jvm/bazel/BUILD
@@ -1,3 +1,5 @@
+load("@io_bazel_rules_java//java:defs.bzl", "java_binary")
+
 package(default_visibility = ["//visibility:public"])
 
 java_binary(

--- a/kythe/java/com/google/devtools/kythe/extractors/shared/BUILD
+++ b/kythe/java/com/google/devtools/kythe/extractors/shared/BUILD
@@ -1,3 +1,5 @@
+load("@io_bazel_rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//visibility:public"])
 
 java_library(

--- a/kythe/java/com/google/devtools/kythe/platform/indexpack/BUILD
+++ b/kythe/java/com/google/devtools/kythe/platform/indexpack/BUILD
@@ -1,3 +1,5 @@
+load("@io_bazel_rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//kythe:default_visibility"])
 
 java_library(

--- a/kythe/java/com/google/devtools/kythe/platform/java/BUILD
+++ b/kythe/java/com/google/devtools/kythe/platform/java/BUILD
@@ -1,3 +1,5 @@
+load("@io_bazel_rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//kythe:default_visibility"])
 
 java_library(

--- a/kythe/java/com/google/devtools/kythe/platform/java/filemanager/BUILD
+++ b/kythe/java/com/google/devtools/kythe/platform/java/filemanager/BUILD
@@ -1,3 +1,5 @@
+load("@io_bazel_rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//kythe:default_visibility"])
 
 java_library(

--- a/kythe/java/com/google/devtools/kythe/platform/java/helpers/BUILD
+++ b/kythe/java/com/google/devtools/kythe/platform/java/helpers/BUILD
@@ -1,3 +1,5 @@
+load("@io_bazel_rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//kythe:default_visibility"])
 
 java_library(

--- a/kythe/java/com/google/devtools/kythe/platform/kzip/BUILD
+++ b/kythe/java/com/google/devtools/kythe/platform/kzip/BUILD
@@ -1,3 +1,5 @@
+load("@io_bazel_rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//kythe:default_visibility"])
 
 java_library(

--- a/kythe/java/com/google/devtools/kythe/platform/shared/BUILD
+++ b/kythe/java/com/google/devtools/kythe/platform/shared/BUILD
@@ -1,3 +1,5 @@
+load("@io_bazel_rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//visibility:public"])
 
 java_library(

--- a/kythe/java/com/google/devtools/kythe/platform/shared/filesystem/BUILD
+++ b/kythe/java/com/google/devtools/kythe/platform/shared/filesystem/BUILD
@@ -1,3 +1,5 @@
+load("@io_bazel_rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//kythe:default_visibility"])
 
 java_library(

--- a/kythe/java/com/google/devtools/kythe/util/BUILD
+++ b/kythe/java/com/google/devtools/kythe/util/BUILD
@@ -1,3 +1,5 @@
+load("@io_bazel_rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//kythe:default_visibility"])
 
 java_library(

--- a/kythe/java/com/google/devtools/kythe/util/schema/BUILD
+++ b/kythe/java/com/google/devtools/kythe/util/schema/BUILD
@@ -1,3 +1,5 @@
+load("@io_bazel_rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//kythe:default_visibility"])
 
 java_library(

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/base/BUILD
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/base/BUILD
@@ -1,3 +1,5 @@
+load("@io_bazel_rules_java//java:defs.bzl", "java_test")
+
 java_test(
     name = "stream_fact_emitter_test",
     size = "small",

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/BUILD
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/BUILD
@@ -1,3 +1,4 @@
+load("@io_bazel_rules_java//java:defs.bzl", "java_library", "java_test")
 load("//tools:build_rules/testing.bzl", "shell_tool_test")
 
 shell_tool_test(

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/BUILD
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/BUILD
@@ -1,3 +1,4 @@
+load("@io_bazel_rules_java//java:defs.bzl", "java_library")
 load("//tools/build_rules/verifier_test:java_verifier_test.bzl", "java_extract_kzip", "java_verifier_test")
 
 exports_files(

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/BUILD
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/BUILD
@@ -1,3 +1,4 @@
+load("@io_bazel_rules_java//java:defs.bzl", "java_library")
 load("//tools/build_rules/verifier_test:java_verifier_test.bzl", "java_verifier_test")
 
 filegroup(

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/regression/BUILD
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/regression/BUILD
@@ -1,3 +1,4 @@
+load("@io_bazel_rules_java//java:defs.bzl", "java_library")
 load("//tools/build_rules/verifier_test:java_verifier_test.bzl", "java_verifier_test")
 
 filegroup(

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/jvm/BUILD
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/jvm/BUILD
@@ -1,3 +1,5 @@
+load("@io_bazel_rules_java//java:defs.bzl", "java_test")
+
 java_test(
     name = "jvm_graph_test",
     size = "small",

--- a/kythe/javatests/com/google/devtools/kythe/doc/BUILD
+++ b/kythe/javatests/com/google/devtools/kythe/doc/BUILD
@@ -1,3 +1,5 @@
+load("@io_bazel_rules_java//java:defs.bzl", "java_test")
+
 package(default_visibility = ["//kythe:default_visibility"])
 
 java_test(

--- a/kythe/javatests/com/google/devtools/kythe/extractors/java/BUILD
+++ b/kythe/javatests/com/google/devtools/kythe/extractors/java/BUILD
@@ -1,3 +1,5 @@
+load("@io_bazel_rules_java//java:defs.bzl", "java_binary", "java_test")
+
 java_test(
     name = "java_extractor_test",
     size = "small",

--- a/kythe/javatests/com/google/devtools/kythe/extractors/shared/BUILD
+++ b/kythe/javatests/com/google/devtools/kythe/extractors/shared/BUILD
@@ -1,3 +1,5 @@
+load("@io_bazel_rules_java//java:defs.bzl", "java_test")
+
 package(default_visibility = ["//kythe:default_visibility"])
 
 java_test(

--- a/kythe/javatests/com/google/devtools/kythe/platform/indexpack/BUILD
+++ b/kythe/javatests/com/google/devtools/kythe/platform/indexpack/BUILD
@@ -1,3 +1,5 @@
+load("@io_bazel_rules_java//java:defs.bzl", "java_test")
+
 package(default_visibility = ["//kythe:default_visibility"])
 
 java_test(

--- a/kythe/javatests/com/google/devtools/kythe/platform/java/BUILD
+++ b/kythe/javatests/com/google/devtools/kythe/platform/java/BUILD
@@ -1,3 +1,5 @@
+load("@io_bazel_rules_java//java:defs.bzl", "java_test")
+
 package(default_visibility = ["//kythe:default_visibility"])
 
 java_test(

--- a/kythe/javatests/com/google/devtools/kythe/platform/java/filemanager/BUILD
+++ b/kythe/javatests/com/google/devtools/kythe/platform/java/filemanager/BUILD
@@ -1,3 +1,5 @@
+load("@io_bazel_rules_java//java:defs.bzl", "java_test")
+
 package(default_visibility = ["//kythe:default_visibility"])
 
 java_test(

--- a/kythe/javatests/com/google/devtools/kythe/platform/kzip/BUILD
+++ b/kythe/javatests/com/google/devtools/kythe/platform/kzip/BUILD
@@ -1,3 +1,5 @@
+load("@io_bazel_rules_java//java:defs.bzl", "java_library", "java_test")
+
 java_test(
     name = "kzip_reader_test",
     srcs = ["KZipReaderTest.java"],
@@ -5,8 +7,8 @@ java_test(
         "//kythe/cxx/common/testdata:empty.kzip",
         "//kythe/cxx/common/testdata:garbage_unit.kzip",
         "//kythe/cxx/common/testdata:malformed.kzip",
-        "//kythe/cxx/common/testdata:missing-unit.kzip",
         "//kythe/cxx/common/testdata:missing-pbunit.kzip",
+        "//kythe/cxx/common/testdata:missing-unit.kzip",
         "//kythe/cxx/common/testdata:stringset.kzip",
         "//kythe/cxx/common/testdata:stringset_with_empty_file.kzip",
     ],

--- a/kythe/javatests/com/google/devtools/kythe/platform/shared/BUILD
+++ b/kythe/javatests/com/google/devtools/kythe/platform/shared/BUILD
@@ -1,3 +1,5 @@
+load("@io_bazel_rules_java//java:defs.bzl", "java_test")
+
 package(default_visibility = ["//kythe:default_visibility"])
 
 java_test(

--- a/kythe/javatests/com/google/devtools/kythe/platform/shared/filesystem/BUILD
+++ b/kythe/javatests/com/google/devtools/kythe/platform/shared/filesystem/BUILD
@@ -1,3 +1,5 @@
+load("@io_bazel_rules_java//java:defs.bzl", "java_test")
+
 package(default_visibility = ["//kythe:default_visibility"])
 
 java_test(

--- a/kythe/javatests/com/google/devtools/kythe/util/BUILD
+++ b/kythe/javatests/com/google/devtools/kythe/util/BUILD
@@ -1,3 +1,5 @@
+load("@io_bazel_rules_java//java:defs.bzl", "java_test")
+
 package(default_visibility = ["//kythe:default_visibility"])
 
 java_test(

--- a/kythe/javatests/com/google/devtools/kythe/util/schema/BUILD
+++ b/kythe/javatests/com/google/devtools/kythe/util/schema/BUILD
@@ -1,3 +1,5 @@
+load("@io_bazel_rules_java//java:defs.bzl", "java_test")
+
 package(default_visibility = ["//kythe:default_visibility"])
 
 java_test(

--- a/kythe/proto/BUILD
+++ b/kythe/proto/BUILD
@@ -1,3 +1,5 @@
+load("@io_bazel_rules_java//java:defs.bzl", "java_proto_library")
+
 package(default_visibility = ["//kythe:proto_visibility"])
 
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")

--- a/setup.bzl
+++ b/setup.bzl
@@ -18,6 +18,13 @@ def kythe_rule_repositories():
         sha256 = "a82a352bffae6bee4e95f68a8d80a70e87f42c4741e6a448bec11998fcc82329",
     )
 
+    http_archive(
+        name = "io_bazel_rules_java",
+        url = "https://github.com/bazelbuild/rules_java/archive/973a93dd2d698929264d1028836f6b9cc60ff817.zip",
+        sha256 = "a6cb0dbe343b67c7d4f3f11a68e327acdfc71fee1e17affa4e605129fc56bb15",
+        strip_prefix = "rules_java-973a93dd2d698929264d1028836f6b9cc60ff817",
+    )
+
     maybe(
         http_archive,
         name = "bazel_gazelle",

--- a/third_party/bazel/BUILD
+++ b/third_party/bazel/BUILD
@@ -1,3 +1,5 @@
+load("@io_bazel_rules_java//java:defs.bzl", "java_proto_library")
+
 package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0

--- a/third_party/guava/BUILD
+++ b/third_party/guava/BUILD
@@ -1,3 +1,5 @@
+load("@io_bazel_rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])

--- a/third_party/javac/BUILD
+++ b/third_party/javac/BUILD
@@ -1,3 +1,5 @@
+load("@io_bazel_rules_java//java:defs.bzl", "java_import")
+
 package(default_visibility = ["//visibility:public"])
 
 licenses(["restricted"])  # GNU GPL v2 with Classpath exception

--- a/third_party/truth/BUILD
+++ b/third_party/truth/BUILD
@@ -1,3 +1,5 @@
+load("@io_bazel_rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])


### PR DESCRIPTION
For now, they are just wrappers around the native rules, but their usage will become manadatory in Bazel 1.0 (issue bazel#8741).