### PR TITLE
feat(kzip): add function for merging multiple KzipInfos together

### DIFF
--- a/kythe/go/platform/kzip/info/BUILD
+++ b/kythe/go/platform/kzip/info/BUILD
@@ -1,4 +1,4 @@
-load("//tools:build_rules/shims.bzl", "go_library")
+load("//tools:build_rules/shims.bzl", "go_library", "go_test")
 
 package(default_visibility = ["//kythe:default_visibility"])
 
@@ -10,5 +10,15 @@ go_library(
     deps = [
         "//kythe/go/platform/kzip",
         "//kythe/proto:analysis_go_proto",
+    ],
+)
+
+go_test(
+    name = "info_test",
+    srcs = ["info_test.go"],
+    library = ":info",
+    deps = [
+        "//kythe/proto:analysis_go_proto",
+        "@com_github_golang_protobuf//proto:go_default_library",
     ],
 )

--- a/kythe/go/platform/kzip/info/info_test.go
+++ b/kythe/go/platform/kzip/info/info_test.go
@@ -1,0 +1,53 @@
+package info
+
+import (
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+
+	apb "kythe.io/kythe/proto/analysis_go_proto"
+)
+
+func TestMergeKzipInfo(t *testing.T) {
+	infos := []*apb.KzipInfo{
+		{
+			TotalUnits: 1,
+			TotalFiles: 2,
+			Corpora: map[string]*apb.KzipInfo_CorpusInfo{
+				"corpus1": {
+					Files: map[string]int32{"python": 2},
+					Units: map[string]int32{"python": 1},
+				},
+			},
+		},
+		{
+			TotalUnits: 1,
+			TotalFiles: 2,
+			Corpora: map[string]*apb.KzipInfo_CorpusInfo{
+				"corpus1": {
+					Files: map[string]int32{"go": 2},
+					Units: map[string]int32{"python": 1},
+				},
+			},
+		},
+	}
+
+	want := &apb.KzipInfo{
+		TotalUnits: 2,
+		TotalFiles: 4,
+		Corpora: map[string]*apb.KzipInfo_CorpusInfo{
+			"corpus1": {
+				Files: map[string]int32{
+					"go":     2,
+					"python": 2,
+				},
+				Units: map[string]int32{"python": 2},
+			},
+		},
+	}
+
+	got := MergeKzipInfo(infos)
+	if !proto.Equal(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}

--- a/kythe/go/platform/kzip/info/info_test.go
+++ b/kythe/go/platform/kzip/info/info_test.go
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 The Kythe Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package info
 
 import (


### PR DESCRIPTION
This is useful when extraction results are spread among multiple
kzips and we want to know the combined details.