### PR TITLE
cleanup(go extractor): remove unused --local_path flag

### DIFF
--- a/kythe/go/extractors/cmd/gotool/gotool.go
+++ b/kythe/go/extractors/cmd/gotool/gotool.go
@@ -41,7 +41,6 @@ var (
 	bc = build.Default // A shallow copy of the default build settings
 
 	corpus     = flag.String("corpus", "", "Default corpus name to use")
-	localPath  = flag.String("local_path", "", "Directory where relative imports are resolved")
 	outputPath = flag.String("output", "", "KZip output path")
 	extraFiles = flag.String("extra_files", "", "Additional files to include in each compilation (CSV)")
 	byDir      = flag.Bool("bydir", false, "Import by directory rather than import path")
@@ -102,7 +101,6 @@ func main() {
 	ctx := context.Background()
 	ext := &golang.Extractor{
 		BuildContext: bc,
-		LocalPath:    *localPath,
 
 		PackageVNameOptions: golang.PackageVNameOptions{
 			DefaultCorpus:             *corpus,

--- a/kythe/go/extractors/golang/golang.go
+++ b/kythe/go/extractors/golang/golang.go
@@ -79,9 +79,6 @@ type Extractor struct {
 	// The configuration for constructing VNames for packages.
 	PackageVNameOptions
 
-	// The local path against which relative imports should be resolved.
-	LocalPath string
-
 	// An alternative installation path for compiled packages.  If this is set,
 	// and a compiled package cannot be found in the normal location, the
 	// extractor will try in this location.


### PR DESCRIPTION
This isn't used anywhere - should it be?