### PR TITLE
fix(build): include C++14 options in default build flags

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -12,9 +12,8 @@ build --auto_cpu_environment_group=//buildenv:cpu
 
 # Ensure clang is used, by default, over any other C++ installation (e.g. gcc).
 # LLVM requires C++14, so ensure that is used.
-build --cxxopt=-std=c++14 --host_cxxopt=-std=c++14
 build --client_env=CC=clang
-build --client_env=BAZEL_CXXOPTS=-std=c++14
+build --cxxopt=-std=c++14 --host_cxxopt=-std=c++14 --client_env=BAZEL_CXXOPTS=-std=c++14
 
 # Ensure environment variables are static across machines; allows for cross-user caching.
 build --experimental_strict_action_env

--- a/.bazelrc
+++ b/.bazelrc
@@ -12,6 +12,7 @@ build --auto_cpu_environment_group=//buildenv:cpu
 
 # Ensure clang is used, by default, over any other C++ installation (e.g. gcc).
 # LLVM requires C++14, so ensure that is used.
+build --cxxopt=-std=c++14 --host_cxxopt=-std=c++14
 build --client_env=CC=clang
 build --client_env=BAZEL_CXXOPTS=-std=c++14
 

--- a/kythe/web/site/getting-started.md
+++ b/kythe/web/site/getting-started.md
@@ -67,6 +67,7 @@ apt-get install \
 {% endhighlight %}
 
 #### Troubleshooting bazel/clang/llvm errors
+
 You must either have `/usr/bin/clang` aliased properly, or the `CC` env var set
 for Bazel:
 
@@ -103,6 +104,14 @@ then you need to clean and rebuild your TOOLCHAIN:
 {% highlight bash %}
 bazel clean --expunge && bazel build @local_config_cc//:toolchain
 {% endhighlight %}
+
+Note also that Kythe depends on LLVM, which in turn requires support for C++14.
+In most installations, C++14 is not enabled by default, so the default Kythe
+`.bazelrc` includes the necessary flag (`-std=c++14`) to enable it.
+
+If you have user-specific Bazel settings that override the defaults, you may
+need to include these flags explicitly. If you get errors about undefined C++14
+names (such as `std::is_final`), check for this.
 
 ## Building Kythe
 


### PR DESCRIPTION
Fixes #4006. Recent versions of LLVM require some C++14 features, which may not be enabled by default. Ensure Bazel enables them for local builds as well as remote (CI) builds.

Also mention the need for C++14 in the setup instructions, to aid someone trying to debug this from an old configuration (as I did).
