### PR TITLE
fix: specify both GoCompile and GoCompilePkg mnemonics

### DIFF
--- a/kythe/release/release.BUILD
+++ b/kythe/release/release.BUILD
@@ -147,7 +147,10 @@ extractor_action(
     ],
     data = [":vnames_config"],
     extractor = ":bazel_go_extractor",
-    mnemonics = ["GoCompilePkg"],
+    mnemonics = [
+        "GoCompile",
+        "GoCompilePkg",
+    ],
     output = "$(ACTION_ID).go.kzip",
 )
 


### PR DESCRIPTION
It's unclear if GoCompilePkg is needed, but GoCompile certainly is for extraction to work on gh/kythe/kythe/go/...