### PR TITLE
chore(cmake): Tell cmake we are clang

### DIFF
--- a/kythe/go/extractors/config/runextractor/cmakecmd/cmakecmd.go
+++ b/kythe/go/extractors/config/runextractor/cmakecmd/cmakecmd.go
@@ -107,7 +107,9 @@ func (c *cmakeCommand) Execute(ctx context.Context, fs *flag.FlagSet, args ...in
 		return c.Fail("Unable to create build directory: %v", err)
 	}
 
-	if err := runIn(exec.CommandContext(ctx, "cmake", "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON", sourceDir), buildDir); err != nil {
+	// The Kythe extractor is clang based, so tell cmake that we are Clang so the right
+	// commands are generated.
+	if err := runIn(exec.CommandContext(ctx, "cmake", "-DCMAKE_CXX_COMPILER_ID=Clang", "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON", sourceDir), buildDir); err != nil {
 		return c.Fail("Error configuring cmake: %v", err)
 	}
 

--- a/kythe/go/extractors/config/runextractor/cmakecmd/cmakecmd.go
+++ b/kythe/go/extractors/config/runextractor/cmakecmd/cmakecmd.go
@@ -107,9 +107,9 @@ func (c *cmakeCommand) Execute(ctx context.Context, fs *flag.FlagSet, args ...in
 		return c.Fail("Unable to create build directory: %v", err)
 	}
 
-	// The Kythe extractor is clang based, so tell cmake that we are Clang so the right
+	// The Kythe extractor is clang based, so tell cmake to use clang so the right
 	// commands are generated.
-	if err := runIn(exec.CommandContext(ctx, "cmake", "-DCMAKE_CXX_COMPILER_ID=Clang", "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON", sourceDir), buildDir); err != nil {
+	if err := runIn(exec.CommandContext(ctx, "cmake", "-DCMAKE_CXX_COMPILER=clang++", "-DCMAKE_C_COMPILER=clang", "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON", sourceDir), buildDir); err != nil {
 		return c.Fail("Error configuring cmake: %v", err)
 	}
 


### PR DESCRIPTION
Set the compiler id in cmake to clang so repos that generate different commands based on the compiler ID will generate the correct commands for us.