### PR TITLE
fix(bazel extractor): change vnames for external paths

### DIFF
--- a/kythe/data/simple_vnames.json
+++ b/kythe/data/simple_vnames.json
@@ -16,11 +16,11 @@
     }
   },
   {
-    "pattern": "external/([^/]+)/(.*)",
+    "pattern": "(external/.*)",
     "vname": {
       "corpus": "CORPUS",
-      "root": "external/@1@",
-      "path": "@2@"
+      "root": "external",
+      "path": "@1@"
     }
   },
   {


### PR DESCRIPTION
Followup to https://github.com/kythe/kythe/pull/4233. The VName path
should be the path we want this file to show up at in the UI.

Before:

    root: "external/com_google_absl"
    path: "absl/strings/string_view.h"

After:

    root: "external"
    path: "external/com_google_absl/absl/strings/string_view.h"