### PR TITLE
chore(extraction): remove kindex support from go/extractors/bazel/...

### DIFF
--- a/kythe/go/extractors/bazel/extractor_test.go
+++ b/kythe/go/extractors/bazel/extractor_test.go
@@ -238,31 +238,6 @@ func TestExtractToFile(t *testing.T) {
 	}
 }
 
-func TestExtractor(t *testing.T) {
-	res := new(results)
-	config := res.newConfig()
-
-	t.Log("Extra action info:\n", proto.MarshalTextString(xa))
-
-	cu, err := config.Extract(context.Background(), ai)
-	if err != nil {
-		t.Errorf("Error in extraction: %v", err)
-	}
-	res.checkValues(t, cu.Proto)
-
-	for i, fd := range cu.Files {
-		if got := fd.Info.Digest; got != wantDigest {
-			t.Errorf("File data %d: wrong digest: got %q, want %q", i+1, got, wantDigest)
-		}
-		if got := string(fd.Content); got != "" {
-			t.Errorf("File data %d: wrong content: got %q, want empty", i+1, got)
-		}
-	}
-	if a, b := len(cu.Files), len(cu.Proto.RequiredInput); a != b {
-		t.Errorf("File count mismatch: %d file data, %d required inputs", a, b)
-	}
-}
-
 func TestFetchInputs(t *testing.T) {
 	tmp, err := ioutil.TempDir("", "TestFetchInputs")
 	if err != nil {

--- a/kythe/go/extractors/bazel/extutil/extutil.go
+++ b/kythe/go/extractors/bazel/extutil/extutil.go
@@ -15,7 +15,7 @@
  */
 
 // Package extutil implements shared code for extracting and writing output
-// from Bazel actions, either to .kindex or a .kzip files. This is a temporary
+// from Bazel actions to .kzip files. This is a temporary
 // measure to support migrating to .kzip output.
 package extutil // import "kythe.io/kythe/go/extractors/bazel/extutil"
 
@@ -30,21 +30,12 @@ import (
 // ExtractAndWrite extracts a spawn action through c and writes the results to
 // the specified output file. The output format is based on the file extension:
 //
-//   .kindex   -- writes a kindex file
 //   .kzip     -- writes a kzip file
 //   otherwise -- reports an error
 //
+// Deprecated: use bazel.ExtractToKzip
 func ExtractAndWrite(ctx context.Context, c *bazel.Config, ai *bazel.ActionInfo, outputPath string) error {
 	switch ext := filepath.Ext(outputPath); ext {
-	case ".kindex":
-		cu, err := c.Extract(ctx, ai)
-		if err != nil {
-			return fmt.Errorf("extracting: %v", err)
-		}
-		if err := bazel.Write(cu, outputPath); err != nil {
-			return fmt.Errorf("writing kindex: %v", err)
-		}
-
 	case ".kzip":
 		w, err := bazel.NewKZIP(outputPath)
 		if err != nil {


### PR DESCRIPTION
* deprecate go/extractors/bazel/extutil
* move the functionality into go/extractors/bazel/extractor.go and extractor.go.