### PR TITLE
fix(extractors): use distinct proto meta files for cc_proto_library

### DIFF
--- a/kythe/extractors/BUILD
+++ b/kythe/extractors/BUILD
@@ -45,6 +45,21 @@ proto_lang_toolchain(
     runtime = "@com_google_protobuf//:protobuf",
 )
 
+# Alternatively, if the plugin doesn't work you can use the default code generator
+# to output the metadata into a separate file.  This needs to be invoked with:
+#
+# bazel build \
+#   --proto_toolchain_for_cc=@io_kythe//kythe/extractor:cc_native_proto_toolchain \
+#   --cc_proto_library_header_suffixes=.pb.h,.pb.h.meta
+proto_lang_toolchain(
+    name = "cc_native_proto_toolchain",
+    blacklisted_protos = [
+        "@com_google_protobuf//:well_known_protos",
+    ],
+    command_line = "--cpp_out=annotate_headers,annotation_pragma_name=kythe_metadata,annotation_guard_name=KYTHE_IS_RUNNING:$(OUT)",
+    runtime = "@com_google_protobuf//:protobuf",
+)
+
 extractor_action(
     name = "extract_kzip_cxx",
     args = [

--- a/kythe/extractors/bazel/extractors.bazelrc
+++ b/kythe/extractors/bazel/extractors.bazelrc
@@ -16,7 +16,8 @@ build --keep_going
 build --experimental_extra_action_top_level_only
 
 # Generate metadata for generated protocol buffer code.
-build --proto_toolchain_for_cc=@kythe_release//:cc_proto_toolchain
+build --cc_proto_library_header_suffixes=.pb.h,.pb.h.meta
+build --proto_toolchain_for_cc=@kythe_release//:cc_native_proto_toolchain
 build --proto_toolchain_for_java=@kythe_release//:java_proto_toolchain
 
 # Enable all supported Kythe extractors.

--- a/kythe/release/release.BUILD
+++ b/kythe/release/release.BUILD
@@ -72,6 +72,21 @@ proto_lang_toolchain(
     runtime = "@com_google_protobuf//:protobuf",
 )
 
+# Alternatively, if the plugin doesn't work you can use the default code generator
+# to output the metadata into a separate file.  This needs to be invoked with:
+#
+# bazel build \
+#   --proto_toolchain_for_cc=@io_kythe//kythe/extractor:cc_native_proto_toolchain \
+#   --cc_proto_library_header_suffixes=.pb.h,.pb.h.meta
+proto_lang_toolchain(
+    name = "cc_native_proto_toolchain",
+    blacklisted_protos = [
+        "@com_google_protobuf//:well_known_protos",
+    ],
+    command_line = "--cpp_out=annotate_headers,annotation_pragma_name=kythe_metadata,annotation_guard_name=KYTHE_IS_RUNNING:$(OUT)",
+    runtime = "@com_google_protobuf//:protobuf",
+)
+
 filegroup(
     name = "cc_proto_metadata_plugin",
     srcs = ["tools/cc_proto_metadata_plugin"],


### PR DESCRIPTION
It appears as though the `--cc_proto_library_header_suffixes` flag works for the .meta files (after manual testing), thus we can use distinct .meta files generated by whatever the source tree in question expects, rather than the version used to compile our release.