### PR TITLE
feature(typescript_indexer): emit reference for "this" keyword

### DIFF
--- a/kythe/typescript/indexer.ts
+++ b/kythe/typescript/indexer.ts
@@ -1534,6 +1534,28 @@ class Visitor {
   }
 
   /**
+   * Emits a reference from a "this" keyword to the type of the "this" object.
+   */
+  visitThisKeyword(keyword: ts.ThisExpression) {
+    const sym = this.host.getSymbolAtLocation(keyword);
+    if (!sym) {
+      // "this" refers to an object with no particular type, e.g.
+      //   let obj = {
+      //     foo() { this.foo(); }
+      //   };
+      return;
+    }
+    if (!sym.declarations || sym.declarations.length === 0) {
+      // "this" keyword is `globalThis`, which has no declarations.
+      return;
+    }
+
+    const type = this.host.getSymbolName(sym, TSNamespace.TYPE);
+    const thisAnchor = this.newAnchor(keyword);
+    this.emitEdge(thisAnchor, EdgeKind.REF, type);
+  }
+
+  /**
    * visitJSDoc attempts to attach a 'doc' node to a given target, by looking
    * for JSDoc comments.
    */
@@ -1625,6 +1647,8 @@ class Visitor {
         // circumstances (e.g. in a type) separately in visitType.
         this.visitExpressionMember(node);
         return;
+      case ts.SyntaxKind.ThisKeyword:
+        return this.visitThisKeyword(node as ts.ThisExpression);
       case ts.SyntaxKind.ModuleDeclaration:
         return this.visitModuleDeclaration(node as ts.ModuleDeclaration);
       default:

--- a/kythe/typescript/testdata/class.ts
+++ b/kythe/typescript/testdata/class.ts
@@ -57,8 +57,10 @@ class Class implements IFace {
     //- Method.node/kind function
     //- Method childof Class
     method() {
+        //- @this ref Class
         //- @member ref Member
         this.member;
+        //- @this ref Class
         //- @method ref Method
         this.method();
     }


### PR DESCRIPTION
Emit a reference between "this" keywords that have a particular type and
the type of the object they refer to. For instance,

```typescript
//- @C defines/binding CType
class C {
  foo() {
    //- @this ref CType
    this.foo();
  }
}
```

Nothing is done for "this" keywords that do not refer to any particular
type. In

```typescript
let obj = {
  foo() {
    this.foo();
  }
}
```

`obj` has no particular type other than `object` and so no reference is
emitted. The same applies to class expressions.