### PR TITLE
feat(serving): experimental support for xrefs indirection

### DIFF
--- a/kythe/go/serving/xrefs/BUILD
+++ b/kythe/go/serving/xrefs/BUILD
@@ -13,6 +13,7 @@ go_library(
         "//kythe/go/serving/xrefs/columnar",
         "//kythe/go/storage/keyvalue",
         "//kythe/go/storage/table",
+        "//kythe/go/util/flagutil",
         "//kythe/go/util/keys",
         "//kythe/go/util/kytheuri",
         "//kythe/go/util/schema",

--- a/kythe/go/serving/xrefs/xrefs.go
+++ b/kythe/go/serving/xrefs/xrefs.go
@@ -35,8 +35,10 @@ import (
 
 	"kythe.io/kythe/go/services/xrefs"
 	"kythe.io/kythe/go/storage/table"
+	"kythe.io/kythe/go/util/flagutil"
 	"kythe.io/kythe/go/util/kytheuri"
 	"kythe.io/kythe/go/util/schema/edges"
+	"kythe.io/kythe/go/util/schema/facts"
 	"kythe.io/kythe/go/util/schema/tickets"
 	"kythe.io/kythe/go/util/span"
 
@@ -55,7 +57,14 @@ import (
 
 var (
 	mergeCrossReferences = flag.Bool("merge_cross_references", true, "Whether to merge nodes when responding to a CrossReferencesRequest")
+
+	experimentalCrossReferenceIndirectionKinds flagutil.StringMultimap
 )
+
+func init() {
+	flag.Var(&experimentalCrossReferenceIndirectionKinds, "experimental_cross_reference_indirection_kinds",
+		`Comma-separated set of key-value pairs (node_kind=edge_kind) to indirect through in CrossReferences.  For example, "talias=/kythe/edge/aliases" indicates that the targets of a 'talias' node's '/kythe/edge/aliases' related nodes will have their cross-references merged into the root 'talias' node's.`)
+}
 
 type staticLookupTables interface {
 	fileDecorations(ctx context.Context, ticket string) (*srvpb.FileDecorations, error)
@@ -523,16 +532,13 @@ func (t *Table) CrossReferences(ctx context.Context, req *xpb.CrossReferencesReq
 		if *mergeCrossReferences {
 			// Add any additional merge nodes to the set of table lookups
 			for _, mergeNode := range cr.MergeWith {
-				if prevMerge, ok := mergeInto[mergeNode]; ok {
-					if prevMerge != ticket {
-						log.Printf("WARNING: node %q already previously merged with %q", mergeNode, prevMerge)
-					}
-					continue
-				}
-				tickets = append(tickets, mergeNode)
-				mergeInto[mergeNode] = ticket
+				tickets = addMergeNode(mergeInto, tickets, ticket, mergeNode)
 			}
 		}
+
+		// Read the set of indirection edge kinds for the given node kind.
+		nodeKind := nodeKind(cr.SourceNode)
+		indirections := experimentalCrossReferenceIndirectionKinds[nodeKind]
 
 		for _, grp := range cr.Group {
 			// Filter anchor groups based on requested build configs
@@ -556,10 +562,19 @@ func (t *Table) CrossReferences(ctx context.Context, req *xpb.CrossReferencesReq
 				if wantMoreCrossRefs {
 					stats.addAnchors(&crs.Reference, grp, req.AnchorText)
 				}
-			case len(req.Filter) > 0 && xrefs.IsRelatedNodeKind(relatedKinds, grp.Kind):
-				reply.Total.RelatedNodesByRelation[grp.Kind] += int64(len(grp.RelatedNode))
-				if wantMoreCrossRefs {
-					stats.addRelatedNodes(reply, crs, grp, patterns)
+			case len(grp.RelatedNode) > 0:
+				// If requested, add related nodes to merge node set.
+				if indirections.Contains(grp.Kind) {
+					for _, rn := range grp.RelatedNode {
+						tickets = addMergeNode(mergeInto, tickets, ticket, rn.Node.GetTicket())
+					}
+				}
+
+				if len(req.Filter) > 0 && xrefs.IsRelatedNodeKind(relatedKinds, grp.Kind) {
+					reply.Total.RelatedNodesByRelation[grp.Kind] += int64(len(grp.RelatedNode))
+					if wantMoreCrossRefs {
+						stats.addRelatedNodes(reply, crs, grp, patterns)
+					}
 				}
 			case xrefs.IsCallerKind(req.CallerKind, grp.Kind):
 				reply.Total.Callers += int64(len(grp.Caller))
@@ -603,14 +618,32 @@ func (t *Table) CrossReferences(ctx context.Context, req *xpb.CrossReferencesReq
 					}
 					stats.addAnchors(&crs.Reference, p.Group, req.AnchorText)
 				}
-			case len(req.Filter) > 0 && xrefs.IsRelatedNodeKind(relatedKinds, idx.Kind):
-				reply.Total.RelatedNodesByRelation[idx.Kind] += int64(idx.Count)
-				if wantMoreCrossRefs && !stats.skipPage(idx) {
-					p, err := t.crossReferencesPage(ctx, idx.PageKey)
+			case xrefs.IsRelatedNodeKind(nil, idx.Kind):
+				var p *srvpb.PagedCrossReferences_Page
+
+				// If requested, add related nodes to merge node set.
+				if indirections.Contains(idx.Kind) {
+					p, err = t.crossReferencesPage(ctx, idx.PageKey)
 					if err != nil {
 						return nil, fmt.Errorf("internal error: error retrieving cross-references page: %v", idx.PageKey)
 					}
-					stats.addRelatedNodes(reply, crs, p.Group, patterns)
+
+					for _, rn := range p.Group.RelatedNode {
+						tickets = addMergeNode(mergeInto, tickets, ticket, rn.Node.GetTicket())
+					}
+				}
+
+				if len(req.Filter) > 0 && xrefs.IsRelatedNodeKind(relatedKinds, idx.Kind) {
+					reply.Total.RelatedNodesByRelation[idx.Kind] += int64(idx.Count)
+					if wantMoreCrossRefs && !stats.skipPage(idx) {
+						if p == nil {
+							p, err = t.crossReferencesPage(ctx, idx.PageKey)
+							if err != nil {
+								return nil, fmt.Errorf("internal error: error retrieving cross-references page: %v", idx.PageKey)
+							}
+						}
+						stats.addRelatedNodes(reply, crs, p.Group, patterns)
+					}
 				}
 			case xrefs.IsCallerKind(req.CallerKind, idx.Kind):
 				reply.Total.Callers += int64(idx.Count)
@@ -667,6 +700,27 @@ func (t *Table) CrossReferences(ctx context.Context, req *xpb.CrossReferencesReq
 	}
 
 	return reply, nil
+}
+
+func addMergeNode(mergeMap map[string]string, allTickets []string, rootNode, mergeNode string) []string {
+	if prevMerge, ok := mergeMap[mergeNode]; ok {
+		if prevMerge != rootNode {
+			log.Printf("WARNING: node %q already previously merged with %q", mergeNode, prevMerge)
+		}
+		return allTickets
+	}
+	allTickets = append(allTickets, mergeNode)
+	mergeMap[mergeNode] = rootNode
+	return allTickets
+}
+
+func nodeKind(n *srvpb.Node) string {
+	for _, f := range n.Fact {
+		if f.Name == facts.NodeKind {
+			return string(f.Value)
+		}
+	}
+	return ""
 }
 
 func sumTotalCrossRefs(ts *xpb.CrossReferencesReply_Total) int {

--- a/kythe/go/serving/xrefs/xrefs_test.go
+++ b/kythe/go/serving/xrefs/xrefs_test.go
@@ -402,7 +402,7 @@ var (
 			SourceTicket: "kythe:#aliasNode",
 			SourceNode:   getNode("kythe:#aliasNode"),
 			Group: []*srvpb.PagedCrossReferences_Group{{
-				Kind: "/kythe/edge/aliases",
+				Kind: "%/kythe/edge/aliases",
 				RelatedNode: []*srvpb.PagedCrossReferences_RelatedNode{{
 					Node: getNode("kythe://someCorpus?lang=otpl#signature"),
 				}},
@@ -1310,7 +1310,7 @@ func TestCrossReferencesIndirection(t *testing.T) {
 	t.Run("talias", func(t *testing.T) {
 		// Enable indirection for talias nodes.
 		experimentalCrossReferenceIndirectionKinds = nil
-		experimentalCrossReferenceIndirectionKinds.Set("talias=/kythe/edge/aliases")
+		experimentalCrossReferenceIndirectionKinds.Set("talias=%/kythe/edge/aliases")
 
 		reply, err := st.CrossReferences(ctx, &xpb.CrossReferencesRequest{
 			Ticket:        []string{ticket},

--- a/kythe/go/util/flagutil/flagutil.go
+++ b/kythe/go/util/flagutil/flagutil.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"kythe.io/kythe/go/util/build"
@@ -137,6 +138,54 @@ func (f *StringSet) String() string {
 func (f *StringSet) Get() interface{} {
 	if f == nil {
 		return stringset.Set(nil)
+	}
+	return *f
+}
+
+// StringMultimap implements a flag.Value that accepts an set of key-value entries as a CSV.
+type StringMultimap map[string]stringset.Set
+
+// Set implements part of the flag.Getter interface and will append new values to the flag.
+func (f *StringMultimap) Set(s string) error {
+	if *f == nil {
+		*f = make(map[string]stringset.Set)
+	}
+	m := *f
+	for _, e := range strings.Split(s, ",") {
+		pair := strings.SplitN(e, "=", 2)
+		if len(pair) != 2 {
+			return fmt.Errorf("invalid key-value entry: %q", e)
+		}
+		key, val := pair[0], pair[1]
+		set := m[key]
+		if set == nil {
+			set = stringset.New()
+			m[key] = set
+		}
+		set.Add(val)
+	}
+	return nil
+}
+
+// String implements part of the flag.Getter interface and returns a string-ish value for the flag.
+func (f *StringMultimap) String() string {
+	if f == nil || *f == nil {
+		return "{}"
+	}
+	entries := make([]string, 0, len(*f))
+	for k, vs := range *f {
+		for _, v := range vs.Elements() {
+			entries = append(entries, fmt.Sprintf("%s=%s", k, v))
+		}
+	}
+	sort.Strings(entries)
+	return strings.Join(entries, ",")
+}
+
+// Get implements flag.Getter and returns a slice of string values.
+func (f *StringMultimap) Get() interface{} {
+	if f == nil {
+		return map[string]stringset.Set(nil)
 	}
 	return *f
 }


### PR DESCRIPTION
Add `--experimental_cross_reference_indirection_kinds` flag, a multimap
from node kind to edge kinds, to Kythe xrefs server.  When handling a
CrossReferences request, if a requested node has a specified node kind,
all related nodes passing through one of the specified edge kinds will
be added the merged node set for the request.  This allows for dynamic
single-directional, top-down indirection through nodes such aliases or
universal name nodes.