### PR TITLE
typescript: index inputs that contain errors

### DIFF
--- a/kythe/typescript/indexer.ts
+++ b/kythe/typescript/indexer.ts
@@ -1809,31 +1809,20 @@ class Visitor {
 export function index(
     vname: VName, pathVNames: Map<string, VName>, paths: string[],
     program: ts.Program, emit?: (obj: {}) => void, plugins?: Plugin[],
-    readFile: (path: string) => Buffer = fs.readFileSync) {
+    readFile: (path: string) => Buffer = fs.readFileSync): ts.Diagnostic[] {
   // Note: we only call getPreEmitDiagnostics (which causes type checking to
   // happen) on the input paths as provided in paths.  This means we don't
   // e.g. type-check the standard library unless we were explicitly told to.
-  const diags = new Set<ts.Diagnostic>();
+  const diags: ts.Diagnostic[] = [];
   for (const path of paths) {
     for (const diag of ts.getPreEmitDiagnostics(
              program, program.getSourceFile(path))) {
-      diags.add(diag);
+      diags.push(diag);
     }
   }
-  if (diags.size > 0) {
-    const message = ts.formatDiagnostics(Array.from(diags), {
-      getCurrentDirectory() {
-        return program.getCompilerOptions().rootDir!;
-      },
-      getCanonicalFileName(fileName: string) {
-        return fileName;
-      },
-      getNewLine() {
-        return '\n';
-      },
-    });
-    throw new Error(message);
-  }
+  // Note: don't abort if there are diagnostics.  This allows us to
+  // index programs with errors.  We return these diagnostics at the end
+  // so the caller can act on them if it wants.
 
   const indexingContext =
       new StandardIndexerContext(vname, pathVNames, paths, program, readFile);
@@ -1863,6 +1852,8 @@ export function index(
       }
     }
   }
+
+  return diags;
 }
 
 /**

--- a/kythe/typescript/testdata/compilefail.ts
+++ b/kythe/typescript/testdata/compilefail.ts
@@ -1,5 +1,11 @@
-// This file exercises what happens when you have a compilation error in a
-// dependent module.  The tests skip checking this file itself (because it
-// fails to typecheck, there's no indexing done) but it's imported by
-// compilefail_import.ts (which doesn't type-check its inputs).
-export type Bad = Undefined;
+// This file exercises what happens when you have a compilation error.
+// It's also imported by compilefail_import.ts.
+
+// This is an error because 'UndefinedSymbol' is never defined.
+export type Bad = UndefinedSymbol;
+
+// But we should still index this valid part.
+//- @x defines/binding X
+let x = 3;
+//- @x ref X
+x++;

--- a/kythe/typescript/testdata/tsconfig.for.tests.json
+++ b/kythe/typescript/testdata/tsconfig.for.tests.json
@@ -29,7 +29,6 @@
         ]
     },
     "exclude": [
-        "compilefail.ts",
 	"plugin.ts"
     ]
 }


### PR DESCRIPTION
This change makes us ignore TypeScript errors and index the parts
of the program that still have type information.  Previously we would
abort.

TypeScript in general has lots of accomodations around programs with
errors, so it's no trouble for TypeScript to do this.  (For example,
the compiler still wants to provide jump-to-definition features even
if you have a type error elsewhere in the same file.)

Within Google we don't run programs that have errors so code in this
state is rare, with one major exception: Clutz
(https://github.com/angular/clutz) output is invalid when its input
JavaScript is also invalid.  So this change has the main effect of
making Kythe able to index Clutz output.

We already had a test that exercised what happens when you have
bad input, so I adjusted that slightly to exercise this adjusted
logic.