### PR TITLE
feat(java_extractor): allow passing search paths as a map

### DIFF
--- a/kythe/java/com/google/devtools/kythe/extractors/java/JavaCompilationUnitExtractor.java
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/JavaCompilationUnitExtractor.java
@@ -292,7 +292,7 @@ public class JavaCompilationUnitExtractor {
     Preconditions.checkNotNull(options);
     Preconditions.checkNotNull(outputPath);
 
-    AnalysisResults results =
+    final AnalysisResults results =
         Iterables.isEmpty(sources)
             ? new AnalysisResults()
             : runJavaAnalysisToExtractCompilationDetails(
@@ -316,7 +316,7 @@ public class JavaCompilationUnitExtractor {
                 })
             .collect(toImmutableList());
 
-    CompilationUnit compilationUnit =
+    final CompilationUnit compilationUnit =
         buildCompilationUnit(
             target,
             removeDestDirOptions(options),
@@ -761,7 +761,7 @@ public class JavaCompilationUnitExtractor {
                   sourceFiles);
       javacTask.addTaskListener(compilationCollector);
       javacTask.setProcessors(
-          loadProcessors(processingClassloader(fileManager), processors, fileManager));
+          loadProcessors(processingClassLoader(fileManager), processors, fileManager));
 
       // Relies on Context.  Must come before javacTask.call, which resets the context.
       Symtab symbolTable = getSymbolTable(javacTask);
@@ -843,7 +843,7 @@ public class JavaCompilationUnitExtractor {
   }
 
   /** Create the ClassLoader to use for annotation processors. */
-  private static ClassLoader processingClassloader(StandardJavaFileManager fileManager)
+  private static ClassLoader processingClassLoader(StandardJavaFileManager fileManager)
       throws ExtractionException {
     // If javac is run with -processor set and -processorpath *unset*, it will fall back to
     // searching the regular classpath for annotation processors.

--- a/kythe/java/com/google/devtools/kythe/extractors/java/JavaCompilationUnitExtractor.java
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/JavaCompilationUnitExtractor.java
@@ -262,12 +262,11 @@ public class JavaCompilationUnitExtractor {
     return extract(
         target,
         sources,
-        ImmutableMap.<Location, Iterable<String>>builder()
-            .put(StandardLocation.CLASS_PATH, classpath)
-            .put(StandardLocation.PLATFORM_CLASS_PATH, bootclasspath)
-            .put(StandardLocation.SOURCE_PATH, sourcepath)
-            .put(StandardLocation.ANNOTATION_PROCESSOR_PATH, processorpath)
-            .build(),
+        ImmutableMap.of(
+            StandardLocation.CLASS_PATH, classpath,
+            StandardLocation.PLATFORM_CLASS_PATH, bootclasspath,
+            StandardLocation.SOURCE_PATH, sourcepath,
+            StandardLocation.ANNOTATION_PROCESSOR_PATH, processorpath),
         processors,
         genSrcDir,
         options,


### PR DESCRIPTION
This changes semantics slightly, so I want to put it into a small and targeted change to keep the Chesterton's Fence damage radius small.  Notable semantic differences:

1) Single-empty-element search paths will be set on the file manager (previously, both [] and [""] would be excluded).
2) Paths are only set on the fileManager, rather than being set on the fileManager and injected into the command line.  This means that if those flags are present on the command line, they will override the specified values.  This shouldn't be a problem as non-Bazel extractors currently pull these search paths out of the command line and then re-inject them, but is something to watch out for.
3) Uses configured fileManager for the processor search path, rather than the iterables directly, but the semantics should be the same.
