### PR TITLE
chore(build): update protobuf dependency and clean up repo names

### DIFF
--- a/external.bzl
+++ b/external.bzl
@@ -2,8 +2,8 @@ load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
-load("@io_bazel_rules_java//java:repositories.bzl", "rules_java_dependencies")
-load("@io_bazel_rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
+load("@rules_java//java:repositories.bzl", "rules_java_dependencies")
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
 load("@io_kythe//:setup.bzl", "maybe")
 load("@io_kythe//tools:build_rules/shims.bzl", "go_repository")
 load("@io_kythe//tools/build_rules/llvm:repo.bzl", "git_llvm_repository")
@@ -18,6 +18,14 @@ def _rule_dependencies():
     rules_proto_dependencies()
 
 def _cc_dependencies():
+    maybe(
+        http_archive,
+        name = "rules_cc",
+        sha256 = "29daf0159f0cf552fcff60b49d8bcd4f08f08506d2da6e41b07058ec50cfeaec",
+        strip_prefix = "rules_cc-b7fe9697c0c76ab2fd431a891dbb9a6a32ed7c3e",
+        urls = ["https://github.com/bazelbuild/rules_cc/archive/b7fe9697c0c76ab2fd431a891dbb9a6a32ed7c3e.tar.gz"],
+    )
+
     maybe(
         http_archive,
         name = "net_zlib",
@@ -697,11 +705,21 @@ def _sample_ui_dependencies():
         version = "2.5.3",
     )
 
+def _py_dependencies():
+    maybe(
+        http_archive,
+        name = "rules_python",  # Needed by com_google_protobuf.
+        sha256 = "e5470e92a18aa51830db99a4d9c492cc613761d5bdb7131c04bd92b9834380f6",
+        strip_prefix = "rules_python-4b84ad270387a7c439ebdccfd530e2339601ef27",
+        urls = ["https://github.com/bazelbuild/rules_python/archive/4b84ad270387a7c439ebdccfd530e2339601ef27.tar.gz"],
+    )
+
 def kythe_dependencies(sample_ui = True):
     """Defines external repositories for Kythe dependencies.
 
     Call this once in your WORKSPACE file to load all @io_kythe dependencies.
     """
+    _py_dependencies()
     _cc_dependencies()
     _go_dependencies()
     _java_dependencies()
@@ -712,9 +730,10 @@ def kythe_dependencies(sample_ui = True):
     maybe(
         http_archive,
         name = "com_google_protobuf",
-        sha256 = "ef62ee52bedc3a0ec0aeb7911279243119d53eac7f8bbbec833761c07e802bcb",
-        strip_prefix = "protobuf-8e5ea65953f3c47e01bca360ecf3abdf2c8b1c33",
-        urls = ["https://github.com/protocolbuffers/protobuf/archive/8e5ea65953f3c47e01bca360ecf3abdf2c8b1c33.zip"],
+        sha256 = "ee128d0b67751cd1095009849c9a13a30b2562f0351d91d30c1ea36379443a07",
+        strip_prefix = "protobuf-402c28a321fce010ad0b9f99010a78890cae7f34",
+        urls = ["https://github.com/protocolbuffers/protobuf/archive/402c28a321fce010ad0b9f99010a78890cae7f34.zip"],
+        repo_mapping = {"@zlib": "@net_zlib"},
     )
 
     maybe(

--- a/kythe/cxx/common/kzip_reader.cc
+++ b/kythe/cxx/common/kzip_reader.cc
@@ -59,7 +59,7 @@ class ZipFileInputStream : public google::protobuf::io::ZeroCopyInputStream {
 
   void BackUp(int count) override { impl_.BackUp(count); }
   bool Skip(int count) override { return impl_.Skip(count); }
-  google::protobuf::int64 ByteCount() const override {
+  google::protobuf::io::ByteCountInt64 ByteCount() const override {
     return impl_.ByteCount();
   }
 

--- a/kythe/cxx/tools/proto_metadata_plugin.cc
+++ b/kythe/cxx/tools/proto_metadata_plugin.cc
@@ -102,7 +102,7 @@ class WrappedOutputStream : public ZeroCopyOutputStream {
     return wrapped_->Next(data, size);
   }
   void BackUp(int count) override { return wrapped_->BackUp(count); }
-  google::protobuf::int64 ByteCount() const override {
+  google::protobuf::io::ByteCountInt64 ByteCount() const override {
     return wrapped_->ByteCount();
   }
   bool WriteAliasedRaw(const void* data, int size) override {
@@ -123,7 +123,7 @@ class GzipStringOutputStream : public ZeroCopyOutputStream {
     return gzip_stream_.Next(data, size);
   }
   void BackUp(int count) override { return gzip_stream_.BackUp(count); }
-  google::protobuf::int64 ByteCount() const override {
+  google::protobuf::io::ByteCountInt64 ByteCount() const override {
     return gzip_stream_.ByteCount();
   }
   bool WriteAliasedRaw(const void* data, int size) override {

--- a/kythe/examples/proto/BUILD
+++ b/kythe/examples/proto/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_proto//proto:defs.bzl", "proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 package(default_visibility = ["//kythe:default_visibility"])
 

--- a/kythe/extractors/BUILD
+++ b/kythe/extractors/BUILD
@@ -1,5 +1,5 @@
-load("@io_bazel_rules_proto//proto:defs.bzl", "proto_lang_toolchain")
-load("@io_bazel_rules_java//java:defs.bzl", "java_library")
+load("@rules_proto//proto:defs.bzl", "proto_lang_toolchain")
+load("@rules_java//java:defs.bzl", "java_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/kythe/go/util/riegeli/BUILD
+++ b/kythe/go/util/riegeli/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_proto//proto:defs.bzl", "proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 load("//kythe/proto:go.bzl", "go_kythe_proto")
 load("//tools:build_rules/shims.bzl", "go_library", "go_test")
 

--- a/kythe/java/com/google/devtools/kythe/analyzers/base/BUILD
+++ b/kythe/java/com/google/devtools/kythe/analyzers/base/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_java//java:defs.bzl", "java_library")
+load("@rules_java//java:defs.bzl", "java_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/kythe/java/com/google/devtools/kythe/analyzers/java/BUILD
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_java//java:defs.bzl", "java_library", "java_binary")
+load("@rules_java//java:defs.bzl", "java_library", "java_binary")
 
 package(default_visibility = ["//kythe:default_visibility"])
 

--- a/kythe/java/com/google/devtools/kythe/analyzers/jvm/BUILD
+++ b/kythe/java/com/google/devtools/kythe/analyzers/jvm/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_java//java:defs.bzl", "java_library", "java_binary")
+load("@rules_java//java:defs.bzl", "java_library", "java_binary")
 
 package(
     default_visibility = ["//kythe:default_visibility"],

--- a/kythe/java/com/google/devtools/kythe/common/BUILD
+++ b/kythe/java/com/google/devtools/kythe/common/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_java//java:defs.bzl", "java_library", "java_plugin")
+load("@rules_java//java:defs.bzl", "java_library", "java_plugin")
 
 package(default_visibility = ["//kythe:default_visibility"])
 

--- a/kythe/java/com/google/devtools/kythe/doc/BUILD
+++ b/kythe/java/com/google/devtools/kythe/doc/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_java//java:defs.bzl", "java_library")
+load("@rules_java//java:defs.bzl", "java_library")
 
 package(default_visibility = ["//kythe:default_visibility"])
 

--- a/kythe/java/com/google/devtools/kythe/extractors/java/BUILD
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_java//java:defs.bzl", "java_library")
+load("@rules_java//java:defs.bzl", "java_library")
 
 package(default_visibility = ["//kythe:default_visibility"])
 

--- a/kythe/java/com/google/devtools/kythe/extractors/java/bazel/BUILD
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/bazel/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_java//java:defs.bzl", "java_binary")
+load("@rules_java//java:defs.bzl", "java_binary")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/kythe/java/com/google/devtools/kythe/extractors/java/standalone/BUILD
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/standalone/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_java//java:defs.bzl", "java_library", "java_binary")
+load("@rules_java//java:defs.bzl", "java_library", "java_binary")
 
 package(default_visibility = ["//kythe:default_visibility"])
 

--- a/kythe/java/com/google/devtools/kythe/extractors/jvm/BUILD
+++ b/kythe/java/com/google/devtools/kythe/extractors/jvm/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_java//java:defs.bzl", "java_library", "java_binary")
+load("@rules_java//java:defs.bzl", "java_library", "java_binary")
 
 package(default_visibility = ["//kythe:default_visibility"])
 

--- a/kythe/java/com/google/devtools/kythe/extractors/jvm/bazel/BUILD
+++ b/kythe/java/com/google/devtools/kythe/extractors/jvm/bazel/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_java//java:defs.bzl", "java_binary")
+load("@rules_java//java:defs.bzl", "java_binary")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/kythe/java/com/google/devtools/kythe/extractors/shared/BUILD
+++ b/kythe/java/com/google/devtools/kythe/extractors/shared/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_java//java:defs.bzl", "java_library")
+load("@rules_java//java:defs.bzl", "java_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/kythe/java/com/google/devtools/kythe/platform/indexpack/BUILD
+++ b/kythe/java/com/google/devtools/kythe/platform/indexpack/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_java//java:defs.bzl", "java_library")
+load("@rules_java//java:defs.bzl", "java_library")
 
 package(default_visibility = ["//kythe:default_visibility"])
 

--- a/kythe/java/com/google/devtools/kythe/platform/java/BUILD
+++ b/kythe/java/com/google/devtools/kythe/platform/java/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_java//java:defs.bzl", "java_library")
+load("@rules_java//java:defs.bzl", "java_library")
 
 package(default_visibility = ["//kythe:default_visibility"])
 

--- a/kythe/java/com/google/devtools/kythe/platform/java/filemanager/BUILD
+++ b/kythe/java/com/google/devtools/kythe/platform/java/filemanager/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_java//java:defs.bzl", "java_library")
+load("@rules_java//java:defs.bzl", "java_library")
 
 package(default_visibility = ["//kythe:default_visibility"])
 

--- a/kythe/java/com/google/devtools/kythe/platform/java/helpers/BUILD
+++ b/kythe/java/com/google/devtools/kythe/platform/java/helpers/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_java//java:defs.bzl", "java_library")
+load("@rules_java//java:defs.bzl", "java_library")
 
 package(default_visibility = ["//kythe:default_visibility"])
 

--- a/kythe/java/com/google/devtools/kythe/platform/kzip/BUILD
+++ b/kythe/java/com/google/devtools/kythe/platform/kzip/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_java//java:defs.bzl", "java_library")
+load("@rules_java//java:defs.bzl", "java_library")
 
 package(default_visibility = ["//kythe:default_visibility"])
 

--- a/kythe/java/com/google/devtools/kythe/platform/shared/BUILD
+++ b/kythe/java/com/google/devtools/kythe/platform/shared/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_java//java:defs.bzl", "java_library")
+load("@rules_java//java:defs.bzl", "java_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/kythe/java/com/google/devtools/kythe/platform/shared/filesystem/BUILD
+++ b/kythe/java/com/google/devtools/kythe/platform/shared/filesystem/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_java//java:defs.bzl", "java_library")
+load("@rules_java//java:defs.bzl", "java_library")
 
 package(default_visibility = ["//kythe:default_visibility"])
 

--- a/kythe/java/com/google/devtools/kythe/util/BUILD
+++ b/kythe/java/com/google/devtools/kythe/util/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_java//java:defs.bzl", "java_library")
+load("@rules_java//java:defs.bzl", "java_library")
 
 package(default_visibility = ["//kythe:default_visibility"])
 

--- a/kythe/java/com/google/devtools/kythe/util/schema/BUILD
+++ b/kythe/java/com/google/devtools/kythe/util/schema/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_java//java:defs.bzl", "java_library")
+load("@rules_java//java:defs.bzl", "java_library")
 
 package(default_visibility = ["//kythe:default_visibility"])
 

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/base/BUILD
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/base/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_java//java:defs.bzl", "java_test")
+load("@rules_java//java:defs.bzl", "java_test")
 
 java_test(
     name = "stream_fact_emitter_test",

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/BUILD
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_java//java:defs.bzl", "java_library", "java_test")
+load("@rules_java//java:defs.bzl", "java_library", "java_test")
 load("//tools:build_rules/testing.bzl", "shell_tool_test")
 
 shell_tool_test(

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/BUILD
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_java//java:defs.bzl", "java_library")
+load("@rules_java//java:defs.bzl", "java_library")
 load("//tools/build_rules/verifier_test:java_verifier_test.bzl", "java_extract_kzip", "java_verifier_test")
 
 exports_files(

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/BUILD
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_java//java:defs.bzl", "java_library")
+load("@rules_java//java:defs.bzl", "java_library")
 load("//tools/build_rules/verifier_test:java_verifier_test.bzl", "java_verifier_test")
 
 filegroup(

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/proto/BUILD
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/proto/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_proto//proto:defs.bzl", "proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 load("//tools/build_rules/verifier_test:java_verifier_test.bzl", "java_proto_verifier_test")
 
 exports_files(glob(["*.proto"]))

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/regression/BUILD
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/regression/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_java//java:defs.bzl", "java_library")
+load("@rules_java//java:defs.bzl", "java_library")
 load("//tools/build_rules/verifier_test:java_verifier_test.bzl", "java_verifier_test")
 
 filegroup(

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/jvm/BUILD
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/jvm/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_java//java:defs.bzl", "java_test")
+load("@rules_java//java:defs.bzl", "java_test")
 
 java_test(
     name = "jvm_graph_test",

--- a/kythe/javatests/com/google/devtools/kythe/doc/BUILD
+++ b/kythe/javatests/com/google/devtools/kythe/doc/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_java//java:defs.bzl", "java_test")
+load("@rules_java//java:defs.bzl", "java_test")
 
 package(default_visibility = ["//kythe:default_visibility"])
 

--- a/kythe/javatests/com/google/devtools/kythe/extractors/java/BUILD
+++ b/kythe/javatests/com/google/devtools/kythe/extractors/java/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_java//java:defs.bzl", "java_binary", "java_test")
+load("@rules_java//java:defs.bzl", "java_binary", "java_test")
 
 java_test(
     name = "java_extractor_test",

--- a/kythe/javatests/com/google/devtools/kythe/extractors/shared/BUILD
+++ b/kythe/javatests/com/google/devtools/kythe/extractors/shared/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_java//java:defs.bzl", "java_test")
+load("@rules_java//java:defs.bzl", "java_test")
 
 package(default_visibility = ["//kythe:default_visibility"])
 

--- a/kythe/javatests/com/google/devtools/kythe/platform/indexpack/BUILD
+++ b/kythe/javatests/com/google/devtools/kythe/platform/indexpack/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_java//java:defs.bzl", "java_test")
+load("@rules_java//java:defs.bzl", "java_test")
 
 package(default_visibility = ["//kythe:default_visibility"])
 

--- a/kythe/javatests/com/google/devtools/kythe/platform/java/BUILD
+++ b/kythe/javatests/com/google/devtools/kythe/platform/java/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_java//java:defs.bzl", "java_test")
+load("@rules_java//java:defs.bzl", "java_test")
 
 package(default_visibility = ["//kythe:default_visibility"])
 

--- a/kythe/javatests/com/google/devtools/kythe/platform/java/filemanager/BUILD
+++ b/kythe/javatests/com/google/devtools/kythe/platform/java/filemanager/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_java//java:defs.bzl", "java_test")
+load("@rules_java//java:defs.bzl", "java_test")
 
 package(default_visibility = ["//kythe:default_visibility"])
 

--- a/kythe/javatests/com/google/devtools/kythe/platform/kzip/BUILD
+++ b/kythe/javatests/com/google/devtools/kythe/platform/kzip/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_java//java:defs.bzl", "java_library", "java_test")
+load("@rules_java//java:defs.bzl", "java_library", "java_test")
 
 java_test(
     name = "kzip_reader_test",

--- a/kythe/javatests/com/google/devtools/kythe/platform/shared/BUILD
+++ b/kythe/javatests/com/google/devtools/kythe/platform/shared/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_java//java:defs.bzl", "java_test")
+load("@rules_java//java:defs.bzl", "java_test")
 
 package(default_visibility = ["//kythe:default_visibility"])
 

--- a/kythe/javatests/com/google/devtools/kythe/platform/shared/filesystem/BUILD
+++ b/kythe/javatests/com/google/devtools/kythe/platform/shared/filesystem/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_java//java:defs.bzl", "java_test")
+load("@rules_java//java:defs.bzl", "java_test")
 
 package(default_visibility = ["//kythe:default_visibility"])
 

--- a/kythe/javatests/com/google/devtools/kythe/util/BUILD
+++ b/kythe/javatests/com/google/devtools/kythe/util/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_java//java:defs.bzl", "java_test")
+load("@rules_java//java:defs.bzl", "java_test")
 
 package(default_visibility = ["//kythe:default_visibility"])
 

--- a/kythe/javatests/com/google/devtools/kythe/util/schema/BUILD
+++ b/kythe/javatests/com/google/devtools/kythe/util/schema/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_java//java:defs.bzl", "java_test")
+load("@rules_java//java:defs.bzl", "java_test")
 
 package(default_visibility = ["//kythe:default_visibility"])
 

--- a/kythe/proto/BUILD
+++ b/kythe/proto/BUILD
@@ -1,5 +1,5 @@
-load("@io_bazel_rules_proto//proto:defs.bzl", "proto_library")
-load("@io_bazel_rules_java//java:defs.bzl", "java_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@rules_java//java:defs.bzl", "java_proto_library")
 
 package(default_visibility = ["//kythe:proto_visibility"])
 

--- a/setup.bzl
+++ b/setup.bzl
@@ -12,21 +12,24 @@ def kythe_rule_repositories():
 
     These repositories must be loaded before calling external.bzl%kythe_dependencies.
     """
-    http_archive(
+    maybe(
+        http_archive,
         name = "io_bazel_rules_go",
         url = "https://github.com/bazelbuild/rules_go/releases/download/0.18.5/rules_go-0.18.5.tar.gz",
         sha256 = "a82a352bffae6bee4e95f68a8d80a70e87f42c4741e6a448bec11998fcc82329",
     )
 
-    http_archive(
-        name = "io_bazel_rules_java",
+    maybe(
+        http_archive,
+        name = "rules_java",
         url = "https://github.com/bazelbuild/rules_java/archive/973a93dd2d698929264d1028836f6b9cc60ff817.zip",
         sha256 = "a6cb0dbe343b67c7d4f3f11a68e327acdfc71fee1e17affa4e605129fc56bb15",
         strip_prefix = "rules_java-973a93dd2d698929264d1028836f6b9cc60ff817",
     )
 
-    http_archive(
-        name = "io_bazel_rules_proto",
+    maybe(
+        http_archive,
+        name = "rules_proto",
         sha256 = "e4fe70af52135d2ee592a07f916e6e1fc7c94cf8786c15e8c0d0f08b1fe5ea16",
         strip_prefix = "rules_proto-97d8af4dc474595af3900dd85cb3a29ad28cc313",
         url = "https://github.com/bazelbuild/rules_proto/archive/97d8af4dc474595af3900dd85cb3a29ad28cc313.zip",

--- a/third_party/bazel/BUILD
+++ b/third_party/bazel/BUILD
@@ -1,5 +1,5 @@
-load("@io_bazel_rules_proto//proto:defs.bzl", "proto_library")
-load("@io_bazel_rules_java//java:defs.bzl", "java_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@rules_java//java:defs.bzl", "java_proto_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/third_party/guava/BUILD
+++ b/third_party/guava/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_java//java:defs.bzl", "java_library")
+load("@rules_java//java:defs.bzl", "java_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/third_party/javac/BUILD
+++ b/third_party/javac/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_java//java:defs.bzl", "java_import")
+load("@rules_java//java:defs.bzl", "java_import")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/third_party/truth/BUILD
+++ b/third_party/truth/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_java//java:defs.bzl", "java_library")
+load("@rules_java//java:defs.bzl", "java_library")
 
 package(default_visibility = ["//visibility:public"])
 


### PR DESCRIPTION
Protobuf is attempting to harmonize some aliases and this is an intermediate step.  Unfortunately, this version introduces some dependencies on rules_python and rules_proto.  The latter highlighted some naming differences between the name we used in the repository rules and that used upstream, so I fixed our rules to use the preferred names.