### PR TITLE
ci(buildbot): add builder to run 'arc lint'

### DIFF
--- a/kythe/release/appengine/buildbot/Dockerfile
+++ b/kythe/release/appengine/buildbot/Dockerfile
@@ -12,25 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:stretch
-
-RUN echo "deb http://ftp.debian.org/debian stretch-backports main" >>/etc/apt/sources.list
+FROM debian:buster
 
 RUN apt-get update && \
     apt-get upgrade -y && \
-    # Required by go tool build of Kythe
-    apt-get -t stretch-backports install -y libbrotli-dev && \
     apt-get install -y \
       # Buildbot dependencies
       python3 python3-dev python3-pip wget git \
+      # Linter dependencies
+      arcanist clang-format shellcheck \
       # Required by go tool build of Kythe
-      libleveldb-dev \
+      libleveldb-dev libbrotli-dev \
       # Bazel's fallback @local_jdk
-      openjdk-8-jdk \
+      openjdk-11-jdk \
       # Bazel dependencies
       pkg-config zip g++ zlib1g-dev unzip \
       # Kythe C++ dependencies
-      gcc uuid-dev flex clang-3.8 bison \
+      gcc uuid-dev flex clang bison \
       # Kythe misc dependencies
       asciidoc source-highlight graphviz curl parallel && \
     apt-get clean
@@ -42,15 +40,19 @@ RUN pip3 install buildbot-www buildbot-console-view buildbot-grid-view buildbot-
 RUN pip3 install --upgrade six service_identity pyasn1 cryptography pyopenssl
 RUN pip3 install buildbot-worker
 
-# Kythe symlink for Kythe to pickup clang installation
-RUN ln -s /usr/bin/clang-3.8 /usr/bin/clang && \
-    ln -s /usr/bin/clang++-3.8 /usr/bin/clang++
-
 # Install Go
-RUN wget https://dl.google.com/go/go1.12.5.linux-amd64.tar.gz && \
+RUN wget https://dl.google.com/go/go1.12.7.linux-amd64.tar.gz && \
     tar -C /usr/local -xzf go*.tar.gz && \
     rm -rf go*.tar.gz
 ENV PATH=$PATH:/usr/local/go/bin
+
+# Install extra linters
+RUN go get github.com/bazelbuild/buildtools/buildifier
+ENV PATH=$PATH:/root/go/bin
+RUN wget https://github.com/google/google-java-format/releases/download/google-java-format-1.7/google-java-format-1.7-all-deps.jar && \
+   mv google-java-format-1.7-all-deps.jar /usr/bin/google-java-format.jar && \
+   echo 'exec java -jar /usr/bin/google-java-format.jar "$@"' >/usr/bin/google-java-format && \
+   chmod +x /usr/bin/google-java-format
 
 # Install Bazelisk and wrapper script
 ADD bazel /usr/bin/bazel

--- a/kythe/release/appengine/buildbot/master/master.cfg
+++ b/kythe/release/appengine/buildbot/master/master.cfg
@@ -189,7 +189,7 @@ c['schedulers'].append(schedulers.ForceScheduler(name="force", builderNames=allB
 arcLintSteps = util.BuildFactory()
 arcLintSteps.addStep(steps.GitHub(repourl=util.Property('repository', 'git://github.com/kythe/kythe.git'),
                                   mode='full', method='copy'))
-arcLintSteps.addStep(steps.ShellCommand(command=["arc", "lint", "--never-apply-patches", "origin/master"]))
+arcLintSteps.addStep(steps.ShellCommand(command=["arc", "lint", "--never-apply-patches", "--rev", "origin/master"]))
 
 bazelKytheSteps = util.BuildFactory()
 bazelKytheSteps.addStep(steps.GitHub(repourl=util.Property('repository', 'git://github.com/kythe/kythe.git'),

--- a/kythe/release/appengine/buildbot/master/master.cfg
+++ b/kythe/release/appengine/buildbot/master/master.cfg
@@ -189,7 +189,7 @@ c['schedulers'].append(schedulers.ForceScheduler(name="force", builderNames=allB
 arcLintSteps = util.BuildFactory()
 arcLintSteps.addStep(steps.GitHub(repourl=util.Property('repository', 'git://github.com/kythe/kythe.git'),
                                   mode='full', method='copy'))
-arcLintSteps.addStep(steps.ShellCommand(command=["arc", "lint", "--never-apply-patches"]))
+arcLintSteps.addStep(steps.ShellCommand(command=["arc", "lint", "--never-apply-patches", "origin/master"]))
 
 bazelKytheSteps = util.BuildFactory()
 bazelKytheSteps.addStep(steps.GitHub(repourl=util.Property('repository', 'git://github.com/kythe/kythe.git'),

--- a/kythe/release/appengine/buildbot/master/master.cfg
+++ b/kythe/release/appengine/buildbot/master/master.cfg
@@ -121,9 +121,20 @@ releaseBuilders = [
     'bazel-release',
 ]
 
-allBuilders = bazelBuilders + goBuilders + releaseBuilders
+linters = [
+    'arc-lint',
+]
+
+allBuilders = bazelBuilders + goBuilders + linters + releaseBuilders
 
 c['schedulers'] = []
+c['schedulers'].append(schedulers.SingleBranchScheduler(
+    name="lint-pull-requests",
+    change_filter=util.ChangeFilter(
+        category='pull',
+        project=['kythe/kythe'],
+    ),
+    builderNames=linters))
 c['schedulers'].append(schedulers.SingleBranchScheduler(
     name="bazel-master",
     change_filter=util.ChangeFilter(
@@ -175,6 +186,11 @@ c['schedulers'].append(schedulers.ForceScheduler(name="force", builderNames=allB
 
 ####### BUILDERS
 
+arcLintSteps = util.BuildFactory()
+arcLintSteps.addStep(steps.GitHub(repourl=util.Property('repository', 'git://github.com/kythe/kythe.git'),
+                                  mode='full', method='copy'))
+arcLintSteps.addStep(steps.ShellCommand(command=["arc", "lint", "--never-apply-patches"]))
+
 bazelKytheSteps = util.BuildFactory()
 bazelKytheSteps.addStep(steps.GitHub(repourl=util.Property('repository', 'git://github.com/kythe/kythe.git'),
                                      mode='full', method='copy'))
@@ -213,6 +229,11 @@ goModuleKytheSteps.addStep(steps.ShellCommand(command="! { git diff --color=alwa
 build_lock = util.WorkerLock("worker_builds", maxCount=1, maxCountForWorker={'local-worker': 3})
 
 c['builders'] = []
+c['builders'].append(
+    util.BuilderConfig(
+        name="arc-lint",
+        workernames=["local-worker"],
+        factory=arcLintSteps))
 c['builders'].append(
     util.BuilderConfig(
         name="bazel-minversion",

--- a/tools/arc/linter.sh
+++ b/tools/arc/linter.sh
@@ -59,8 +59,9 @@ case $file in
       gofmt -l "$file" | sed 's/^/gofmt::error:1 /'
     fi ;;
   *.h|*.cc|*.c|*.proto|*.js)
-    if command -v clang-format &>/dev/null; then
-      if ! diff -q <(clang-format --style=file "$file") "$file"; then
+    cf="$(command -v clang-format-7 clang-format 2>/dev/null | head -n1)"
+    if [[ -n "$cf" ]]; then
+      if ! diff -q <("$cf" --style=file "$file") "$file"; then
         echo "clang-format::error:1 $file"
       fi
     fi ;;


### PR DESCRIPTION
Update buildbot to use latest clang/Go versions (7.0 and 1.12.7) and their formatters.