### PR TITLE
drop a log line that always prints

### DIFF
--- a/kythe/typescript/indexer.ts
+++ b/kythe/typescript/indexer.ts
@@ -1844,7 +1844,6 @@ export function index(
 
   if (plugins) {
     for (const plugin of plugins) {
-      console.warn(`${plugin.name} plugin is running.`);
       try {
         plugin.index(indexingContext);
       } catch (err) {


### PR DESCRIPTION
We don't want to clutter our logs with 'plugin is running' messages,
given that they always run.