### PR TITLE
fix(javac-wrapper): use `set -e` to propagate errors

### DIFF
--- a/kythe/java/com/google/devtools/kythe/extractors/java/standalone/javac-wrapper.sh
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/standalone/javac-wrapper.sh
@@ -39,6 +39,8 @@
 # Other environment variables that may be passed to this script include:
 #   KYTHE_EXTRACT_ONLY: if set, suppress the call to javac after extraction
 
+set -e
+
 if [[ -z "$JAVA_HOME" ]]; then
   readonly JAVABIN="$(which java)"
 else


### PR DESCRIPTION
If the extractor or javac calls in the wrapper fail, the wrapper should return an error code.