### PR TITLE
feat(go extractor): add vnames.json support

### DIFF
--- a/kythe/go/extractors/bazel/settings.go
+++ b/kythe/go/extractors/bazel/settings.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"kythe.io/kythe/go/util/vnameutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -131,7 +132,7 @@ func NewFromSettings(s Settings) (*Config, *xapb.ExtraActionInfo, error) {
 	pkg := PackageName(info.GetOwner())
 	log.Printf("Extra action for target %q (package %q)", info.GetOwner(), pkg)
 
-	rules, err := LoadRules(s.VNameRules)
+	rules, err := vnameutil.LoadRules(s.VNameRules)
 	if err != nil {
 		return nil, nil, fmt.Errorf("loading rules: %v", err)
 	}

--- a/kythe/go/extractors/bazel/utils.go
+++ b/kythe/go/extractors/bazel/utils.go
@@ -30,7 +30,6 @@ import (
 
 	"kythe.io/kythe/go/platform/kzip"
 	"kythe.io/kythe/go/util/ptypes"
-	"kythe.io/kythe/go/util/vnameutil"
 
 	"bitbucket.org/creachadair/stringset"
 	"github.com/golang/protobuf/proto"
@@ -85,23 +84,6 @@ func LoadAction(path string) (*xapb.ExtraActionInfo, error) {
 	}
 	log.Printf("Read %d bytes from extra action file %q", len(xa), path)
 	return &info, nil
-}
-
-// LoadRules loads and parses the vname mapping rules in path.
-// If path == "", this returns nil without error (no rules).
-func LoadRules(path string) (vnameutil.Rules, error) {
-	if path == "" {
-		return nil, nil
-	}
-	data, err := ioutil.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("reading vname rules: %v", err)
-	}
-	rules, err := vnameutil.ParseRules(data)
-	if err != nil {
-		return nil, fmt.Errorf("parsing vname rules: %v", err)
-	}
-	return rules, nil
 }
 
 // PackageName extracts the base name of a Bazel package from a target label,

--- a/kythe/go/extractors/cmd/bazel/bazel_go_extractor/bazel_go_extractor.go
+++ b/kythe/go/extractors/cmd/bazel/bazel_go_extractor/bazel_go_extractor.go
@@ -78,7 +78,7 @@ func main() {
 	// Load vname rewriting rules. We handle this directly, becaues the Bazel
 	// Go rules have some pathological symlink handling that the normal rules
 	// need to be patched for.
-	rules, err := bazel.LoadRules(vnameRuleFile)
+	rules, err := vnameutil.LoadRules(vnameRuleFile)
 	if err != nil {
 		log.Fatalf("Error loading vname rules: %v", err)
 	}

--- a/kythe/go/extractors/cmd/gotool/BUILD
+++ b/kythe/go/extractors/cmd/gotool/BUILD
@@ -12,6 +12,7 @@ go_binary(
         "//kythe/go/platform/kzip",
         "//kythe/go/platform/vfs",
         "//kythe/go/util/flagutil",
+        "//kythe/go/util/vnameutil",
         "//kythe/proto:analysis_go_proto",
     ],
 )

--- a/kythe/go/extractors/golang/golang.go
+++ b/kythe/go/extractors/golang/golang.go
@@ -385,6 +385,16 @@ func (p *Package) addFiles(cu *apb.CompilationUnit, root, base string, names []s
 			Corpus: p.ext.DefaultCorpus,
 			Path:   trimmed,
 		}
