### PR TITLE
fix(extractors): Don't include kzip creation time in kzip

### DIFF
--- a/kythe/go/platform/kzip/kzip.go
+++ b/kythe/go/platform/kzip/kzip.go
@@ -113,6 +113,12 @@ const (
 	prefixProto = "pbunits"
 )
 
+var (
+	// Use a constant file modification time in the kzip so file diffs only compare the contents,
+	// not when the kzips were created.
+	modifiedTime = time.Unix(0, 0)
+)
+
 // EncodingFor converts a string to an Encoding.
 func EncodingFor(v string) (Encoding, error) {
 	v = strings.ToUpper(v)
@@ -468,11 +474,11 @@ func NewWriter(w io.Writer, options ...WriterOption) (*Writer, error) {
 	archive := zip.NewWriter(w)
 	// Create an entry for the root directory, which must be first.
 	root := &zip.FileHeader{
-		Name:    "root/",
-		Comment: "kzip root directory",
+		Name:     "root/",
+		Comment:  "kzip root directory",
+		Modified: modifiedTime,
 	}
 	root.SetMode(os.ModeDir | 0755)
-	root.Modified = time.Now()
 	if _, err := archive.CreateHeader(root); err != nil {
 		return nil, err
 	}
@@ -606,7 +612,7 @@ func (w *Writer) Close() error {
 func newFileHeader(parts ...string) *zip.FileHeader {
 	fh := &zip.FileHeader{Name: path.Join(parts...), Method: zip.Deflate}
 	fh.SetMode(0600)
-	fh.Modified = time.Now()
+	fh.Modified = modifiedTime
 	return fh
 }
 


### PR DESCRIPTION
Kzips were setting the internal file modification times to when the kzip was
created. This prevents bazel from caching the results since each time the extra
action is run, it will produce a different kzip.