### PR TITLE
chore(cxx_common): replace uses of llvm::make_unique w/ absl::make_unique

### DIFF
--- a/kythe/cxx/extractor/cxx_extractor.cc
+++ b/kythe/cxx/extractor/cxx_extractor.cc
@@ -856,7 +856,7 @@ class ExtractorAction : public clang::PreprocessorFrontendAction {
     main_source_file_ = inputs[0].getFile();
     auto* preprocessor = &getCompilerInstance().getPreprocessor();
     preprocessor->addPPCallbacks(
-        llvm::make_unique<ExtractorPPCallbacks>(ExtractorState{
+        absl::make_unique<ExtractorPPCallbacks>(ExtractorState{
             index_writer_, &getCompilerInstance().getSourceManager(),
             preprocessor, &main_source_file_, &main_source_file_transcript_,
             &source_files_, &main_source_file_stdin_alternate_}));

--- a/kythe/cxx/indexer/cxx/IndexerASTHooks.h
+++ b/kythe/cxx/indexer/cxx/IndexerASTHooks.h
@@ -646,13 +646,13 @@ class IndexerASTVisitor : public clang::RecursiveASTVisitor<IndexerASTVisitor> {
   void Work(clang::Decl* InitialDecl,
             std::unique_ptr<IndexerWorklist> NewWorklist) {
     Worklist = std::move(NewWorklist);
-    Worklist->EnqueueJob(llvm::make_unique<IndexJob>(InitialDecl));
+    Worklist->EnqueueJob(absl::make_unique<IndexJob>(InitialDecl));
     while (!ShouldStopIndexing() && Worklist->DoWork())
       ;
     Observer.iterateOverClaimedFiles(
         [this, InitialDecl](clang::FileID Id,
                             const GraphObserver::NodeId& FileNode) {
-          RunJob(llvm::make_unique<IndexJob>(InitialDecl, Id, FileNode));
+          RunJob(absl::make_unique<IndexJob>(InitialDecl, Id, FileNode));
           return !ShouldStopIndexing();
         });
     Worklist.reset();

--- a/kythe/cxx/indexer/cxx/IndexerFrontendAction.h
+++ b/kythe/cxx/indexer/cxx/IndexerFrontendAction.h
@@ -33,6 +33,7 @@
 #include "GraphObserver.h"
 #include "IndexerASTHooks.h"
 #include "IndexerPPCallbacks.h"
+#include "absl/memory/memory.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Frontend/FrontendAction.h"
 #include "clang/Lex/HeaderSearch.h"
@@ -142,14 +143,14 @@ class IndexerFrontendAction : public clang::ASTFrontendAction {
       Observer->setLangOptions(&CI.getLangOpts());
       Observer->setPreprocessor(&CI.getPreprocessor());
     }
-    return llvm::make_unique<IndexerASTConsumer>(
+    return absl::make_unique<IndexerASTConsumer>(
         Observer, IgnoreUnimplemented, TemplateMode, Verbosity, ObjCFwdDocs,
         CppFwdDocs, Supports, ShouldStopIndexing, CreateWorklist, UsrByteSize);
   }
 
   bool BeginSourceFileAction(clang::CompilerInstance& CI) override {
     if (Observer) {
-      CI.getPreprocessor().addPPCallbacks(llvm::make_unique<IndexerPPCallbacks>(
+      CI.getPreprocessor().addPPCallbacks(absl::make_unique<IndexerPPCallbacks>(
           CI.getPreprocessor(), *Observer, Verbosity));
     }
     CI.getLangOpts().CommentOpts.ParseAllComments = true;

--- a/kythe/cxx/indexer/cxx/KytheIndexerMain.cc
+++ b/kythe/cxx/indexer/cxx/KytheIndexerMain.cc
@@ -24,6 +24,7 @@
 //       indexer some/index.kindex
 
 #include "absl/strings/str_format.h"
+#include "absl/memory/memory.h"
 #include "gflags/gflags.h"
 #include "google/protobuf/stubs/common.h"
 #include "kythe/cxx/common/protobuf_metadata_file.h"
@@ -96,13 +97,13 @@ int main(int argc, char* argv[]) {
     options.EffectiveWorkingDirectory = job.unit.working_directory();
 
     kythe::MetadataSupports meta_supports;
-    meta_supports.Add(llvm::make_unique<ProtobufMetadataSupport>());
-    meta_supports.Add(llvm::make_unique<KytheMetadataSupport>());
+    meta_supports.Add(absl::make_unique<ProtobufMetadataSupport>());
+    meta_supports.Add(absl::make_unique<KytheMetadataSupport>());
 
     kythe::LibrarySupports library_supports;
-    library_supports.push_back(llvm::make_unique<GoogleFlagsLibrarySupport>());
-    library_supports.push_back(llvm::make_unique<GoogleProtoLibrarySupport>());
-    library_supports.push_back(llvm::make_unique<ImputedConstructorSupport>());
+    library_supports.push_back(absl::make_unique<GoogleFlagsLibrarySupport>());
+    library_supports.push_back(absl::make_unique<GoogleProtoLibrarySupport>());
+    library_supports.push_back(absl::make_unique<ImputedConstructorSupport>());
 
     std::string result = IndexCompilationUnit(
         job.unit, job.virtual_files, *context.claim_client(),

--- a/kythe/cxx/indexer/cxx/KytheIndexerMain.cc
+++ b/kythe/cxx/indexer/cxx/KytheIndexerMain.cc
@@ -23,8 +23,8 @@
 //       indexer -i foo.cc | verifier foo.cc
 //       indexer some/index.kindex
 
-#include "absl/strings/str_format.h"
 #include "absl/memory/memory.h"
+#include "absl/strings/str_format.h"
 #include "gflags/gflags.h"
 #include "google/protobuf/stubs/common.h"
 #include "kythe/cxx/common/protobuf_metadata_file.h"

--- a/kythe/cxx/indexer/cxx/frontend.cc
+++ b/kythe/cxx/indexer/cxx/frontend.cc
@@ -351,7 +351,7 @@ void IndexerContext::CloseOutputStreams() {
 
 void IndexerContext::OpenHashCache() {
   if (!FLAGS_cache.empty()) {
-    auto memcache_hash_cache = llvm::make_unique<MemcachedHashCache>();
+    auto memcache_hash_cache = absl::make_unique<MemcachedHashCache>();
     CHECK(memcache_hash_cache->OpenMemcache(FLAGS_cache));
     memcache_hash_cache->SetSizeLimits(FLAGS_min_size, FLAGS_max_size);
     hash_cache_ = std::move(memcache_hash_cache);

--- a/kythe/cxx/indexer/cxx/indexer_worklist.cc
+++ b/kythe/cxx/indexer/cxx/indexer_worklist.cc
@@ -16,6 +16,7 @@
 
 #include "kythe/cxx/indexer/cxx/indexer_worklist.h"
 
+#include "absl/memory/memory.h"
 #include "kythe/cxx/indexer/cxx/IndexerASTHooks.h"
 
 namespace kythe {
@@ -27,7 +28,7 @@ class IndexerWorklistImpl : public IndexerWorklist {
   void EnqueueJobForImplicitDecl(clang::Decl* decl,
                                  bool set_prune_incomplete_functions,
                                  const std::string& id) override {
-    worklist_.emplace_back(llvm::make_unique<IndexJob>(
+    worklist_.emplace_back(absl::make_unique<IndexJob>(
         indexer_->getCurrentJob(), decl, set_prune_incomplete_functions, id));
   }
 
@@ -54,6 +55,6 @@ class IndexerWorklistImpl : public IndexerWorklist {
 
 std::unique_ptr<IndexerWorklist> IndexerWorklist::CreateDefaultWorklist(
     IndexerASTVisitor* indexer) {
-  return llvm::make_unique<IndexerWorklistImpl>(indexer);
+  return absl::make_unique<IndexerWorklistImpl>(indexer);
 }
 }  // namespace kythe

--- a/kythe/cxx/tools/fyi/fyi.cc
+++ b/kythe/cxx/tools/fyi/fyi.cc
@@ -18,6 +18,7 @@
 
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
+#include "absl/memory/memory.h"
 #include "clang/Frontend/ASTUnit.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Frontend/TextDiagnosticPrinter.h"
@@ -320,9 +321,9 @@ class Action : public clang::ASTFrontendAction,
     if (tracker_->state() == FileTracker::State::kBusy) {
       tracker_->BeginPass();
       compiler.getPreprocessor().addPPCallbacks(
-          llvm::make_unique<PreprocessorHooks>(this));
+          absl::make_unique<PreprocessorHooks>(this));
     }
-    return llvm::make_unique<clang::ASTConsumer>();
+    return absl::make_unique<clang::ASTConsumer>();
   }
 
   /// \copydoc ASTFrontendAction::ExecuteAction
@@ -587,7 +588,7 @@ bool ActionFactory::runInvocation(
   clang::ASTUnit* ast_unit = nullptr;
   // We only consider one full parse on one input file for now, so we only ever
   // need one Action.
-  auto action = llvm::make_unique<Action>(*this);
+  auto action = absl::make_unique<Action>(*this);
   do {
     BeginNextIteration();
     if (!ast_unit) {

--- a/kythe/cxx/tools/fyi/fyi.cc
+++ b/kythe/cxx/tools/fyi/fyi.cc
@@ -16,9 +16,9 @@
 
 #include "kythe/cxx/tools/fyi/fyi.h"
 
+#include "absl/memory/memory.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
-#include "absl/memory/memory.h"
 #include "clang/Frontend/ASTUnit.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Frontend/TextDiagnosticPrinter.h"

--- a/kythe/cxx/tools/fyi/fyi_main.cc
+++ b/kythe/cxx/tools/fyi/fyi_main.cc
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "absl/memory/memory.h"
 #include "clang/Tooling/CommonOptionsParser.h"
 #include "clang/Tooling/Tooling.h"
 #include "gflags/gflags.h"
@@ -39,8 +40,8 @@ int main(int argc, const char** argv) {
   gflags::SetUsageMessage("fyi: repair a C++ file with missing includes");
   clang::tooling::CommonOptionsParser options(argc, argv, fyi_options);
   kythe::JsonClient::InitNetwork();
-  auto xrefs_db = llvm::make_unique<kythe::XrefsJsonClient>(
-      llvm::make_unique<kythe::JsonClient>(), xrefs);
+  auto xrefs_db = absl::make_unique<kythe::XrefsJsonClient>(
+      absl::make_unique<kythe::JsonClient>(), xrefs);
   clang::tooling::ClangTool tool(options.getCompilations(),
                                  options.getSourcePathList());
   kythe::fyi::ActionFactory factory(std::move(xrefs_db), 5);


### PR DESCRIPTION
The former is going away now that LLVM has switched to C++14 upstream