### PR TITLE
fix(java_extractor): preserve dummy output path for modular builds

### DIFF
--- a/kythe/javatests/com/google/devtools/kythe/extractors/java/JavaExtractorTest.java
+++ b/kythe/javatests/com/google/devtools/kythe/extractors/java/JavaExtractorTest.java
@@ -700,6 +700,31 @@ public class JavaExtractorTest extends TestCase {
             join(TEST_DATA_DIR, "/system_modules/lib/modules"));
   }
 
+  public void testModuleSourcePath() throws ExtractionException, InvalidProtocolBufferException {
+    JavaCompilationUnitExtractor java = new JavaCompilationUnitExtractor(CORPUS);
+
+    List<String> sources = testFiles("/mod/module-info.java", "/mod/pkg/A.java", "/mod/pkg/B.java");
+    CompilationDescription description =
+        java.extract(
+            TARGET1,
+            sources,
+            EMPTY,
+            EMPTY,
+            EMPTY,
+            EMPTY,
+            EMPTY,
+            Optional.empty(),
+            ImmutableList.of("--module-source-path", "/", "-d", "/output"),
+            "/output");
+    CompilationUnit unit = description.getCompilationUnit();
+    assertThat(unit).isNotNull();
+    assertThat(unit.getVName().getSignature()).isEqualTo(TARGET1);
+    assertThat(unit.getSourceFileList()).containsExactlyElementsIn(sources).inOrder();
+    assertThat(unit.getArgumentList())
+        .containsExactly("--module-source-path", "/", "-d", "/dev/null")
+        .inOrder();
+  }
+
   private List<String> testFiles(String... files) {
     List<String> res = new ArrayList<>();
     for (String file : files) {

--- a/kythe/javatests/com/google/devtools/kythe/extractors/java/testdata/mod/module-info.java
+++ b/kythe/javatests/com/google/devtools/kythe/extractors/java/testdata/mod/module-info.java
@@ -1,0 +1,1 @@
+module mod {}

--- a/kythe/javatests/com/google/devtools/kythe/extractors/java/testdata/mod/pkg/A.java
+++ b/kythe/javatests/com/google/devtools/kythe/extractors/java/testdata/mod/pkg/A.java
@@ -1,0 +1,8 @@
+package pkg;
+
+/**
+ * Test helper
+ */
+public class A {
+// Semicolon will end up as JCSkip node in ast.
+};

--- a/kythe/javatests/com/google/devtools/kythe/extractors/java/testdata/mod/pkg/B.java
+++ b/kythe/javatests/com/google/devtools/kythe/extractors/java/testdata/mod/pkg/B.java
@@ -1,0 +1,7 @@
+package pkg;
+
+/**
+ * Test helper
+ */
+public class B {
+}


### PR DESCRIPTION
Fixes #3671 for extraction (at least partially)