### PR TITLE
chore: update boringssl and use github mirror

### DIFF
--- a/external.bzl
+++ b/external.bzl
@@ -50,12 +50,18 @@ def _cc_dependencies():
     )
 
     maybe(
-        http_archive,
+        git_repository,
         name = "boringssl",
-        # Gitiles creates gzip files with an embedded timestamp, so we cannot use
-        # sha256 to validate the archives.  We must rely on the commit hash and https.
+        # Use the github mirror because the official source at
+        # https://boringssl.googlesource.com/boringssl does not allow
+        # unauthenticated git clone and the archives suffer from
+        # https://github.com/google/gitiles/issues/84 preventing the use of
+        # sha256sum on archives.
+        remote = "https://github.com/google/boringssl",
         # Commits must come from the master-with-bazel branch.
-        url = "https://boringssl.googlesource.com/boringssl/+archive/4be3aa87917b20fedc45fa1fc5b6a2f3738612ad.tar.gz",
+        # branch = "master-with-bazel",
+        commit = "e0c35d6c06fd800de1092f0b4d4326570ca2617a",
+        shallow_since = "1566966435 +0000",
     )
 
     maybe(


### PR DESCRIPTION
This also switches to using git_repository over http_archive to do the fetch because it potentially makes updates easier and more clearly encodes the branch requirement.