### PR TITLE
fix(cxx_indexer): whitelist and test std::make_shared

### DIFF
--- a/kythe/cxx/indexer/cxx/ImputedConstructorSupport.h
+++ b/kythe/cxx/indexer/cxx/ImputedConstructorSupport.h
@@ -33,7 +33,7 @@ class ImputedConstructorSupport : public LibrarySupport {
  public:
   explicit ImputedConstructorSupport(
       std::unordered_set<std::string> allowed_constructor_patterns = {
-          "std(::\\w+)*::make_unique", "absl::make_unique",
+          "std(::\\w+)*::make_(unique|shared)", "absl::make_unique",
           "llvm::make_unique"});
 
   explicit ImputedConstructorSupport(

--- a/kythe/cxx/indexer/cxx/testdata/BUILD
+++ b/kythe/cxx/indexer/cxx/testdata/BUILD
@@ -1583,6 +1583,8 @@ cc_indexer_test(
     tags = ["libraries"],
 )
 
+# Note: this depends on the platform <memory> header and
+# as such is a cc_extractor_test rather than hermetic cc_indexer_test.
 cc_extractor_test(
     name = "make_shared_factories",
     srcs = ["libraries/make_shared_factories.cc"],

--- a/kythe/cxx/indexer/cxx/testdata/BUILD
+++ b/kythe/cxx/indexer/cxx/testdata/BUILD
@@ -4,6 +4,7 @@ load(
     "//tools/build_rules/verifier_test:cc_indexer_test.bzl",
     "cc_indexer_test",
     "objc_indexer_test",
+    "cc_extractor_test",
 )
 
 sh_test(
@@ -1579,6 +1580,12 @@ cc_indexer_test(
     name = "make_unique_factories",
     srcs = ["libraries/make_unique_factories.cc"],
     ignore_dups = True,
+    tags = ["libraries"],
+)
+
+cc_extractor_test(
+    name = "make_shared_factories",
+    srcs = ["libraries/make_shared_factories.cc"],
     tags = ["libraries"],
 )
 

--- a/kythe/cxx/indexer/cxx/testdata/libraries/make_shared_factories.cc
+++ b/kythe/cxx/indexer/cxx/testdata/libraries/make_shared_factories.cc
@@ -1,0 +1,21 @@
+#include <memory>
+
+//- @B defines/binding StructB
+struct B {
+  //- @B defines/binding ConsB1
+  explicit B(int, void*);
+  //- @B defines/binding ConsB2
+  explicit B(char);
+};
+
+void f() {
+  //- @B ref StructB
+  //- @"make_shared<B>" ref ConsB1
+  //- @"std::make_shared<B>(1, nullptr)" ref/call ConsB1
+  std::make_shared<B>(1, nullptr);
+
+  //- @B ref StructB
+  //- @"make_shared<B>" ref ConsB2
+  //- @"std::make_shared<B>('a')" ref/call ConsB2
+  std::make_shared<B>('a');
+}

--- a/kythe/cxx/indexer/cxx/testdata/libraries/make_unique_factories.cc
+++ b/kythe/cxx/indexer/cxx/testdata/libraries/make_unique_factories.cc
@@ -19,7 +19,7 @@ unique_ptr<T> make_unique(Args&&... args) {
 struct B {
   //- @B defines/binding ConsB1
   explicit B(int, void*);
-  //- @B defines/binding ConstB2
+  //- @B defines/binding ConsB2
   explicit B(char);
 };
 


### PR DESCRIPTION
It appears as though is was already supported, but just needed whitelisting and testing.