### PR TITLE
fix(java): disable errorprone plugin for java extraction

### DIFF
--- a/kythe/java/com/google/devtools/kythe/extractors/java/standalone/AbstractJavacWrapper.java
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/standalone/AbstractJavacWrapper.java
@@ -159,7 +159,11 @@ public abstract class AbstractJavacWrapper {
       } else if (!(skipArg
           || arg.startsWith("-J")
           || arg.startsWith("-XD")
-          || arg.startsWith("-Werror"))) {
+          || arg.startsWith("-Werror")
+          // The errorprone plugin complicates the build due to certain other
+          // flags it requires (such as -XDcompilePolicy=byfile) and is not
+          // necessary for extraction.
+          || arg.startsWith("-Xplugin:ErrorProne"))) {
         cleanedUpArgs.add(arg);
       }
       skipArg = false;


### PR DESCRIPTION
The errorprone plugin complicates the build due to certain other
flags it requires (such as -XDcompilePolicy=byfile) and is not
necessary for extraction.

Another workaround would be to disable the errorprone plugin in the
project's gradle config, but that's often a fairly invasive change
(AFAIK) and requires removing config options in several places.