### PR TITLE
chore(java indexer): log filemanager exceptions

### DIFF
--- a/kythe/java/com/google/devtools/kythe/platform/java/filemanager/ForwardingStandardJavaFileManager.java
+++ b/kythe/java/com/google/devtools/kythe/platform/java/filemanager/ForwardingStandardJavaFileManager.java
@@ -297,6 +297,10 @@ public class ForwardingStandardJavaFileManager
       String methodName, ReflectiveOperationException error, Class<IOException> declaredType)
       throws IOException {
     if (error instanceof InvocationTargetException) {
+      // Log the exception because the propagated destination may not provide a nice error log.
+      logger.atWarning().withCause(error).log(
+          "Error in underlying filemanager. A more detailed message may have been output to"
+              + " stderr.");
       Throwables.propagateIfPossible(((InvocationTargetException) error).getCause(), declaredType);
     }
     return unsupportedVersionError(methodName, error);

--- a/kythe/java/com/google/devtools/kythe/platform/java/filemanager/ForwardingStandardJavaFileManager.java
+++ b/kythe/java/com/google/devtools/kythe/platform/java/filemanager/ForwardingStandardJavaFileManager.java
@@ -298,10 +298,11 @@ public class ForwardingStandardJavaFileManager
       throws IOException {
     if (error instanceof InvocationTargetException) {
       // Log the exception because the propagated destination may not provide a nice error log.
-      logger.atWarning().withCause(error).log(
+      Throwable t = ((InvocationTargetException) error).getCause();
+      logger.atWarning().withCause(t).log(
           "Error in underlying filemanager. A more detailed message may have been output to"
               + " stderr.");
-      Throwables.propagateIfPossible(((InvocationTargetException) error).getCause(), declaredType);
+      Throwables.propagateIfPossible(t, declaredType);
     }
     return unsupportedVersionError(methodName, error);
   }


### PR DESCRIPTION
The filemanager sometimes logs errors to stderr without any context and that makes it more difficult than it should be to debug problems. Add an explicit log invocation in all methods called via reflection. We could add the log to non-reflective calls as well, but that would be a more invasive change.