### PR TITLE
don't assume Symbol.valueDeclaration exists

### DIFF
--- a/kythe/typescript/indexer.ts
+++ b/kythe/typescript/indexer.ts
@@ -916,7 +916,7 @@ class Visitor {
     // This can happen in cases of importing local modules, like
     //   declare namespace Foo {}
     //   import foo = Foo;
-    if (!ts.isSourceFile(sf)) return undefined;
+    if (!sf || !ts.isSourceFile(sf)) return undefined;
     return this.host.moduleName(sf.fileName);
   }
 
@@ -1054,7 +1054,7 @@ class Visitor {
       // Check if module being imported is declared via `declare module`
       // and if so - output ref to that statement.
       const decl = moduleSym.valueDeclaration;
-      if (ts.isModuleDeclaration(decl)) {
+      if (decl && ts.isModuleDeclaration(decl)) {
         const kModule =
             this.host.getSymbolName(moduleSym, TSNamespace.NAMESPACE);
         if (!kModule) return;


### PR DESCRIPTION
From the TypeScript compiler source, it's possible for
symbol.valueDeclaration to be undefined, and within Google we have code
that crashes on it being undefined.

I have been unable to come up with a test case that reproduces this
crash, so instead I just looked for references to .valueDeclaration in
the code and added an additional check at each reference.

(You might ask, doesn't TypeScript's type system help with exactly this
problem?  And the answer is yes, but the TS compiler API itself
unfortunately lies in its types, and claims that .valueDeclaration is
never undefined. Sadness.)