### PR TITLE
typescript: handle the case where symbol has no name

### DIFF
--- a/kythe/typescript/indexer.ts
+++ b/kythe/typescript/indexer.ts
@@ -48,7 +48,8 @@ export interface IndexerHost {
    * optionally specified to help disambiguate nodes with multiple declarations.
    * See the documentation of Context for more information.
    */
-  getSymbolName(sym: ts.Symbol, ns: TSNamespace, context?: Context): VName;
+  getSymbolName(sym: ts.Symbol, ns: TSNamespace, context?: Context): VName
+      |undefined;
   /**
    * scopedSignature computes a scoped name for a ts.Node.
    * E.g. if you have a function `foo` containing a block containing a variable
@@ -575,13 +576,14 @@ class StandardIndexerContext implements IndexerHost {
    * See the documentation of Context for more information.
    */
   getSymbolName(
-      sym: ts.Symbol, ns: TSNamespace, context: Context = Context.Any): VName {
+      sym: ts.Symbol, ns: TSNamespace, context: Context = Context.Any): VName
+      |undefined {
     const stored = this.symbolNames.get(sym, ns, context);
     if (stored) return stored;
 
     let declarations = sym.declarations;
-    if (declarations.length < 1) {
-      throw new Error('TODO: symbol has no declarations?');
+    if (!declarations || declarations.length < 1) {
+      return undefined;
     }
 
     // Disambiguate symbols with multiple declarations using a context.
@@ -752,6 +754,7 @@ class Visitor {
         return;
       }
       const kType = this.host.getSymbolName(sym, TSNamespace.TYPE);
+      if (!kType) continue;
       this.emitNode(kType, 'absvar');
       this.emitEdge(
           this.newAnchor(param.name), EdgeKind.DEFINES_BINDING, kType);
@@ -803,8 +806,10 @@ class Visitor {
       return;
     }
     const kType = this.host.getSymbolName(sym, TSNamespace.TYPE);
-    this.emitNode(kType, 'interface');
-    this.emitEdge(this.newAnchor(decl.name), EdgeKind.DEFINES_BINDING, kType);
+    if (kType) {
+      this.emitNode(kType, 'interface');
+      this.emitEdge(this.newAnchor(decl.name), EdgeKind.DEFINES_BINDING, kType);
+    }
 
     if (decl.typeParameters) this.visitTypeParameters(decl.typeParameters);
     if (decl.heritageClauses) this.visitHeritage(decl.heritageClauses);
@@ -822,6 +827,7 @@ class Visitor {
       return;
     }
     const kType = this.host.getSymbolName(sym, TSNamespace.TYPE);
+    if (!kType) return;
     this.emitNode(kType, 'talias');
     this.emitEdge(this.newAnchor(decl.name), EdgeKind.DEFINES_BINDING, kType);
 
@@ -865,6 +871,7 @@ class Visitor {
           return;
         }
         const name = this.host.getSymbolName(sym, TSNamespace.TYPE);
+        if (!name) return;
         this.emitEdge(this.newAnchor(node), EdgeKind.REF, name);
         return name;
       case ts.SyntaxKind.TypeReference:
@@ -980,6 +987,7 @@ class Visitor {
       const kRemoteValue =
           this.host.getSymbolName(remoteSym, TSNamespace.VALUE);
       const kLocalValue = this.host.getSymbolName(localSym, TSNamespace.VALUE);
+      if (!kRemoteValue || !kLocalValue) return;
 
       // The local import value is a "variable" with an "import" subkind, and
       // aliases its remote definition.
@@ -995,6 +1003,7 @@ class Visitor {
     if (remoteSym.flags & ts.SymbolFlags.Type) {
       const kRemoteType = this.host.getSymbolName(remoteSym, TSNamespace.TYPE);
       const kLocalType = this.host.getSymbolName(localSym, TSNamespace.TYPE);
+      if (!kRemoteType || !kLocalType) return;
 
       // The local import value is a "talias" (type alias) with an "import"
       // subkind, and aliases its remote definition.
@@ -1048,6 +1057,7 @@ class Visitor {
       if (ts.isModuleDeclaration(decl)) {
         const kModule =
             this.host.getSymbolName(moduleSym, TSNamespace.NAMESPACE);
+        if (!kModule) return;
         this.emitEdge(this.newAnchor(moduleRef), EdgeKind.REF_IMPORTS, kModule);
       }
     }
@@ -1119,6 +1129,7 @@ class Visitor {
           return;
         }
         const kModuleObject = this.host.getSymbolName(sym, TSNamespace.VALUE);
+        if (!kModuleObject) return;
         this.emitNode(kModuleObject, 'variable');
         this.emitEdge(
             this.newAnchor(name), EdgeKind.DEFINES_BINDING, kModuleObject);
@@ -1192,12 +1203,14 @@ class Visitor {
       // Emit a "property/reads" edge between the getter and the property
       const getter =
           this.host.getSymbolName(sym, TSNamespace.VALUE, Context.Getter);
+      if (!getter) return;
       this.emitEdge(getter, EdgeKind.PROPERTY_READS, implicitProp);
     }
     if (sym.declarations.find(ts.isSetAccessor)) {
       // Emit a "property/writes" edge between the setter and the property
       const setter =
           this.host.getSymbolName(sym, TSNamespace.VALUE, Context.Setter);
+      if (!setter) return;
       this.emitEdge(setter, EdgeKind.PROPERTY_WRITES, implicitProp);
     }
   }
@@ -1251,17 +1264,21 @@ class Visitor {
         // Symbol is a value.
         if (remoteSym.flags & ts.SymbolFlags.Value) {
           const kExport = this.host.getSymbolName(remoteSym, TSNamespace.VALUE);
-          this.emitEdge(anchor, EdgeKind.REF, kExport);
-          if (propertyAnchor) {
-            this.emitEdge(propertyAnchor, EdgeKind.REF, kExport);
+          if (kExport) {
+            this.emitEdge(anchor, EdgeKind.REF, kExport);
+            if (propertyAnchor) {
+              this.emitEdge(propertyAnchor, EdgeKind.REF, kExport);
+            }
           }
         }
         // Symbol is a type.
         if (remoteSym.flags & ts.SymbolFlags.Type) {
           const kExport = this.host.getSymbolName(remoteSym, TSNamespace.TYPE);
-          this.emitEdge(anchor, EdgeKind.REF, kExport);
-          if (propertyAnchor) {
-            this.emitEdge(propertyAnchor, EdgeKind.REF, kExport);
+          if (kExport) {
+            this.emitEdge(anchor, EdgeKind.REF, kExport);
+            if (propertyAnchor) {
+              this.emitEdge(propertyAnchor, EdgeKind.REF, kExport);
+            }
           }
         }
       }
@@ -1321,10 +1338,11 @@ class Visitor {
           return undefined;
         }
         vname = this.host.getSymbolName(sym, TSNamespace.VALUE);
-        this.emitNode(vname, 'variable');
-
-        this.emitEdge(
-            this.newAnchor(decl.name), EdgeKind.DEFINES_BINDING, vname);
+        if (vname) {
+          this.emitNode(vname, 'variable');
+          this.emitEdge(
+              this.newAnchor(decl.name), EdgeKind.DEFINES_BINDING, vname);
+        }
 
         decl.name.forEachChild(child => this.visit(child));
         break;
@@ -1369,7 +1387,10 @@ class Visitor {
             `function declaration ${decl.name.getText()} has no symbol`);
         return;
       }
-      kFunc = this.host.getSymbolName(funcSym, TSNamespace.VALUE, context);
+      const vname =
+          this.host.getSymbolName(funcSym, TSNamespace.VALUE, context);
+      if (!vname) return;
+      kFunc = vname;
 
       const declAnchor = this.newAnchor(decl.name);
       this.emitNode(kFunc, 'function');
@@ -1404,7 +1425,9 @@ class Visitor {
             return;
           }
           const kParent = this.host.getSymbolName(parentSym, TSNamespace.TYPE);
-          this.emitEdge(kFunc, EdgeKind.CHILD_OF, kParent);
+          if (kParent) {
+            this.emitEdge(kFunc, EdgeKind.CHILD_OF, kParent);
+          }
         }
 
         // Emit "overrides" edges if this method overrides extended classes or
@@ -1429,15 +1452,17 @@ class Visitor {
 
               // Find a member of with the same type (same flags) and same name
               // as the overriding method.
-              const overridenCondition = (sym: ts.Symbol) =>
+              const overriddenCondition = (sym: ts.Symbol) =>
                   Boolean(sym.flags & funcFlags) && sym.name === funcName;
 
-              const overriden =
-                  toArray(baseSym.members.values()).find(overridenCondition);
-              if (overriden) {
-                this.emitEdge(
-                    kFunc, EdgeKind.OVERRIDES,
-                    this.host.getSymbolName(overriden, TSNamespace.VALUE));
+              const overridden =
+                  toArray(baseSym.members.values()).find(overriddenCondition);
+              if (overridden) {
+                const base =
+                    this.host.getSymbolName(overridden, TSNamespace.VALUE);
+                if (base) {
+                  this.emitEdge(kFunc, EdgeKind.OVERRIDES, base);
+                }
               }
             }
           }
@@ -1484,6 +1509,7 @@ class Visitor {
                 return;
               }
               const kParam = this.host.getSymbolName(sym, TSNamespace.VALUE);
+              if (!kParam) return;
               this.emitNode(kParam, 'variable');
 
               this.emitEdge(
@@ -1499,6 +1525,7 @@ class Visitor {
                   if (parentSym !== undefined) {
                     const kClass =
                         this.host.getSymbolName(parentSym, TSNamespace.TYPE);
+                    if (!kClass) return;
                     this.emitEdge(kParam, EdgeKind.CHILD_OF, kClass);
                   }
                 }
@@ -1557,6 +1584,7 @@ class Visitor {
     // module with declarations).
     const kNamespace = this.host.getSymbolName(sym, TSNamespace.NAMESPACE);
     const kValue = this.host.getSymbolName(sym, TSNamespace.VALUE);
+    if (!kNamespace || !kValue) return;
     // It's possible that same namespace appears multiple time. We need to
     // emit only single node for that namespace and single defines/binding
     // edge.
@@ -1596,8 +1624,10 @@ class Visitor {
       // instances of the class) and a value (least ambigiously, also the
       // class declaration).
       const kClass = this.host.getSymbolName(sym, TSNamespace.TYPE);
+      if (!kClass) return;
       this.emitNode(kClass, 'record');
       const kClassCtor = this.host.getSymbolName(sym, TSNamespace.VALUE);
+      if (!kClassCtor) return;
       this.emitNode(kClassCtor, 'function');
 
       const anchor = this.newAnchor(decl.name);
@@ -1613,6 +1643,7 @@ class Visitor {
 
         const ctorVName =
             this.host.getSymbolName(ctorSymbol, TSNamespace.VALUE);
+        if (!ctorVName) return;
 
         this.emitNode(ctorVName, 'function');
         this.emitSubkind(ctorVName, Subkind.CONSTRUCTOR);
@@ -1632,8 +1663,10 @@ class Visitor {
     const sym = this.host.getSymbolAtLocation(decl.name);
     if (!sym) return;
     const kType = this.host.getSymbolName(sym, TSNamespace.TYPE);
+    if (!kType) return;
     this.emitNode(kType, 'record');
     const kValue = this.host.getSymbolName(sym, TSNamespace.VALUE);
+    if (!kValue) return;
     this.emitNode(kValue, 'constant');
 
     const anchor = this.newAnchor(decl.name);
@@ -1648,6 +1681,7 @@ class Visitor {
     const sym = this.host.getSymbolAtLocation(decl.name);
     if (!sym) return;
     const kMember = this.host.getSymbolName(sym, TSNamespace.VALUE);
+    if (!kMember) return;
     this.emitNode(kMember, 'constant');
     this.emitEdge(this.newAnchor(decl.name), EdgeKind.DEFINES_BINDING, kMember);
   }
@@ -1663,6 +1697,7 @@ class Visitor {
       return;
     }
     const name = this.host.getSymbolName(sym, TSNamespace.VALUE);
+    if (!name) return;
     const anchor = this.newAnchor(node);
     this.emitEdge(anchor, EdgeKind.REF, name);
 
@@ -1675,6 +1710,7 @@ class Visitor {
         if (ctorSymbol) {
           const ctorVName =
               this.host.getSymbolName(ctorSymbol, TSNamespace.VALUE);
+          if (!ctorVName) return;
           this.emitEdge(anchor, EdgeKind.REF_CALL, ctorVName);
         }
       }
@@ -1699,6 +1735,7 @@ class Visitor {
     }
 
     const type = this.host.getSymbolName(sym, TSNamespace.TYPE);
+    if (!type) return;
     const thisAnchor = this.newAnchor(keyword);
     this.emitEdge(thisAnchor, EdgeKind.REF, type);
   }

--- a/kythe/typescript/testdata/compilefail.ts
+++ b/kythe/typescript/testdata/compilefail.ts
@@ -1,6 +1,11 @@
 // This file exercises what happens when you have a compilation error.
 // It's also imported by compilefail_import.ts.
 
+// This is an error because 'no-such-module' doesn't exist.
+import * as bad from 'no-such-module';
+let badType: bad.Type;  // use a type
+let badValue = bad.value;  // use a value
+
 // This is an error because 'UndefinedSymbol' is never defined.
 export type Bad = UndefinedSymbol;
 


### PR DESCRIPTION
In some cases we encounter a symbol that doesn't have an associated
VName.  Rather than crashing, change the calling code to move on to
subsequent code by adding a million return statements.

The associated test adds more badly formed code that reproduces this
problem.  The test will crash without the corresponding indexer change.