### PR TITLE
feat(bazel extractor): put everything in the same corpus by default

### DIFF
--- a/kythe/data/BUILD
+++ b/kythe/data/BUILD
@@ -18,12 +18,16 @@ construct_vnames_config(
 filegroup(
     name = "raw_vnames_config",
     srcs = [
-        "simple_vnames.json",
         "vnames.cxx.json",
         "vnames.go.json",
         "vnames.java.json",
         "vnames.json",
     ],
+)
+
+filegroup(
+    name = "simple_vnames_config",
+    srcs = ["simple_vnames.json"],
 )
 
 filegroup(

--- a/kythe/data/BUILD
+++ b/kythe/data/BUILD
@@ -18,6 +18,7 @@ construct_vnames_config(
 filegroup(
     name = "raw_vnames_config",
     srcs = [
+        "simple_vnames.json",
         "vnames.cxx.json",
         "vnames.go.json",
         "vnames.java.json",

--- a/kythe/data/simple_vnames.json
+++ b/kythe/data/simple_vnames.json
@@ -1,13 +1,6 @@
 [
   {
-    "pattern": "bazel-out/[^/]+/bin/external/[^/]+/(.+)",
-    "vname": {
-      "corpus": "CORPUS",
-      "path": "@1@"
-    }
-  },
-  {
-    "pattern": "bazel-out/[^/]+/([^/]+)/external/[^/]+/(.+)",
+    "pattern": "bazel-out/[^/]+/([^/]+/external/[^/]+)/(.+)",
     "vname": {
       "corpus": "CORPUS",
       "root": "bazel-out/@1@",

--- a/kythe/data/simple_vnames.json
+++ b/kythe/data/simple_vnames.json
@@ -1,0 +1,32 @@
+[
+  {
+    "pattern": "bazel-out/[^/]+/bin/external/[^/]+/(.+)",
+    "vname": {
+      "corpus": "CORPUS",
+      "path": "@1@"
+    }
+  },
+  {
+    "pattern": "bazel-out/[^/]+/([^/]+)/external/[^/]+/(.+)",
+    "vname": {
+      "corpus": "CORPUS",
+      "root": "bazel-out/@1@",
+      "path": "@2@"
+    }
+  },
+  {
+    "pattern": "bazel-out/[^/]+/(\\w+)/(.*)",
+    "vname": {
+      "corpus": "CORPUS",
+      "path": "@2@",
+      "root": "bazel-out/@1@"
+    }
+  },
+  {
+    "pattern": "(.*)",
+    "vname": {
+      "corpus": "CORPUS",
+      "path": "@1@"
+    }
+  }
+]

--- a/kythe/release/BUILD
+++ b/kythe/release/BUILD
@@ -108,6 +108,7 @@ filegroup(
         "//:LICENSE",
         "//:RELEASES.md",
         "//kythe/data:raw_vnames_config",
+        "//kythe/data:simple_vnames_config",
         "//kythe/data:vnames.bzl",
         "//kythe/extractors:extractors.bzl",
     ],

--- a/kythe/release/release.BUILD
+++ b/kythe/release/release.BUILD
@@ -11,14 +11,28 @@ exports_files([
 load(":extractors.bzl", "extractor_action")
 load(":vnames.bzl", "construct_vnames_config")
 
+config_setting(
+    name = "assign_external_projects_to_separate_corpora",
+    values = {
+        "define": "kythe_assign_external_projects_to_separate_corpora=true",
+    },
+)
+
 construct_vnames_config(
     name = "vnames_config",
-    srcs = [
-        "vnames.cxx.json",
-        "vnames.go.json",
-        "vnames.java.json",
-        "vnames.json",
-    ],
+    srcs = select({
+        "//conditions:default": [
+            # by default, the simple vname rules are used, which map everything
+            # to the corpus set via `--define kythe_corpus=<my corpus>`.
+            "simple_vnames.json",
+        ],
+        ":assign_external_projects_to_separate_corpora": [
+            "vnames.cxx.json",
+            "vnames.go.json",
+            "vnames.java.json",
+            "vnames.json",
+        ],
+    }),
 )
 
 # Clone of default Java proto toolchain with "annotate_code" enabled for


### PR DESCRIPTION
Provide a flag for using the old behavior, which maps external projects to their own corpora:

`--define kythe_assign_external_projects_to_separate_corpora=true`

I'm open to better names for this.