### PR TITLE
fix(tests): make proto/textproto tests not rely on `jq`

### DIFF
--- a/kythe/cxx/extractor/proto/testdata/custom_corpus.UNIT
+++ b/kythe/cxx/extractor/proto/testdata/custom_corpus.UNIT
@@ -1,20 +1,20 @@
 {
-  "required_input": [
-    {
-      "v_name": {
-        "corpus": "my_custom_corpus",
-        "path": "kythe/cxx/extractor/proto/testdata/simple1.proto"
-      },
-      "info": {
-        "path": "kythe/cxx/extractor/proto/testdata/simple1.proto",
-        "digest": "36aa2295772636e8e940333faa06f0838953101f353ab52d72279389e16117be"
-      }
-    }
-  ],
-  "argument": [
-    "kythe/cxx/extractor/proto/testdata/simple1.proto"
-  ],
-  "source_file": [
-    "kythe/cxx/extractor/proto/testdata/simple1.proto"
-  ]
+    "argument": [
+        "kythe/cxx/extractor/proto/testdata/simple1.proto"
+    ],
+    "required_input": [
+        {
+            "info": {
+                "digest": "36aa2295772636e8e940333faa06f0838953101f353ab52d72279389e16117be",
+                "path": "kythe/cxx/extractor/proto/testdata/simple1.proto"
+            },
+            "v_name": {
+                "corpus": "my_custom_corpus",
+                "path": "kythe/cxx/extractor/proto/testdata/simple1.proto"
+            }
+        }
+    ],
+    "source_file": [
+        "kythe/cxx/extractor/proto/testdata/simple1.proto"
+    ],
 }

--- a/kythe/cxx/extractor/proto/testdata/custom_root_directory.UNIT
+++ b/kythe/cxx/extractor/proto/testdata/custom_root_directory.UNIT
@@ -1,31 +1,31 @@
 {
-  "required_input": [
-    {
-      "v_name": {
-        "path": "relative_imports.proto"
-      },
-      "info": {
-        "path": "relative_imports.proto",
-        "digest": "c91db27db87695c42ab03479f5393d83fd881c5c4982579b0115a20c36342d2c"
-      }
-    },
-    {
-      "v_name": {
-        "path": "subdir/other.proto"
-      },
-      "info": {
-        "path": "subdir/other.proto",
-        "digest": "c9d3571c48d70781dc7d4984b1b8974f44cb5953c3be17cacacc15f35f5981eb"
-      }
-    }
-  ],
-  "argument": [
-    "kythe/cxx/extractor/proto/testdata/relative_imports.proto",
-    "--",
-    "--proto_path",
-    "kythe/cxx/extractor/proto/testdata/subdir"
-  ],
-  "source_file": [
-    "relative_imports.proto"
-  ]
+    "argument": [
+        "kythe/cxx/extractor/proto/testdata/relative_imports.proto",
+        "--",
+        "--proto_path",
+        "kythe/cxx/extractor/proto/testdata/subdir"
+    ],
+    "required_input": [
+        {
+            "info": {
+                "digest": "c91db27db87695c42ab03479f5393d83fd881c5c4982579b0115a20c36342d2c",
+                "path": "relative_imports.proto"
+            },
+            "v_name": {
+                "path": "relative_imports.proto"
+            }
+        },
+        {
+            "info": {
+                "digest": "c9d3571c48d70781dc7d4984b1b8974f44cb5953c3be17cacacc15f35f5981eb",
+                "path": "subdir/other.proto"
+            },
+            "v_name": {
+                "path": "subdir/other.proto"
+            }
+        }
+    ],
+    "source_file": [
+        "relative_imports.proto"
+    ],
 }

--- a/kythe/cxx/extractor/proto/testdata/custom_vname_config.UNIT
+++ b/kythe/cxx/extractor/proto/testdata/custom_vname_config.UNIT
@@ -1,33 +1,33 @@
 {
-  "required_input": [
-    {
-      "v_name": {
-        "corpus": "corpus1",
-        "path": "kythe/cxx/extractor/proto/testdata/simple1.proto"
-      },
-      "info": {
-        "path": "kythe/cxx/extractor/proto/testdata/simple1.proto",
-        "digest": "36aa2295772636e8e940333faa06f0838953101f353ab52d72279389e16117be"
-      }
-    },
-    {
-      "v_name": {
-        "corpus": "corpus2",
-        "root": "kythe/cxx/extractor/proto/testdata",
-        "path": "simple2.proto"
-      },
-      "info": {
-        "path": "kythe/cxx/extractor/proto/testdata/simple2.proto",
-        "digest": "0db133854842fd4a2112176264bb7e596671db36d1d91dcb9910c662278680ae"
-      }
-    }
-  ],
-  "argument": [
-    "kythe/cxx/extractor/proto/testdata/simple1.proto",
-    "kythe/cxx/extractor/proto/testdata/simple2.proto"
-  ],
-  "source_file": [
-    "kythe/cxx/extractor/proto/testdata/simple1.proto",
-    "kythe/cxx/extractor/proto/testdata/simple2.proto"
-  ]
+    "argument": [
+        "kythe/cxx/extractor/proto/testdata/simple1.proto",
+        "kythe/cxx/extractor/proto/testdata/simple2.proto"
+    ],
+    "required_input": [
+        {
+            "info": {
+                "digest": "36aa2295772636e8e940333faa06f0838953101f353ab52d72279389e16117be",
+                "path": "kythe/cxx/extractor/proto/testdata/simple1.proto"
+            },
+            "v_name": {
+                "corpus": "corpus1",
+                "path": "kythe/cxx/extractor/proto/testdata/simple1.proto"
+            }
+        },
+        {
+            "info": {
+                "digest": "0db133854842fd4a2112176264bb7e596671db36d1d91dcb9910c662278680ae",
+                "path": "kythe/cxx/extractor/proto/testdata/simple2.proto"
+            },
+            "v_name": {
+                "corpus": "corpus2",
+                "path": "simple2.proto",
+                "root": "kythe/cxx/extractor/proto/testdata"
+            }
+        }
+    ],
+    "source_file": [
+        "kythe/cxx/extractor/proto/testdata/simple1.proto",
+        "kythe/cxx/extractor/proto/testdata/simple2.proto"
+    ],
 }

