### PR TITLE
build: migrate to Starlark Proto rules

### DIFF
--- a/external.bzl
+++ b/external.bzl
@@ -3,6 +3,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 load("@io_bazel_rules_java//java:repositories.bzl", "rules_java_dependencies")
+load("@io_bazel_rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
 load("@io_kythe//:setup.bzl", "maybe")
 load("@io_kythe//tools:build_rules/shims.bzl", "go_repository")
 load("@io_kythe//tools/build_rules/llvm:repo.bzl", "git_llvm_repository")
@@ -14,6 +15,7 @@ def _rule_dependencies():
     go_rules_dependencies()
     go_register_toolchains()
     rules_java_dependencies()
+    rules_proto_dependencies()
 
 def _cc_dependencies():
     maybe(
@@ -731,8 +733,9 @@ def kythe_dependencies(sample_ui = True):
         strip_prefix = "llvmbzlgen-435bad1d07f7a8d32979d66cd5547e1b32dca812",
     )
 
+    _bindings()
     _rule_dependencies()
+
     if sample_ui:
         _sample_ui_dependencies()
-    _bindings()
     _extractor_image_dependencies()

--- a/kythe/examples/proto/BUILD
+++ b/kythe/examples/proto/BUILD
@@ -1,3 +1,5 @@
+load("@io_bazel_rules_proto//proto:defs.bzl", "proto_library")
+
 package(default_visibility = ["//kythe:default_visibility"])
 
 # TODO(fromberger): The baseline proto_library rule does not have a hook to

--- a/kythe/extractors/BUILD
+++ b/kythe/extractors/BUILD
@@ -1,3 +1,4 @@
+load("@io_bazel_rules_proto//proto:defs.bzl", "proto_lang_toolchain")
 load("@io_bazel_rules_java//java:defs.bzl", "java_library")
 
 package(default_visibility = ["//visibility:public"])

--- a/kythe/go/util/riegeli/BUILD
+++ b/kythe/go/util/riegeli/BUILD
@@ -1,3 +1,4 @@
+load("@io_bazel_rules_proto//proto:defs.bzl", "proto_library")
 load("//kythe/proto:go.bzl", "go_kythe_proto")
 load("//tools:build_rules/shims.bzl", "go_library", "go_test")
 

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/proto/BUILD
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/proto/BUILD
@@ -1,3 +1,4 @@
+load("@io_bazel_rules_proto//proto:defs.bzl", "proto_library")
 load("//tools/build_rules/verifier_test:java_verifier_test.bzl", "java_proto_verifier_test")
 
 exports_files(glob(["*.proto"]))

--- a/kythe/proto/BUILD
+++ b/kythe/proto/BUILD
@@ -1,3 +1,4 @@
+load("@io_bazel_rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_java//java:defs.bzl", "java_proto_library")
 
 package(default_visibility = ["//kythe:proto_visibility"])

--- a/setup.bzl
+++ b/setup.bzl
@@ -25,6 +25,13 @@ def kythe_rule_repositories():
         strip_prefix = "rules_java-973a93dd2d698929264d1028836f6b9cc60ff817",
     )
 
+    http_archive(
+        name = "io_bazel_rules_proto",
+        sha256 = "e4fe70af52135d2ee592a07f916e6e1fc7c94cf8786c15e8c0d0f08b1fe5ea16",
+        strip_prefix = "rules_proto-97d8af4dc474595af3900dd85cb3a29ad28cc313",
+        url = "https://github.com/bazelbuild/rules_proto/archive/97d8af4dc474595af3900dd85cb3a29ad28cc313.zip",
+    )
+
     maybe(
         http_archive,
         name = "bazel_gazelle",

--- a/third_party/bazel/BUILD
+++ b/third_party/bazel/BUILD
@@ -1,3 +1,4 @@
+load("@io_bazel_rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_java//java:defs.bzl", "java_proto_library")
 
 package(default_visibility = ["//visibility:public"])


### PR DESCRIPTION
For now, they are just wrappers around the native rules, but their usage will become mandatory in Bazel 1.0 (issue bazel#8922).