### PR TITLE
fix: be more precise for ijwb targets

### DIFF
--- a/kythe/java/com/google/devtools/kythe/analyzers/indexer.bazelproject
+++ b/kythe/java/com/google/devtools/kythe/analyzers/indexer.bazelproject
@@ -29,7 +29,7 @@ targets:
   //kythe/java/com/google/devtools/kythe/analyzers/java/...:all
   //kythe/java/com/google/devtools/kythe/analyzers/jvm/...:all
   //kythe/javatests/com/google/devtools/kythe/analyzers/base/...:all
-  //kythe/javatests/com/google/devtools/kythe/analyzers/java/...:all
+  //kythe/javatests/com/google/devtools/kythe/analyzers/java:all
   //kythe/javatests/com/google/devtools/kythe/analyzers/jvm/...:all
   //kythe/java/com/google/devtools/kythe/extractors/shared
 


### PR DESCRIPTION
There is no need to build all java verification test sources in intellij