### PR TITLE
chore: libraries with main should be binaries

### DIFF
--- a/kythe/cxx/doc/BUILD
+++ b/kythe/cxx/doc/BUILD
@@ -81,8 +81,8 @@ cc_test(
     ],
 )
 
-cc_library(
-    name = "doclib",
+cc_binary(
+    name = "doc",
     srcs = [
         "doc.cc",
     ],
@@ -100,12 +100,5 @@ cc_library(
         "@com_google_absl//absl/flags:usage",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings:str_format",
-    ],
-)
-
-cc_binary(
-    name = "doc",
-    deps = [
-        ":doclib",
     ],
 )

--- a/kythe/cxx/indexer/cxx/BUILD
+++ b/kythe/cxx/indexer/cxx/BUILD
@@ -435,8 +435,8 @@ cc_library(
     ],
 )
 
-cc_library(
-    name = "cmdlib",
+cc_binary(
+    name = "indexer",
     srcs = [
         "KytheIndexerMain.cc",
     ],
@@ -458,37 +458,6 @@ cc_library(
     ],
 )
 
-cc_binary(
-    name = "indexer",
-    deps = [
-        ":cmdlib",
-    ],
-)
-
-cc_library(
-    name = "testlib",
-    testonly = 1,
-    srcs = [
-        "KytheIndexerUnitTest.cc",
-    ],
-    copts = [
-        "-Wno-non-virtual-dtor",
-        "-Wno-unused-variable",
-        "-Wno-implicit-fallthrough",
-    ],
-    deps = [
-        ":lib",
-        "//kythe/cxx/common/indexing:testlib",
-        "//third_party:gtest",
-        "@com_google_absl//absl/memory",
-        "@com_google_protobuf//:protobuf",
-        "@org_llvm//:LLVMSupport",
-        "@org_llvm//:clangAST",
-        "@org_llvm//:clangFrontend",
-        "@org_llvm//:clangTooling",
-    ],
-)
-
 cc_library(
     name = "node_set",
     hdrs = ["node_set.h"],
@@ -501,12 +470,28 @@ cc_library(
 cc_test(
     name = "test",
     size = "small",
+    srcs = [
+        "KytheIndexerUnitTest.cc",
+    ],
+    copts = [
+        "-Wno-non-virtual-dtor",
+        "-Wno-unused-variable",
+        "-Wno-implicit-fallthrough",
+    ],
     linkopts = select({
         ":darwin": ["-headerpad_max_install_names"],
         "//conditions:default": [],
     }),
     deps = [
-        ":testlib",
+        ":lib",
+        "//kythe/cxx/common/indexing:testlib",
+        "//third_party:gtest",
+        "@com_google_absl//absl/memory",
+        "@com_google_protobuf//:protobuf",
+        "@org_llvm//:LLVMSupport",
+        "@org_llvm//:clangAST",
+        "@org_llvm//:clangFrontend",
+        "@org_llvm//:clangTooling",
     ],
 )
 

--- a/kythe/cxx/indexer/proto/BUILD
+++ b/kythe/cxx/indexer/proto/BUILD
@@ -110,18 +110,13 @@ cc_library(
 
 cc_binary(
     name = "indexer",
-    visibility = ["//visibility:public"],
-    deps = [":cmdlib"],
-)
-
-cc_library(
-    name = "cmdlib",
     srcs = ["kythe_indexer_main.cc"],
     copts = [
         "-Wno-non-virtual-dtor",
         "-Wno-unused-variable",
         "-Wno-implicit-fallthrough",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         ":proto_analyzer",
         "//kythe/cxx/common:json_proto",

--- a/kythe/cxx/tools/fyi/BUILD
+++ b/kythe/cxx/tools/fyi/BUILD
@@ -1,13 +1,11 @@
 package(default_visibility = ["//kythe:default_visibility"])
 
-cc_library(
-    name = "fyilib",
+cc_binary(
+    name = "fyi",
     srcs = [
         "fyi.cc",
-        "fyi_main.cc",
-    ],
-    hdrs = [
         "fyi.h",
+        "fyi_main.cc",
     ],
     copts = [
         "-Wno-non-virtual-dtor",
@@ -35,12 +33,5 @@ cc_library(
         "@org_llvm//:clangRewrite",
         "@org_llvm//:clangSema",
         "@org_llvm//:clangTooling",
-    ],
-)
-
-cc_binary(
-    name = "fyi",
-    deps = [
-        ":fyilib",
     ],
 )

--- a/kythe/cxx/verifier/BUILD
+++ b/kythe/cxx/verifier/BUILD
@@ -82,8 +82,8 @@ cc_library(
     ],
 )
 
-cc_library(
-    name = "cmd_lib",
+cc_binary(
+    name = "verifier",
     srcs = [
         "verifier_main.cc",
     ],
@@ -92,6 +92,7 @@ cc_library(
         "-Wno-unused-variable",
         "-Wno-implicit-fallthrough",
     ],
+    visibility = [PUBLIC_VISIBILITY],
     deps = [
         ":lib",
         "//kythe/proto:storage_cc_proto",
@@ -104,22 +105,11 @@ cc_library(
     ],
 )
 
-cc_binary(
-    name = "verifier",
-    visibility = [PUBLIC_VISIBILITY],
-    deps = [
-        ":cmd_lib",
-    ],
-)
-
-cc_library(
-    name = "testlib",
-    testonly = 1,
+cc_test(
+    name = "test",
+    size = "small",
     srcs = [
         "verifier_unit_test.cc",
-    ],
-    hdrs = [
-        "verifier.h",
     ],
     copts = [
         "-Wno-non-virtual-dtor",
@@ -133,13 +123,5 @@ cc_library(
         "//third_party:gtest",
         "@com_github_google_glog//:glog",
         "@com_google_protobuf//:protobuf",
-    ],
-)
-
-cc_test(
-    name = "test",
-    size = "small",
-    deps = [
-        ":testlib",
     ],
 )


### PR DESCRIPTION
Generally, files which define `main` should be `cc_binary` unless it's something like gtest_main, which defines a general purpose reusable `main`.  Or, to paraphrase Indiana Jones: "These [mains] belong in a [cc_binary]!".