### PR TITLE
chore(cmake): log the command we are running

### DIFF
--- a/kythe/go/extractors/config/runextractor/cmakecmd/cmakecmd.go
+++ b/kythe/go/extractors/config/runextractor/cmakecmd/cmakecmd.go
@@ -133,5 +133,6 @@ func cleanBuild(dir string) {
 func runIn(cmd *exec.Cmd, dir string) error {
 	cmd.Dir = dir
 	cmd.Stderr = os.Stderr
+	log.Printf("Running: %q in %q", cmd.String(), cmd.Dir)
 	return cmd.Run()
 }

--- a/kythe/go/extractors/config/runextractor/cmakecmd/cmakecmd.go
+++ b/kythe/go/extractors/config/runextractor/cmakecmd/cmakecmd.go
@@ -133,6 +133,6 @@ func cleanBuild(dir string) {
 func runIn(cmd *exec.Cmd, dir string) error {
 	cmd.Dir = dir
 	cmd.Stderr = os.Stderr
-	log.Printf("Running: %q in %q", cmd.String(), cmd.Dir)
+	log.Printf("Running: %q in %q", cmd, cmd.Dir)
 	return cmd.Run()
 }


### PR DESCRIPTION
Logging the command we are running makes it easier to understand error messages that come from cmake.