### PR TITLE
fix(kzip info): determine unit corpus and file language more robustly

### DIFF
--- a/kythe/go/platform/kzip/info/BUILD
+++ b/kythe/go/platform/kzip/info/BUILD
@@ -10,6 +10,7 @@ go_library(
     deps = [
         "//kythe/go/platform/kzip",
         "//kythe/proto:analysis_go_proto",
+        "@org_bitbucket_creachadair_stringset//:go_default_library",
     ],
 )
 

--- a/kythe/go/platform/kzip/info/info.go
+++ b/kythe/go/platform/kzip/info/info.go
@@ -54,8 +54,8 @@ func KzipInfo(f kzip.File, scanOpts ...kzip.ScanOption) (*apb.KzipInfo, error) {
 
 		for _, ri := range u.Proto.RequiredInput {
 			kzipInfo.TotalFiles++
-			// File VNames don't generally specify a language, so we determine
-			// it from the unit VName.
+			// Determine language from the unit VName (note that file VNames are
+			// forbidden from specifying a language).
 			corpusInfo(ri.GetVName().GetCorpus()).Files[u.Proto.GetVName().GetLanguage()]++
 			if srcs.Contains(ri.Info.Path) {
 				srcCorpora.Add(ri.GetVName().GetCorpus())


### PR DESCRIPTION
* unit vnames typically omit the corpus, so determine it from the
contained source files instead.
* file vnames omit the language, so determine it from the unit vname.

To test, I ran `kzip info` on a recent kzip of the kythe repo before and after this code change. Here's a partial diff of the output:

```diff
     "com_google_protobuf": {
       "files": {
-        "": 1862
+        "c++": 39,
+        "java": 1816,
+        "protobuf": 7
       },
       "units": {
-        "c++": 1
+        "c++": 1,
+        "java": 2
       }
     },
     "com_google_re2j_re2j": {
       "files": {
-        "": 2
+        "java": 2
       },
       "units": {}
     },
     "cstdlib": {
       "files": {
-        "": 27034
+        "c++": 27034
       },
       "units": {}
     },
     "github.com/kythe/kythe": {
       "files": {
-        "": 22511
+        "c++": 17012,
+        "java": 1380,
+        "jvm": 3441,
+        "protobuf": 68,
+        "typescript": 610
       },
       "units": {
         "c++": 150,
+        "java": 146,
+        "protobuf": 35,
         "typescript": 8
       }
     },
```