### PR TITLE
fix(cxx_extractor): update comments to mention kzip instead of kindex

### DIFF
--- a/kythe/cxx/extractor/README.md
+++ b/kythe/cxx/extractor/README.md
@@ -1,7 +1,7 @@
 ## Bazel C++ extractor
 
 An extractor that builds index files from a Bazel-based project. Extractor
-builds a kindex file for each `cc_library` and `cc_binary` in the project. This
+builds a kzip file for each `cc_library` and `cc_binary` in the project. This
 extractor based on Bazel
 [action_listener](https://docs.bazel.build/versions/master/be/extra-actions.html)
 rule.
@@ -20,9 +20,9 @@ the project.
 extra_action(
     name = "extractor",
     cmd = ("/opt/kythe/extractors/bazel_cxx_extractor " +
-           "$(EXTRA_ACTION_FILE) $(output $(ACTION_ID).cxx.kindex) $(location :vnames.json)"),
+           "$(EXTRA_ACTION_FILE) $(output $(ACTION_ID).cxx.kzip) $(location :vnames.json)"),
     data = [":vnames.json"],
-    out_templates = ["$(ACTION_ID).cxx.kindex"],
+    out_templates = ["$(ACTION_ID).cxx.kzip"],
 )
 
 action_listener(
@@ -59,12 +59,12 @@ bazel test --experimental_action_listener=:extract_cxx  //...
 bazel test --experimental_action_listener=:extract_cxx  //java/some/folder:foo
 ```
 
-Extracted kindex files will be in
-`bazel-out/local-fastbuild/extra_actions/extractor` folder. One kindex file per
+Extracted kzip files will be in
+`bazel-out/local-fastbuild/extra_actions/extractor` folder. One kzip file per
 target.
 
 ```shell
-find -L bazel-out -name '*cxx.kindex'
+find -L bazel-out -name '*cxx.kzip'
 ```
 
 #### Development

--- a/kythe/cxx/extractor/cxx_extractor_main.cc
+++ b/kythe/cxx/extractor/cxx_extractor_main.cc
@@ -17,7 +17,7 @@
 // cxx_extractor is meant to be a drop-in replacement for clang/gcc's frontend.
 // It collects all of the resources that clang would use to compile a single
 // source file (as determined by the command line arguments) and produces a
-// .kindex file.
+// .kzip file.
 //
 // We read environment variables KYTHE_CORPUS (to set the default corpus),
 // KYTHE_ROOT_DIRECTORY (to set the default root directory and to configure

--- a/kythe/cxx/extractor/objc_extractor_bazel_main.cc
+++ b/kythe/cxx/extractor/objc_extractor_bazel_main.cc
@@ -22,7 +22,7 @@
 // For example:
 //
 //  action_listener(
-//    name = "extract_kindex",
+//    name = "extract_kzip",
 //    extra_actions = [":extra_action"],
 //    mnemonics = ["ObjcCompile"],
 //    visibility = ["//visibility:public"],
@@ -32,7 +32,7 @@
 //    name = "extra_action",
 //    cmd = "$(location :objc_extractor_binary) \
 //             $(EXTRA_ACTION_FILE) \
-//             $(output $(ACTION_ID).objc.kindex) \
+//             $(output $(ACTION_ID).objc.kzip) \
 //             $(location :vnames_config) \
 //             $(location :get_devdir) \
 //             $(location :get_sdkroot)",
@@ -41,7 +41,7 @@
 //      ":get_sdkroot",
 //      ":vnames_config",
 //    ],
-//    out_templates = ["$(ACTION_ID).objc.kindex"],
+//    out_templates = ["$(ACTION_ID).objc.kzip"],
 //    tools = [":objc_extractor_binary"],
 //  )
 //

--- a/kythe/cxx/extractor/testdata/run_cxx_bazel_extraction.sh
+++ b/kythe/cxx/extractor/testdata/run_cxx_bazel_extraction.sh
@@ -17,7 +17,7 @@ set -o pipefail
 
 BAZELOUT="$(bazel info workspace)/bazel-out"
 bazel build \
-  --experimental_action_listener=//kythe/cxx/extractor:extract_kindex \
+  --experimental_action_listener=//kythe/extractors:extract_kzip_cxx \
   --experimental_extra_action_top_level_only \
   --experimental_proto_extra_actions \
   :cc_lib

--- a/kythe/cxx/extractor/testdata/run_objc_bazel_extraction.sh
+++ b/kythe/cxx/extractor/testdata/run_objc_bazel_extraction.sh
@@ -22,7 +22,7 @@ fi
 
 BAZELOUT="$(bazel info workspace)/bazel-out"
 bazel build \
-  --experimental_action_listener=//kythe/cxx/extractor:extract_kindex_objc \
+  --experimental_action_listener=//kythe/extractors:extract_kzip_objc \
   --experimental_extra_action_top_level_only \
   --experimental_proto_extra_actions \
   --ios_sdk_version=10.0 \


### PR DESCRIPTION
The cxx extractor only supports kzip outputs