--- a/kythe/cxx/extractor/proto/testdata/duplicate_imports.UNIT
+++ b/kythe/cxx/extractor/proto/testdata/duplicate_imports.UNIT
@@ -1,33 +1,33 @@
 {
-  "required_input": [
-    {
-      "v_name": {
-        "path": "kythe/cxx/extractor/proto/testdata/relative_imports.proto"
-      },
-      "info": {
-        "path": "kythe/cxx/extractor/proto/testdata/relative_imports.proto",
-        "digest": "c91db27db87695c42ab03479f5393d83fd881c5c4982579b0115a20c36342d2c"
-      }
-    },
-    {
-      "v_name": {
-        "path": "kythe/cxx/extractor/proto/testdata/subdir/other.proto"
-      },
-      "info": {
-        "path": "kythe/cxx/extractor/proto/testdata/subdir/other.proto",
-        "digest": "c9d3571c48d70781dc7d4984b1b8974f44cb5953c3be17cacacc15f35f5981eb"
-      }
-    }
-  ],
-  "argument": [
-    "kythe/cxx/extractor/proto/testdata/relative_imports.proto",
-    "kythe/cxx/extractor/proto/testdata/subdir/other.proto",
-    "--",
-    "--proto_path",
-    "kythe/cxx/extractor/proto/testdata/subdir"
-  ],
-  "source_file": [
-    "kythe/cxx/extractor/proto/testdata/relative_imports.proto",
-    "kythe/cxx/extractor/proto/testdata/subdir/other.proto"
-  ]
+    "argument": [
+        "kythe/cxx/extractor/proto/testdata/relative_imports.proto",
+        "kythe/cxx/extractor/proto/testdata/subdir/other.proto",
+        "--",
+        "--proto_path",
+        "kythe/cxx/extractor/proto/testdata/subdir"
+    ],
+    "required_input": [
+        {
+            "info": {
+                "digest": "c91db27db87695c42ab03479f5393d83fd881c5c4982579b0115a20c36342d2c",
+                "path": "kythe/cxx/extractor/proto/testdata/relative_imports.proto"
+            },
+            "v_name": {
+                "path": "kythe/cxx/extractor/proto/testdata/relative_imports.proto"
+            }
+        },
+        {
+            "info": {
+                "digest": "c9d3571c48d70781dc7d4984b1b8974f44cb5953c3be17cacacc15f35f5981eb",
+                "path": "kythe/cxx/extractor/proto/testdata/subdir/other.proto"
+            },
+            "v_name": {
+                "path": "kythe/cxx/extractor/proto/testdata/subdir/other.proto"
+            }
+        }
+    ],
+    "source_file": [
+        "kythe/cxx/extractor/proto/testdata/relative_imports.proto",
+        "kythe/cxx/extractor/proto/testdata/subdir/other.proto"
+    ],
 }

--- a/kythe/cxx/extractor/proto/testdata/duplicate_imports2.UNIT
+++ b/kythe/cxx/extractor/proto/testdata/duplicate_imports2.UNIT
@@ -1,33 +1,33 @@
 {
-  "required_input": [
-    {
-      "v_name": {
-        "path": "kythe/cxx/extractor/proto/testdata/relative_imports.proto"
-      },
-      "info": {
-        "path": "kythe/cxx/extractor/proto/testdata/relative_imports.proto",
-        "digest": "c91db27db87695c42ab03479f5393d83fd881c5c4982579b0115a20c36342d2c"
-      }
-    },
-    {
-      "v_name": {
-        "path": "kythe/cxx/extractor/proto/testdata/subdir/other.proto"
-      },
-      "info": {
-        "path": "kythe/cxx/extractor/proto/testdata/subdir/other.proto",
-        "digest": "c9d3571c48d70781dc7d4984b1b8974f44cb5953c3be17cacacc15f35f5981eb"
-      }
-    }
-  ],
-  "argument": [
-    "kythe/cxx/extractor/proto/testdata/subdir/other.proto",
-    "kythe/cxx/extractor/proto/testdata/relative_imports.proto",
-    "--",
-    "--proto_path",
-    "kythe/cxx/extractor/proto/testdata/subdir"
-  ],
-  "source_file": [
-    "kythe/cxx/extractor/proto/testdata/subdir/other.proto",
-    "kythe/cxx/extractor/proto/testdata/relative_imports.proto"
-  ]
+    "argument": [
+        "kythe/cxx/extractor/proto/testdata/subdir/other.proto",
+        "kythe/cxx/extractor/proto/testdata/relative_imports.proto",
+        "--",
+        "--proto_path",
+        "kythe/cxx/extractor/proto/testdata/subdir"
+    ],
+    "required_input": [
+        {
+            "info": {
+                "digest": "c91db27db87695c42ab03479f5393d83fd881c5c4982579b0115a20c36342d2c",
+                "path": "kythe/cxx/extractor/proto/testdata/relative_imports.proto"
+            },
+            "v_name": {
+                "path": "kythe/cxx/extractor/proto/testdata/relative_imports.proto"
+            }
+        },
+        {
+            "info": {
+                "digest": "c9d3571c48d70781dc7d4984b1b8974f44cb5953c3be17cacacc15f35f5981eb",
+                "path": "kythe/cxx/extractor/proto/testdata/subdir/other.proto"
+            },
+            "v_name": {
+                "path": "kythe/cxx/extractor/proto/testdata/subdir/other.proto"
+            }
+        }
+    ],
+    "source_file": [
+        "kythe/cxx/extractor/proto/testdata/subdir/other.proto",
+        "kythe/cxx/extractor/proto/testdata/relative_imports.proto"
+    ],
 }

