### PR TITLE
fix(java): record EntrySet emission before calling emitter

### DIFF
--- a/kythe/java/com/google/devtools/kythe/analyzers/base/EntrySet.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/base/EntrySet.java
@@ -60,7 +60,7 @@ public final class EntrySet {
   private final ImmutableMap<String, byte[]> properties;
 
   /** Used to detect when an {@link EntrySet} was not emitted exactly once. */
-  private volatile boolean emitted;
+  private boolean emitted;
 
   protected EntrySet(
       VName source,
@@ -96,10 +96,10 @@ public final class EntrySet {
     if (emitted) {
       logger.atWarning().log("EntrySet already emitted: %s", this);
     }
+    emitted = true;
     for (Map.Entry<String, byte[]> entry : properties.entrySet()) {
       emitter.emit(source, edgeKind, target, entry.getKey(), entry.getValue());
     }
-    emitted = true;
   }
 
   /**


### PR DESCRIPTION
This isn't perfect; if `emit()` throws and is retried, we'll get a different spurious warning. (as @creachadair suggested in #4140, the emitter is where this tracking belongs, if it belongs anywhere at all.)