### PR TITLE
fix(kzip): use canonical digesting for kzip compilation units

### DIFF
--- a/kythe/docs/kythe-kzip.txt
+++ b/kythe/docs/kythe-kzip.txt
@@ -93,11 +93,12 @@ subdirectories, one named `units` and one named `files`.
 
 A *unit file* is a file containing a compilation unit description.
 The name of a unit file is computed by digesting the JSON
-representation of the compilation unit with SHA256, and encoding the
-resulting hash as a string of lowercase ASCII hexadecimal digits. This
-string becomes the filename of the unit file. Note that the digest
-should only process the CompilationUnit itself, and should not include
-the other contents of the wrapper message.
+representation of the `kythe.proto.IndexedCompilation` with SHA256,
+and encoding the resulting hash as a string of lowercase ASCII
+hexadecimal digits. This string becomes the filename of the unit
+file. Note that the digest should only process the CompilationUnit
+itself, and should not include the other contents of the wrapper
+message.
 
 A *data file* is a file containing an unstructured blob of raw (uncompressed)
 file data.  The name name of a data file is computed by hashing the file

--- a/kythe/go/platform/kcd/kcd.go
+++ b/kythe/go/platform/kcd/kcd.go
@@ -243,7 +243,7 @@ type Unit interface {
 
 	// Digest writes a unique representation of the unit to w sufficient to
 	// generate a content-addressable digest.
-	Digest(w io.Writer)
+	Digest(w io.Writer) error
 }
 
 // Index represents the indexable terms of a compilation.

--- a/kythe/go/platform/kcd/kcd_test.go
+++ b/kythe/go/platform/kcd/kcd_test.go
@@ -48,7 +48,10 @@ type stubUnit struct {
 	Unit
 }
 
-func (s stubUnit) Digest(w io.Writer) { w.Write([]byte(s.bits)) }
+func (s stubUnit) Digest(w io.Writer) error {
+	_, err := w.Write([]byte(s.bits))
+	return err
+}
 
 func regexps(exprs ...string) (res []*regexp.Regexp) {
 	for _, expr := range exprs {

--- a/kythe/go/platform/kcd/kythe/units.go
+++ b/kythe/go/platform/kcd/kythe/units.go
@@ -18,7 +18,6 @@
 package kythe // import "kythe.io/kythe/go/platform/kcd/kythe"
 
 import (
-	"fmt"
 	"io"
 	"sort"
 	"strings"
@@ -94,36 +93,12 @@ func (u Unit) Canonicalize() {
 }
 
 // Digest satisfies part of the kcd.Unit interface.
-func (u Unit) Digest(w io.Writer) {
+func (u Unit) Digest(w io.Writer) error {
 	pb := u.Proto
 	if pb == nil {
 		pb = new(apb.CompilationUnit)
 	}
-	put := func(tag string, ss ...string) {
-		fmt.Fprintln(w, tag)
-		for _, s := range ss {
-			fmt.Fprint(w, s, "\x00")
-		}
-	}
-	putv := func(tag string, v *spb.VName) {
-		put(tag, v.GetSignature(), v.GetCorpus(), v.GetRoot(), v.GetPath(), v.GetLanguage())
-	}
-	putv("CU", pb.VName)
-	for _, ri := range pb.RequiredInput {
-		putv("RI", ri.VName)
-		put("IN", ri.Info.GetPath(), ri.Info.GetDigest())
-	}
-	put("ARG", pb.Argument...)
-	put("OUT", pb.OutputKey)
-	put("SRC", pb.SourceFile...)
-	put("CWD", pb.WorkingDirectory)
-	put("CTX", pb.EntryContext)
-	for _, env := range pb.Environment {
-		put("ENV", env.Name, env.Value)
-	}
-	for _, d := range pb.Details {
-		put("DET", d.TypeUrl, string(d.Value))
-	}
+	return toJSON.Marshal(w, pb)
 }
 
 // ConvertUnit reports whether v can be converted to a Kythe kcd.Unit, and if


### PR DESCRIPTION
I couldn't find a clean way to reuse the JSON-ified CU created in unit::Digest() in kzip::AddUnit().