### PR TITLE
chore(java_extractor): refactor extraction into a separate class

### DIFF
--- a/kythe/java/com/google/devtools/kythe/extractors/java/JavaCompilationUnitExtractor.java
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/JavaCompilationUnitExtractor.java
@@ -801,7 +801,7 @@ public class JavaCompilationUnitExtractor {
     return results;
   }
 
-  /** Sets the given location using command-line flags and the FileManager API. */
+  /** Sets the given location using the FileManager API. */
   private static void setLocation(
       UsageAsInputReportingFileManager fileManager, Location location, Iterable<String> searchpath)
       throws ExtractionException {

--- a/kythe/java/com/google/devtools/kythe/extractors/java/JavaCompilationUnitExtractor.java
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/JavaCompilationUnitExtractor.java
@@ -127,7 +127,11 @@ public class JavaCompilationUnitExtractor {
   private final FileVNames fileVNames;
   private String systemDir;
 
-  public static class CompilationTask implements AutoCloseable {
+  /**
+   * ExtractionTask represents a single invocation of the java compiler in order to determine the
+   * required inputs.
+   */
+  public static class ExtractionTask implements AutoCloseable {
     private final TemporaryDirectory tempDir = new TemporaryDirectory();
 
     // Can only be intiailized once the task is created.
@@ -140,7 +144,7 @@ public class JavaCompilationUnitExtractor {
     private final UsageAsInputReportingFileManager fileManager =
         JavaCompilationUnitExtractor.getFileManager(compiler, diagnosticCollector);
 
-    CompilationTask() throws ExtractionException {}
+    ExtractionTask() throws ExtractionException {}
 
     public UsageAsInputReportingFileManager getFileManager() {
       return fileManager;
@@ -824,7 +828,7 @@ public class JavaCompilationUnitExtractor {
     AnalysisResults results = new AnalysisResults();
 
     // Generate class files in a temporary directory
-    try (CompilationTask task = new CompilationTask()) {
+    try (ExtractionTask task = new ExtractionTask()) {
       for (Map.Entry<Location, Iterable<String>> entry : searchPaths.entrySet()) {
         setLocation(task.getFileManager(), entry.getKey(), entry.getValue());
       }


### PR DESCRIPTION
This splits the extraction task into a separate class which is responsible for doing most of the setup of the extraction, but decouples this from turning the results into an AnalysisResults and CompilationDescription class.  This should make it easier follow and change in the future, in particular with an eye towards more accurately extracting openjdk11.