### PR TITLE
fix(java_extractor): and tests should use ambient langtools

### DIFF
--- a/kythe/java/com/google/devtools/kythe/extractors/java/bazel/BUILD
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/bazel/BUILD
@@ -5,15 +5,6 @@ package(default_visibility = ["//visibility:public"])
 java_binary(
     name = "java_extractor",
     srcs = ["JavaExtractor.java"],
-    data = [
-        "//third_party/javac:java_compiler_jar",
-        "//third_party/javac:jdk_compiler_jar",
-    ],
-    jvm_flags = [
-        "--add-opens=jdk.compiler/com.sun.tools.javac.api=java.compiler",
-        "--patch-module=java.compiler=$${RUNPATH}$(location //third_party/javac:java_compiler_jar)",
-        "--patch-module=jdk.compiler=$${RUNPATH}$(location //third_party/javac:jdk_compiler_jar)",
-    ],
     main_class = "com.google.devtools.kythe.extractors.java.bazel.JavaExtractor",
     deps = [
         "//kythe/java/com/google/devtools/kythe/common:flogger",
@@ -25,7 +16,6 @@ java_binary(
         "//kythe/proto:java_java_proto",
         "//third_party/bazel:extra_actions_base_java_proto",
         "//third_party/guava",
-        "//third_party/javac",
         "@com_google_protobuf//:protobuf_java",
         "@com_google_protobuf//:protobuf_java_util",
     ],

--- a/kythe/javatests/com/google/devtools/kythe/extractors/java/BUILD
+++ b/kythe/javatests/com/google/devtools/kythe/extractors/java/BUILD
@@ -6,15 +6,8 @@ java_test(
     srcs = ["JavaExtractorTest.java"],
     data = glob(["testdata/**"]) + [
         ":SillyProcessor_deploy.jar",
-        "//third_party/javac:java_compiler_jar",
-        "//third_party/javac:jdk_compiler_jar",
     ],
     javacopts = ["-Xlint:all"],
-    jvm_flags = [
-        "--add-opens=jdk.compiler/com.sun.tools.javac.api=java.compiler",
-        "--patch-module=java.compiler=$${RUNPATH}$(location //third_party/javac:java_compiler_jar)",
-        "--patch-module=jdk.compiler=$${RUNPATH}$(location //third_party/javac:jdk_compiler_jar)",
-    ],
     test_class = "com.google.devtools.kythe.extractors.java.JavaExtractorTest",
     deps = [
         "//kythe/java/com/google/devtools/kythe/extractors/java",
@@ -23,7 +16,6 @@ java_test(
         "//kythe/proto:java_java_proto",
         "//kythe/proto:storage_java_proto",
         "//third_party/guava",
-        "//third_party/javac",
         "//third_party/truth",
         "@com_google_protobuf//:any_proto",
         "@com_google_protobuf//:protobuf_java",


### PR DESCRIPTION
Without this, if the JDK under which we're running the extractor is newer than the patched-in version of langtools, we'll fail to read .class files provided by the JDK (as they have a newer language version set).