### PR TITLE
chore(java_common): allow for lazily reading file contents

### DIFF
--- a/kythe/java/com/google/devtools/kythe/platform/shared/filesystem/ByteBufferByteChannel.java
+++ b/kythe/java/com/google/devtools/kythe/platform/shared/filesystem/ByteBufferByteChannel.java
@@ -23,7 +23,6 @@ import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.NonWritableChannelException;
 import java.nio.channels.SeekableByteChannel;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
@@ -31,10 +30,6 @@ import java.util.concurrent.Future;
 class ByteBufferByteChannel implements SeekableByteChannel {
   private Future<byte[]> buffer;
   private long position;
-
-  public ByteBufferByteChannel(byte[] data) {
-    this(CompletableFuture.completedFuture(data));
-  }
 
   public ByteBufferByteChannel(Future<byte[]> data) {
     buffer = data;

--- a/kythe/java/com/google/devtools/kythe/platform/shared/filesystem/ByteBufferByteChannel.java
+++ b/kythe/java/com/google/devtools/kythe/platform/shared/filesystem/ByteBufferByteChannel.java
@@ -23,13 +23,20 @@ import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.NonWritableChannelException;
 import java.nio.channels.SeekableByteChannel;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 
-/** Read-only {@link SeekableByteChannel} backed by byte[] data. */
+/** Read-only {@link SeekableByteChannel} lazily backed by byte[] data. */
 class ByteBufferByteChannel implements SeekableByteChannel {
-  private byte[] buffer;
+  private Future<byte[]> buffer;
   private long position;
 
   public ByteBufferByteChannel(byte[] data) {
+    this(CompletableFuture.completedFuture(data));
+  }
+
+  public ByteBufferByteChannel(Future<byte[]> data) {
     buffer = data;
     position = 0;
   }
@@ -41,6 +48,9 @@ class ByteBufferByteChannel implements SeekableByteChannel {
 
   @Override
   public void close() throws IOException {
+    if (buffer != null) {
+      buffer.cancel(true);
+    }
     buffer = null;
   }
 
@@ -55,7 +65,11 @@ class ByteBufferByteChannel implements SeekableByteChannel {
       return -1;
     }
     wanted = (int) Math.min(possible, wanted);
-    dst.put(buffer, (int) position, wanted);
+    try {
+      dst.put(buffer.get(), (int) position, wanted);
+    } catch (InterruptedException | ExecutionException exc) {
+      throw new IOException(exc);
+    }
     position += wanted;
     return wanted;
   }
@@ -79,7 +93,11 @@ class ByteBufferByteChannel implements SeekableByteChannel {
 
   @Override
   public long size() throws IOException {
-    return buffer.length;
+    try {
+      return buffer.get().length;
+    } catch (InterruptedException | ExecutionException exc) {
+      throw new IOException(exc);
+    }
   }
 
   @Override

--- a/kythe/java/com/google/devtools/kythe/platform/shared/filesystem/CompilationUnitFileSystem.java
+++ b/kythe/java/com/google/devtools/kythe/platform/shared/filesystem/CompilationUnitFileSystem.java
@@ -37,7 +37,6 @@ import java.nio.file.attribute.UserPrincipalLookupService;
 import java.nio.file.spi.FileSystemProvider;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
 /**

--- a/kythe/java/com/google/devtools/kythe/platform/shared/filesystem/CompilationUnitFileSystem.java
+++ b/kythe/java/com/google/devtools/kythe/platform/shared/filesystem/CompilationUnitFileSystem.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.ListenableFuture;
 import com.google.devtools.kythe.platform.java.filemanager.CompilationUnitFileTree;
 import com.google.devtools.kythe.platform.shared.FileDataProvider;
 import com.google.devtools.kythe.proto.Analysis.CompilationUnit;
@@ -202,16 +203,12 @@ public final class CompilationUnitFileSystem extends FileSystem {
     return entries.keySet().stream().map(k -> dir.resolve(k)).collect(Collectors.toSet());
   }
 
-  byte[] read(Path file) throws IOException {
+  ListenableFuture<byte[]> startRead(Path file) throws IOException {
     String digest = digest(file);
     if (digest == null || digest.equals(CompilationUnitFileTree.DIRECTORY_DIGEST)) {
       throw new NoSuchFileException(file.toString());
     }
-    try {
-      return fileDataProvider.startLookup(file.toString(), digest).get();
-    } catch (InterruptedException | ExecutionException exc) {
-      throw new IOException(exc);
-    }
+    return fileDataProvider.startLookup(file.toString(), digest);
   }
 
   CompilationUnitFileAttributes readAttributes(Path path) throws IOException {

--- a/kythe/java/com/google/devtools/kythe/platform/shared/filesystem/CompilationUnitPath.java
+++ b/kythe/java/com/google/devtools/kythe/platform/shared/filesystem/CompilationUnitPath.java
@@ -238,7 +238,7 @@ final class CompilationUnitPath implements Path {
   }
 
   SeekableByteChannel newByteChannel() throws IOException {
-    return new ByteBufferByteChannel(fileSystem.read(this));
+    return new ByteBufferByteChannel(fileSystem.startRead(this));
   }
 
   DirectoryStream<Path> newDirectoryStream(DirectoryStream.Filter<? super Path> filter)


### PR DESCRIPTION
Rather than reading all file contents upfront, initiate the read on creation, but don't wait for it to complete until necessary.  This more closely follows the behavior of the legacy JavaFileObjects