### PR TITLE
fix: EntrySet::emitted becomes volatile

### DIFF
--- a/kythe/java/com/google/devtools/kythe/analyzers/base/EntrySet.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/base/EntrySet.java
@@ -60,7 +60,7 @@ public final class EntrySet {
   private final ImmutableMap<String, byte[]> properties;
 
   /** Used to detect when an {@link EntrySet} was not emitted exactly once. */
-  private boolean emitted;
+  private volatile boolean emitted;
 
   protected EntrySet(
       VName source,


### PR DESCRIPTION
We've seen warnings emitted from finalize() in non-error cases, suspicion is that it may be caused by memory barrier propagation (finalize runs in a different thread).