### PR TITLE
chore(java indexer): Use optional for possibly empty values

### DIFF
--- a/kythe/java/com/google/devtools/kythe/platform/java/JavaCompilationDetails.java
+++ b/kythe/java/com/google/devtools/kythe/platform/java/JavaCompilationDetails.java
@@ -180,8 +180,8 @@ public class JavaCompilationDetails implements AutoCloseable {
   }
 
   /** Returns the AST for the current analysis target. */
-  public Optional<Iterable<? extends CompilationUnitTree>> getAsts() {
-    return Optional.ofNullable(asts);
+  public Iterable<? extends CompilationUnitTree> getAsts() {
+    return asts == null ? ImmutableList.of() : asts;
   }
 
   /** Returns the protocol buffer describing the current analysis target. */

--- a/kythe/java/com/google/devtools/kythe/platform/java/JavaCompilationDetails.java
+++ b/kythe/java/com/google/devtools/kythe/platform/java/JavaCompilationDetails.java
@@ -37,6 +37,7 @@ import java.lang.reflect.Method;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Optional;
 import javax.annotation.processing.Processor;
 import javax.tools.Diagnostic;
 import javax.tools.Diagnostic.Kind;
@@ -50,9 +51,9 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public class JavaCompilationDetails implements AutoCloseable {
   private final JavacTask javac;
   private final DiagnosticCollector<JavaFileObject> diagnostics;
-  private final Iterable<? extends CompilationUnitTree> asts;
+  @Nullable private final Iterable<? extends CompilationUnitTree> asts;
   private final CompilationUnit compilationUnit;
-  private final Throwable analysisCrash;
+  @Nullable private final Throwable analysisCrash;
   private final Charset encoding;
   private final StandardJavaFileManager fileManager;
 
@@ -137,9 +138,9 @@ public class JavaCompilationDetails implements AutoCloseable {
   private JavaCompilationDetails(
       JavacTask javac,
       DiagnosticCollector<JavaFileObject> diagnostics,
-      Iterable<? extends CompilationUnitTree> asts,
+      @Nullable Iterable<? extends CompilationUnitTree> asts,
       CompilationUnit compilationUnit,
-      Throwable analysisCrash,
+      @Nullable Throwable analysisCrash,
       Charset encoding,
       StandardJavaFileManager fileManager) {
     this.javac = javac;
@@ -179,8 +180,8 @@ public class JavaCompilationDetails implements AutoCloseable {
   }
 
   /** Returns the AST for the current analysis target. */
-  public Iterable<? extends CompilationUnitTree> getAsts() {
-    return asts;
+  public Optional<Iterable<? extends CompilationUnitTree>> getAsts() {
+    return Optional.ofNullable(asts);
   }
 
   /** Returns the protocol buffer describing the current analysis target. */
@@ -189,8 +190,8 @@ public class JavaCompilationDetails implements AutoCloseable {
   }
 
   /** Returns any unexpected crash that might have occurred during javac analysis. */
-  public Throwable getAnalysisCrash() {
-    return analysisCrash;
+  public Optional<Throwable> getAnalysisCrash() {
+    return Optional.ofNullable(analysisCrash);
   }
 
   /** Returns he encoding for the source files in this compilation */

--- a/kythe/java/com/google/devtools/kythe/platform/java/JavacAnalyzer.java
+++ b/kythe/java/com/google/devtools/kythe/platform/java/JavacAnalyzer.java
@@ -51,17 +51,19 @@ public abstract class JavacAnalyzer implements Serializable {
   public void analyzeCompilationUnit(JavaCompilationDetails compilationDetails)
       throws AnalysisException {
     try {
-      for (CompilationUnitTree file : compilationDetails.getAsts()) {
-        URI uri = file.getSourceFile().toUri();
-        String fullPath = file.getSourceFile().toUri().getRawPath();
-        if (!uri.getScheme().equals("file")) {
-          fullPath = fullPath.substring(1);
+      if (compilationDetails.getAsts().isPresent()) {
+        for (CompilationUnitTree file : compilationDetails.getAsts().get()) {
+          URI uri = file.getSourceFile().toUri();
+          String fullPath = file.getSourceFile().toUri().getRawPath();
+          if (!uri.getScheme().equals("file")) {
+            fullPath = fullPath.substring(1);
+          }
+          if (Strings.isNullOrEmpty(fullPath)) {
+            continue;
+          }
+          analyzeFile(compilationDetails, file);
+          getStatisticsCollector().incrementCounter("files-analyzed");
         }
-        if (Strings.isNullOrEmpty(fullPath)) {
-          continue;
-        }
-        analyzeFile(compilationDetails, file);
-        getStatisticsCollector().incrementCounter("files-analyzed");
       }
       getStatisticsCollector().incrementCounter("compilations-analyzed");
     } catch (Throwable t) {

--- a/kythe/java/com/google/devtools/kythe/platform/java/JavacAnalyzer.java
+++ b/kythe/java/com/google/devtools/kythe/platform/java/JavacAnalyzer.java
@@ -51,19 +51,17 @@ public abstract class JavacAnalyzer implements Serializable {
   public void analyzeCompilationUnit(JavaCompilationDetails compilationDetails)
       throws AnalysisException {
     try {
-      if (compilationDetails.getAsts().isPresent()) {
-        for (CompilationUnitTree file : compilationDetails.getAsts().get()) {
-          URI uri = file.getSourceFile().toUri();
-          String fullPath = file.getSourceFile().toUri().getRawPath();
-          if (!uri.getScheme().equals("file")) {
-            fullPath = fullPath.substring(1);
-          }
-          if (Strings.isNullOrEmpty(fullPath)) {
-            continue;
-          }
-          analyzeFile(compilationDetails, file);
-          getStatisticsCollector().incrementCounter("files-analyzed");
+      for (CompilationUnitTree file : compilationDetails.getAsts()) {
+        URI uri = file.getSourceFile().toUri();
+        String fullPath = file.getSourceFile().toUri().getRawPath();
+        if (!uri.getScheme().equals("file")) {
+          fullPath = fullPath.substring(1);
         }
+        if (Strings.isNullOrEmpty(fullPath)) {
+          continue;
+        }
+        analyzeFile(compilationDetails, file);
+        getStatisticsCollector().incrementCounter("files-analyzed");
       }
       getStatisticsCollector().incrementCounter("compilations-analyzed");
     } catch (Throwable t) {


### PR DESCRIPTION
A few values from compilation details may be null so return an optional so it
is easier to make sure the clients use them correctly.