### PR TITLE
fix(java indexer): Clean up after exceptions

### DIFF
--- a/kythe/java/com/google/devtools/kythe/analyzers/java/KytheJavacAnalyzer.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/KytheJavacAnalyzer.java
@@ -121,7 +121,12 @@ public class KytheJavacAnalyzer extends JavacAnalyzer {
       throws AnalysisException {
     Preconditions.checkState(
         entrySets != null, "analyzeCompilationUnit must be called to analyze each file");
-    Context context = ((JavacTaskImpl) details.getJavac()).getContext();
+    if (!details.getJavac().isPresent()) {
+      throw new AnalysisException(
+          "No javac in details while analyzing file: " + ast.getSourceFile().getName());
+    }
+    JavacTaskImpl javac = (JavacTaskImpl) details.getJavac().get();
+    Context context = javac.getContext();
     JCCompilationUnit compilation = (JCCompilationUnit) ast;
     final Map<JCTree, Plugin.KytheNode> nodes = new HashMap<>();
     SourceText src = null;


### PR DESCRIPTION
We may store some temporary files on disk when we create our file manager. Normally we clean them up when the compilation details object is closed, but if an exception happens before we return the compilations details object, we will leave artifacts on disk. Handle exceptions while we are creating the compilation details object so this doesn't happen.