### PR TITLE
refactor(typescript_indexer): allow to pass multiple files in indexer test

### DIFF
--- a/kythe/typescript/test.ts
+++ b/kythe/typescript/test.ts
@@ -25,6 +25,7 @@
 
 import * as assert from 'assert';
 import * as child_process from 'child_process';
+import * as fs from 'fs';
 import * as path from 'path';
 import * as ts from 'typescript';
 
@@ -68,7 +69,7 @@ function createTestCompilerHost(options: ts.CompilerOptions): ts.CompilerHost {
  * be run async; if there's an error, it will reject the promise.
  */
 function verify(
-    host: ts.CompilerHost, options: ts.CompilerOptions, test: string,
+    host: ts.CompilerHost, options: ts.CompilerOptions, testFiles: string[],
     plugins?: indexer.Plugin[]): Promise<void> {
   const compilationUnit: kythe.VName = {
     corpus: 'testcorpus',
@@ -77,15 +78,16 @@ function verify(
     signature: '',
     language: '',
   };
-  const program = ts.createProgram([test], options, host);
+  const program = ts.createProgram(testFiles, options, host);
 
   const verifier = child_process.spawn(
-      `${ENTRYSTREAM} --read_format=json | ${VERIFIER} ${test}`, [], {
+      `${ENTRYSTREAM} --read_format=json | ${VERIFIER} ${testFiles.join(' ')}`,
+      [], {
         stdio: ['pipe', process.stdout, process.stderr],
         shell: true,
       });
 
-  indexer.index(compilationUnit, new Map(), [test], program, (obj: {}) => {
+  indexer.index(compilationUnit, new Map(), testFiles, program, (obj: {}) => {
     verifier.stdin.write(JSON.stringify(obj) + '\n');
   }, plugins);
   verifier.stdin.end();
@@ -108,23 +110,77 @@ function testLoadTsConfig() {
   assert.deepEqual(config.fileNames, [path.resolve('testdata/alt.ts')]);
 }
 
-async function testIndexer(args: string[], plugins?: indexer.Plugin[]) {
+function collectTSFilesInDirectoryRecursively(dir: string, result: string[]) {
+  for (const file of fs.readdirSync(dir, {withFileTypes: true})) {
+    if (file.isDirectory()) {
+      collectTSFilesInDirectoryRecursively(`${dir}/${file.name}`, result);
+    } else if (file.name.endsWith('.ts')) {
+      result.push(path.resolve(`${dir}/${file.name}`));
+    }
+  }
+}
+
+/**
+ * Returns list of files to test. Each group of files will be tested together:
+ * all files from a group will be passed to indexer and verifier.
+ *
+ * The rules of constructing groups are the following:
+ * 1. All individual files in testdata will be returned as group of one file.
+ *    So they are tested separately.
+ * 2. All files in subfolders in testdata/ will be returned as one group. These
+ *    are used when cross-file references need to be tested.
+ */
+function getTestFileGroups(): string[][] {
+  const result = [];
+  for (const file of fs.readdirSync('testdata', {withFileTypes: true})) {
+    const relativeName = `testdata/${file.name}`;
+    if (file.isDirectory()) {
+      const group: string[] = [];
+      collectTSFilesInDirectoryRecursively(relativeName, group);
+      result.push(group);
+    } else if (file.name.endsWith('.ts')) {
+      result.push([path.resolve(relativeName)]);
+    }
+  }
+  return result;
+}
+
+/**
+ * Given filters passed as command line arguments by user - returns only
+ * groups that contain at least one file that matches at least one filter.
+ * Matching is done by simply checking for substring.
+ */
+function filterTestFileGroups(
+    testFileGroups: string[][], filters: string[]): string[][] {
+  return testFileGroups.filter(fileGroup => {
+    for (const file of fileGroup) {
+      if (filters.some(filter => file.includes(filter))) {
+        return true;
+      }
+    }
+    return false;
+  });
+}
+
+async function testIndexer(filters: string[], plugins?: indexer.Plugin[]) {
   const config =
       indexer.loadTsConfig('testdata/tsconfig.for.tests.json', 'testdata');
-  let testPaths = args.map(arg => path.resolve(arg));
-  if (args.length === 0) {
-    // If no tests were passed on the command line, run all the .ts files found
-    // by the tsconfig.json, which covers all the tests in testdata/.
-    testPaths = config.fileNames;
+  let testFilesGroups = getTestFileGroups();
+  if (filters.length !== 0) {
+    testFilesGroups = filterTestFileGroups(testFilesGroups, filters);
   }
 
   const host = createTestCompilerHost(config.options);
-  for (const test of testPaths) {
-    const testName = path.relative(config.options.rootDir!, test);
+  for (const testFiles of testFilesGroups) {
+    const testName = path.relative(config.options.rootDir!, testFiles[0]);
+    if (testName.endsWith('plugin.ts')) {
+      // plugin.ts is tested by testPlugin() test.
+      continue;
+    }
     const start = new Date().valueOf();
     process.stdout.write(`${testName}: `);
     try {
-      await verify(host, config.options, test, plugins);
+      await verify(host, config.options, testFiles, plugins);
     } catch (e) {
       console.log('FAIL');
       throw e;

--- a/package-lock.json
+++ b/package-lock.json
@@ -367,9 +367,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "7.10.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.10.6.tgz",
-      "integrity": "sha512-d0BOAicT0tEdbdVQlLGOVul1kvg6YvbaADRCThGCz5NJ0e9r00SofcR1x69hmlCyrHuB6jd4cKzL9bMLjPnpAA==",
+      "version": "10.17.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.3.tgz",
+      "integrity": "sha512-QZ9CjUB3QoA3f2afw3utKlfRPhpmufB7jC2+oDhLWnXqoyx333fhKSQDLQu2EK7OE0a15X67eYiRAaJsHXrpMA==",
       "dev": true
     },
     "@types/semver": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@commitlint/cli": "^8.1.0",
     "@commitlint/config-conventional": "^8.1.0",
     "@types/jasmine": "^3.3.13",
-    "@types/node": "^7.0.4"
+    "@types/node": "^10.0.0"
   },
   "dependencies": {
     "source-map-support": "^0.5.12",


### PR DESCRIPTION
Today TS test runs test files one at a time. This makes it impossible to
test scenarios that check references between multiple files. For example
when TS file requires module declared in `.d.ts` file. In this scenario
both `.ts` and `.d.ts` files must be passed togeter to indexer and
verifier.

This commit changes the way how test files are scanned by test. Now
test files passed as array instead of single file. All `.ts` files
immediately places inside testdata/ are still passed as array of single
files. Files in subfolders of testdata/ are passed as single array, one
per subfolder.