### PR TITLE
fix(extractor): Don't include time in kzips for java

### DIFF
--- a/kythe/java/com/google/devtools/kythe/platform/kzip/KZipWriter.java
+++ b/kythe/java/com/google/devtools/kythe/platform/kzip/KZipWriter.java
@@ -32,6 +32,9 @@ import java.util.zip.ZipOutputStream;
 public final class KZipWriter implements KZip.Writer {
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();
 
+  // Constant time used so time information is not stored in the kzip. This way files can be diff'd
+  // and they will only be different if the contents are different.
+  private static final long MODIFIED_TIME = 0;
   private static final KZip.Encoding DEFAULT_ENCODING;
 
   static {
@@ -76,6 +79,7 @@ public final class KZipWriter implements KZip.Writer {
     // Add an entry for the root directory prefix (required by the spec).
     ZipEntry root = new ZipEntry(descriptor.root() + "/");
     root.setComment("kzip root directory");
+    root.setTime(MODIFIED_TIME);
     this.output.putNextEntry(root);
     this.output.closeEntry();
 
@@ -120,6 +124,7 @@ public final class KZipWriter implements KZip.Writer {
   private void appendZip(byte[] data, String path) throws IOException {
     if (pathsWritten.add(path)) {
       ZipEntry entry = new ZipEntry(path);
+      entry.setTime(MODIFIED_TIME);
       output.putNextEntry(entry);
       output.write(data);
       output.closeEntry();


### PR DESCRIPTION
Don't include time in kzips so diffs only compare the contents of the kzip, not when it was created.