### PR TITLE
fix: bump nokogiri to 1.10.4

### DIFF
--- a/kythe/web/site/Gemfile.lock
+++ b/kythe/web/site/Gemfile.lock
@@ -45,7 +45,7 @@ GEM
       ruby_dep (~> 1.2)
     mercenary (0.3.6)
     mini_portile2 (2.4.0)
-    nokogiri (1.10.1)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)


### PR DESCRIPTION
CVE-2019-5477 is fixed in 1.10.4