### PR TITLE
fix(typescript_indexer): emit refs to TYPE nodes in export statements

### DIFF
--- a/kythe/typescript/indexer.ts
+++ b/kythe/typescript/indexer.ts
@@ -1241,14 +1241,28 @@ class Visitor {
           console.error(`TODO: export ${exp.name} has no symbol`);
           continue;
         }
-        // TODO: import a type, not just a value.
         const remoteSym = this.typeChecker.getAliasedSymbol(localSym);
-        const kExport = this.host.getSymbolName(remoteSym, TSNamespace.VALUE);
-        this.emitEdge(this.newAnchor(exp.name), EdgeKind.REF, kExport);
-        if (exp.propertyName) {
-          // Aliased export; propertyName is the 'as <...>' bit.
-          this.emitEdge(
-              this.newAnchor(exp.propertyName), EdgeKind.REF, kExport);
+        const anchor = this.newAnchor(exp.name);
+        // Aliased export; propertyName is the 'as <...>' bit.
+        const propertyAnchor = exp.propertyName ?
+            this.newAnchor(exp.propertyName) : null;
+        // Symbol is a value.
+        if (remoteSym.flags & ts.SymbolFlags.Value) {
+          const kExport =
+              this.host.getSymbolName(remoteSym, TSNamespace.VALUE);
+          this.emitEdge(anchor, EdgeKind.REF, kExport);
+          if (propertyAnchor) {
+            this.emitEdge(propertyAnchor, EdgeKind.REF, kExport);
+          }
+        }
+        // Symbol is a type.
+        if (remoteSym.flags & ts.SymbolFlags.Type) {
+          const kExport =
+              this.host.getSymbolName(remoteSym, TSNamespace.TYPE);
+          this.emitEdge(anchor, EdgeKind.REF, kExport);
+          if (propertyAnchor) {
+            this.emitEdge(propertyAnchor, EdgeKind.REF, kExport);
+          }
         }
       }
     }

--- a/kythe/typescript/testdata/reexport/main.ts
+++ b/kythe/typescript/testdata/reexport/main.ts
@@ -1,0 +1,19 @@
+/** @fileoverview See description in reexport.ts */
+
+//- @Interface defines/binding Interface
+export interface Interface {}
+
+//- @Class defines/binding Class
+export class Class {}
+
+//- @someFunction defines/binding SomeFunction
+export function someFunction() {}
+
+//- @CONSTANT defines/binding Constant
+export const CONSTANT = 1;
+
+//- @Enum defines/binding Enum
+export enum Enum {}
+
+//- @Type defines/binding Type
+export type Type = string;

--- a/kythe/typescript/testdata/reexport/reexport.ts
+++ b/kythe/typescript/testdata/reexport/reexport.ts
@@ -1,0 +1,23 @@
+/** @fileoverview Verify that reexporting indexed correctly. */
+
+export {
+  //- @#0Class ref Class
+  //- @ClassAlias ref Class
+  Class as ClassAlias,
+  //- @#0CONSTANT ref Constant
+  //- @CONSTANT_ALIAS ref Constant
+  CONSTANT as CONSTANT_ALIAS,
+  //- @#0Enum ref Enum
+  //- @EnumAlias ref Enum
+  Enum as EnumAlias,
+  //- @#0Interface ref Interface
+  //- @InterfaceAlias ref Interface
+  Interface as InterfaceAlias,
+  //- @#0Type ref Type
+  //- @TypeAlias ref Type
+  Type as TypeAlias,
+  //- @#0someFunction ref SomeFunction
+  //- @someFunctionAlias ref SomeFunction
+  someFunction as someFunctionAlias}
+//- @"'./main'" ref/imports vname("module", _, _, "testdata/reexport/main", _)
+from './main';


### PR DESCRIPTION
Some symbols like interfaces don't have VALUE nodes and only have TYPE
nodes. This commit fixes refs for such symbols.

Tested:
  unit test