--- a/kythe/cxx/extractor/proto/testdata/kzip_diff_test.sh
+++ b/kythe/cxx/extractor/proto/testdata/kzip_diff_test.sh
@@ -13,21 +13,56 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
+
+# Output every line except ones that contains match_string. Also, do not output
+# extra_lines_to_skip lines that follow the line that contained match_string.
+function skip() {
+  if [ $# -ne 3 ] && [ $# -ne 2 ]; then
+    echo "Usage: $0 match_string extra_lines_to_skip [input_file]"
+    return 1
+  fi
+  local -r match_string="$1"
+  local -r lines_to_skip="$2"
+
+   if [ $# -eq 2 ]; then
+    awk "/$match_string/{skip=$lines_to_skip;next} skip>0{--skip;next} {print}"
+  else
+    awk "/$match_string/{skip=$lines_to_skip;next} skip>0{--skip;next} {print}" "$3"
+  fi
+  return 0
+}
+
+# Modify input_file to remove lines that contains match_string. Also remove
+# extra_lines_to_skip lines that follow the line that contained match_string.
+function skip_inplace() {
+  if [ $# -ne 3 ]; then
+    echo "Usage: $0 match_string lines_to_skip input_file"
+    return 1
+  fi
+  local -r match_string="$1"
+  local -r lines_to_skip="$2"
+  local -r input_file="$3"
+
+   local -r temp_file=$(mktemp)
+  skip "$match_string" "$lines_to_skip" "$input_file" > "$temp_file"
+  mv "$temp_file" "$input_file"
+}
+
+
+set -ex
 
 KZIP_TOOL=$1; shift
-JQ=$1; shift
 KZIP=$1; shift
 GOLDEN=$1; shift
 
 # Work in tmpdir because the runfiles dir is not writable
 cp $KZIP "${TEST_TMPDIR}/file.kzip"
-# Extract textproto version of compilation unit from kzip.
-UNIT=$("${KZIP_TOOL}" view "${TEST_TMPDIR}/file.kzip")
+# Extract json version of compilation unit from kzip.
 UNIT_FILE="${TEST_TMPDIR}/$(basename $GOLDEN)"
+"${KZIP_TOOL}" view "${TEST_TMPDIR}/file.kzip" | python -m json.tool > "$UNIT_FILE"
 # Remove working_directory, which will change depending on the machine the test
 # is run on.
-echo "$UNIT" | $JQ 'del(.working_directory)' > "$UNIT_FILE"
+skip_inplace "working_directory" 0 $UNIT_FILE
 
 echo
 echo "Diffing generated unit against golden"

--- a/kythe/cxx/extractor/proto/testdata/kzip_diff_test.sh
+++ b/kythe/cxx/extractor/proto/testdata/kzip_diff_test.sh
@@ -52,6 +52,7 @@ function skip_inplace() {
 set -ex
 
 KZIP_TOOL=$1; shift
+FORMATJSON=$1; shift
 KZIP=$1; shift
 GOLDEN=$1; shift
 
@@ -59,7 +60,7 @@ GOLDEN=$1; shift
 cp $KZIP "${TEST_TMPDIR}/file.kzip"
 # Extract json version of compilation unit from kzip.
 UNIT_FILE="${TEST_TMPDIR}/$(basename $GOLDEN)"
-"${KZIP_TOOL}" view "${TEST_TMPDIR}/file.kzip" | python -m json.tool > "$UNIT_FILE"
+"${KZIP_TOOL}" view "${TEST_TMPDIR}/file.kzip" | "$FORMATJSON" > "$UNIT_FILE"
 # Remove working_directory, which will change depending on the machine the test
 # is run on.
 skip_inplace "working_directory" 0 $UNIT_FILE

--- a/kythe/cxx/extractor/proto/testdata/kzip_diff_test.sh
+++ b/kythe/cxx/extractor/proto/testdata/kzip_diff_test.sh
@@ -49,7 +49,7 @@ function skip_inplace() {
 }
 
 
-set -ex
+set -e
 
 KZIP_TOOL=$1; shift
 FORMATJSON=$1; shift

--- a/kythe/cxx/extractor/proto/testdata/multiple_source_files.UNIT
+++ b/kythe/cxx/extractor/proto/testdata/multiple_source_files.UNIT
@@ -1,30 +1,30 @@
 {
-  "required_input": [
-    {
-      "v_name": {
-        "path": "kythe/cxx/extractor/proto/testdata/simple1.proto"
-      },
-      "info": {
-        "path": "kythe/cxx/extractor/proto/testdata/simple1.proto",
-        "digest": "36aa2295772636e8e940333faa06f0838953101f353ab52d72279389e16117be"
-      }
-    },
-    {
-      "v_name": {
-        "path": "kythe/cxx/extractor/proto/testdata/simple2.proto"
-      },
-      "info": {
-        "path": "kythe/cxx/extractor/proto/testdata/simple2.proto",
-        "digest": "0db133854842fd4a2112176264bb7e596671db36d1d91dcb9910c662278680ae"
-      }
-    }
-  ],
-  "argument": [
-    "kythe/cxx/extractor/proto/testdata/simple1.proto",
-    "kythe/cxx/extractor/proto/testdata/simple2.proto"
-  ],
-  "source_file": [
-    "kythe/cxx/extractor/proto/testdata/simple1.proto",
-    "kythe/cxx/extractor/proto/testdata/simple2.proto"
-  ]
+    "argument": [
+        "kythe/cxx/extractor/proto/testdata/simple1.proto",
+        "kythe/cxx/extractor/proto/testdata/simple2.proto"
+    ],
+    "required_input": [
+        {
+            "info": {
+                "digest": "36aa2295772636e8e940333faa06f0838953101f353ab52d72279389e16117be",
+                "path": "kythe/cxx/extractor/proto/testdata/simple1.proto"
+            },
+            "v_name": {
+                "path": "kythe/cxx/extractor/proto/testdata/simple1.proto"
+            }
+        },
+        {
+            "info": {
+                "digest": "0db133854842fd4a2112176264bb7e596671db36d1d91dcb9910c662278680ae",
+                "path": "kythe/cxx/extractor/proto/testdata/simple2.proto"
+            },
+            "v_name": {
+                "path": "kythe/cxx/extractor/proto/testdata/simple2.proto"
+            }
+        }
+    ],
+    "source_file": [
+        "kythe/cxx/extractor/proto/testdata/simple1.proto",
+        "kythe/cxx/extractor/proto/testdata/simple2.proto"
+    ],
 }

--- a/kythe/cxx/extractor/proto/testdata/proto_extractor_test.bzl
+++ b/kythe/cxx/extractor/proto/testdata/proto_extractor_test.bzl
@@ -49,6 +49,7 @@ def _kzip_diff_test_impl(ctx):
     script = " ".join([
         ctx.executable.diff_bin.short_path,
         ctx.executable.kzip_tool.short_path,
+        ctx.executable.formatjson.short_path,
         ctx.files.kzip[0].short_path,
         ctx.files.golden_file[0].short_path,
     ])
@@ -60,6 +61,7 @@ def _kzip_diff_test_impl(ctx):
     runfiles = ctx.runfiles(files = [
         ctx.executable.diff_bin,
         ctx.executable.kzip_tool,
+        ctx.executable.formatjson,
         ctx.file.kzip,
         ctx.file.golden_file,
     ])
@@ -79,6 +81,11 @@ kzip_diff_test = rule(
             cfg = "host",
             executable = True,
             default = Label("//kythe/go/platform/tools/kzip"),
+        ),
+        "formatjson": attr.label(
+            cfg = "host",
+            executable = True,
+            default = Label("//kythe/go/util/formatjson"),
         ),
     },
     test = True,

--- a/kythe/cxx/extractor/proto/testdata/proto_extractor_test.bzl
+++ b/kythe/cxx/extractor/proto/testdata/proto_extractor_test.bzl
@@ -49,7 +49,6 @@ def _kzip_diff_test_impl(ctx):
     script = " ".join([
         ctx.executable.diff_bin.short_path,
         ctx.executable.kzip_tool.short_path,
-        ctx.executable.jq.short_path,
         ctx.files.kzip[0].short_path,
         ctx.files.golden_file[0].short_path,
     ])
@@ -61,7 +60,6 @@ def _kzip_diff_test_impl(ctx):
     runfiles = ctx.runfiles(files = [
         ctx.executable.diff_bin,
         ctx.executable.kzip_tool,
-        ctx.executable.jq,
         ctx.file.kzip,
         ctx.file.golden_file,
     ])
@@ -81,11 +79,6 @@ kzip_diff_test = rule(
             cfg = "host",
             executable = True,
             default = Label("//kythe/go/platform/tools/kzip"),
-        ),
-        "jq": attr.label(
-            cfg = "host",
-            executable = True,
-            default = Label("@com_github_stedolan_jq//:jq"),
         ),
     },
     test = True,

--- a/kythe/cxx/extractor/proto/testdata/relative_imports.UNIT
+++ b/kythe/cxx/extractor/proto/testdata/relative_imports.UNIT
@@ -1,31 +1,31 @@
 {
-  "required_input": [
-    {
-      "v_name": {
-        "path": "kythe/cxx/extractor/proto/testdata/relative_imports.proto"
-      },
-      "info": {
-        "path": "kythe/cxx/extractor/proto/testdata/relative_imports.proto",
-        "digest": "c91db27db87695c42ab03479f5393d83fd881c5c4982579b0115a20c36342d2c"
-      }
-    },
-    {
-      "v_name": {
-        "path": "kythe/cxx/extractor/proto/testdata/subdir/other.proto"
-      },
-      "info": {
-        "path": "kythe/cxx/extractor/proto/testdata/subdir/other.proto",
-        "digest": "c9d3571c48d70781dc7d4984b1b8974f44cb5953c3be17cacacc15f35f5981eb"
-      }
-    }
-  ],
-  "argument": [
-    "kythe/cxx/extractor/proto/testdata/relative_imports.proto",
-    "--",
-    "--proto_path",
-    "kythe/cxx/extractor/proto/testdata/subdir"
-  ],
-  "source_file": [
-    "kythe/cxx/extractor/proto/testdata/relative_imports.proto"
-  ]
+    "argument": [
+        "kythe/cxx/extractor/proto/testdata/relative_imports.proto",
+        "--",
+        "--proto_path",
+        "kythe/cxx/extractor/proto/testdata/subdir"
+    ],
+    "required_input": [
+        {
+            "info": {
+                "digest": "c91db27db87695c42ab03479f5393d83fd881c5c4982579b0115a20c36342d2c",
+                "path": "kythe/cxx/extractor/proto/testdata/relative_imports.proto"
+            },
+            "v_name": {
+                "path": "kythe/cxx/extractor/proto/testdata/relative_imports.proto"
+            }
+        },
+        {
+            "info": {
+                "digest": "c9d3571c48d70781dc7d4984b1b8974f44cb5953c3be17cacacc15f35f5981eb",
+                "path": "kythe/cxx/extractor/proto/testdata/subdir/other.proto"
+            },
+            "v_name": {
+                "path": "kythe/cxx/extractor/proto/testdata/subdir/other.proto"
+            }
+        }
+    ],
+    "source_file": [
+        "kythe/cxx/extractor/proto/testdata/relative_imports.proto"
+    ],
 }

--- a/kythe/cxx/extractor/proto/testdata/simple.UNIT
+++ b/kythe/cxx/extractor/proto/testdata/simple.UNIT
@@ -1,19 +1,19 @@
 {
-  "required_input": [
-    {
-      "v_name": {
-        "path": "kythe/cxx/extractor/proto/testdata/simple1.proto"
-      },
-      "info": {
-        "path": "kythe/cxx/extractor/proto/testdata/simple1.proto",
-        "digest": "36aa2295772636e8e940333faa06f0838953101f353ab52d72279389e16117be"
-      }
-    }
-  ],
-  "argument": [
-    "kythe/cxx/extractor/proto/testdata/simple1.proto"
-  ],
-  "source_file": [
-    "kythe/cxx/extractor/proto/testdata/simple1.proto"
-  ]
+    "argument": [
+        "kythe/cxx/extractor/proto/testdata/simple1.proto"
+    ],
+    "required_input": [
+        {
+            "info": {
+                "digest": "36aa2295772636e8e940333faa06f0838953101f353ab52d72279389e16117be",
+                "path": "kythe/cxx/extractor/proto/testdata/simple1.proto"
+            },
+            "v_name": {
+                "path": "kythe/cxx/extractor/proto/testdata/simple1.proto"
+            }
+        }
+    ],
+    "source_file": [
+        "kythe/cxx/extractor/proto/testdata/simple1.proto"
+    ],
 }

--- a/kythe/cxx/extractor/textproto/testdata/custom_corpus.UNIT
+++ b/kythe/cxx/extractor/textproto/testdata/custom_corpus.UNIT
@@ -1,35 +1,35 @@
 {
-  "required_input": [
-    {
-      "v_name": {
-        "corpus": "custom_corpus",
-        "path": "kythe/cxx/extractor/textproto/testdata/example.proto"
-      },
-      "info": {
-        "path": "kythe/cxx/extractor/textproto/testdata/example.proto",
-        "digest": "b51fdc6bd2a3b2cbb0c1609cb8d62dcc8940853d6dfd0147c26f73a402e4cc3a"
-      }
-    },
-    {
-      "v_name": {
-        "corpus": "custom_corpus",
-        "path": "kythe/cxx/extractor/textproto/testdata/simple.pbtxt"
-      },
-      "info": {
-        "path": "kythe/cxx/extractor/textproto/testdata/simple.pbtxt",
-        "digest": "40e64606167c9bea6f8c2a60f489901565aca97c6a676d25db195d4af91bcb9f"
-      }
-    }
-  ],
-  "argument": [
-    "kythe/cxx/extractor/textproto/testdata/simple.pbtxt",
-    "--proto_message",
-    "textproto_test.MyMessage",
-    "--",
-    "--proto_path",
-    "kythe/cxx/extractor/textproto/testdata"
-  ],
-  "source_file": [
-    "kythe/cxx/extractor/textproto/testdata/simple.pbtxt"
-  ]
+    "argument": [
+        "kythe/cxx/extractor/textproto/testdata/simple.pbtxt",
+        "--proto_message",
+        "textproto_test.MyMessage",
+        "--",
+        "--proto_path",
+        "kythe/cxx/extractor/textproto/testdata"
+    ],
+    "required_input": [
+        {
+            "info": {
+                "digest": "b51fdc6bd2a3b2cbb0c1609cb8d62dcc8940853d6dfd0147c26f73a402e4cc3a",
+                "path": "kythe/cxx/extractor/textproto/testdata/example.proto"
+            },
+            "v_name": {
+                "corpus": "custom_corpus",
+                "path": "kythe/cxx/extractor/textproto/testdata/example.proto"
+            }
+        },
+        {
+            "info": {
+                "digest": "40e64606167c9bea6f8c2a60f489901565aca97c6a676d25db195d4af91bcb9f",
+                "path": "kythe/cxx/extractor/textproto/testdata/simple.pbtxt"
+            },
+            "v_name": {
+                "corpus": "custom_corpus",
+                "path": "kythe/cxx/extractor/textproto/testdata/simple.pbtxt"
+            }
+        }
+    ],
+    "source_file": [
+        "kythe/cxx/extractor/textproto/testdata/simple.pbtxt"
+    ],
 }

--- a/kythe/cxx/extractor/textproto/testdata/deps.UNIT
+++ b/kythe/cxx/extractor/textproto/testdata/deps.UNIT
@@ -1,42 +1,42 @@
 {
-  "required_input": [
-    {
-      "v_name": {
-        "path": "kythe/cxx/extractor/textproto/testdata/dep.proto"
-      },
-      "info": {
-        "path": "kythe/cxx/extractor/textproto/testdata/dep.proto",
-        "digest": "79c8f75a937c637a84f2a839ebcef7de60427d22b9e951c9ae8d9cf3c143756f"
-      }
-    },
-    {
-      "v_name": {
-        "path": "kythe/cxx/extractor/textproto/testdata/example_with_deps.proto"
-      },
-      "info": {
-        "path": "kythe/cxx/extractor/textproto/testdata/example_with_deps.proto",
-        "digest": "6046d4a5cbc7c4cea29c6be6ba378799000c7d214e8f0e029e347bcf4631c0f1"
-      }
-    },
-    {
-      "v_name": {
-        "path": "kythe/cxx/extractor/textproto/testdata/deps.pbtxt"
-      },
-      "info": {
-        "path": "kythe/cxx/extractor/textproto/testdata/deps.pbtxt",
-        "digest": "aaf1ace9a35d6a70518c7e7630d0ed6c6c27933b8dbac9db1aa24254a7b67102"
-      }
-    }
-  ],
-  "argument": [
-    "kythe/cxx/extractor/textproto/testdata/deps.pbtxt",
-    "--proto_message",
-    "deps_test.MyMessage",
-    "--",
-    "--proto_path",
-    "kythe/cxx/extractor/textproto/testdata"
-  ],
-  "source_file": [
-    "kythe/cxx/extractor/textproto/testdata/deps.pbtxt"
-  ]
+    "argument": [
+        "kythe/cxx/extractor/textproto/testdata/deps.pbtxt",
+        "--proto_message",
+        "deps_test.MyMessage",
+        "--",
+        "--proto_path",
+        "kythe/cxx/extractor/textproto/testdata"
+    ],
+    "required_input": [
+        {
+            "info": {
+                "digest": "79c8f75a937c637a84f2a839ebcef7de60427d22b9e951c9ae8d9cf3c143756f",
+                "path": "kythe/cxx/extractor/textproto/testdata/dep.proto"
+            },
+            "v_name": {
+                "path": "kythe/cxx/extractor/textproto/testdata/dep.proto"
+            }
+        },
+        {
+            "info": {
+                "digest": "6046d4a5cbc7c4cea29c6be6ba378799000c7d214e8f0e029e347bcf4631c0f1",
+                "path": "kythe/cxx/extractor/textproto/testdata/example_with_deps.proto"
+            },
+            "v_name": {
+                "path": "kythe/cxx/extractor/textproto/testdata/example_with_deps.proto"
+            }
+        },
+        {
+            "info": {
+                "digest": "aaf1ace9a35d6a70518c7e7630d0ed6c6c27933b8dbac9db1aa24254a7b67102",
+                "path": "kythe/cxx/extractor/textproto/testdata/deps.pbtxt"
+            },
+            "v_name": {
+                "path": "kythe/cxx/extractor/textproto/testdata/deps.pbtxt"
+            }
+        }
+    ],
+    "source_file": [
+        "kythe/cxx/extractor/textproto/testdata/deps.pbtxt"
+    ],
 }

--- a/kythe/cxx/extractor/textproto/testdata/extra_imports.UNIT
+++ b/kythe/cxx/extractor/textproto/testdata/extra_imports.UNIT
@@ -1,42 +1,42 @@
 {
-  "required_input": [
-    {
-      "v_name": {
-        "path": "kythe/cxx/extractor/textproto/testdata/dep.proto"
-      },
-      "info": {
-        "path": "kythe/cxx/extractor/textproto/testdata/dep.proto",
-        "digest": "79c8f75a937c637a84f2a839ebcef7de60427d22b9e951c9ae8d9cf3c143756f"
-      }
-    },
-    {
-      "v_name": {
-        "path": "kythe/cxx/extractor/textproto/testdata/example.proto"
-      },
-      "info": {
-        "path": "kythe/cxx/extractor/textproto/testdata/example.proto",
-        "digest": "b51fdc6bd2a3b2cbb0c1609cb8d62dcc8940853d6dfd0147c26f73a402e4cc3a"
-      }
-    },
-    {
-      "v_name": {
-        "path": "kythe/cxx/extractor/textproto/testdata/extra_imports.pbtxt"
-      },
-      "info": {
-        "path": "kythe/cxx/extractor/textproto/testdata/extra_imports.pbtxt",
-        "digest": "b3462a501dafa3eea3d3fd7e8ed1ae6be6b3fba38849b20effeeea4cd8448c3e"
-      }
-    }
-  ],
-  "argument": [
-    "kythe/cxx/extractor/textproto/testdata/extra_imports.pbtxt",
-    "--proto_message",
-    "textproto_test.MyMessage",
-    "--",
-    "--proto_path",
-    "kythe/cxx/extractor/textproto/testdata"
-  ],
-  "source_file": [
-    "kythe/cxx/extractor/textproto/testdata/extra_imports.pbtxt"
-  ]
+    "argument": [
+        "kythe/cxx/extractor/textproto/testdata/extra_imports.pbtxt",
+        "--proto_message",
+        "textproto_test.MyMessage",
+        "--",
+        "--proto_path",
+        "kythe/cxx/extractor/textproto/testdata"
+    ],
+    "required_input": [
+        {
+            "info": {
+                "digest": "79c8f75a937c637a84f2a839ebcef7de60427d22b9e951c9ae8d9cf3c143756f",
+                "path": "kythe/cxx/extractor/textproto/testdata/dep.proto"
+            },
+            "v_name": {
+                "path": "kythe/cxx/extractor/textproto/testdata/dep.proto"
+            }
+        },
+        {
+            "info": {
+                "digest": "b51fdc6bd2a3b2cbb0c1609cb8d62dcc8940853d6dfd0147c26f73a402e4cc3a",
+                "path": "kythe/cxx/extractor/textproto/testdata/example.proto"
+            },
+            "v_name": {
+                "path": "kythe/cxx/extractor/textproto/testdata/example.proto"
+            }
+        },
+        {
+            "info": {
+                "digest": "b3462a501dafa3eea3d3fd7e8ed1ae6be6b3fba38849b20effeeea4cd8448c3e",
+                "path": "kythe/cxx/extractor/textproto/testdata/extra_imports.pbtxt"
+            },
+            "v_name": {
+                "path": "kythe/cxx/extractor/textproto/testdata/extra_imports.pbtxt"
+            }
+        }
+    ],
+    "source_file": [
+        "kythe/cxx/extractor/textproto/testdata/extra_imports.pbtxt"
+    ],
 }

--- a/kythe/cxx/extractor/textproto/testdata/multiple_proto_files.UNIT
+++ b/kythe/cxx/extractor/textproto/testdata/multiple_proto_files.UNIT
@@ -1,42 +1,42 @@
 {
-  "required_input": [
-    {
-      "v_name": {
-        "path": "kythe/cxx/extractor/textproto/testdata/dep.proto"
-      },
-      "info": {
-        "path": "kythe/cxx/extractor/textproto/testdata/dep.proto",
-        "digest": "79c8f75a937c637a84f2a839ebcef7de60427d22b9e951c9ae8d9cf3c143756f"
-      }
-    },
-    {
-      "v_name": {
-        "path": "kythe/cxx/extractor/textproto/testdata/example.proto"
-      },
-      "info": {
-        "path": "kythe/cxx/extractor/textproto/testdata/example.proto",
-        "digest": "b51fdc6bd2a3b2cbb0c1609cb8d62dcc8940853d6dfd0147c26f73a402e4cc3a"
-      }
-    },
-    {
-      "v_name": {
-        "path": "kythe/cxx/extractor/textproto/testdata/without_schema.pbtxt"
-      },
-      "info": {
-        "path": "kythe/cxx/extractor/textproto/testdata/without_schema.pbtxt",
-        "digest": "3c9f75215b7ed9e95e678d5a43ad75fb4afc72d7c052bd508cd819cc21dc60b7"
-      }
-    }
-  ],
-  "argument": [
-    "kythe/cxx/extractor/textproto/testdata/without_schema.pbtxt",
-    "--proto_message",
-    "textproto_test.MyMessage",
-    "--",
-    "--proto_path",
-    "kythe/cxx/extractor/textproto/testdata"
-  ],
-  "source_file": [
-    "kythe/cxx/extractor/textproto/testdata/without_schema.pbtxt"
-  ]
+    "argument": [
+        "kythe/cxx/extractor/textproto/testdata/without_schema.pbtxt",
+        "--proto_message",
+        "textproto_test.MyMessage",
+        "--",
+        "--proto_path",
+        "kythe/cxx/extractor/textproto/testdata"
+    ],
+    "required_input": [
+        {
+            "info": {
+                "digest": "79c8f75a937c637a84f2a839ebcef7de60427d22b9e951c9ae8d9cf3c143756f",
+                "path": "kythe/cxx/extractor/textproto/testdata/dep.proto"
+            },
+            "v_name": {
+                "path": "kythe/cxx/extractor/textproto/testdata/dep.proto"
+            }
+        },
+        {
+            "info": {
+                "digest": "b51fdc6bd2a3b2cbb0c1609cb8d62dcc8940853d6dfd0147c26f73a402e4cc3a",
+                "path": "kythe/cxx/extractor/textproto/testdata/example.proto"
+            },
+            "v_name": {
+                "path": "kythe/cxx/extractor/textproto/testdata/example.proto"
+            }
+        },
+        {
+            "info": {
+                "digest": "3c9f75215b7ed9e95e678d5a43ad75fb4afc72d7c052bd508cd819cc21dc60b7",
+                "path": "kythe/cxx/extractor/textproto/testdata/without_schema.pbtxt"
+            },
+            "v_name": {
+                "path": "kythe/cxx/extractor/textproto/testdata/without_schema.pbtxt"
+            }
+        }
+    ],
+    "source_file": [
+        "kythe/cxx/extractor/textproto/testdata/without_schema.pbtxt"
+    ],
 }

--- a/kythe/cxx/extractor/textproto/testdata/simple.UNIT
+++ b/kythe/cxx/extractor/textproto/testdata/simple.UNIT
@@ -1,33 +1,33 @@
 {
-  "required_input": [
-    {
-      "v_name": {
-        "path": "kythe/cxx/extractor/textproto/testdata/example.proto"
-      },
-      "info": {
-        "path": "kythe/cxx/extractor/textproto/testdata/example.proto",
-        "digest": "b51fdc6bd2a3b2cbb0c1609cb8d62dcc8940853d6dfd0147c26f73a402e4cc3a"
-      }
-    },
-    {
-      "v_name": {
-        "path": "kythe/cxx/extractor/textproto/testdata/simple.pbtxt"
-      },
-      "info": {
-        "path": "kythe/cxx/extractor/textproto/testdata/simple.pbtxt",
-        "digest": "40e64606167c9bea6f8c2a60f489901565aca97c6a676d25db195d4af91bcb9f"
-      }
-    }
-  ],
-  "argument": [
-    "kythe/cxx/extractor/textproto/testdata/simple.pbtxt",
-    "--proto_message",
-    "textproto_test.MyMessage",
-    "--",
-    "--proto_path",
-    "kythe/cxx/extractor/textproto/testdata"
-  ],
-  "source_file": [
-    "kythe/cxx/extractor/textproto/testdata/simple.pbtxt"
-  ]
+    "argument": [
+        "kythe/cxx/extractor/textproto/testdata/simple.pbtxt",
+        "--proto_message",
+        "textproto_test.MyMessage",
+        "--",
+        "--proto_path",
+        "kythe/cxx/extractor/textproto/testdata"
+    ],
+    "required_input": [
+        {
+            "info": {
+                "digest": "b51fdc6bd2a3b2cbb0c1609cb8d62dcc8940853d6dfd0147c26f73a402e4cc3a",
+                "path": "kythe/cxx/extractor/textproto/testdata/example.proto"
+            },
+            "v_name": {
+                "path": "kythe/cxx/extractor/textproto/testdata/example.proto"
+            }
+        },
+        {
+            "info": {
+                "digest": "40e64606167c9bea6f8c2a60f489901565aca97c6a676d25db195d4af91bcb9f",
+                "path": "kythe/cxx/extractor/textproto/testdata/simple.pbtxt"
+            },
+            "v_name": {
+                "path": "kythe/cxx/extractor/textproto/testdata/simple.pbtxt"
+            }
+        }
+    ],
+    "source_file": [
+        "kythe/cxx/extractor/textproto/testdata/simple.pbtxt"
+    ],
 }

--- a/kythe/cxx/extractor/textproto/testdata/subdir.UNIT
+++ b/kythe/cxx/extractor/textproto/testdata/subdir.UNIT
@@ -1,33 +1,33 @@
 {
-  "required_input": [
-    {
-      "v_name": {
-        "path": "subdir.proto"
-      },
-      "info": {
-        "path": "subdir.proto",
-        "digest": "b51fdc6bd2a3b2cbb0c1609cb8d62dcc8940853d6dfd0147c26f73a402e4cc3a"
-      }
-    },
-    {
-      "v_name": {
-        "path": "subdir.pbtxt"
-      },
-      "info": {
-        "path": "subdir.pbtxt",
-        "digest": "f68ebecf9ed486124180fd0a25fb41200435b8bc0aee39f061c71f3d18dcaff6"
-      }
-    }
-  ],
-  "argument": [
-    "kythe/cxx/extractor/textproto/testdata/subdir/subdir.pbtxt",
-    "--proto_message",
-    "textproto_test.MyMessage",
-    "--",
-    "--proto_path",
-    "kythe/cxx/extractor/textproto/testdata/subdir"
-  ],
-  "source_file": [
-    "subdir.pbtxt"
-  ]
+    "argument": [
+        "kythe/cxx/extractor/textproto/testdata/subdir/subdir.pbtxt",
+        "--proto_message",
+        "textproto_test.MyMessage",
+        "--",
+        "--proto_path",
+        "kythe/cxx/extractor/textproto/testdata/subdir"
+    ],
+    "required_input": [
+        {
+            "info": {
+                "digest": "b51fdc6bd2a3b2cbb0c1609cb8d62dcc8940853d6dfd0147c26f73a402e4cc3a",
+                "path": "subdir.proto"
+            },
+            "v_name": {
+                "path": "subdir.proto"
+            }
+        },
+        {
+            "info": {
+                "digest": "f68ebecf9ed486124180fd0a25fb41200435b8bc0aee39f061c71f3d18dcaff6",
+                "path": "subdir.pbtxt"
+            },
+            "v_name": {
+                "path": "subdir.pbtxt"
+            }
+        }
+    ],
+    "source_file": [
+        "subdir.pbtxt"
+    ],
 }

--- a/kythe/cxx/extractor/textproto/testdata/without_schema.UNIT
+++ b/kythe/cxx/extractor/textproto/testdata/without_schema.UNIT
@@ -1,33 +1,33 @@
 {
-  "required_input": [
-    {
-      "v_name": {
-        "path": "kythe/cxx/extractor/textproto/testdata/example.proto"
-      },
-      "info": {
-        "path": "kythe/cxx/extractor/textproto/testdata/example.proto",
-        "digest": "b51fdc6bd2a3b2cbb0c1609cb8d62dcc8940853d6dfd0147c26f73a402e4cc3a"
-      }
-    },
-    {
-      "v_name": {
-        "path": "kythe/cxx/extractor/textproto/testdata/without_schema.pbtxt"
-      },
-      "info": {
-        "path": "kythe/cxx/extractor/textproto/testdata/without_schema.pbtxt",
-        "digest": "3c9f75215b7ed9e95e678d5a43ad75fb4afc72d7c052bd508cd819cc21dc60b7"
-      }
-    }
-  ],
-  "argument": [
-    "kythe/cxx/extractor/textproto/testdata/without_schema.pbtxt",
-    "--proto_message",
-    "textproto_test.MyMessage",
-    "--",
-    "--proto_path",
-    "kythe/cxx/extractor/textproto/testdata"
-  ],
-  "source_file": [
-    "kythe/cxx/extractor/textproto/testdata/without_schema.pbtxt"
-  ]
+    "argument": [
+        "kythe/cxx/extractor/textproto/testdata/without_schema.pbtxt",
+        "--proto_message",
+        "textproto_test.MyMessage",
+        "--",
+        "--proto_path",
+        "kythe/cxx/extractor/textproto/testdata"
+    ],
+    "required_input": [
+        {
+            "info": {
+                "digest": "b51fdc6bd2a3b2cbb0c1609cb8d62dcc8940853d6dfd0147c26f73a402e4cc3a",
+                "path": "kythe/cxx/extractor/textproto/testdata/example.proto"
+            },
+            "v_name": {
+                "path": "kythe/cxx/extractor/textproto/testdata/example.proto"
+            }
+        },
+        {
+            "info": {
+                "digest": "3c9f75215b7ed9e95e678d5a43ad75fb4afc72d7c052bd508cd819cc21dc60b7",
+                "path": "kythe/cxx/extractor/textproto/testdata/without_schema.pbtxt"
+            },
+            "v_name": {
+                "path": "kythe/cxx/extractor/textproto/testdata/without_schema.pbtxt"
+            }
+        }
+    ],
+    "source_file": [
+        "kythe/cxx/extractor/textproto/testdata/without_schema.pbtxt"
+    ],
 }

--- a/kythe/go/util/formatjson/BUILD
+++ b/kythe/go/util/formatjson/BUILD
@@ -1,0 +1,8 @@
+load("//tools:build_rules/shims.bzl", "go_binary")
+
+package(default_visibility = ["//kythe:default_visibility"])
+
+go_binary(
+    name = "formatjson",
+    srcs = ["formatjson.go"],
+)

--- a/kythe/go/util/formatjson/formatjson.go
+++ b/kythe/go/util/formatjson/formatjson.go
@@ -2,15 +2,15 @@
 package main
 
 import (
-	"os"
 	"encoding/json"
 	"log"
+	"os"
 )
 
 func main() {
 	obj := make(map[string]interface{})
 	d := json.NewDecoder(os.Stdin)
-	if err:= d.Decode(&obj); err != nil {
+	if err := d.Decode(&obj); err != nil {
 		log.Fatal(err)
 	}
 

--- a/kythe/go/util/formatjson/formatjson.go
+++ b/kythe/go/util/formatjson/formatjson.go
@@ -1,0 +1,22 @@
+// Binary formatjson reads json from stdin and writes formatted json to stdout.
+package main
+
+import (
+	"os"
+	"encoding/json"
+	"log"
+)
+
+func main() {
+	obj := make(map[string]interface{})
+	d := json.NewDecoder(os.Stdin)
+	if err:= d.Decode(&obj); err != nil {
+		log.Fatal(err)
+	}
+
+	e := json.NewEncoder(os.Stdout)
+	e.SetIndent("", "    ")
+	if err := e.Encode(obj); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/kythe/go/util/formatjson/formatjson.go
+++ b/kythe/go/util/formatjson/formatjson.go
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 The Kythe Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // Binary formatjson reads json from stdin and writes formatted json to stdout.
 package main
 


### PR DESCRIPTION
unfortunately `jq` is not available in google3, so I changed the tests
back to awk for skipping nondeterministic fields and python's json.tool
for formatting. Because python's json output is different than jq's, all
our golden files had to be updated too.