### PR TITLE
fix(jdk_extractor): bazel runfiles no longer expect the workspace name

### DIFF
--- a/kythe/extractors/openjdk11/extract/extract.go
+++ b/kythe/extractors/openjdk11/extract/extract.go
@@ -46,9 +46,9 @@ const (
 	kytheVNameVar  = "KYTHE_VNAMES"
 
 	javaMakeVar           = "JAVA_CMD"
-	runfilesWrapperPath   = "io_kythe/kythe/extractors/openjdk11/java_wrapper"
-	runfilesVNamesPath    = "io_kythe/kythe/extractors/openjdk11/vnames.json"
-	runfilesExtractorPath = "io_kythe/kythe/java/com/google/devtools/kythe/extractors/java/standalone/javac9_extractor_deploy.jar"
+	runfilesWrapperPath   = "kythe/extractors/openjdk11/java_wrapper"
+	runfilesVNamesPath    = "kythe/extractors/openjdk11/vnames.json"
+	runfilesExtractorPath = "kythe/java/com/google/devtools/kythe/extractors/java/standalone/javac9_extractor_deploy.jar"
 )
 
 var (


### PR DESCRIPTION
I'm not sure when this changed, but including the workspace name now fails to find Bazel runfiles, whereas it was previously required.