### PR TITLE
fix: add an ErrPermissionDenied for services to return

### DIFF
--- a/kythe/go/services/xrefs/xrefs.go
+++ b/kythe/go/services/xrefs/xrefs.go
@@ -55,6 +55,10 @@ type Service interface {
 }
 
 var (
+	// ErrPermissionDenied is returned by an implementation of a method when the
+	// user is not allowed to view the content because of some restrictions.
+	ErrPermissionDenied = status.Error(codes.PermissionDenied, "access denied")
+
 	// ErrDecorationsNotFound is returned by an implementation of the Decorations
 	// method when decorations for the given file cannot be found.
 	ErrDecorationsNotFound = status.Error(codes.NotFound, "file decorations not found")


### PR DESCRIPTION
Sometimes it is ok to return PERMISSION_DENIED instead of NOT_FOUND,
when protecting the name of an asset isn't necessary.

Be careful to not use this when protecting even the existince of some
thing is important - the nit would be better to still return NOT_FOUND.