### PR TITLE
typescript: update from 3.3 => 3.5

### DIFF
--- a/kythe/typescript/package.json
+++ b/kythe/typescript/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "source-map-support": "^0.4.11",
-    "typescript": "~3.3.3"
+    "typescript": "~3.5.3"
   },
   "devDependencies": {
     "@types/jasmine": "^2.8.8",

--- a/kythe/typescript/yarn.lock
+++ b/kythe/typescript/yarn.lock
@@ -88,9 +88,10 @@ source-map@^0.5.3:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
 
-typescript@~3.3.3:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.3.3.tgz#f1657fc7daa27e1a8930758ace9ae8da31403221"
+typescript@~3.5.3:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
+  integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
 
 wrappy@1:
   version "1.0.2"


### PR DESCRIPTION
There are no changes needed for this particular upgrade but it's good to
keep this in sync with current TypeScript in case the difference
matters.