### PR TITLE
feat(typescript): Support AngularTemplateCompile mnemonic

### DIFF
--- a/kythe/extractors/BUILD
+++ b/kythe/extractors/BUILD
@@ -131,7 +131,10 @@ extractor_action(
     ],
     data = ["//external:vnames_config"],
     extractor = "@io_kythe//kythe/go/extractors/cmd/bazel:extract_kzip",
-    mnemonics = ["TypeScriptCompile"],
+    mnemonics = [
+        "TypeScriptCompile",
+        "AngularTemplateCompile",
+    ],
     output = "$(ACTION_ID).typescript.kzip",
 )
 

--- a/kythe/extractors/bazel/README.md
+++ b/kythe/extractors/bazel/README.md
@@ -10,6 +10,7 @@ to extract Kythe `.kzip` compilations from supported targets: `gcr.io/kythe-publ
 * java_{library,binary,test,import,proto_library} (`Javac` and `JavaIjar` action mnemonics)
 * proto_library (`GenProtoDescriptorSet` action mnemonic)
 * typescript_library (`TypeScriptCompile` action mnemonic)
+* ng_module (`AngularTemplateCompile` action mnemonic)
 
 ## Building
 

--- a/kythe/release/release.BUILD
+++ b/kythe/release/release.BUILD
@@ -164,7 +164,10 @@ extractor_action(
     ],
     data = [":vnames_config"],
     extractor = ":bazel_extract_kzip",
-    mnemonics = ["TypeScriptCompile"],
+    mnemonics = [
+        "TypeScriptCompile",
+        "AngularTemplateCompile",
+    ],
     output = "$(ACTION_ID).typescript.kzip",
 )
 


### PR DESCRIPTION
The ng_module produces actions with the AngularTemplateCompile mnemonic (not
TypeScriptCompile). The two actions should both produce extra action data that
can be processed by the same extraction config.