### PR TITLE
feat: allow excluding modules from openjdk11 extraction

### DIFF
--- a/kythe/extractors/openjdk11/java_wrapper/BUILD
+++ b/kythe/extractors/openjdk11/java_wrapper/BUILD
@@ -8,6 +8,7 @@ go_binary(
     ],
     deps = [
         "@org_bitbucket_creachadair_shell//:go_default_library",
+        "@org_bitbucket_creachadair_stringset//:go_default_library",
         "@org_golang_x_sys//unix:go_default_library",
     ],
 )

--- a/kythe/extractors/openjdk11/java_wrapper/java_wrapper.go
+++ b/kythe/extractors/openjdk11/java_wrapper/java_wrapper.go
@@ -157,8 +157,10 @@ func main() {
 	excludeModules := loadExclusions()
 	java := javaCommand()
 	jar := extractorJar()
-	if !excludeModules.Contains(moduleName()) {
-		if args := extractorArgs(os.Args[1:], jar); len(args) > 0 {
+	if args := extractorArgs(os.Args[1:], jar); len(args) > 0 {
+		if excludeModules.Contains(moduleName()) {
+			log.Printf("*** Skipping: %s", moduleName())
+		} else {
 			cmd := exec.Command(java, args...)
 			cmd.Env = extractorEnv()
 			log.Printf("*** Extracting: %s", moduleName())


### PR DESCRIPTION
There are a few problematic modules at the moment, specifically: jdk.internal.vm.compiler, jdk.aot, and jdk.internal.vm.compiler.management.  While work is ongoing to fix them, in the meantime it we can start indexing the rest of the modules.