### PR TITLE
feat(go_indexer): option to emit an edge for an anchor's semantic scope

### DIFF
--- a/kythe/go/indexer/BUILD
+++ b/kythe/go/indexer/BUILD
@@ -103,6 +103,12 @@ go_indexer_test(
 )
 
 go_indexer_test(
+    name = "scopes_test",
+    srcs = ["testdata/basic/scopes.go"],
+    emit_anchor_scopes = True,
+)
+
+go_indexer_test(
     name = "comment_test",
     srcs = ["testdata/basic/comments.go"],
 )

--- a/kythe/go/indexer/cmd/go_indexer/go_indexer.go
+++ b/kythe/go/indexer/cmd/go_indexer/go_indexer.go
@@ -40,13 +40,14 @@ import (
 )
 
 var (
-	doJSON      = flag.Bool("json", false, "Write output as JSON")
-	doLibNodes  = flag.Bool("libnodes", false, "Emit nodes for standard library packages")
-	doCodeFacts = flag.Bool("code", false, "Emit code facts containing MarkedSource markup")
-	metaSuffix  = flag.String("meta", "", "If set, treat files with this suffix as JSON linkage metadata")
-	docBase     = flag.String("docbase", "http://godoc.org", "If set, use as the base URL for godoc links")
-	verbose     = flag.Bool("verbose", false, "Emit verbose log information")
-	contOnErr   = flag.Bool("continue", false, "Log errors encountered during analysis but do not exit unsuccessfully")
+	doJSON         = flag.Bool("json", false, "Write output as JSON")
+	doLibNodes     = flag.Bool("libnodes", false, "Emit nodes for standard library packages")
+	doCodeFacts    = flag.Bool("code", false, "Emit code facts containing MarkedSource markup")
+	doAnchorScopes = flag.Bool("anchor_scopes", false, "Emit childof edges to an anchor's semantic scope")
+	metaSuffix     = flag.String("meta", "", "If set, treat files with this suffix as JSON linkage metadata")
+	docBase        = flag.String("docbase", "http://godoc.org", "If set, use as the base URL for godoc links")
+	verbose        = flag.Bool("verbose", false, "Emit verbose log information")
+	contOnErr      = flag.Bool("continue", false, "Log errors encountered during analysis but do not exit unsuccessfully")
 
 	writeEntry func(context.Context, *spb.Entry) error
 	docURL     *url.URL
@@ -145,6 +146,7 @@ func indexGo(ctx context.Context, unit *apb.CompilationUnit, f indexer.Fetcher) 
 	return pi.Emit(ctx, writeEntry, &indexer.EmitOptions{
 		EmitStandardLibs: *doLibNodes,
 		EmitMarkedSource: *doCodeFacts,
+		EmitAnchorScopes: *doAnchorScopes,
 		EmitLinkages:     *metaSuffix != "",
 		DocBase:          docURL,
 	})

--- a/kythe/go/indexer/emit.go
+++ b/kythe/go/indexer/emit.go
@@ -55,6 +55,9 @@ type EmitOptions struct {
 	// If true, emit linkages specified by metadata rules.
 	EmitLinkages bool
 
+	// If true, emit childof edges for an anchor's semantic scope.
+	EmitAnchorScopes bool
+
 	// If set, use this as the base URL for links to godoc.  The import path is
 	// appended to the path of this URL to obtain the target URL to link to.
 	DocBase *url.URL
@@ -65,6 +68,13 @@ func (e *EmitOptions) emitMarkedSource() bool {
 		return false
 	}
 	return e.EmitMarkedSource
+}
+
+func (e *EmitOptions) emitAnchorScopes() bool {
+	if e == nil {
+		return false
+	}
+	return e.EmitAnchorScopes
 }
 
 // shouldEmit reports whether the indexer should emit a node for the given
@@ -191,7 +201,10 @@ func (e *emitter) visitIdent(id *ast.Ident, stack stackFunc) {
 		})
 		return
 	}
-	e.writeRef(id, target, edges.Ref)
+	ref := e.writeRef(id, target, edges.Ref)
+	if e.opts.emitAnchorScopes() {
+		e.writeEdge(ref, e.callContext(stack).vname, edges.ChildOf)
+	}
 	if call, ok := isCall(id, obj, stack); ok {
 		callAnchor := e.writeRef(call, target, edges.RefCall)
 

--- a/kythe/go/indexer/testdata/basic/scopes.go
+++ b/kythe/go/indexer/testdata/basic/scopes.go
@@ -1,0 +1,11 @@
+package scopes
+
+//- @Ident defines/binding Ident
+var Ident bool
+
+//- @F defines/binding F
+func F() {
+	//- IdentRef=@Ident ref Ident
+	//- IdentRef childof F
+	Ident = true
+}

--- a/kythe/go/indexer/testdata/go_indexer_test.bzl
+++ b/kythe/go/indexer/testdata/go_indexer_test.bzl
@@ -150,6 +150,9 @@ def _go_entries(ctx):
     if ctx.attr.has_marked_source:
         iargs.append("-code")
 
+    if ctx.attr.emit_anchor_scopes:
+        iargs.append("-anchor_scopes")
+
     # If the test wants linkage metadata, enable support for it in the indexer.
     if ctx.attr.metadata_suffix:
         iargs += ["-meta", ctx.attr.metadata_suffix]
@@ -172,6 +175,9 @@ go_entries = rule(
     attrs = {
         # Whether to enable explosion of MarkedSource facts.
         "has_marked_source": attr.bool(default = False),
+
+        # Whether to enable anchor scope edges.
+        "emit_anchor_scopes": attr.bool(default = False),
 
         # The go_extract output to pass to the indexer.
         "kzip": attr.label(
@@ -225,6 +231,7 @@ def _go_indexer(
         importpath = None,
         data = None,
         has_marked_source = False,
+        emit_anchor_scopes = False,
         allow_duplicates = False,
         metadata_suffix = ""):
     if len(deps) > 0:
@@ -249,6 +256,7 @@ def _go_indexer(
     go_entries(
         name = entries,
         has_marked_source = has_marked_source,
+        emit_anchor_scopes = emit_anchor_scopes,
         kzip = ":" + kzip,
         metadata_suffix = metadata_suffix,
     )
@@ -266,6 +274,7 @@ def go_indexer_test(
         log_entries = False,
         data = None,
         has_marked_source = False,
+        emit_anchor_scopes = False,
         allow_duplicates = False,
         metadata_suffix = ""):
     entries = _go_indexer(
@@ -273,6 +282,7 @@ def go_indexer_test(
         srcs = srcs,
         data = data,
         has_marked_source = has_marked_source,
+        emit_anchor_scopes = emit_anchor_scopes,
         importpath = import_path,
         metadata_suffix = metadata_suffix,
         deps = deps,


### PR DESCRIPTION
This generalizes the `ref/call` scopes to all identifier references like https://github.com/kythe/kythe/commit/0a3afc9bffba3e09c638ae28575605a1441ebf5e does for the Java indexer.