### PR TITLE
fix(go extractor): treat -arc flag like -importpath

### DIFF
--- a/kythe/go/extractors/cmd/bazel/bazel_go_extractor/bazel_go_extractor.go
+++ b/kythe/go/extractors/cmd/bazel/bazel_go_extractor/bazel_go_extractor.go
@@ -207,7 +207,7 @@ func parseCompileArgs(args []string) *compileArgs {
 		switch flag {
 		case "dep":
 			c.deps = append(c.deps, arg)
-		case "importmap":
+		case "importmap", "arc":
 			// Only record the mappings that change something.
 			ps := strings.SplitN(arg, "=", 2)
 			if len(ps) == 2 && ps[0] != ps[1] {


### PR DESCRIPTION
This fixes extraction so that the go indexer can correctly add cross-references
for import statements. I tested this by extracting the cmdutil package
in this repo after making these changes and indexing the resulting
compilation unit.

I'm having trouble finding documentation on -arc, but it seems to do the same
thing as -importpath, except for archive files. See for example the arguments
list for the kythe/go/util/cmdutil/cmdutil.go compilation unit:

```
  "argument": [
    "bazel-out/host/bin/external/go_sdk/builder",
    "compilepkg",
    "-sdk",
    "external/go_sdk",
    "-installsuffix",
    "linux_amd64",
    "-src",
    "kythe/go/util/cmdutil/cmdutil.go",
    "-arc",
    "github.com/google/subcommands=github.com/google/subcommands=bazel-out/k8-fastbuild/bin/external/com_github_google_subcommands/linux_amd64_stripped/go_default_library%/github.com/google/subcommands.a=",
    "-importpath",
    "kythe.io/kythe/go/util/cmdutil",
    "-p",
    "kythe.io/kythe/go/util/cmdutil",
    "-package_list",
    "bazel-out/host/bin/external/go_sdk/packages.txt",
    "-o",
    "bazel-out/k8-fastbuild/bin/kythe/go/util/cmdutil/linux_amd64_stripped/cmdutil%/kythe.io/kythe/go/util/cmdutil.a",
    "-gcflags",
    "",
    "-asmflags",
    ""
  ],
```

Here's what the required_input entry for cmdutil's import of the 'subcommands'
package looks like before and after this change:

Before:
```
"v_name": {
  "corpus": "github.com/kythe/kythe",
  "root": "bazel-out/bin/external/com_github_google_subcommands",
  "path": "linux_amd64_stripped/go_default_library%/github.com/google/subcommands.a"
},
info": {
  "path": "bazel-out/k8-fastbuild/bin/external/com_github_google_subcommands/linux_amd64_stripped/go_default_library%/github.com/google/subcommands.a",
  "digest": "147e0decd83747d48d79a9d47ed55e64179cfd1894e610b0fe5b3cbb617717be"
}
```

After:
```
"v_name": {
  "corpus": "github.com/google/subcommands"
},
"info": {
  "path": "bazel-out/k8-fastbuild/bin/external/com_github_google_subcommands/linux_amd64_stripped/go_default_library%/github.com/google/subcommands.a",
  "digest": "147e0decd83747d48d79a9d47ed55e64179cfd1894e610b0fe5b3cbb617717be"
}
```