### PR TITLE
feat(java indexer): better support system modules

### DIFF
--- a/kythe/java/com/google/devtools/kythe/analyzers/java/JavaIndexer.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/JavaIndexer.java
@@ -47,6 +47,8 @@ import java.io.OutputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ServiceLoader;
@@ -167,7 +169,12 @@ public class JavaIndexer {
             metadataLoaders);
     plugins.forEach(analyzer::registerPlugin);
 
-    new JavacAnalysisDriver(ImmutableList.of(), config.getUseExperimentalPathFileManager())
+    Path tempPath =
+        Strings.isNullOrEmpty(config.getTemporaryDirectory())
+            ? null
+            : FileSystems.getDefault().getPath(config.getTemporaryDirectory());
+    new JavacAnalysisDriver(
+            ImmutableList.of(), config.getUseExperimentalPathFileManager(), tempPath)
         .analyze(analyzer, desc.getCompilationUnit(), new FileDataCache(desc.getFileContents()));
   }
 

--- a/kythe/java/com/google/devtools/kythe/analyzers/java/JavaIndexerConfig.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/JavaIndexerConfig.java
@@ -77,6 +77,13 @@ public class JavaIndexerConfig extends IndexerConfig {
       description = "Use the experimental Path-based FileManager on JDK9+")
   private boolean useExperimentalPathFileManager;
 
+  @Parameter(
+      names = "--temp_directory",
+      description =
+          "Directory on the local file system that can be used to store files that the java"
+              + " compiler insists on being read from the local file system.")
+  private String temporaryDirectory;
+
   public static enum JvmMode {
     NAMES,
     SEMANTIC;
@@ -118,6 +125,10 @@ public class JavaIndexerConfig extends IndexerConfig {
     return useExperimentalPathFileManager;
   }
 
+  public String getTemporaryDirectory() {
+    return temporaryDirectory;
+  }
+
   public JavaIndexerConfig setIgnoreVNamePaths(boolean ignoreVNamePaths) {
     this.ignoreVNamePaths = ignoreVNamePaths;
     return this;
@@ -156,6 +167,11 @@ public class JavaIndexerConfig extends IndexerConfig {
   public JavaIndexerConfig setUseExperimentalPathFileManager(
       boolean useExperimentalPathFileManager) {
     this.useExperimentalPathFileManager = useExperimentalPathFileManager;
+    return this;
+  }
+
+  public JavaIndexerConfig setTemporaryDirectory(String temporaryDirectory) {
+    this.temporaryDirectory = temporaryDirectory;
     return this;
   }
 }

--- a/kythe/java/com/google/devtools/kythe/platform/java/BUILD
+++ b/kythe/java/com/google/devtools/kythe/platform/java/BUILD
@@ -23,6 +23,7 @@ java_library(
         "//third_party/javac",
         "@com_google_protobuf//:protobuf_java",
         "@maven//:com_google_code_findbugs_jsr305",
+        "@maven//:org_checkerframework_checker_qual",
     ],
 )
 

--- a/kythe/java/com/google/devtools/kythe/platform/java/JavacAnalysisDriver.java
+++ b/kythe/java/com/google/devtools/kythe/platform/java/JavacAnalysisDriver.java
@@ -22,9 +22,11 @@ import com.google.devtools.kythe.platform.shared.AnalysisException;
 import com.google.devtools.kythe.platform.shared.FileDataProvider;
 import com.google.devtools.kythe.proto.Analysis.CompilationUnit;
 import com.sun.tools.javac.api.JavacTool;
+import java.nio.file.Path;
 import java.util.List;
 import javax.annotation.processing.Processor;
 import javax.tools.JavaCompiler;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Base implementation for the various analysis drivers. Allows running {@link JavacAnalyzer} over
@@ -34,14 +36,19 @@ public class JavacAnalysisDriver {
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();
   private final List<Processor> processors;
   private final boolean useExperimentalPathFileManager;
+  @Nullable private final Path temporaryDirectory;
 
   public JavacAnalysisDriver() {
-    this(ImmutableList.of(), false);
+    this(ImmutableList.of(), false, null);
   }
 
-  public JavacAnalysisDriver(List<Processor> processors, boolean useExperimentalPathFileManager) {
+  public JavacAnalysisDriver(
+      List<Processor> processors,
+      boolean useExperimentalPathFileManager,
+      @Nullable Path temporaryDirectory) {
     this.processors = processors;
     this.useExperimentalPathFileManager = useExperimentalPathFileManager;
+    this.temporaryDirectory = temporaryDirectory;
   }
 
   /**
@@ -63,8 +70,14 @@ public class JavacAnalysisDriver {
       return;
     }
 
-    analyzer.analyzeCompilationUnit(
+    try (JavaCompilationDetails details =
         JavaCompilationDetails.createDetails(
-            compilationUnit, fileDataProvider, processors, useExperimentalPathFileManager));
+            compilationUnit,
+            fileDataProvider,
+            processors,
+            useExperimentalPathFileManager,
+            temporaryDirectory)) {
+      analyzer.analyzeCompilationUnit(details);
+    }
   }
 }

--- a/kythe/java/com/google/devtools/kythe/platform/java/filemanager/BUILD
+++ b/kythe/java/com/google/devtools/kythe/platform/java/filemanager/BUILD
@@ -52,6 +52,7 @@ java_library(
         "@com_google_protobuf//:any_proto",
         "@com_google_protobuf//:protobuf_java",
         "@maven//:com_google_guava_guava",
+        "@maven//:org_checkerframework_checker_qual",
     ],
 )
 


### PR DESCRIPTION
The Java libraries handle the system module path in a special way so our normal
methods for reading from a compilation unit instead of the local file system do
not work. The easiest way to deal with this is to treat system modules
specially in our indexer and unpack them to a local temp directory for java to
read from. This is not ideal because it pollutes the local file system but given
what the Java libraries do, it doesn't look like there are any better options.

H/T @shahms for the majority of this PR.