### PR TITLE
fix(java_extractor): include working directory in extracted proto

### DIFF
--- a/kythe/java/com/google/devtools/kythe/extractors/java/JavaCompilationUnitExtractor.java
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/JavaCompilationUnitExtractor.java
@@ -208,6 +208,7 @@ public class JavaCompilationUnitExtractor {
       unit.addSourceFile(sourceFile);
     }
     unit.setOutputKey(outputPath);
+    unit.setWorkingDirectory(rootDirectory);
     unit.addDetails(
         Any.newBuilder()
             .setTypeUrl(JAVA_DETAILS_URL)

--- a/kythe/javatests/com/google/devtools/kythe/extractors/java/JavaExtractorTest.java
+++ b/kythe/javatests/com/google/devtools/kythe/extractors/java/JavaExtractorTest.java
@@ -76,6 +76,7 @@ public class JavaExtractorTest extends TestCase {
             TARGET1, sources, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, Optional.empty(), EMPTY, "output");
 
     CompilationUnit unit = description.getCompilationUnit();
+    assertThat(unit.getWorkingDirectory()).isEqualTo(ExtractorUtils.getCurrentWorkingDirectory());
     assertThat(unit).isNotNull();
     assertThat(unit.getVName().getSignature()).isEqualTo(TARGET1);
 


### PR DESCRIPTION
The only thing which currently uses the working_directory from Java is the `CompilationUnitPathFileSystem`, but with this enabled that Just Works with modular compilation units, without having to do much surgery to the paths provided on the command line.