### PR TITLE
fix(extraction): update bazel-extractor Docker image to clang-6.0

### DIFF
--- a/kythe/extractors/bazel/Dockerfile
+++ b/kythe/extractors/bazel/Dockerfile
@@ -17,8 +17,12 @@ FROM gcr.io/cloud-builders/bazel
 # Install C++ compilers for cc_* rule support.
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y gcc clang && \
+    apt-get install -y gcc clang-6.0 && \
     apt-get clean
+
+# Create clang symlinks
+RUN ln -s /usr/bin/clang-6.0 /usr/bin/clang && \
+    ln -s /usr/bin/clang++-6.0 /usr/bin/clang++
 
 # Extract the Kythe release archive to /kythe
 COPY kythe/release/kythe-v*.tar.gz /tmp/


### PR DESCRIPTION
This version of clang supports the cc_configure change made in https://github.com/bazelbuild/bazel/commit/cdd0c3cdba270115940e8ca5ec8104cbcd694671#diff-9899f9deb6047fe5ab4a4d2f8a96122e.