### PR TITLE
fix(bazel extractor): give external paths a root

### DIFF
--- a/kythe/data/simple_vnames.json
+++ b/kythe/data/simple_vnames.json
@@ -16,6 +16,14 @@
     }
   },
   {
+    "pattern": "external/([^/]+)/(.*)",
+    "vname": {
+      "corpus": "CORPUS",
+      "root": "external/@1@",
+      "path": "@2@"
+    }
+  },
+  {
     "pattern": "(.*)",
     "vname": {
       "corpus": "CORPUS",


### PR DESCRIPTION
Paths under 'external/' correspond to external dependencies pulled in
via the WORKSPACE file. Because these files are not present in the main
repo, they must be given a 'root'.

As an example, string_view.h from abseil was previously given a vname like:

    path: "external/com_google_absl/absl/strings/string_view.h"

After this change, the vname is:

    root: "external/com_google_absl"
    path: "absl/strings/string_view.h"