### PR TITLE
fix(bazel-extractor): fix permissions when extracting release archive

### DIFF
--- a/kythe/extractors/bazel/Dockerfile
+++ b/kythe/extractors/bazel/Dockerfile
@@ -26,7 +26,7 @@ RUN ln -s /usr/bin/clang-6.0 /usr/bin/clang && \
 
 # Extract the Kythe release archive to /kythe
 COPY kythe/release/kythe-v*.tar.gz /tmp/
-RUN tar xzf /tmp/kythe-v*.tar.gz && \
+RUN tar --no-same-owner -xzf /tmp/kythe-v*.tar.gz && \
     mv kythe-v*/ /kythe && \
     rm /tmp/kythe-v*.tar.gz
 


### PR DESCRIPTION
without this flag, tar was assigning a file owner from the host machine that didn't exist in the docker image