### PR TITLE
feat(release): add extractors.bazelrc to release

### DIFF
--- a/kythe/extractors/bazel/BUILD
+++ b/kythe/extractors/bazel/BUILD
@@ -6,7 +6,6 @@ docker_build(
     data = [
         "bazel_wrapper.sh",
         "extract.sh",
-        "extractors.bazelrc",
         "//kythe/release",
         "//kythe/release/base:fix_permissions.sh",
         "@com_github_philwo_bazelisk//:bazelisk",
@@ -15,4 +14,10 @@ docker_build(
     image_name = "gcr.io/kythe-public/bazel-extractor",
     tags = ["manual"],
     use_cache = True,
+)
+
+filegroup(
+    name = "extractors_bazelrc",
+    srcs = ["extractors.bazelrc"],
+    visibility = ["//kythe:default_visibility"],
 )

--- a/kythe/extractors/bazel/Dockerfile
+++ b/kythe/extractors/bazel/Dockerfile
@@ -36,9 +36,6 @@ ADD kythe/extractors/bazel/bazel_wrapper.sh /kythe/
 ADD kythe/release/base/fix_permissions.sh /kythe/
 ADD external/javax_annotation_jsr250_api/jar/jsr250-api-1.0.jar /kythe/
 
-# Bazel repository setup
-ADD kythe/extractors/bazel/extractors.bazelrc /kythe/bazelrc
-
 # Bazelisk
 ADD external/com_github_philwo_bazelisk/linux_amd64_stripped/bazelisk /kythe/
 

--- a/kythe/extractors/bazel/extract.sh
+++ b/kythe/extractors/bazel/extract.sh
@@ -62,6 +62,8 @@ if [[ -n "$KYTHE_PRE_BUILD_STEP" ]]; then
   eval "$KYTHE_PRE_BUILD_STEP"
 fi
 
+KYTHE_RELEASE=/kythe
+
 if [[ -n "$KYTHE_BAZEL_TARGET" ]]; then
   # $KYTHE_BAZEL_TARGET is unquoted because bazel_wrapper needs to see each
   # target expression in KYTHE_BAZEL_WRAPPER as individual arguments. For
@@ -69,14 +71,15 @@ if [[ -n "$KYTHE_BAZEL_TARGET" ]]; then
   # needs to see two valid target expressions (//foo/... and -//foo/test/...)
   # not one invalid target expression with white space
   # ("//foo/... -//foo/test/...").
-  /kythe/bazel_wrapper.sh --bazelrc=/kythe/bazelrc "$@" -- $KYTHE_BAZEL_TARGET
+  /kythe/bazel_wrapper.sh --bazelrc=$KYTHE_RELEASE/extractors.bazelrc --override_repository kythe_release=$KYTHE_RELEASE "$@" -- $KYTHE_BAZEL_TARGET
 else
   # If the user supplied a bazel query, execute it and run bazel, but we have to
   # shard the results to different bazel runs because the bazel command line
   # cannot take many arguments. Right now we build 30 targets at a time. We can
   # change this value or make it settable once we have more data on the
   # implications.
-  /kythe/bazelisk query "$KYTHE_BAZEL_QUERY" | xargs -t -L 30 /kythe/bazel_wrapper.sh --bazelrc=/kythe/bazelrc "$@" --
+  /kythe/bazelisk query "$KYTHE_BAZEL_QUERY" | \
+    xargs -t -L 30 /kythe/bazel_wrapper.sh  --bazelrc=$KYTHE_RELEASE/extractors.bazelrc --override_repository kythe_release=$KYTHE_RELEASE  "$@" --
 fi
 
 # Collect any extracted compilations.

--- a/kythe/extractors/bazel/extract.sh
+++ b/kythe/extractors/bazel/extract.sh
@@ -71,7 +71,7 @@ if [[ -n "$KYTHE_BAZEL_TARGET" ]]; then
   # needs to see two valid target expressions (//foo/... and -//foo/test/...)
   # not one invalid target expression with white space
   # ("//foo/... -//foo/test/...").
-  /kythe/bazel_wrapper.sh --bazelrc=$KYTHE_RELEASE/extractors.bazelrc --override_repository kythe_release=$KYTHE_RELEASE "$@" -- $KYTHE_BAZEL_TARGET
+  /kythe/bazel_wrapper.sh --bazelrc=$KYTHE_RELEASE/extractors.bazelrc "$@" --override_repository kythe_release=$KYTHE_RELEASE -- $KYTHE_BAZEL_TARGET
 else
   # If the user supplied a bazel query, execute it and run bazel, but we have to
   # shard the results to different bazel runs because the bazel command line
@@ -79,7 +79,7 @@ else
   # change this value or make it settable once we have more data on the
   # implications.
   /kythe/bazelisk query "$KYTHE_BAZEL_QUERY" | \
-    xargs -t -L 30 /kythe/bazel_wrapper.sh  --bazelrc=$KYTHE_RELEASE/extractors.bazelrc --override_repository kythe_release=$KYTHE_RELEASE  "$@" --
+    xargs -t -L 30 /kythe/bazel_wrapper.sh --bazelrc=$KYTHE_RELEASE/extractors.bazelrc "$@" --override_repository kythe_release=$KYTHE_RELEASE --
 fi
 
 # Collect any extracted compilations.

--- a/kythe/extractors/bazel/extractors.bazelrc
+++ b/kythe/extractors/bazel/extractors.bazelrc
@@ -1,5 +1,13 @@
-# Setup the local repository for the Kythe extraction tools.
-build --override_repository kythe_release=/kythe
+# This file configures bazel for extraction using the binaries from a Kythe
+# release.
+
+# Example usage:
+#   KYTHE_RELEASE=/opt/kythe
+#   bazel \
+#     --bazelrc=$KYTHE_RELEASE/extractors.bazelrc
+#     build \
+#     --override_repository kythe_release=$KYTHE_RELEASE \
+#     //targets/to:extract
 
 # By default, keep building after errors.
 build --keep_going

--- a/kythe/release/BUILD
+++ b/kythe/release/BUILD
@@ -53,6 +53,7 @@ genrule(
         ":misc",
         "//kythe/proto:public",
         "//third_party:licenses",
+        "//kythe/extractors/bazel:extractors_bazelrc",
     ],
     outs = [
         "kythe-" + release_version + ".tar.gz",
@@ -86,6 +87,7 @@ genrule(
         "--cp $(location proto_extractor) extractors/proto_extractor",
         "--cp $(location textproto_extractor) extractors/textproto_extractor",
         "--cp $(location cc_proto_metadata_plugin) tools/cc_proto_metadata_plugin",
+        "--cp $(location //kythe/extractors/bazel:extractors_bazelrc) ./",
         "--path tools/ $(locations tools)",
         "--path proto/ $(locations //kythe/proto:public)",
         "--relpaths 'third_party' --path 'third_party' $(locations //third_party:licenses)",


### PR DESCRIPTION
This config adds extra_action_listeners for each of the extractors in the kythe release, so extraction can be done in a simple invocation of bazel:

```shell
KYTHE_RELEASE=/opt/kythe
bazel \
  --bazelrc=$KYTHE_RELEASE/extractors.bazelrc
  build \
  --override_repository kythe_release=$KYTHE_RELEASE \
  //targets/to:extract
```