### PR TITLE
fix(extractor): Set cxx extractor kzip times to a constant

### DIFF
--- a/kythe/cxx/common/kzip_writer.cc
+++ b/kythe/cxx/common/kzip_writer.cc
@@ -41,7 +41,7 @@ constexpr absl::string_view kProtoUnitRoot = "root/pbunits/";
 constexpr absl::string_view kFileRoot = "root/files/";
 // Set all file modified times to 0 so zip file diffs only show content diffs,
 // not zip creation time diffs.
-const time_t kModTime = 0;
+constexpr time_t kModTime = 0;
 
 std::string SHA256Digest(absl::string_view content) {
   std::array<unsigned char, SHA256_DIGEST_LENGTH> buf;
@@ -55,12 +55,8 @@ Status WriteTextFile(zip_t* archive, const std::string& path,
                      absl::string_view content) {
   if (auto source =
           zip_source_buffer(archive, content.data(), content.size(), 0)) {
-    if (auto idx =
-            zip_file_add(archive, path.c_str(), source, ZIP_FL_ENC_UTF_8);
-        idx >= 0) {
-      if (idx == 0) {
-        return OkStatus();
-      }
+    auto idx = zip_file_add(archive, path.c_str(), source, ZIP_FL_ENC_UTF_8);
+    if (idx >= 0) {
       // If a file was added, set the last modified time.
       if (zip_file_set_mtime(archive, idx, kModTime, 0) == 0) {
         return OkStatus();

--- a/kythe/cxx/common/kzip_writer.cc
+++ b/kythe/cxx/common/kzip_writer.cc
@@ -39,6 +39,9 @@ constexpr absl::string_view kRoot = "root/";
 constexpr absl::string_view kJsonUnitRoot = "root/units/";
 constexpr absl::string_view kProtoUnitRoot = "root/pbunits/";
 constexpr absl::string_view kFileRoot = "root/files/";
+// Set all file modified times to 0 so zip file diffs only show content diffs,
+// not zip creation time diffs.
+const time_t kModTime = 0;
 
 std::string SHA256Digest(absl::string_view content) {
   std::array<unsigned char, SHA256_DIGEST_LENGTH> buf;
@@ -52,8 +55,16 @@ Status WriteTextFile(zip_t* archive, const std::string& path,
                      absl::string_view content) {
   if (auto source =
           zip_source_buffer(archive, content.data(), content.size(), 0)) {
-    if (zip_file_add(archive, path.c_str(), source, ZIP_FL_ENC_UTF_8) >= 0) {
-      return OkStatus();
+    if (auto idx =
+            zip_file_add(archive, path.c_str(), source, ZIP_FL_ENC_UTF_8);
+        idx >= 0) {
+      if (idx == 0) {
+        return OkStatus();
+      }
+      // If a file was added, set the last modified time.
+      if (zip_file_set_mtime(archive, idx, kModTime, 0) == 0) {
+        return OkStatus();
+      }
     }
     zip_source_free(source);
   }
@@ -114,7 +125,13 @@ Status KzipWriter::InitializeArchive(zip_t* archive) {
     dirs.push_back(kProtoUnitRoot);
   }
   for (const auto& name : dirs) {
-    if (zip_dir_add(archive, name.data(), ZIP_FL_ENC_UTF_8) < 0) {
+    auto idx = zip_dir_add(archive, name.data(), ZIP_FL_ENC_UTF_8);
+    if (idx < 0) {
+      Status status = libzip::ToStatus(zip_get_error(archive));
+      zip_error_clear(archive);
+      return status;
+    }
+    if (zip_file_set_mtime(archive, idx, kModTime, 0) < 0) {
       Status status = libzip::ToStatus(zip_get_error(archive));
       zip_error_clear(archive);
       return status;


### PR DESCRIPTION
Don't include the kzip creation time in cxx kzips so kzips can be compared on only on contents, not on when they were created.