### PR TITLE
fix(java_indexer): only attempt to load implilcit metadata if it exists

### DIFF
--- a/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
@@ -1405,6 +1405,7 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
         return;
       }
       FileObject file = Iterables.getOnlyElement(fileManager.getJavaFileObjects(fullPath));
+      // getJavaFileObjects only check that the path isn't a directory, not whether it exists.
       if (file == null || !isFileReadable(file)) {
         return;
       }

--- a/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
@@ -1405,7 +1405,7 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
         return;
       }
       FileObject file = Iterables.getOnlyElement(fileManager.getJavaFileObjects(fullPath));
-      if (file == null) {
+      if (file == null || !isFileReadable(file)) {
         return;
       }
       loadAnnotationsFile(fullPath, file);
@@ -1529,6 +1529,15 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
   private static ReferenceType referenceType(Type referent) {
     String qualifiedName = referent.tsym.flatName().toString();
     return JvmGraph.Type.referenceType(qualifiedName);
+  }
+
+  /** Returns true if the FileObject exists and is readable */
+  private static boolean isFileReadable(FileObject file) {
+    try (InputStream stream = file.openInputStream()) {
+      return true;
+    } catch (IOException unused) {
+      return false;
+    }
   }
 
   private static JvmGraph.VoidableType toJvmReturnType(Type type) {

--- a/kythe/java/com/google/devtools/kythe/platform/java/filemanager/ForwardingStandardJavaFileManager.java
+++ b/kythe/java/com/google/devtools/kythe/platform/java/filemanager/ForwardingStandardJavaFileManager.java
@@ -85,7 +85,7 @@ public class ForwardingStandardJavaFileManager
     // TODO(shahms): return fileManager.getLocationForModule(location, fo);
     try {
       return (Location) getLocationForModuleNameMethod.invoke(fileManager, location, moduleName);
-    } catch (ReflectiveOperationException e) {
+    } catch (NullPointerException | ReflectiveOperationException e) {
       throw propagateInvocationTargetErrorIfPossible("getLocationForModule", e, IOException.class);
     }
   }
@@ -95,7 +95,7 @@ public class ForwardingStandardJavaFileManager
     // TODO(shahms): return fileManager.getLocationForModule(location, fo);
     try {
       return (Location) getLocationForModuleFileMethod.invoke(fileManager, location, fo);
-    } catch (ReflectiveOperationException e) {
+    } catch (NullPointerException | ReflectiveOperationException e) {
       throw propagateInvocationTargetErrorIfPossible("getLocationForModule", e, IOException.class);
     }
   }
@@ -107,7 +107,7 @@ public class ForwardingStandardJavaFileManager
     // TODO(shahms): return fileManager.getServiceLoader(location, service);
     try {
       return (ServiceLoader<S>) getServiceLoaderMethod.invoke(location, service);
-    } catch (ReflectiveOperationException e) {
+    } catch (NullPointerException | ReflectiveOperationException e) {
       throw propagateInvocationTargetErrorIfPossible("getServiceLoader", e, IOException.class);
     }
   }
@@ -117,7 +117,7 @@ public class ForwardingStandardJavaFileManager
     // TODO(shahms): return fileManager.inferModuleName(location);
     try {
       return (String) inferModuleNameMethod.invoke(fileManager, location);
-    } catch (ReflectiveOperationException e) {
+    } catch (NullPointerException | ReflectiveOperationException e) {
       throw propagateInvocationTargetErrorIfPossible("inferModuleName", e, IOException.class);
     }
   }
@@ -128,7 +128,7 @@ public class ForwardingStandardJavaFileManager
     // TODO(shahms): return fileManager.listLocationsForModules(location);
     try {
       return (Iterable<Set<Location>>) listLocationsForModulesMethod.invoke(fileManager, location);
-    } catch (ReflectiveOperationException e) {
+    } catch (NullPointerException | ReflectiveOperationException e) {
       throw propagateInvocationTargetErrorIfPossible(
           "listLocationsForModules", e, IOException.class);
     }
@@ -139,7 +139,7 @@ public class ForwardingStandardJavaFileManager
     // TODO(shahms): return fileManager.contains(location, fo);
     try {
       return (Boolean) containsMethod.invoke(fileManager, location, fo);
-    } catch (ReflectiveOperationException e) {
+    } catch (NullPointerException | ReflectiveOperationException e) {
       throw propagateInvocationTargetErrorIfPossible("contains", e, IOException.class);
     }
   }
@@ -158,7 +158,7 @@ public class ForwardingStandardJavaFileManager
     try {
       return (Iterable<? extends JavaFileObject>)
           getJavaFileObjectsFromPathsMethod.invoke(fileManager, paths);
-    } catch (ReflectiveOperationException e) {
+    } catch (NullPointerException | ReflectiveOperationException e) {
       throw propagateInvocationTargetErrorIfPossible("getJavaFileObjectsFromPaths", e);
     }
   }
