### PR TITLE
typescript: depend on node v10 definition of types

### DIFF
--- a/kythe/typescript/package.json
+++ b/kythe/typescript/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@types/jasmine": "^2.8.8",
-    "@types/node": "^7.0.4",
+    "@types/node": "^10.15.3",
     "jasmine": "^3.1.0"
   },
   "license": "Apache-2.0"

--- a/kythe/typescript/yarn.lock
+++ b/kythe/typescript/yarn.lock
@@ -6,9 +6,10 @@
   version "2.8.8"
   resolved "https://registry.yarnpkg.com/@types/jasmine/-/jasmine-2.8.8.tgz#bf53a7d193ea8b03867a38bfdb4fbb0e0bf066c9"
 
-"@types/node@^7.0.4":
-  version "7.0.4"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.4.tgz#9aabc135979ded383325749f508894c662948c8b"
+"@types/node@^10.15.3":
+  version "10.17.13"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.13.tgz#ccebcdb990bd6139cd16e84c39dc2fb1023ca90c"
+  integrity sha512-pMCcqU2zT4TjqYFrWtYHKal7Sl30Ims6ulZ4UFXxI4xbtQqK/qqKwkDoBFCfooRqqmRu9vY3xaJRwxSh673aYg==
 
 balanced-match@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Node 10 is the current LTS version, and test.ts already depends on some
of its functionality.