### PR TITLE
fix(java_common): add file digest as Path URI host

### DIFF
--- a/kythe/java/com/google/devtools/kythe/platform/shared/filesystem/CompilationUnitFileSystem.java
+++ b/kythe/java/com/google/devtools/kythe/platform/shared/filesystem/CompilationUnitFileSystem.java
@@ -179,7 +179,7 @@ final class CompilationUnitFileSystem extends FileSystem {
     }
   }
 
-  String digest(Path file) throws IOException {
+  String digest(Path file) {
     checkNotNull(file);
     file = getRootDirectory().resolve(file);
     if (file.getFileName() == null) {


### PR DESCRIPTION
The Java indexer uses the JavaFileObject's URI host as a key for looking up (or constructing) a file VName.  While it should likely just use the path directly, it's easy enough to support this in CompilationUnitPath for now.