### PR TITLE
fix(java_build): remove jvm_flags which complicate running on newer JDKs

### DIFF
--- a/kythe/java/com/google/devtools/kythe/analyzers/java/BUILD
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/BUILD
@@ -72,11 +72,6 @@ java_library(
 java_binary(
     name = "indexer",
     srcs = ["JavaIndexer.java"],
-    data = ["//third_party/javac:java_compiler_jar"],
-    jvm_flags = [
-        "--add-opens=jdk.compiler/com.sun.tools.javac.api=java.compiler",
-        "--patch-module=java.compiler=$${RUNPATH}$(location //third_party/javac:java_compiler_jar)",
-    ],
     main_class = "com.google.devtools.kythe.analyzers.java.JavaIndexer",
     deps = [
         ":analyzer",

--- a/kythe/java/com/google/devtools/kythe/extractors/java/JavaCompilationUnitExtractor.java
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/JavaCompilationUnitExtractor.java
@@ -83,6 +83,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.Set;
+import java.util.regex.Pattern;
 import javax.annotation.processing.Processor;
 import javax.tools.Diagnostic;
 import javax.tools.DiagnosticCollector;
@@ -109,7 +110,7 @@ public class JavaCompilationUnitExtractor {
 
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();
 
-  private static final String JDK_MODULE_PREFIX = "/modules/java.";
+  private static final Pattern JDK_MODULE_PATTERN = Pattern.compile("^/modules/(java|jdk)[.].*");
   private static final String MODULE_INFO_NAME = "module-info";
   private static final String SOURCE_JAR_ROOT = "!SOURCE_JAR!";
 
@@ -495,7 +496,7 @@ public class JavaCompilationUnitExtractor {
 
     // If the file was part of the JDK we do not store it as the JDK is tied
     // to the analyzer we'll run on this information later on.
-    if ((isJarPath && jarPath.startsWith(jdkJar)) || path.startsWith(JDK_MODULE_PREFIX)) {
+    if ((isJarPath && jarPath.startsWith(jdkJar)) || JDK_MODULE_PATTERN.matcher(path).matches()) {
       return;
     }
 

--- a/kythe/java/com/google/devtools/kythe/extractors/java/standalone/BUILD
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/standalone/BUILD
@@ -7,15 +7,6 @@ exports_files(["javac-wrapper.sh"])
 java_binary(
     name = "javac_extractor",
     srcs = ["Javac8Wrapper.java"],
-    data = [
-        "//third_party/javac:java_compiler_jar",
-        "//third_party/javac:jdk_compiler_jar",
-    ],
-    jvm_flags = [
-        "--add-opens=jdk.compiler/com.sun.tools.javac.api=java.compiler",
-        "--patch-module=java.compiler=$${RUNPATH}$(location //third_party/javac:java_compiler_jar)",
-        "--patch-module=jdk.compiler=$${RUNPATH}$(location //third_party/javac:jdk_compiler_jar)",
-    ],
     main_class = "com.google.devtools.kythe.extractors.java.standalone.Javac8Wrapper",
     visibility = ["//visibility:public"],
     deps = [
@@ -31,15 +22,6 @@ java_binary(
 java_binary(
     name = "javac9_extractor",
     srcs = ["Javac9Wrapper.java"],
-    data = [
-        "//third_party/javac:java_compiler_jar",
-        "//third_party/javac:jdk_compiler_jar",
-    ],
-    jvm_flags = [
-        "--add-opens=jdk.compiler/com.sun.tools.javac.api=java.compiler",
-        "--patch-module=java.compiler=$${RUNPATH}$(location //third_party/javac:java_compiler_jar)",
-        "--patch-module=jdk.compiler=$${RUNPATH}$(location //third_party/javac:jdk_compiler_jar)",
-    ],
     main_class = "com.google.devtools.kythe.extractors.java.standalone.Javac9Wrapper",
     visibility = ["//visibility:public"],
     deps = [

--- a/kythe/javatests/com/google/devtools/kythe/platform/java/BUILD
+++ b/kythe/javatests/com/google/devtools/kythe/platform/java/BUILD
@@ -6,15 +6,6 @@ java_test(
     name = "options_utils_test",
     size = "small",
     srcs = ["OptionsTest.java"],
-    data = [
-        "//third_party/javac:java_compiler_jar",
-        "//third_party/javac:jdk_compiler_jar",
-    ],
-    jvm_flags = [
-        "--add-opens=jdk.compiler/com.sun.tools.javac.api=java.compiler",
-        "--patch-module=java.compiler=$${RUNPATH}$(location //third_party/javac:java_compiler_jar)",
-        "--patch-module=jdk.compiler=$${RUNPATH}$(location //third_party/javac:jdk_compiler_jar)",
-    ],
     test_class = "com.google.devtools.kythe.platform.java.OptionsTest",
     deps = [
         "//kythe/java/com/google/devtools/kythe/platform/java:options",


### PR DESCRIPTION
In particular the Bazel extractor has not been updated as it actually needs the --patch-module flags.

Also updates the check for "jdk-owned" modules.
