### PR TITLE
chore(doc): remove stale script

### DIFF
--- a/kythe/web/site/examples.md
+++ b/kythe/web/site/examples.md
@@ -67,13 +67,6 @@ bazel build -k \
 find -L bazel-out -name '*.kzip'
 {% endhighlight %}
 
-The provided utility script,
-[https://github.com/kythe/kythe/blob/master/kythe/extractors/bazel/extract.sh]({{site.data.development.source_browser}}/kythe/extractors/bazel/extract.sh),
-does a full extraction using Bazel and then moves the compilations into the
-directory structure used by the
-[kythe/kythe]({{site.data.development.source_browser}}/kythe/release/kythe.sh)
-Docker image.
-
 ### Extracting other Bazel based repositories
 
 You can use the Kythe release to extract compilations from other Bazel based


### PR DESCRIPTION
The extract.sh script is meant to be run in a docker container. The
instructions on our examples page no longer work, so remove it. There is
still a reference to this script later in the page, but that is a more
invasive change and will require more work to update.