### PR TITLE
fix(kzip info): trim extra spaces from error message

### DIFF
--- a/kythe/go/platform/kzip/info/info.go
+++ b/kythe/go/platform/kzip/info/info.go
@@ -53,6 +53,7 @@ func KzipInfo(f kzip.File, fileSize int64, scanOpts ...kzip.ScanOption) (*apb.Kz
 		for _, ri := range u.Proto.RequiredInput {
 			riCorpus := requiredInputCorpus(u, ri)
 			if riCorpus == "" {
+				// Trim spaces to work around the fact that log("%v", proto) is inconsistent about trailing spaces in google3 vs open-source go.
 				msg := strings.TrimSpace(fmt.Sprintf("unable to determine corpus for required_input %q in CU %v", ri.Info.Path, u.Proto.GetVName()))
 				kzipInfo.CriticalKzipErrors = append(kzipInfo.CriticalKzipErrors, msg)
 				return nil

--- a/kythe/go/platform/kzip/info/info.go
+++ b/kythe/go/platform/kzip/info/info.go
@@ -53,7 +53,7 @@ func KzipInfo(f kzip.File, fileSize int64, scanOpts ...kzip.ScanOption) (*apb.Kz
 		for _, ri := range u.Proto.RequiredInput {
 			riCorpus := requiredInputCorpus(u, ri)
 			if riCorpus == "" {
-				msg := strings.TrimSuffix(fmt.Sprintf("unable to determine corpus for required_input %q in CU %v", ri.Info.Path, u.Proto.GetVName()), " ")
+				msg := strings.TrimSpace(fmt.Sprintf("unable to determine corpus for required_input %q in CU %v", ri.Info.Path, u.Proto.GetVName()))
 				kzipInfo.CriticalKzipErrors = append(kzipInfo.CriticalKzipErrors, msg)
 				return nil
 			}

--- a/kythe/go/platform/kzip/info/info.go
+++ b/kythe/go/platform/kzip/info/info.go
@@ -20,6 +20,7 @@ package info // import "kythe.io/kythe/go/platform/kzip/info"
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"bitbucket.org/creachadair/stringset"
 
@@ -52,7 +53,7 @@ func KzipInfo(f kzip.File, fileSize int64, scanOpts ...kzip.ScanOption) (*apb.Kz
 		for _, ri := range u.Proto.RequiredInput {
 			riCorpus := requiredInputCorpus(u, ri)
 			if riCorpus == "" {
-				msg := fmt.Sprintf("unable to determine corpus for required_input %q in CU %v", ri.Info.Path, u.Proto.GetVName())
+				msg := strings.TrimSuffix(fmt.Sprintf("unable to determine corpus for required_input %q in CU %v", ri.Info.Path, u.Proto.GetVName()), " ")
 				kzipInfo.CriticalKzipErrors = append(kzipInfo.CriticalKzipErrors, msg)
 				return nil
 			}

--- a/kythe/go/platform/kzip/info/info_test.go
+++ b/kythe/go/platform/kzip/info/info_test.go
@@ -212,7 +212,7 @@ var infoTests = []struct {
 			},
 		},
 		&apb.KzipInfo{
-			CriticalKzipErrors: []string{"unable to determine corpus for required_input \"file1.py\" in CU language:\"python\" "},
+			CriticalKzipErrors: []string{"unable to determine corpus for required_input \"file1.py\" in CU language:\"python\""},
 		},
 	},
 }


### PR DESCRIPTION
this works around the fact that log("%v", proto) is inconsistent about spacing in open source go vs google3