### PR TITLE
chore: run buildifier-lint as part of #4264

### DIFF
--- a/external.bzl
+++ b/external.bzl
@@ -267,7 +267,7 @@ def _java_dependencies():
             "https://repo1.maven.org/maven2",
         ],
         fetch_sources = True,
-        generate_compat_repositories = True, # Required by bazel-common's dependencies
+        generate_compat_repositories = True,  # Required by bazel-common's dependencies
         version_conflict_policy = "pinned",
     )
 

--- a/kythe/cxx/indexer/cxx/testdata/BUILD
+++ b/kythe/cxx/indexer/cxx/testdata/BUILD
@@ -2,9 +2,9 @@ package(default_visibility = ["//kythe:default_visibility"])
 
 load(
     "//tools/build_rules/verifier_test:cc_indexer_test.bzl",
+    "cc_extractor_test",
     "cc_indexer_test",
     "objc_indexer_test",
-    "cc_extractor_test",
 )
 
 cc_indexer_test(

--- a/kythe/java/com/google/devtools/kythe/analyzers/java/BUILD
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/BUILD
@@ -1,4 +1,4 @@
-load("@rules_java//java:defs.bzl", "java_library", "java_binary")
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
 
 package(default_visibility = ["//kythe:default_visibility"])
 

--- a/kythe/java/com/google/devtools/kythe/analyzers/jvm/BUILD
+++ b/kythe/java/com/google/devtools/kythe/analyzers/jvm/BUILD
@@ -1,4 +1,4 @@
-load("@rules_java//java:defs.bzl", "java_library", "java_binary")
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
 
 package(
     default_visibility = ["//kythe:default_visibility"],

--- a/kythe/java/com/google/devtools/kythe/extractors/java/standalone/BUILD
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/standalone/BUILD
@@ -1,4 +1,4 @@
-load("@rules_java//java:defs.bzl", "java_library", "java_binary")
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
 
 package(default_visibility = ["//kythe:default_visibility"])
 

--- a/kythe/java/com/google/devtools/kythe/extractors/jvm/BUILD
+++ b/kythe/java/com/google/devtools/kythe/extractors/jvm/BUILD
@@ -1,4 +1,4 @@
-load("@rules_java//java:defs.bzl", "java_library", "java_binary")
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
 
 package(default_visibility = ["//kythe:default_visibility"])
 

--- a/kythe/typescript/BUILD
+++ b/kythe/typescript/BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["//kythe:default_visibility"])
 
-load("@npm_bazel_typescript//:index.bzl", "ts_library", "ts_config")
+load("@npm_bazel_typescript//:index.bzl", "ts_config", "ts_library")
 load("@npm_bazel_jasmine//:index.bzl", "jasmine_node_test")
 load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_test")
 

--- a/tools/build_rules/lexyacc/BUILD
+++ b/tools/build_rules/lexyacc/BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools/build_rules/lexyacc:lexyacc.bzl", "lexyacc_variables", "lexyacc_toolchain")
+load("//tools/build_rules/lexyacc:lexyacc.bzl", "lexyacc_toolchain", "lexyacc_variables")
 
 exports_files(["lexyacc.bzl"])
 

--- a/tools/build_rules/verifier_test/cc_indexer_test.bzl
+++ b/tools/build_rules/verifier_test/cc_indexer_test.bzl
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 
+load("@rules_proto//proto:defs.bzl", "ProtoInfo")
 load(
     "@bazel_tools//tools/build_defs/cc:action_names.bzl",
     "CPP_COMPILE_ACTION_NAME",


### PR DESCRIPTION
While this doesn't fix the underlying bug (due to a problem in one of our myriad dependencies), it does clean things up a bit.