### PR TITLE
cleanup(tests): use kzip instead of kindex_tool in proto/textproto tests

### DIFF
--- a/kythe/cxx/extractor/proto/testdata/custom_corpus.UNIT
+++ b/kythe/cxx/extractor/proto/testdata/custom_corpus.UNIT
@@ -1,13 +1,20 @@
-required_input {
-  v_name {
-    corpus: "my_custom_corpus"
-    path: "kythe/cxx/extractor/proto/testdata/simple1.proto"
-  }
-  info {
-    path: "kythe/cxx/extractor/proto/testdata/simple1.proto"
-    digest: "36aa2295772636e8e940333faa06f0838953101f353ab52d72279389e16117be"
-  }
+{
+  "required_input": [
+    {
+      "v_name": {
+        "corpus": "my_custom_corpus",
+        "path": "kythe/cxx/extractor/proto/testdata/simple1.proto"
+      },
+      "info": {
+        "path": "kythe/cxx/extractor/proto/testdata/simple1.proto",
+        "digest": "36aa2295772636e8e940333faa06f0838953101f353ab52d72279389e16117be"
+      }
+    }
+  ],
+  "argument": [
+    "kythe/cxx/extractor/proto/testdata/simple1.proto"
+  ],
+  "source_file": [
+    "kythe/cxx/extractor/proto/testdata/simple1.proto"
+  ]
 }
-argument: "kythe/cxx/extractor/proto/testdata/simple1.proto"
-source_file: "kythe/cxx/extractor/proto/testdata/simple1.proto"
-entry_context: "hash0"

--- a/kythe/cxx/extractor/proto/testdata/custom_root_directory.UNIT
+++ b/kythe/cxx/extractor/proto/testdata/custom_root_directory.UNIT
@@ -1,24 +1,31 @@
-required_input {
-  v_name {
-    path: "relative_imports.proto"
-  }
-  info {
-    path: "relative_imports.proto"
-    digest: "c91db27db87695c42ab03479f5393d83fd881c5c4982579b0115a20c36342d2c"
-  }
+{
+  "required_input": [
+    {
+      "v_name": {
+        "path": "relative_imports.proto"
+      },
+      "info": {
+        "path": "relative_imports.proto",
+        "digest": "c91db27db87695c42ab03479f5393d83fd881c5c4982579b0115a20c36342d2c"
+      }
+    },
+    {
+      "v_name": {
+        "path": "subdir/other.proto"
+      },
+      "info": {
+        "path": "subdir/other.proto",
+        "digest": "c9d3571c48d70781dc7d4984b1b8974f44cb5953c3be17cacacc15f35f5981eb"
+      }
+    }
+  ],
+  "argument": [
+    "kythe/cxx/extractor/proto/testdata/relative_imports.proto",
+    "--",
+    "--proto_path",
+    "kythe/cxx/extractor/proto/testdata/subdir"
+  ],
+  "source_file": [
+    "relative_imports.proto"
+  ]
 }
-required_input {
-  v_name {
-    path: "subdir/other.proto"
-  }
-  info {
-    path: "subdir/other.proto"
-    digest: "c9d3571c48d70781dc7d4984b1b8974f44cb5953c3be17cacacc15f35f5981eb"
-  }
-}
-argument: "kythe/cxx/extractor/proto/testdata/relative_imports.proto"
-argument: "--"
-argument: "--proto_path"
-argument: "kythe/cxx/extractor/proto/testdata/subdir"
-source_file: "relative_imports.proto"
-entry_context: "hash0"

--- a/kythe/cxx/extractor/proto/testdata/custom_vname_config.UNIT
+++ b/kythe/cxx/extractor/proto/testdata/custom_vname_config.UNIT
@@ -1,26 +1,33 @@
-required_input {
-  v_name {
-    corpus: "corpus1"
-    path: "kythe/cxx/extractor/proto/testdata/simple1.proto"
-  }
-  info {
-    path: "kythe/cxx/extractor/proto/testdata/simple1.proto"
-    digest: "36aa2295772636e8e940333faa06f0838953101f353ab52d72279389e16117be"
-  }
+{
+  "required_input": [
+    {
+      "v_name": {
+        "corpus": "corpus1",
+        "path": "kythe/cxx/extractor/proto/testdata/simple1.proto"
+      },
+      "info": {
+        "path": "kythe/cxx/extractor/proto/testdata/simple1.proto",
+        "digest": "36aa2295772636e8e940333faa06f0838953101f353ab52d72279389e16117be"
+      }
+    },
+    {
+      "v_name": {
+        "corpus": "corpus2",
+        "root": "kythe/cxx/extractor/proto/testdata",
+        "path": "simple2.proto"
+      },
+      "info": {
+        "path": "kythe/cxx/extractor/proto/testdata/simple2.proto",
+        "digest": "0db133854842fd4a2112176264bb7e596671db36d1d91dcb9910c662278680ae"
+      }
+    }
+  ],
+  "argument": [
+    "kythe/cxx/extractor/proto/testdata/simple1.proto",
+    "kythe/cxx/extractor/proto/testdata/simple2.proto"
+  ],
+  "source_file": [
+    "kythe/cxx/extractor/proto/testdata/simple1.proto",
+    "kythe/cxx/extractor/proto/testdata/simple2.proto"
+  ]
 }
-required_input {
-  v_name {
-    corpus: "corpus2"
-    root: "kythe/cxx/extractor/proto/testdata"
-    path: "simple2.proto"
-  }
-  info {
-    path: "kythe/cxx/extractor/proto/testdata/simple2.proto"
-    digest: "0db133854842fd4a2112176264bb7e596671db36d1d91dcb9910c662278680ae"
-  }
-}
-argument: "kythe/cxx/extractor/proto/testdata/simple1.proto"
-argument: "kythe/cxx/extractor/proto/testdata/simple2.proto"
-source_file: "kythe/cxx/extractor/proto/testdata/simple1.proto"
-source_file: "kythe/cxx/extractor/proto/testdata/simple2.proto"
-entry_context: "hash0"

--- a/kythe/cxx/extractor/proto/testdata/duplicate_imports.UNIT
+++ b/kythe/cxx/extractor/proto/testdata/duplicate_imports.UNIT
@@ -1,26 +1,33 @@
-required_input {
-  v_name {
-    path: "kythe/cxx/extractor/proto/testdata/relative_imports.proto"
-  }
-  info {
-    path: "kythe/cxx/extractor/proto/testdata/relative_imports.proto"
-    digest: "c91db27db87695c42ab03479f5393d83fd881c5c4982579b0115a20c36342d2c"
-  }
+{
+  "required_input": [
+    {
+      "v_name": {
+        "path": "kythe/cxx/extractor/proto/testdata/relative_imports.proto"
+      },
+      "info": {
+        "path": "kythe/cxx/extractor/proto/testdata/relative_imports.proto",
+        "digest": "c91db27db87695c42ab03479f5393d83fd881c5c4982579b0115a20c36342d2c"
+      }
+    },
+    {
+      "v_name": {
+        "path": "kythe/cxx/extractor/proto/testdata/subdir/other.proto"
+      },
+      "info": {
+        "path": "kythe/cxx/extractor/proto/testdata/subdir/other.proto",
+        "digest": "c9d3571c48d70781dc7d4984b1b8974f44cb5953c3be17cacacc15f35f5981eb"
+      }
+    }
+  ],
+  "argument": [
+    "kythe/cxx/extractor/proto/testdata/relative_imports.proto",
+    "kythe/cxx/extractor/proto/testdata/subdir/other.proto",
+    "--",
+    "--proto_path",
+    "kythe/cxx/extractor/proto/testdata/subdir"
+  ],
+  "source_file": [
+    "kythe/cxx/extractor/proto/testdata/relative_imports.proto",
+    "kythe/cxx/extractor/proto/testdata/subdir/other.proto"
+  ]
 }
-required_input {
-  v_name {
-    path: "kythe/cxx/extractor/proto/testdata/subdir/other.proto"
-  }
-  info {
-    path: "kythe/cxx/extractor/proto/testdata/subdir/other.proto"
-    digest: "c9d3571c48d70781dc7d4984b1b8974f44cb5953c3be17cacacc15f35f5981eb"
-  }
-}
-argument: "kythe/cxx/extractor/proto/testdata/relative_imports.proto"
-argument: "kythe/cxx/extractor/proto/testdata/subdir/other.proto"
-argument: "--"
-argument: "--proto_path"
-argument: "kythe/cxx/extractor/proto/testdata/subdir"
-source_file: "kythe/cxx/extractor/proto/testdata/relative_imports.proto"
-source_file: "kythe/cxx/extractor/proto/testdata/subdir/other.proto"
-entry_context: "hash0"

--- a/kythe/cxx/extractor/proto/testdata/duplicate_imports2.UNIT
+++ b/kythe/cxx/extractor/proto/testdata/duplicate_imports2.UNIT
@@ -1,26 +1,33 @@
-required_input {
-  v_name {
-    path: "kythe/cxx/extractor/proto/testdata/relative_imports.proto"
-  }
-  info {
-    path: "kythe/cxx/extractor/proto/testdata/relative_imports.proto"
-    digest: "c91db27db87695c42ab03479f5393d83fd881c5c4982579b0115a20c36342d2c"
-  }
+{
+  "required_input": [
+    {
+      "v_name": {
+        "path": "kythe/cxx/extractor/proto/testdata/relative_imports.proto"
+      },
+      "info": {
+        "path": "kythe/cxx/extractor/proto/testdata/relative_imports.proto",
+        "digest": "c91db27db87695c42ab03479f5393d83fd881c5c4982579b0115a20c36342d2c"
+      }
+    },
+    {
+      "v_name": {
+        "path": "kythe/cxx/extractor/proto/testdata/subdir/other.proto"
+      },
+      "info": {
+        "path": "kythe/cxx/extractor/proto/testdata/subdir/other.proto",
+        "digest": "c9d3571c48d70781dc7d4984b1b8974f44cb5953c3be17cacacc15f35f5981eb"
+      }
+    }
+  ],
+  "argument": [
+    "kythe/cxx/extractor/proto/testdata/subdir/other.proto",
+    "kythe/cxx/extractor/proto/testdata/relative_imports.proto",
+    "--",
+    "--proto_path",
+    "kythe/cxx/extractor/proto/testdata/subdir"
+  ],
+  "source_file": [
+    "kythe/cxx/extractor/proto/testdata/subdir/other.proto",
+    "kythe/cxx/extractor/proto/testdata/relative_imports.proto"
+  ]
 }
-required_input {
-  v_name {
-    path: "kythe/cxx/extractor/proto/testdata/subdir/other.proto"
-  }
-  info {
-    path: "kythe/cxx/extractor/proto/testdata/subdir/other.proto"
-    digest: "c9d3571c48d70781dc7d4984b1b8974f44cb5953c3be17cacacc15f35f5981eb"
-  }
-}
-argument: "kythe/cxx/extractor/proto/testdata/subdir/other.proto"
-argument: "kythe/cxx/extractor/proto/testdata/relative_imports.proto"
-argument: "--"
-argument: "--proto_path"
-argument: "kythe/cxx/extractor/proto/testdata/subdir"
-source_file: "kythe/cxx/extractor/proto/testdata/subdir/other.proto"
-source_file: "kythe/cxx/extractor/proto/testdata/relative_imports.proto"
-entry_context: "hash0"

--- a/kythe/cxx/extractor/proto/testdata/kzip_diff_test.sh
+++ b/kythe/cxx/extractor/proto/testdata/kzip_diff_test.sh
@@ -16,6 +16,7 @@
 set -e
 
 KZIP_TOOL=$1; shift
+JQ=$1; shift
 KZIP=$1; shift
 GOLDEN=$1; shift
 
@@ -26,7 +27,7 @@ UNIT=$("${KZIP_TOOL}" view "${TEST_TMPDIR}/file.kzip")
 UNIT_FILE="${TEST_TMPDIR}/$(basename $GOLDEN)"
 # Remove working_directory, which will change depending on the machine the test
 # is run on.
-echo "$UNIT" | jq 'del(.working_directory)' > "$UNIT_FILE"
+echo "$UNIT" | $JQ 'del(.working_directory)' > "$UNIT_FILE"
 
 echo
 echo "Diffing generated unit against golden"

--- a/kythe/cxx/extractor/proto/testdata/kzip_diff_test.sh
+++ b/kythe/cxx/extractor/proto/testdata/kzip_diff_test.sh
@@ -13,60 +13,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Output every line except ones that contains match_string. Also, do not output
-# extra_lines_to_skip lines that follow the line that contained match_string.
-function skip() {
-  if [ $# -ne 3 ] && [ $# -ne 2 ]; then
-    echo "Usage: $0 match_string extra_lines_to_skip [input_file]"
-    return 1
-  fi
-  local -r match_string="$1"
-  local -r lines_to_skip="$2"
-
-  if [ $# -eq 2 ]; then
-    awk "/$match_string/{skip=$lines_to_skip;next} skip>0{--skip;next} {print}"
-  else
-    awk "/$match_string/{skip=$lines_to_skip;next} skip>0{--skip;next} {print}" "$3"
-  fi
-  return 0
-}
-
-# Modify input_file to remove lines that contains match_string. Also remove
-# extra_lines_to_skip lines that follow the line that contained match_string.
-function skip_inplace() {
-  if [ $# -ne 3 ]; then
-    echo "Usage: $0 match_string lines_to_skip input_file"
-    return 1
-  fi
-  local -r match_string="$1"
-  local -r lines_to_skip="$2"
-  local -r input_file="$3"
-
-  local -r temp_file=$(mktemp)
-  skip "$match_string" "$lines_to_skip" "$input_file" > "$temp_file"
-  mv "$temp_file" "$input_file"
-}
-
-
 set -e
 
-KINDEX_TOOL=$1; shift
+KZIP_TOOL=$1; shift
 KZIP=$1; shift
 GOLDEN=$1; shift
 
 # Work in tmpdir because the runfiles dir is not writable
 cp $KZIP "${TEST_TMPDIR}/file.kzip"
 # Extract textproto version of compilation unit from kzip.
-"${KINDEX_TOOL}" -canonicalize_hashes -suppress_details -explode "${TEST_TMPDIR}/file.kzip"
-UNIT="${TEST_TMPDIR}/file.kzip_UNIT"
-
-# Remove lines that will change depending on the machine the test is run on.
-skip_inplace "-target" 1 $UNIT
-skip_inplace "signature" 0 $UNIT
-skip_inplace "working_directory" 0 $UNIT
+UNIT=$("${KZIP_TOOL}" view "${TEST_TMPDIR}/file.kzip")
+UNIT_FILE="${TEST_TMPDIR}/$(basename $GOLDEN)"
+# Remove working_directory, which will change depending on the machine the test
+# is run on.
+echo "$UNIT" | jq 'del(.working_directory)' > "$UNIT_FILE"
 
 echo
 echo "Diffing generated unit against golden"
 echo "-------------------------------------"
-diff -u $GOLDEN $UNIT
+diff -u $GOLDEN $UNIT_FILE
 echo "No diffs found!"

--- a/kythe/cxx/extractor/proto/testdata/multiple_source_files.UNIT
+++ b/kythe/cxx/extractor/proto/testdata/multiple_source_files.UNIT
@@ -1,23 +1,30 @@
-required_input {
-  v_name {
-    path: "kythe/cxx/extractor/proto/testdata/simple1.proto"
-  }
-  info {
-    path: "kythe/cxx/extractor/proto/testdata/simple1.proto"
-    digest: "36aa2295772636e8e940333faa06f0838953101f353ab52d72279389e16117be"
-  }
+{
+  "required_input": [
+    {
+      "v_name": {
+        "path": "kythe/cxx/extractor/proto/testdata/simple1.proto"
+      },
+      "info": {
+        "path": "kythe/cxx/extractor/proto/testdata/simple1.proto",
+        "digest": "36aa2295772636e8e940333faa06f0838953101f353ab52d72279389e16117be"
+      }
+    },
+    {
+      "v_name": {
+        "path": "kythe/cxx/extractor/proto/testdata/simple2.proto"
+      },
+      "info": {
+        "path": "kythe/cxx/extractor/proto/testdata/simple2.proto",
+        "digest": "0db133854842fd4a2112176264bb7e596671db36d1d91dcb9910c662278680ae"
+      }
+    }
+  ],
+  "argument": [
+    "kythe/cxx/extractor/proto/testdata/simple1.proto",
+    "kythe/cxx/extractor/proto/testdata/simple2.proto"
+  ],
+  "source_file": [
+    "kythe/cxx/extractor/proto/testdata/simple1.proto",
+    "kythe/cxx/extractor/proto/testdata/simple2.proto"
+  ]
 }
-required_input {
-  v_name {
-    path: "kythe/cxx/extractor/proto/testdata/simple2.proto"
-  }
-  info {
-    path: "kythe/cxx/extractor/proto/testdata/simple2.proto"
-    digest: "0db133854842fd4a2112176264bb7e596671db36d1d91dcb9910c662278680ae"
-  }
-}
-argument: "kythe/cxx/extractor/proto/testdata/simple1.proto"
-argument: "kythe/cxx/extractor/proto/testdata/simple2.proto"
-source_file: "kythe/cxx/extractor/proto/testdata/simple1.proto"
-source_file: "kythe/cxx/extractor/proto/testdata/simple2.proto"
-entry_context: "hash0"

--- a/kythe/cxx/extractor/proto/testdata/proto_extractor_test.bzl
+++ b/kythe/cxx/extractor/proto/testdata/proto_extractor_test.bzl
@@ -49,6 +49,7 @@ def _kzip_diff_test_impl(ctx):
     script = " ".join([
         ctx.executable.diff_bin.short_path,
         ctx.executable.kzip_tool.short_path,
+        ctx.executable.jq.short_path,
         ctx.files.kzip[0].short_path,
         ctx.files.golden_file[0].short_path,
     ])
@@ -60,6 +61,7 @@ def _kzip_diff_test_impl(ctx):
     runfiles = ctx.runfiles(files = [
         ctx.executable.diff_bin,
         ctx.executable.kzip_tool,
+        ctx.executable.jq,
         ctx.file.kzip,
         ctx.file.golden_file,
     ])
@@ -79,6 +81,11 @@ kzip_diff_test = rule(
             cfg = "host",
             executable = True,
             default = Label("//kythe/go/platform/tools/kzip"),
+        ),
+        "jq": attr.label(
+            cfg = "host",
+            executable = True,
+            default = Label("@com_github_stedolan_jq//:jq"),
         ),
     },
     test = True,

--- a/kythe/cxx/extractor/proto/testdata/proto_extractor_test.bzl
+++ b/kythe/cxx/extractor/proto/testdata/proto_extractor_test.bzl
@@ -48,7 +48,7 @@ def _kzip_diff_test_impl(ctx):
     # Write a script that `bazel test` will execute.
     script = " ".join([
         ctx.executable.diff_bin.short_path,
-        ctx.executable.kindex_tool.short_path,
+        ctx.executable.kzip_tool.short_path,
         ctx.files.kzip[0].short_path,
         ctx.files.golden_file[0].short_path,
     ])
@@ -59,7 +59,7 @@ def _kzip_diff_test_impl(ctx):
 
     runfiles = ctx.runfiles(files = [
         ctx.executable.diff_bin,
-        ctx.executable.kindex_tool,
+        ctx.executable.kzip_tool,
         ctx.file.kzip,
         ctx.file.golden_file,
     ])
@@ -75,10 +75,10 @@ kzip_diff_test = rule(
             executable = True,
             default = Label("//kythe/cxx/extractor/proto/testdata:kzip_diff_test"),
         ),
-        "kindex_tool": attr.label(
+        "kzip_tool": attr.label(
             cfg = "host",
             executable = True,
-            default = Label("//kythe/cxx/tools:kindex_tool"),
+            default = Label("//kythe/go/platform/tools/kzip"),
         ),
     },
     test = True,

--- a/kythe/cxx/extractor/proto/testdata/relative_imports.UNIT
+++ b/kythe/cxx/extractor/proto/testdata/relative_imports.UNIT
@@ -1,24 +1,31 @@
-required_input {
-  v_name {
-    path: "kythe/cxx/extractor/proto/testdata/relative_imports.proto"
-  }
-  info {
-    path: "kythe/cxx/extractor/proto/testdata/relative_imports.proto"
-    digest: "c91db27db87695c42ab03479f5393d83fd881c5c4982579b0115a20c36342d2c"
-  }
+{
+  "required_input": [
+    {
+      "v_name": {
+        "path": "kythe/cxx/extractor/proto/testdata/relative_imports.proto"
+      },
+      "info": {
+        "path": "kythe/cxx/extractor/proto/testdata/relative_imports.proto",
+        "digest": "c91db27db87695c42ab03479f5393d83fd881c5c4982579b0115a20c36342d2c"
+      }
+    },
+    {
+      "v_name": {
+        "path": "kythe/cxx/extractor/proto/testdata/subdir/other.proto"
+      },
+      "info": {
+        "path": "kythe/cxx/extractor/proto/testdata/subdir/other.proto",
+        "digest": "c9d3571c48d70781dc7d4984b1b8974f44cb5953c3be17cacacc15f35f5981eb"
+      }
+    }
+  ],
+  "argument": [
+    "kythe/cxx/extractor/proto/testdata/relative_imports.proto",
+    "--",
+    "--proto_path",
+    "kythe/cxx/extractor/proto/testdata/subdir"
+  ],
+  "source_file": [
+    "kythe/cxx/extractor/proto/testdata/relative_imports.proto"
+  ]
 }
-required_input {
-  v_name {
-    path: "kythe/cxx/extractor/proto/testdata/subdir/other.proto"
-  }
-  info {
-    path: "kythe/cxx/extractor/proto/testdata/subdir/other.proto"
-    digest: "c9d3571c48d70781dc7d4984b1b8974f44cb5953c3be17cacacc15f35f5981eb"
-  }
-}
-argument: "kythe/cxx/extractor/proto/testdata/relative_imports.proto"
-argument: "--"
-argument: "--proto_path"
-argument: "kythe/cxx/extractor/proto/testdata/subdir"
-source_file: "kythe/cxx/extractor/proto/testdata/relative_imports.proto"
-entry_context: "hash0"

--- a/kythe/cxx/extractor/proto/testdata/simple.UNIT
+++ b/kythe/cxx/extractor/proto/testdata/simple.UNIT
@@ -1,12 +1,19 @@
-required_input {
-  v_name {
-    path: "kythe/cxx/extractor/proto/testdata/simple1.proto"
-  }
-  info {
-    path: "kythe/cxx/extractor/proto/testdata/simple1.proto"
-    digest: "36aa2295772636e8e940333faa06f0838953101f353ab52d72279389e16117be"
-  }
+{
+  "required_input": [
+    {
+      "v_name": {
+        "path": "kythe/cxx/extractor/proto/testdata/simple1.proto"
+      },
+      "info": {
+        "path": "kythe/cxx/extractor/proto/testdata/simple1.proto",
+        "digest": "36aa2295772636e8e940333faa06f0838953101f353ab52d72279389e16117be"
+      }
+    }
+  ],
+  "argument": [
+    "kythe/cxx/extractor/proto/testdata/simple1.proto"
+  ],
+  "source_file": [
+    "kythe/cxx/extractor/proto/testdata/simple1.proto"
+  ]
 }
-argument: "kythe/cxx/extractor/proto/testdata/simple1.proto"
-source_file: "kythe/cxx/extractor/proto/testdata/simple1.proto"
-entry_context: "hash0"

--- a/kythe/cxx/extractor/textproto/testdata/custom_corpus.UNIT
+++ b/kythe/cxx/extractor/textproto/testdata/custom_corpus.UNIT
@@ -1,28 +1,35 @@
-required_input {
-  v_name {
-    corpus: "custom_corpus"
-    path: "kythe/cxx/extractor/textproto/testdata/example.proto"
-  }
-  info {
-    path: "kythe/cxx/extractor/textproto/testdata/example.proto"
-    digest: "b51fdc6bd2a3b2cbb0c1609cb8d62dcc8940853d6dfd0147c26f73a402e4cc3a"
-  }
+{
+  "required_input": [
+    {
+      "v_name": {
+        "corpus": "custom_corpus",
+        "path": "kythe/cxx/extractor/textproto/testdata/example.proto"
+      },
+      "info": {
+        "path": "kythe/cxx/extractor/textproto/testdata/example.proto",
+        "digest": "b51fdc6bd2a3b2cbb0c1609cb8d62dcc8940853d6dfd0147c26f73a402e4cc3a"
+      }
+    },
+    {
+      "v_name": {
+        "corpus": "custom_corpus",
+        "path": "kythe/cxx/extractor/textproto/testdata/simple.pbtxt"
+      },
+      "info": {
+        "path": "kythe/cxx/extractor/textproto/testdata/simple.pbtxt",
+        "digest": "40e64606167c9bea6f8c2a60f489901565aca97c6a676d25db195d4af91bcb9f"
+      }
+    }
+  ],
+  "argument": [
+    "kythe/cxx/extractor/textproto/testdata/simple.pbtxt",
+    "--proto_message",
+    "textproto_test.MyMessage",
+    "--",
+    "--proto_path",
+    "kythe/cxx/extractor/textproto/testdata"
+  ],
+  "source_file": [
+    "kythe/cxx/extractor/textproto/testdata/simple.pbtxt"
+  ]
 }
-required_input {
-  v_name {
-    corpus: "custom_corpus"
-    path: "kythe/cxx/extractor/textproto/testdata/simple.pbtxt"
-  }
-  info {
-    path: "kythe/cxx/extractor/textproto/testdata/simple.pbtxt"
-    digest: "40e64606167c9bea6f8c2a60f489901565aca97c6a676d25db195d4af91bcb9f"
-  }
-}
-argument: "kythe/cxx/extractor/textproto/testdata/simple.pbtxt"
-argument: "--proto_message"
-argument: "textproto_test.MyMessage"
-argument: "--"
-argument: "--proto_path"
-argument: "kythe/cxx/extractor/textproto/testdata"
-source_file: "kythe/cxx/extractor/textproto/testdata/simple.pbtxt"
-entry_context: "hash0"

--- a/kythe/cxx/extractor/textproto/testdata/deps.UNIT
+++ b/kythe/cxx/extractor/textproto/testdata/deps.UNIT
@@ -1,35 +1,42 @@
-required_input {
-  v_name {
-    path: "kythe/cxx/extractor/textproto/testdata/dep.proto"
-  }
-  info {
-    path: "kythe/cxx/extractor/textproto/testdata/dep.proto"
-    digest: "79c8f75a937c637a84f2a839ebcef7de60427d22b9e951c9ae8d9cf3c143756f"
-  }
+{
+  "required_input": [
+    {
+      "v_name": {
+        "path": "kythe/cxx/extractor/textproto/testdata/dep.proto"
+      },
+      "info": {
+        "path": "kythe/cxx/extractor/textproto/testdata/dep.proto",
+        "digest": "79c8f75a937c637a84f2a839ebcef7de60427d22b9e951c9ae8d9cf3c143756f"
+      }
+    },
+    {
+      "v_name": {
+        "path": "kythe/cxx/extractor/textproto/testdata/example_with_deps.proto"
+      },
+      "info": {
+        "path": "kythe/cxx/extractor/textproto/testdata/example_with_deps.proto",
+        "digest": "6046d4a5cbc7c4cea29c6be6ba378799000c7d214e8f0e029e347bcf4631c0f1"
+      }
+    },
+    {
+      "v_name": {
+        "path": "kythe/cxx/extractor/textproto/testdata/deps.pbtxt"
+      },
+      "info": {
+        "path": "kythe/cxx/extractor/textproto/testdata/deps.pbtxt",
+        "digest": "aaf1ace9a35d6a70518c7e7630d0ed6c6c27933b8dbac9db1aa24254a7b67102"
+      }
+    }
+  ],
+  "argument": [
+    "kythe/cxx/extractor/textproto/testdata/deps.pbtxt",
+    "--proto_message",
+    "deps_test.MyMessage",
+    "--",
+    "--proto_path",
+    "kythe/cxx/extractor/textproto/testdata"
+  ],
+  "source_file": [
+    "kythe/cxx/extractor/textproto/testdata/deps.pbtxt"
+  ]
 }
-required_input {
-  v_name {
-    path: "kythe/cxx/extractor/textproto/testdata/example_with_deps.proto"
-  }
-  info {
-    path: "kythe/cxx/extractor/textproto/testdata/example_with_deps.proto"
-    digest: "6046d4a5cbc7c4cea29c6be6ba378799000c7d214e8f0e029e347bcf4631c0f1"
-  }
-}
-required_input {
-  v_name {
-    path: "kythe/cxx/extractor/textproto/testdata/deps.pbtxt"
-  }
-  info {
-    path: "kythe/cxx/extractor/textproto/testdata/deps.pbtxt"
-    digest: "aaf1ace9a35d6a70518c7e7630d0ed6c6c27933b8dbac9db1aa24254a7b67102"
-  }
-}
-argument: "kythe/cxx/extractor/textproto/testdata/deps.pbtxt"
-argument: "--proto_message"
-argument: "deps_test.MyMessage"
-argument: "--"
-argument: "--proto_path"
-argument: "kythe/cxx/extractor/textproto/testdata"
-source_file: "kythe/cxx/extractor/textproto/testdata/deps.pbtxt"
-entry_context: "hash0"

--- a/kythe/cxx/extractor/textproto/testdata/extra_imports.UNIT
+++ b/kythe/cxx/extractor/textproto/testdata/extra_imports.UNIT
@@ -1,35 +1,42 @@
-required_input {
-  v_name {
-    path: "kythe/cxx/extractor/textproto/testdata/dep.proto"
-  }
-  info {
-    path: "kythe/cxx/extractor/textproto/testdata/dep.proto"
-    digest: "79c8f75a937c637a84f2a839ebcef7de60427d22b9e951c9ae8d9cf3c143756f"
-  }
+{
+  "required_input": [
+    {
+      "v_name": {
+        "path": "kythe/cxx/extractor/textproto/testdata/dep.proto"
+      },
+      "info": {
+        "path": "kythe/cxx/extractor/textproto/testdata/dep.proto",
+        "digest": "79c8f75a937c637a84f2a839ebcef7de60427d22b9e951c9ae8d9cf3c143756f"
+      }
+    },
+    {
+      "v_name": {
+        "path": "kythe/cxx/extractor/textproto/testdata/example.proto"
+      },
+      "info": {
+        "path": "kythe/cxx/extractor/textproto/testdata/example.proto",
+        "digest": "b51fdc6bd2a3b2cbb0c1609cb8d62dcc8940853d6dfd0147c26f73a402e4cc3a"
+      }
+    },
+    {
+      "v_name": {
+        "path": "kythe/cxx/extractor/textproto/testdata/extra_imports.pbtxt"
+      },
+      "info": {
+        "path": "kythe/cxx/extractor/textproto/testdata/extra_imports.pbtxt",
+        "digest": "b3462a501dafa3eea3d3fd7e8ed1ae6be6b3fba38849b20effeeea4cd8448c3e"
+      }
+    }
+  ],
+  "argument": [
+    "kythe/cxx/extractor/textproto/testdata/extra_imports.pbtxt",
+    "--proto_message",
+    "textproto_test.MyMessage",
+    "--",
+    "--proto_path",
+    "kythe/cxx/extractor/textproto/testdata"
+  ],
+  "source_file": [
+    "kythe/cxx/extractor/textproto/testdata/extra_imports.pbtxt"
+  ]
 }
-required_input {
-  v_name {
-    path: "kythe/cxx/extractor/textproto/testdata/example.proto"
-  }
-  info {
-    path: "kythe/cxx/extractor/textproto/testdata/example.proto"
-    digest: "b51fdc6bd2a3b2cbb0c1609cb8d62dcc8940853d6dfd0147c26f73a402e4cc3a"
-  }
-}
-required_input {
-  v_name {
-    path: "kythe/cxx/extractor/textproto/testdata/extra_imports.pbtxt"
-  }
-  info {
-    path: "kythe/cxx/extractor/textproto/testdata/extra_imports.pbtxt"
-    digest: "b3462a501dafa3eea3d3fd7e8ed1ae6be6b3fba38849b20effeeea4cd8448c3e"
-  }
-}
-argument: "kythe/cxx/extractor/textproto/testdata/extra_imports.pbtxt"
-argument: "--proto_message"
-argument: "textproto_test.MyMessage"
-argument: "--"
-argument: "--proto_path"
-argument: "kythe/cxx/extractor/textproto/testdata"
-source_file: "kythe/cxx/extractor/textproto/testdata/extra_imports.pbtxt"
-entry_context: "hash0"

--- a/kythe/cxx/extractor/textproto/testdata/multiple_proto_files.UNIT
+++ b/kythe/cxx/extractor/textproto/testdata/multiple_proto_files.UNIT
@@ -1,35 +1,42 @@
-required_input {
-  v_name {
-    path: "kythe/cxx/extractor/textproto/testdata/dep.proto"
-  }
-  info {
-    path: "kythe/cxx/extractor/textproto/testdata/dep.proto"
-    digest: "79c8f75a937c637a84f2a839ebcef7de60427d22b9e951c9ae8d9cf3c143756f"
-  }
+{
+  "required_input": [
+    {
+      "v_name": {
+        "path": "kythe/cxx/extractor/textproto/testdata/dep.proto"
+      },
+      "info": {
+        "path": "kythe/cxx/extractor/textproto/testdata/dep.proto",
+        "digest": "79c8f75a937c637a84f2a839ebcef7de60427d22b9e951c9ae8d9cf3c143756f"
+      }
+    },
+    {
+      "v_name": {
+        "path": "kythe/cxx/extractor/textproto/testdata/example.proto"
+      },
+      "info": {
+        "path": "kythe/cxx/extractor/textproto/testdata/example.proto",
+        "digest": "b51fdc6bd2a3b2cbb0c1609cb8d62dcc8940853d6dfd0147c26f73a402e4cc3a"
+      }
+    },
+    {
+      "v_name": {
+        "path": "kythe/cxx/extractor/textproto/testdata/without_schema.pbtxt"
+      },
+      "info": {
+        "path": "kythe/cxx/extractor/textproto/testdata/without_schema.pbtxt",
+        "digest": "3c9f75215b7ed9e95e678d5a43ad75fb4afc72d7c052bd508cd819cc21dc60b7"
+      }
+    }
+  ],
+  "argument": [
+    "kythe/cxx/extractor/textproto/testdata/without_schema.pbtxt",
+    "--proto_message",
+    "textproto_test.MyMessage",
+    "--",
+    "--proto_path",
+    "kythe/cxx/extractor/textproto/testdata"
+  ],
+  "source_file": [
+    "kythe/cxx/extractor/textproto/testdata/without_schema.pbtxt"
+  ]
 }
-required_input {
-  v_name {
-    path: "kythe/cxx/extractor/textproto/testdata/example.proto"
-  }
-  info {
-    path: "kythe/cxx/extractor/textproto/testdata/example.proto"
-    digest: "b51fdc6bd2a3b2cbb0c1609cb8d62dcc8940853d6dfd0147c26f73a402e4cc3a"
-  }
-}
-required_input {
-  v_name {
-    path: "kythe/cxx/extractor/textproto/testdata/without_schema.pbtxt"
-  }
-  info {
-    path: "kythe/cxx/extractor/textproto/testdata/without_schema.pbtxt"
-    digest: "3c9f75215b7ed9e95e678d5a43ad75fb4afc72d7c052bd508cd819cc21dc60b7"
-  }
-}
-argument: "kythe/cxx/extractor/textproto/testdata/without_schema.pbtxt"
-argument: "--proto_message"
-argument: "textproto_test.MyMessage"
-argument: "--"
-argument: "--proto_path"
-argument: "kythe/cxx/extractor/textproto/testdata"
-source_file: "kythe/cxx/extractor/textproto/testdata/without_schema.pbtxt"
-entry_context: "hash0"

--- a/kythe/cxx/extractor/textproto/testdata/simple.UNIT
+++ b/kythe/cxx/extractor/textproto/testdata/simple.UNIT
@@ -1,26 +1,33 @@
-required_input {
-  v_name {
-    path: "kythe/cxx/extractor/textproto/testdata/example.proto"
-  }
-  info {
-    path: "kythe/cxx/extractor/textproto/testdata/example.proto"
-    digest: "b51fdc6bd2a3b2cbb0c1609cb8d62dcc8940853d6dfd0147c26f73a402e4cc3a"
-  }
+{
+  "required_input": [
+    {
+      "v_name": {
+        "path": "kythe/cxx/extractor/textproto/testdata/example.proto"
+      },
+      "info": {
+        "path": "kythe/cxx/extractor/textproto/testdata/example.proto",
+        "digest": "b51fdc6bd2a3b2cbb0c1609cb8d62dcc8940853d6dfd0147c26f73a402e4cc3a"
+      }
+    },
+    {
+      "v_name": {
+        "path": "kythe/cxx/extractor/textproto/testdata/simple.pbtxt"
+      },
+      "info": {
+        "path": "kythe/cxx/extractor/textproto/testdata/simple.pbtxt",
+        "digest": "40e64606167c9bea6f8c2a60f489901565aca97c6a676d25db195d4af91bcb9f"
+      }
+    }
+  ],
+  "argument": [
+    "kythe/cxx/extractor/textproto/testdata/simple.pbtxt",
+    "--proto_message",
+    "textproto_test.MyMessage",
+    "--",
+    "--proto_path",
+    "kythe/cxx/extractor/textproto/testdata"
+  ],
+  "source_file": [
+    "kythe/cxx/extractor/textproto/testdata/simple.pbtxt"
+  ]
 }
-required_input {
-  v_name {
-    path: "kythe/cxx/extractor/textproto/testdata/simple.pbtxt"
-  }
-  info {
-    path: "kythe/cxx/extractor/textproto/testdata/simple.pbtxt"
-    digest: "40e64606167c9bea6f8c2a60f489901565aca97c6a676d25db195d4af91bcb9f"
-  }
-}
-argument: "kythe/cxx/extractor/textproto/testdata/simple.pbtxt"
-argument: "--proto_message"
-argument: "textproto_test.MyMessage"
-argument: "--"
-argument: "--proto_path"
-argument: "kythe/cxx/extractor/textproto/testdata"
-source_file: "kythe/cxx/extractor/textproto/testdata/simple.pbtxt"
-entry_context: "hash0"

--- a/kythe/cxx/extractor/textproto/testdata/subdir.UNIT
+++ b/kythe/cxx/extractor/textproto/testdata/subdir.UNIT
@@ -1,26 +1,33 @@
-required_input {
-  v_name {
-    path: "subdir.proto"
-  }
-  info {
-    path: "subdir.proto"
-    digest: "b51fdc6bd2a3b2cbb0c1609cb8d62dcc8940853d6dfd0147c26f73a402e4cc3a"
-  }
+{
+  "required_input": [
+    {
+      "v_name": {
+        "path": "subdir.proto"
+      },
+      "info": {
+        "path": "subdir.proto",
+        "digest": "b51fdc6bd2a3b2cbb0c1609cb8d62dcc8940853d6dfd0147c26f73a402e4cc3a"
+      }
+    },
+    {
+      "v_name": {
+        "path": "subdir.pbtxt"
+      },
+      "info": {
+        "path": "subdir.pbtxt",
+        "digest": "f68ebecf9ed486124180fd0a25fb41200435b8bc0aee39f061c71f3d18dcaff6"
+      }
+    }
+  ],
+  "argument": [
+    "kythe/cxx/extractor/textproto/testdata/subdir/subdir.pbtxt",
+    "--proto_message",
+    "textproto_test.MyMessage",
+    "--",
+    "--proto_path",
+    "kythe/cxx/extractor/textproto/testdata/subdir"
+  ],
+  "source_file": [
+    "subdir.pbtxt"
+  ]
 }
-required_input {
-  v_name {
-    path: "subdir.pbtxt"
-  }
-  info {
-    path: "subdir.pbtxt"
-    digest: "f68ebecf9ed486124180fd0a25fb41200435b8bc0aee39f061c71f3d18dcaff6"
-  }
-}
-argument: "kythe/cxx/extractor/textproto/testdata/subdir/subdir.pbtxt"
-argument: "--proto_message"
-argument: "textproto_test.MyMessage"
-argument: "--"
-argument: "--proto_path"
-argument: "kythe/cxx/extractor/textproto/testdata/subdir"
-source_file: "subdir.pbtxt"
-entry_context: "hash0"

--- a/kythe/cxx/extractor/textproto/testdata/without_schema.UNIT
+++ b/kythe/cxx/extractor/textproto/testdata/without_schema.UNIT
@@ -1,26 +1,33 @@
-required_input {
-  v_name {
-    path: "kythe/cxx/extractor/textproto/testdata/example.proto"
-  }
-  info {
-    path: "kythe/cxx/extractor/textproto/testdata/example.proto"
-    digest: "b51fdc6bd2a3b2cbb0c1609cb8d62dcc8940853d6dfd0147c26f73a402e4cc3a"
-  }
+{
+  "required_input": [
+    {
+      "v_name": {
+        "path": "kythe/cxx/extractor/textproto/testdata/example.proto"
+      },
+      "info": {
+        "path": "kythe/cxx/extractor/textproto/testdata/example.proto",
+        "digest": "b51fdc6bd2a3b2cbb0c1609cb8d62dcc8940853d6dfd0147c26f73a402e4cc3a"
+      }
+    },
+    {
+      "v_name": {
+        "path": "kythe/cxx/extractor/textproto/testdata/without_schema.pbtxt"
+      },
+      "info": {
+        "path": "kythe/cxx/extractor/textproto/testdata/without_schema.pbtxt",
+        "digest": "3c9f75215b7ed9e95e678d5a43ad75fb4afc72d7c052bd508cd819cc21dc60b7"
+      }
+    }
+  ],
+  "argument": [
+    "kythe/cxx/extractor/textproto/testdata/without_schema.pbtxt",
+    "--proto_message",
+    "textproto_test.MyMessage",
+    "--",
+    "--proto_path",
+    "kythe/cxx/extractor/textproto/testdata"
+  ],
+  "source_file": [
+    "kythe/cxx/extractor/textproto/testdata/without_schema.pbtxt"
+  ]
 }
-required_input {
-  v_name {
-    path: "kythe/cxx/extractor/textproto/testdata/without_schema.pbtxt"
-  }
-  info {
-    path: "kythe/cxx/extractor/textproto/testdata/without_schema.pbtxt"
-    digest: "3c9f75215b7ed9e95e678d5a43ad75fb4afc72d7c052bd508cd819cc21dc60b7"
-  }
-}
-argument: "kythe/cxx/extractor/textproto/testdata/without_schema.pbtxt"
-argument: "--proto_message"
-argument: "textproto_test.MyMessage"
-argument: "--"
-argument: "--proto_path"
-argument: "kythe/cxx/extractor/textproto/testdata"
-source_file: "kythe/cxx/extractor/textproto/testdata/without_schema.pbtxt"
-entry_context: "hash0"

--- a/kythe/cxx/tools/BUILD
+++ b/kythe/cxx/tools/BUILD
@@ -77,6 +77,7 @@ cc_library(
 
 cc_binary(
     name = "kindex_tool",
+    deprecation = "kindex has been deprecated in favor of kzip",
     visibility = [PUBLIC_VISIBILITY],
     deps = [
         ":cmdlib",


### PR DESCRIPTION
* The meaningful part of this change is in kzip_diff_test.sh, most everything else is golden file updates
* Using `kzip view` instead of `kindex_tool -explode` to get units out of kzips.
* Fields that we don't want to diff test are removed with `jq` instead of bash functions and `awk`.
* Resulting unit files and goldens are now json instead of textproto