### PR TITLE
fix(java_indexer): dynamically resolve JRE 9 bootclasspath

### DIFF
--- a/kythe/java/com/google/devtools/kythe/platform/java/JavacOptionsUtils.java
+++ b/kythe/java/com/google/devtools/kythe/platform/java/JavacOptionsUtils.java
@@ -42,12 +42,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
-import javax.tools.JavaFileManager;
 import javax.tools.OptionChecker;
 import javax.tools.StandardJavaFileManager;
 import javax.tools.StandardLocation;
@@ -100,18 +98,8 @@ public class JavacOptionsUtils {
 
   /** Returns the JRE 9-style bootclasspath. */
   private static ImmutableList<String> getBootclassPath() throws IOException {
-    Context context = new Context();
-    JavacTool.create()
-        .getTask(
-            /* out = */ null,
-            /* fileManager = */ null,
-            /* diagnosticListener = */ null,
-            /* options = */ Arrays.asList("--system", JAVA_HOME.toString()),
-            /* classes = */ null,
-            /* compilationUnits = */ null,
-            context);
     StandardJavaFileManager fileManager =
-        (StandardJavaFileManager) context.get(JavaFileManager.class);
+        JavacTool.create().getStandardFileManager(null, null, null);
 
     ImmutableList.Builder<String> paths = ImmutableList.builder();
     for (File file : fileManager.getLocation(StandardLocation.PLATFORM_CLASS_PATH)) {

--- a/kythe/java/com/google/devtools/kythe/platform/java/JavacOptionsUtils.java
+++ b/kythe/java/com/google/devtools/kythe/platform/java/JavacOptionsUtils.java
@@ -34,15 +34,23 @@ import com.sun.tools.javac.api.JavacTool;
 import com.sun.tools.javac.file.JavacFileManager;
 import com.sun.tools.javac.main.Option;
 import com.sun.tools.javac.util.Context;
+import java.io.File;
+import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
+import javax.tools.JavaFileManager;
 import javax.tools.OptionChecker;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.StandardLocation;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
@@ -52,18 +60,64 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  */
 public class JavacOptionsUtils {
 
+  private static final Path JAVA_HOME = Paths.get(StandardSystemProperty.JAVA_HOME.value());
   private static final ImmutableList<String> JRE_JARS =
-      ImmutableList.of(
-          "lib/rt.jar", "lib/resources.jar", "lib/jsse.jar", "lib/jce.jar", "lib/charsets.jar");
+      ImmutableList.of("rt.jar", "resources.jar", "jsse.jar", "jce.jar", "charsets.jar");
   private static final ImmutableList<String> JRE_PATHS;
 
   static {
-    ImmutableList.Builder<String> paths = ImmutableList.builder();
-    Path javaHome = Paths.get(StandardSystemProperty.JAVA_HOME.value());
-    for (String jreJar : JRE_JARS) {
-      paths.add(javaHome.resolve(jreJar).toString());
+    try {
+      ImmutableList<String> paths = getBootClassPath8();
+      if (paths.isEmpty()) {
+        paths = getBootclassPath();
+      }
+      JRE_PATHS = paths;
+    } catch (IOException ioe) {
+      throw new IllegalStateException(ioe);
     }
-    JRE_PATHS = paths.build();
+  }
+
+  /** Returns the JRE 8-style bootclasspath. */
+  private static ImmutableList<String> getBootClassPath8() throws IOException {
+    Path jreLib = JAVA_HOME.resolve("lib");
+    ImmutableList.Builder<String> jars = ImmutableList.builder();
+    Path extDir = jreLib.resolve("ext");
+    if (Files.exists(extDir)) {
+      try (DirectoryStream<Path> dirStream = Files.newDirectoryStream(extDir, "*.jar")) {
+        for (Path extJar : dirStream) {
+          jars.add(extJar.toString());
+        }
+      }
+    }
+    for (String jar : JRE_JARS) {
+      Path path = jreLib.resolve(jar);
+      if (Files.exists(path)) {
+        jars.add(path.toString());
+      }
+    }
+    return jars.build();
+  }
+
+  /** Returns the JRE 9-style bootclasspath. */
+  private static ImmutableList<String> getBootclassPath() throws IOException {
+    Context context = new Context();
+    JavacTool.create()
+        .getTask(
+            /* out = */ null,
+            /* fileManager = */ null,
+            /* diagnosticListener = */ null,
+            /* options = */ Arrays.asList("--system", JAVA_HOME.toString()),
+            /* classes = */ null,
+            /* compilationUnits = */ null,
+            context);
+    StandardJavaFileManager fileManager =
+        (StandardJavaFileManager) context.get(JavaFileManager.class);
+
+    ImmutableList.Builder<String> paths = ImmutableList.builder();
+    for (File file : fileManager.getLocation(StandardLocation.PLATFORM_CLASS_PATH)) {
+      paths.add(file.toString());
+    }
+    return paths.build();
   }
 
   private static final Splitter PATH_SPLITTER = Splitter.on(':').trimResults().omitEmptyStrings();

--- a/kythe/javatests/com/google/devtools/kythe/platform/java/OptionsTest.java
+++ b/kythe/javatests/com/google/devtools/kythe/platform/java/OptionsTest.java
@@ -17,7 +17,6 @@
 package com.google.devtools.kythe.platform.java;
 
 import static com.google.common.truth.Truth.assertThat;
-import static com.google.common.truth.Truth.assertWithMessage;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -144,10 +143,7 @@ public class OptionsTest {
     int idx = updatedArgs.indexOf("--boot-class-path");
     assertThat(updatedArgs).hasSize(idx + 2);
     assertThat(updatedArgs.get(idx + 1)).startsWith("not/a/real/path:also/fake");
-    assertThat(updatedArgs.get(idx + 1)).contains(".jar");
-    assertWithMessage("--boot-class-path should have a bunch of jars added")
-        .that(updatedArgs.get(idx + 1).length() > 50)
-        .isTrue();
+    assertThat(updatedArgs.get(idx + 1)).contains("lib/modules");
   }
 
   @Test
@@ -160,7 +156,8 @@ public class OptionsTest {
     assertThat(updatedArgs.get(updatedArgs.indexOf("--class-path") + 1))
         .startsWith("not/a/real/path:also/fake");
 
-    assertThat(updatedArgs.get(updatedArgs.indexOf("--boot-class-path") + 1)).contains(".jar");
+    assertThat(updatedArgs.get(updatedArgs.indexOf("--boot-class-path") + 1))
+        .contains("lib/modules");
   }
 
   @Test
@@ -208,6 +205,7 @@ public class OptionsTest {
     assertThat(updatedArgs).containsAtLeast("-doe", "--source-path", "--boot-class-path").inOrder();
     assertThat(updatedArgs.get(updatedArgs.indexOf("--source-path") + 1))
         .matches("source/from/details");
-    assertThat(updatedArgs.get(updatedArgs.indexOf("--boot-class-path") + 1)).contains(".jar");
+    assertThat(updatedArgs.get(updatedArgs.indexOf("--boot-class-path") + 1))
+        .contains("lib/modules");
   }
 }


### PR DESCRIPTION
If no JRE 8-style jars are found, fall-back to finding the default
bootclasspath for JRE 9+ using a StandardFileManager instance.