### PR TITLE
feat(java_indexer): command line option to use path-based file manager

### DIFF
--- a/kythe/java/com/google/devtools/kythe/analyzers/java/JavaIndexer.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/JavaIndexer.java
@@ -18,6 +18,7 @@ package com.google.devtools.kythe.analyzers.java;
 
 import com.beust.jcommander.Parameter;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 import com.google.common.flogger.FluentLogger;
 import com.google.devtools.kythe.analyzers.base.FactEmitter;
 import com.google.devtools.kythe.analyzers.base.StreamFactEmitter;
@@ -166,7 +167,7 @@ public class JavaIndexer {
             metadataLoaders);
     plugins.forEach(analyzer::registerPlugin);
 
-    new JavacAnalysisDriver()
+    new JavacAnalysisDriver(ImmutableList.of(), config.getUseExperimentalPathFileManager())
         .analyze(analyzer, desc.getCompilationUnit(), new FileDataCache(desc.getFileContents()));
   }
 
@@ -208,6 +209,11 @@ public class JavaIndexer {
         description = "Write the entries to this file (or stdout if unspecified)")
     private String outputPath;
 
+    @Parameter(
+        names = "--experimental_use_path_file_manager",
+        description = "Use the experimental Path-based FileManager on JDK9+")
+    private boolean useExperimentalPathFileManager;
+
     public StandaloneConfig() {
       super("java-indexer");
     }
@@ -238,6 +244,10 @@ public class JavaIndexer {
 
     public final List<String> getCompilation() {
       return compilation;
+    }
+
+    public final boolean getUseExperimentalPathFileManager() {
+      return useExperimentalPathFileManager;
     }
   }
 }

--- a/kythe/java/com/google/devtools/kythe/platform/java/JavaCompilationDetails.java
+++ b/kythe/java/com/google/devtools/kythe/platform/java/JavaCompilationDetails.java
@@ -56,7 +56,6 @@ public class JavaCompilationDetails {
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();
 
   private static final Charset DEFAULT_ENCODING = UTF_8;
-  private static final boolean USE_EXPERIMENTAL_PATH_FILE_MANAGER = false;
 
   private static final Predicate<Diagnostic<?>> ERROR_DIAGNOSTIC =
       diag -> diag.getKind() == Kind.ERROR;
@@ -64,7 +63,8 @@ public class JavaCompilationDetails {
   public static JavaCompilationDetails createDetails(
       CompilationUnit compilationUnit,
       FileDataProvider fileDataProvider,
-      List<Processor> processors) {
+      List<Processor> processors,
+      boolean useExperimentalPathFileManager) {
 
     JavaCompiler compiler = JavacAnalysisDriver.getCompiler();
     DiagnosticCollector<JavaFileObject> diagnosticsCollector = new DiagnosticCollector<>();
@@ -78,7 +78,7 @@ public class JavaCompilationDetails {
     StandardJavaFileManager fileManager =
         // The Path-based JavaFileManager is only compatible with JDK9+ and for now,
         // we have to remain compatible with JDK8.
-        USE_EXPERIMENTAL_PATH_FILE_MANAGER && isJdk9OrNewer()
+        useExperimentalPathFileManager && isJdk9OrNewer()
             ? new CompilationUnitPathFileManager(
                 compilationUnit,
                 fileDataProvider,

--- a/kythe/java/com/google/devtools/kythe/platform/java/JavacAnalysisDriver.java
+++ b/kythe/java/com/google/devtools/kythe/platform/java/JavacAnalysisDriver.java
@@ -33,13 +33,15 @@ import javax.tools.JavaCompiler;
 public class JavacAnalysisDriver {
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();
   private final List<Processor> processors;
+  private final boolean useExperimentalPathFileManager;
 
   public JavacAnalysisDriver() {
-    this(ImmutableList.of());
+    this(ImmutableList.of(), false);
   }
 
-  public JavacAnalysisDriver(List<Processor> processors) {
+  public JavacAnalysisDriver(List<Processor> processors, boolean useExperimentalPathFileManager) {
     this.processors = processors;
+    this.useExperimentalPathFileManager = useExperimentalPathFileManager;
   }
 
   /**
@@ -62,6 +64,7 @@ public class JavacAnalysisDriver {
     }
 
     analyzer.analyzeCompilationUnit(
-        JavaCompilationDetails.createDetails(compilationUnit, fileDataProvider, processors));
+        JavaCompilationDetails.createDetails(
+            compilationUnit, fileDataProvider, processors, useExperimentalPathFileManager));
   }
 }


### PR DESCRIPTION
This also refines the path logic within CompilationUnitPathFileManager to restrict the use of the underlying filesystem to *only* bootclasspath paths which aren't present in the CompilationUnit and updates the various comments to more accurately describe the desired semantics.