### PR TITLE
typescript: handle 'typeof'

### DIFF
--- a/kythe/typescript/indexer.ts
+++ b/kythe/typescript/indexer.ts
@@ -828,6 +828,12 @@ class Visitor {
         }
         // Otherwise, leave it to the default handling.
         break;
+      case ts.SyntaxKind.TypeQuery:
+        // This is a 'typeof' expression, which takes a value as its argument,
+        // so use visit() instead of visitType().
+        const typeQuery = node as ts.TypeQueryNode;
+        this.visit(typeQuery.exprName);
+        return;  // Avoid default recursion.
     }
 
     // Default recursion, but using visitType(), not visit().

--- a/kythe/typescript/testdata/typeof.ts
+++ b/kythe/typescript/testdata/typeof.ts
@@ -1,0 +1,12 @@
+export {};
+
+//- @obj defines/binding Obj
+const obj = {
+  a: ''
+};
+
+// Verify that a reference within a 'typeof' clause refers to the value.
+//- @obj ref Obj
+const user: typeof obj = {
+  a: ''
+};


### PR DESCRIPTION
'typeof' appears in type expressions and takes a value as its argument,
so when we encounter one we continue recursion using the value visitor
visit() instead of the type visitor visitType().