### PR TITLE
fix(go): Change action go bazel extractor runs on

### DIFF
--- a/kythe/extractors/BUILD
+++ b/kythe/extractors/BUILD
@@ -81,7 +81,7 @@ extractor_action(
     ],
     data = ["//external:vnames_config"],
     extractor = "@io_kythe//kythe/go/extractors/cmd/bazel:bazel_go_extractor",
-    mnemonics = ["GoCompile"],
+    mnemonics = ["GoCompilePkg"],
     output = "$(ACTION_ID).go.kzip",
 )
 

--- a/kythe/extractors/BUILD
+++ b/kythe/extractors/BUILD
@@ -71,6 +71,7 @@ extractor_action(
     output = "$(ACTION_ID).java.kzip",
 )
 
+# We only support Bazel rules_go 0.19.0 and up.
 extractor_action(
     name = "extract_kzip_go",
     args = [

--- a/kythe/go/extractors/cmd/bazel/bazel_go_extractor/bazel_go_extractor.go
+++ b/kythe/go/extractors/cmd/bazel/bazel_go_extractor/bazel_go_extractor.go
@@ -70,7 +70,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Error loading extra action: %v", err)
 	}
-	if m := info.GetMnemonic(); m != "GoCompile" {
+	if m := info.GetMnemonic(); m != "GoCompilePkg" {
 		log.Fatalf("Extractor is not applicable to this action: %q", m)
 	}
 
@@ -168,7 +168,7 @@ func (e *extractor) fixup(unit *apb.CompilationUnit) error {
 	})
 }
 
-// compileArgs records the build information extracted from the GoCompile
+// compileArgs records the build information extracted from the GoCompilePkg
 // action's argument list.
 type compileArgs struct {
 	original    []string          // the original args, as provided

--- a/kythe/go/util/tools/print_extra_action/BUILD
+++ b/kythe/go/util/tools/print_extra_action/BUILD
@@ -7,7 +7,7 @@ action_listener(
     extra_actions = [":printer"],
     mnemonics = [
         "CppCompile",
-        "GoCompile",
+        "GoCompilePkg",
         "JavaIjar",
         "Javac",
     ],

--- a/kythe/release/release.BUILD
+++ b/kythe/release/release.BUILD
@@ -137,6 +137,7 @@ extractor_action(
     output = "$(ACTION_ID).jvm.kzip",
 )
 
+# We only support Bazel rules_go 0.19.0 and up.
 extractor_action(
     name = "extract_kzip_go",
     args = [

--- a/kythe/release/release.BUILD
+++ b/kythe/release/release.BUILD
@@ -146,7 +146,7 @@ extractor_action(
     ],
     data = [":vnames_config"],
     extractor = ":bazel_go_extractor",
-    mnemonics = ["GoCompile"],
+    mnemonics = ["GoCompilePkg"],
     output = "$(ACTION_ID).go.kzip",
 )
 


### PR DESCRIPTION
The go bazel rules we use now produce a GoCompilePkg action instead of a
GoCompile action.