@@ -185,7 +185,7 @@ public class ForwardingStandardJavaFileManager
     try {
       return (Iterable<? extends JavaFileObject>)
           getJavaFileObjectsMethod.invoke(fileManager, (Object) paths);
-    } catch (ReflectiveOperationException e) {
+    } catch (NullPointerException | ReflectiveOperationException e) {
       throw propagateInvocationTargetErrorIfPossible("getJavaFileObjects", e);
     }
   }
@@ -196,7 +196,7 @@ public class ForwardingStandardJavaFileManager
     // TODO(shahms): fileManager.setLocationFromPaths(location, paths);
     try {
       setLocationFromPathsMethod.invoke(fileManager, location, paths);
-    } catch (ReflectiveOperationException e) {
+    } catch (NullPointerException | ReflectiveOperationException e) {
       throw propagateInvocationTargetErrorIfPossible("setLocationFromPaths", e, IOException.class);
     }
   }
@@ -207,7 +207,7 @@ public class ForwardingStandardJavaFileManager
     // TODO(shahms): fileManager.setLocationForModule(location, moduleName, paths);
     try {
       setLocationForModuleMethod.invoke(fileManager, location, moduleName, paths);
-    } catch (ReflectiveOperationException e) {
+    } catch (NullPointerException | ReflectiveOperationException e) {
       throw propagateInvocationTargetErrorIfPossible("setLocationForModule", e, IOException.class);
     }
   }
@@ -223,7 +223,7 @@ public class ForwardingStandardJavaFileManager
     // TODO(shahms): return fileManager.getLocationAsPaths(location);
     try {
       return (Iterable<? extends Path>) getLocationAsPathsMethod.invoke(fileManager, location);
-    } catch (ReflectiveOperationException e) {
+    } catch (NullPointerException | ReflectiveOperationException e) {
       throw propagateInvocationTargetErrorIfPossible("getLocationAsPaths", e);
     }
   }
@@ -243,7 +243,7 @@ public class ForwardingStandardJavaFileManager
     // TODO(shahms): return fileManager.asPath(fo);
     try {
       return (Path) asPathMethod.invoke(fileManager, fo);
-    } catch (ReflectiveOperationException e) {
+    } catch (NullPointerException | ReflectiveOperationException e) {
       throw propagateInvocationTargetErrorIfPossible("asPath", e);
     }
   }
@@ -259,7 +259,7 @@ public class ForwardingStandardJavaFileManager
               (proxy, method, args) -> {
                 return factory.getPath((String) args[0], (String[]) args[1]);
               }));
-    } catch (ReflectiveOperationException e) {
+    } catch (NullPointerException | ReflectiveOperationException e) {
       throw propagateInvocationTargetErrorIfPossible("setPathFactory", e);
     }
   }
@@ -285,17 +285,16 @@ public class ForwardingStandardJavaFileManager
     return null;
   }
 
-  private static IllegalStateException propagateInvocationTargetErrorIfPossible(
-      String methodName, ReflectiveOperationException error) {
+  private static UnsupportedOperationException propagateInvocationTargetErrorIfPossible(
+      String methodName, Throwable error) {
     if (error instanceof InvocationTargetException) {
       Throwables.throwIfUnchecked(((InvocationTargetException) error).getCause());
     }
     return unsupportedVersionError(methodName, error);
   }
 
-  private static IllegalStateException propagateInvocationTargetErrorIfPossible(
-      String methodName, ReflectiveOperationException error, Class<IOException> declaredType)
-      throws IOException {
+  private static UnsupportedOperationException propagateInvocationTargetErrorIfPossible(
+      String methodName, Throwable error, Class<IOException> declaredType) throws IOException {
     if (error instanceof InvocationTargetException) {
       // Log the exception because the propagated destination may not provide a nice error log.
       Throwable t = ((InvocationTargetException) error).getCause();
@@ -307,8 +306,9 @@ public class ForwardingStandardJavaFileManager
     return unsupportedVersionError(methodName, error);
   }
 
-  private static IllegalStateException unsupportedVersionError(
-      String methodName, ReflectiveOperationException cause) {
-    return new IllegalStateException(methodName + " called by unsupported Java version", cause);
+  private static UnsupportedOperationException unsupportedVersionError(
+      String methodName, Throwable cause) {
+    return new UnsupportedOperationException(
+        methodName + " called by unsupported Java version", cause);
   }
 }


### PR DESCRIPTION
Without this the logs are filled with:
```
Jan 22, 2020 9:20:12 AM com.google.devtools.kythe.analyzers.java.KytheTreeScanner loadImplicitAnnotationsFile
WARNING: Can't read metadata for x-kythe-compilation://....
```
for *every* file.