### PR TITLE
feat(java_extractor): use Optional<Location> and allow updating it

### DIFF
--- a/kythe/java/com/google/devtools/kythe/extractors/java/InputUsageRecord.java
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/InputUsageRecord.java
@@ -18,9 +18,9 @@ package com.google.devtools.kythe.extractors.java;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import java.util.Optional;
 import javax.tools.JavaFileManager.Location;
 import javax.tools.JavaFileObject;
-import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * A compilation with multiple rounds of annotation processing will create new file objects for each
@@ -30,14 +30,14 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public class InputUsageRecord {
 
   private final JavaFileObject fileObject;
-  private final Location location;
+  private Optional<Location> location;
 
   private boolean isUsed = false;
 
-  /** @param location of a class file object, or {@code null} for source files. */
-  public InputUsageRecord(JavaFileObject fileObject, @Nullable Location location) {
+  /** @param location of a java file object, if known. */
+  public InputUsageRecord(JavaFileObject fileObject, Optional<Location> location) {
     this.fileObject = checkNotNull(fileObject);
-    this.location = location;
+    this.location = checkNotNull(location);
   }
 
   /** Record that the compiler used this file as input. */
@@ -55,8 +55,15 @@ public class InputUsageRecord {
     return fileObject;
   }
 
-  /** Return the file's {@link Location}. */
-  public Location location() {
+  /** Return the file's {@link Optional<Location>}. */
+  public Optional<Location> location() {
     return location;
+  }
+
+  /** Update the location, preferring a non-empty location. */
+  public void updateLocation(Optional<Location> value) {
+    if (value.isPresent()) {
+      location = value;
+    }
   }
 }

--- a/kythe/java/com/google/devtools/kythe/extractors/java/JavaCompilationUnitExtractor.java
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/JavaCompilationUnitExtractor.java
@@ -435,7 +435,12 @@ public class JavaCompilationUnitExtractor {
       throws ExtractionException {
     for (InputUsageRecord input : fileManager.getUsages()) {
       processRequiredInput(
-          input.fileObject(), input.location(), fileManager, sourceFiles, genSrcDir, results);
+          input.fileObject(),
+          input.location().orElse(null),
+          fileManager,
+          sourceFiles,
+          genSrcDir,
+          results);
     }
   }
 


### PR DESCRIPTION
Often, the first use of a path is unaware of the location, so allow that to be filled in on subsequent uses, if possible.

Also, use Optional instead of Nullable to indicate the appropriate semantics here.  `.orElse(null)` is used here to avoid dealing with the two separate Optional types.