+
+		if p.ext.Rules != nil {
+			v2, ok := p.ext.Rules.Apply(trimmed)
+			if ok {
+				vn.Corpus = v2.Corpus
+				vn.Root = v2.Root
+				vn.Path = v2.Path
+			}
+		}
+
 		if vn.Corpus == "" {
 			// If no default corpus is specified, use the package's corpus for each of
 			// its files.  The package corpus is based on the rules in

--- a/kythe/go/extractors/govname/BUILD
+++ b/kythe/go/extractors/govname/BUILD
@@ -11,6 +11,7 @@ go_library(
     ],
     visibility = [PUBLIC_VISIBILITY],
     deps = [
+        "//kythe/go/util/vnameutil",
         "//kythe/proto:storage_go_proto",
         "@org_golang_x_tools//go/vcs:go_default_library",
     ],

--- a/kythe/go/extractors/govname/govname_test.go
+++ b/kythe/go/extractors/govname/govname_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"kythe.io/kythe/go/util/kytheuri"
+	"kythe.io/kythe/go/util/vnameutil"
 
 	"github.com/golang/protobuf/proto"
 	"golang.org/x/tools/go/vcs"
@@ -30,13 +31,25 @@ import (
 )
 
 func TestForPackage(t *testing.T) {
+	var exampleRules = `[{
+		"pattern": "(.*)",
+		"vname": {
+			"corpus": "rule_corpus",
+			"path": "rule_path/@1@"
+		}}]`
+
 	tests := []struct {
-		path      string
+		path      string // import path
+		dir       string // on-disk directory that contains this package
+		root      string // GOPATH if set, otherwise working directory from which extractor was invoked
 		ticket    string
 		canonical string
 		isRoot    bool
+		rulesJSON string
 	}{
 		{path: "bytes", ticket: "kythe://golang.org?lang=go?path=bytes#package", isRoot: true},
+		// Rules should have no effect on go stdlib packages.
+		{path: "bytes", ticket: "kythe://golang.org?lang=go?path=bytes#package", isRoot: true, rulesJSON: exampleRules},
 		{path: "go/types", ticket: "kythe://golang.org?lang=go?path=go/types#package", isRoot: true},
 		{path: "golang.org/x/net/context", ticket: "kythe://golang.org/x/net?lang=go?path=context#package",
 			canonical: "kythe://go.googlesource.com/net?lang=go?path=context#package"},
@@ -45,17 +58,29 @@ func TestForPackage(t *testing.T) {
 		{path: "github.com/kythe/kythe/kythe/go/util/kytheuri", ticket: "kythe://github.com/kythe/kythe?lang=go?path=kythe/go/util/kytheuri#package"},
 		{path: "fuzzy1.googlecode.com/alpha", ticket: "kythe://fuzzy1.googlecode.com?lang=go?path=alpha#package"},
 		{path: "github.com/kythe/kythe/foo", ticket: "kythe://github.com/kythe/kythe?lang=go?path=foo#package"},
+		{root: "/workspace", dir: "/workspace/kythe/foo", path: "github.com/kythe/kythe/foo",
+			ticket: "kythe://rule_corpus?lang=go?path=rule_path/kythe/foo#package", rulesJSON: exampleRules},
 		{path: "bitbucket.org/creachadair/stringset/makeset", ticket: "kythe://bitbucket.org/creachadair/stringset?lang=go?path=makeset#package"},
 		{path: "launchpad.net/~frood/blee/blor", ticket: "kythe://launchpad.net/~frood/blee/blor?lang=go#package"},
 		{path: "launchpad.net/~frood/blee/blor/baz", ticket: "kythe://launchpad.net/~frood/blee/blor?lang=go?path=baz#package"},
 	}
-	canonicalOpts := &PackageVNameOptions{CanonicalizePackageCorpus: true}
 	for _, test := range tests {
+		var rules vnameutil.Rules
+		if test.rulesJSON != "" {
+			var err error
+			rules, err = vnameutil.ParseRules([]byte(test.rulesJSON))
+			if err != nil {
+				t.Errorf("parsing vname rules: %v", err)
+			}
+		}
+
 		pkg := &build.Package{
 			ImportPath: test.path,
 			Goroot:     test.isRoot,
+			Dir:        test.dir,
+			Root:       test.root,
 		}
-		got := ForPackage(pkg, nil)
+		got := ForPackage(pkg, &PackageVNameOptions{Rules: rules})
 		gotTicket := kytheuri.ToString(got)
 		if gotTicket != test.ticket {
 			t.Errorf(`ForPackage([%s], nil): got %q, want %q`, test.path, gotTicket, test.ticket)
@@ -65,6 +90,7 @@ func TestForPackage(t *testing.T) {
 		if test.canonical != "" {
 			canonical = test.canonical
 		}
+		canonicalOpts := &PackageVNameOptions{CanonicalizePackageCorpus: true, Rules: rules}
 		if got := kytheuri.ToString(ForPackage(pkg, canonicalOpts)); got != canonical {
 			t.Errorf(`ForPackage([%s], %#v): got %q, want canonicalized %q`, test.path, canonicalOpts, got, canonical)
 		}

--- a/kythe/go/extractors/proto/extract_proto_kzip.go
+++ b/kythe/go/extractors/proto/extract_proto_kzip.go
@@ -32,6 +32,7 @@ import (
 	"bitbucket.org/creachadair/stringset"
 	"kythe.io/kythe/go/extractors/bazel"
 	"kythe.io/kythe/go/extractors/bazel/extutil"
+	"kythe.io/kythe/go/util/vnameutil"
 
 	apb "kythe.io/kythe/proto/analysis_go_proto"
 )
@@ -83,7 +84,7 @@ func main() {
 	pkg := bazel.PackageName(info.GetOwner())
 	log.Printf("Extra action for target %q (package %q)", info.GetOwner(), pkg)
 
-	rules, err := bazel.LoadRules(*vnameRules)
+	rules, err := vnameutil.LoadRules(*vnameRules)
 	if err != nil {
 		log.Fatalf("Loading rules: %v", err)
 	}

--- a/kythe/go/util/vnameutil/rewrite.go
+++ b/kythe/go/util/vnameutil/rewrite.go
@@ -21,6 +21,7 @@ package vnameutil // import "kythe.io/kythe/go/util/vnameutil"
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"regexp"
 	"strings"
 
@@ -169,6 +170,23 @@ func ParseRules(data []byte) (Rules, error) {
 	var rules Rules
 	for _, r := range rr {
 		rules = append(rules, r.toRule())
+	}
+	return rules, nil
+}
+
+// LoadRules loads and parses the vname mapping rules in path.
+// If path == "", this returns nil without error (no rules).
+func LoadRules(path string) (Rules, error) {
+	if path == "" {
+		return nil, nil
+	}
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading vname rules: %v", err)
+	}
+	rules, err := ParseRules(data)
+	if err != nil {
+		return nil, fmt.Errorf("parsing vname rules: %v", err)
 	}
 	return rules, nil
 }


### PR DESCRIPTION
The new --rules flag allows providing a vnames.json file that re-maps package/file paths to custom corpus, root, path in the output.

The rules are applied to both packages and files. File paths are relative to the "root" directory, which is either GOPATH (if set) or the current working directory of the program.

I added some test cases to govname_test.go which cover applying rules to go package vnames. I don't have tests yet for the application to file paths (`addFiles()` in golang.go). Is there an existing test somewhere I should add to?