### PR TITLE
fix(java_common): cufs shares FileDataProvider and should not close it

### DIFF
--- a/kythe/java/com/google/devtools/kythe/platform/shared/filesystem/CompilationUnitFileSystem.java
+++ b/kythe/java/com/google/devtools/kythe/platform/shared/filesystem/CompilationUnitFileSystem.java
@@ -102,17 +102,9 @@ public final class CompilationUnitFileSystem extends FileSystem {
   public void close() throws IOException {
     synchronized (this) {
       if (closed) return;
-      try {
-        fileDataProvider.close();
-      } catch (IOException e) {
-        throw e;
-      } catch (Exception e) {
-        throw new RuntimeException(e);
-      } finally {
-        fileDataProvider = null;
-        compilationFileTree = null;
-        closed = true;
-      }
+      fileDataProvider = null;
+      compilationFileTree = null;
+      closed = true;
     }
   }
 

--- a/kythe/javatests/com/google/devtools/kythe/platform/shared/filesystem/CompilationUnitFileSystemTest.java
+++ b/kythe/javatests/com/google/devtools/kythe/platform/shared/filesystem/CompilationUnitFileSystemTest.java
@@ -38,6 +38,17 @@ import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public final class CompilationUnitFileSystemTest {
+  private static class UncloseableFileDataCache extends FileDataCache {
+    public UncloseableFileDataCache(List<FileData> fileData) {
+      super(fileData);
+    }
+
+    @Override
+    public void close() {
+      throw new UnsupportedOperationException();
+    }
+  }
+
   private static class FileSystemBuilder {
     private final ImmutableMap.Builder<String, byte[]> inputFiles = new ImmutableMap.Builder<>();
     private String workingDirectory = "";
@@ -59,7 +70,7 @@ public final class CompilationUnitFileSystemTest {
               .addAllRequiredInput(ExtractorUtils.toFileInputs(fileData))
               .setWorkingDirectory(workingDirectory)
               .build();
-      FileDataProvider fileDataProvider = new FileDataCache(fileData);
+      FileDataProvider fileDataProvider = new UncloseableFileDataCache(fileData);
       return CompilationUnitFileSystem.create(compilationUnit, fileDataProvider);
     }
   }


### PR DESCRIPTION
As the FileDataProvider stub is typically an RPC endpoint which can be shared between CompilationUnitFileSystems, a single file system should not close it.