### PR TITLE
typescript: Make the typescript signatures more specific to their module

### DIFF
--- a/kythe/typescript/indexer.ts
+++ b/kythe/typescript/indexer.ts
@@ -684,7 +684,11 @@ class Visitor {
 
     this.typeChecker = this.host.program.getTypeChecker();
 
-    this.kFile = this.newFileVName(file.fileName);
+    if (process.env.KYTHE_ROOT_DIRECTORY) {
+      this.kFile = this.newFileVName(path.relative(process.env.KYTHE_ROOT_DIRECTORY, file.fileName));
+    } else {
+      this.kFile = this.newFileVName(file.fileName);
+    }
   }
 
   /**

--- a/kythe/typescript/indexer.ts
+++ b/kythe/typescript/indexer.ts
@@ -1961,7 +1961,7 @@ function main(argv: string[]) {
 
   // This program merely demonstrates the API, so use a fake corpus/root/etc.
   const compilationUnit: VName = {
-    corpus: 'corpus',
+    corpus: process.env.KYTHE_CORPUS || 'corpus',
     root: '',
     path: '',
     signature: '',

--- a/kythe/typescript/test.ts
+++ b/kythe/typescript/test.ts
@@ -92,9 +92,11 @@ function verify(
       });
 
   try {
-    indexer.index(compilationUnit, new Map(), testFiles, program, (obj: {}) => {
-      verifier.stdin.write(JSON.stringify(obj) + '\n');
-    }, plugins);
+    indexer.index(
+        compilationUnit, new Map(), testFiles, program, '',
+        undefined, (obj: {}) => {
+          verifier.stdin.write(JSON.stringify(obj) + '\n');
+        }, plugins);
   } finally {
     // Ensure we close stdin on the verifier even on crashes, or otherwise
     // we hang waiting for the verifier to complete.

--- a/kythe/typescript/testdata/binding_pattern.ts
+++ b/kythe/typescript/testdata/binding_pattern.ts
@@ -1,15 +1,15 @@
 // Tests TypeScript binding patterns.
 
-//- @a defines/binding A=vname("a", _, _, _, _)
-//- @b defines/binding B=vname("b", _, _, _, _)
+//- @a defines/binding A=vname("testdata/binding_pattern/a", _, _, _, _)
+//- @b defines/binding B=vname("testdata/binding_pattern/b", _, _, _, _)
 let [a, b] = [1, 2];
 
 //- @a ref A
 //- @b ref B
 a = b;
 
-//- @#0"c" defines/binding C=vname("c", _, _, _, _)
-//- @letD defines/binding D=vname("letD", _, _, _, _)
+//- @#0"c" defines/binding C=vname("testdata/binding_pattern/c", _, _, _, _)
+//- @letD defines/binding D=vname("testdata/binding_pattern/letD", _, _, _, _)
 let {c, d: letD} = {c: 0, d: 0};
 
 //- @c ref C

--- a/kythe/typescript/testdata/class.ts
+++ b/kythe/typescript/testdata/class.ts
@@ -21,9 +21,9 @@ interface IExtended extends IFace {
     ifaceMethod(): void;
 }
 
-//- @Class defines/binding Class=vname("Class#type", _, _, _, _)
+//- @Class defines/binding Class=vname("testdata/class/Class#type", _, _, _, _)
 //- Class.node/kind record
-//- @Class defines/binding ClassValue=vname("Class", _, _, _, _)
+//- @Class defines/binding ClassValue=vname("testdata/class/Class", _, _, _, _)
 //- ClassValue.node/kind function
 //- @IFace ref IFace
 class Class implements IFace {
@@ -40,7 +40,7 @@ class Class implements IFace {
     // This ctor declares a new member var named 'otherMember', and also
     // declares an ordinary parameter named 'member' (to ensure we don't get
     // confused about params to the ctor vs true member variables).
-    //- @constructor defines/binding ClassCtor=vname("Class#type.constructor", _, _, _, _)
+    //- @constructor defines/binding ClassCtor=vname("testdata/class/Class#type.constructor", _, _, _, _)
     //- ClassCtor.node/kind function
     //- ClassCtor.subkind constructor
     //- @otherMember defines/binding OtherMember

--- a/kythe/typescript/testdata/computed_property.ts
+++ b/kythe/typescript/testdata/computed_property.ts
@@ -2,8 +2,8 @@ export {}
 
 interface HasIterator {
   // Just verify we index into the computed property:
-  //- @Symbol ref Sym=VName("Symbol", _, _, _, _)
-  //- @iterator ref _Iter=VName("SymbolConstructor.iterator", _, _, _, _)
+  //- @Symbol ref Sym=VName("typescript/lib/lib.es5/Symbol", _, _, _, _)
+  //- @iterator ref _Iter=VName("typescript/lib/lib.es2015.iterable/SymbolConstructor.iterator", _, _, _, _)
   [Symbol.iterator](): number;
 }
 

--- a/kythe/typescript/testdata/default_export.ts
+++ b/kythe/typescript/testdata/default_export.ts
@@ -1,7 +1,7 @@
 // This is imported by the default_import.ts test.
 
 // An "export default" defines a variable named "default".
-//- @default defines/binding _Def=vname("default", _, _, _, _)
+//- @default defines/binding _Def=vname("testdata/default_export/default", _, _, _, _)
 export default {
   key: 'value'
 };

--- a/kythe/typescript/testdata/default_import.ts
+++ b/kythe/typescript/testdata/default_import.ts
@@ -1,7 +1,7 @@
 // This test uses a default import, which should behave like importing
 // a field named "default".
 
-//- @obj ref/imports ObjDef=vname("default", _, _, "testdata/default_export", _)
+//- @obj ref/imports ObjDef=vname("testdata/default_export/default", _, _, "testdata/default_export", _)
 //- @import defines/binding LocalObj=vname(_, _, _, "testdata/default_import", _)
 //- LocalObj.node/kind variable
 //- LocalObj.subkind import

--- a/kythe/typescript/testdata/equals_export.ts
+++ b/kythe/typescript/testdata/equals_export.ts
@@ -1,7 +1,7 @@
 // This is imported by the equals_import.ts test.
 
 // An "export =" defines a variable named "export=".
-//- @"export =" defines/binding _Def=vname("export=", _, _, _, _)
+//- @"export =" defines/binding _Def=vname("testdata/equals_export/export=", _, _, _, _)
 export = {
   key: 'value'
 };

--- a/kythe/typescript/testdata/equals_import.ts
+++ b/kythe/typescript/testdata/equals_import.ts
@@ -1,7 +1,7 @@
 // This tests an equals import of an external module reference that uses the
 // export equals syntax.
 
-//- @obj ref/imports Def=vname("export=", _, _, "testdata/equals_export", _)
+//- @obj ref/imports Def=vname("testdata/equals_export/export=", _, _, "testdata/equals_export", _)
 //- @import defines/binding LocalObj
 //- LocalObj.node/kind variable
 //- LocalObj.subkind import

--- a/kythe/typescript/testdata/export.ts
+++ b/kythe/typescript/testdata/export.ts
@@ -1,5 +1,5 @@
 // Syntax 1: exporting a value from another module.
-//- @"'./module'" ref/imports vname("module", _, _, "testdata/module", _)
+//- @"'./module'" ref/imports vname("testdata/module", _, _, "testdata/module", _)
 export {value} from './module';
 
 // Syntax 2: a bare "export" statement.

--- a/kythe/typescript/testdata/fake-genfiles/testdata/alt_module.ts
+++ b/kythe/typescript/testdata/fake-genfiles/testdata/alt_module.ts
@@ -1,5 +1,5 @@
 // This module is imported by the root_dirs.ts test.
 // See that file for more comments.
 
-//- @exported defines/binding _Alt=vname("exported", _, _, "testdata/alt_module", _)
+//- @exported defines/binding _Alt=vname("testdata/alt_module/exported", _, _, "testdata/alt_module", _)
 export const exported = 3;

--- a/kythe/typescript/testdata/getter_setter.ts
+++ b/kythe/typescript/testdata/getter_setter.ts
@@ -4,17 +4,17 @@
 class A {
   prop = 0;
 
-  //- @foo defines/binding PropFoo=VName("A#type.foo", _, _, _, _)
+  //- @foo defines/binding PropFoo=VName("testdata/getter_setter/A#type.foo", _, _, _, _)
   //- PropFoo.node/kind variable
   //- PropFoo.subkind implicit
-  //- @foo defines/binding GetFoo=VName("A#type.foo:getter", _, _, _, _)
+  //- @foo defines/binding GetFoo=VName("testdata/getter_setter/A#type.foo:getter", _, _, _, _)
   //- GetFoo.node/kind function
   //- GetFoo property/reads PropFoo
   get foo() {
     return this.prop;
   }
 
-  //- @foo defines/binding SetFoo=VName("A#type.foo:setter", _, _, _, _)
+  //- @foo defines/binding SetFoo=VName("testdata/getter_setter/A#type.foo:setter", _, _, _, _)
   //- SetFoo.node/kind function
   //- SetFoo property/writes PropFoo
   set foo(nFoo) {
@@ -33,10 +33,10 @@ class A {
 class B {
   iProp = 0;
 
-  //- @prop defines/binding PropProp=VName("B#type.prop", _, _, _, _)
+  //- @prop defines/binding PropProp=VName("testdata/getter_setter/B#type.prop", _, _, _, _)
   //- PropProp.node/kind variable
   //- PropProp.subkind implicit
-  //- @prop defines/binding GetProp=VName("B#type.prop:getter", _, _, _, _)
+  //- @prop defines/binding GetProp=VName("testdata/getter_setter/B#type.prop:getter", _, _, _, _)
   //- GetProp.node/kind function
   //- GetProp property/reads PropProp
   get prop() {
@@ -53,10 +53,10 @@ class B {
 class C {
   prop = 0;
 
-  //- @mem defines/binding PropMem=VName("C#type.mem", _, _, _, _)
+  //- @mem defines/binding PropMem=VName("testdata/getter_setter/C#type.mem", _, _, _, _)
   //- PropMem.node/kind variable
   //- PropMem.subkind implicit
-  //- @mem defines/binding SetMem=VName("C#type.mem:setter", _, _, _, _)
+  //- @mem defines/binding SetMem=VName("testdata/getter_setter/C#type.mem:setter", _, _, _, _)
   //- SetMem.node/kind function
   //- SetMem property/writes PropMem
   set mem(nMem) {

--- a/kythe/typescript/testdata/import.ts
+++ b/kythe/typescript/testdata/import.ts
@@ -1,11 +1,11 @@
 // This test imports the same value in a variety of names and ensures
 // they all resolve to the same VName.
 
-//- @"'./module'" ref/imports ModRef=VName("module", _, _, "testdata/module", _)
+//- @"'./module'" ref/imports ModRef=VName("testdata/module", _, _, "testdata/module", _)
 import './module';
 
 //- @mod_imp defines/binding ModLocal
-//- @"'./module'" ref/imports ModRef=VName("module", _, _, "testdata/module", _)
+//- @"'./module'" ref/imports ModRef=VName("testdata/module", _, _, "testdata/module", _)
 import * as mod_imp from './module';
 
 // Importing from a module gets a VName that refers into the other module.

--- a/kythe/typescript/testdata/index_importer.ts
+++ b/kythe/typescript/testdata/index_importer.ts
@@ -2,5 +2,5 @@
 // you import a path "foo/bar" that refers to a directory, it
 // may resolve to a file "foo/bar/index.[something]".
 
-//- @"'./index_module'" ref/imports _ModRef=vname("module", _, _, "testdata/index_module/index", _)
+//- @"'./index_module'" ref/imports _ModRef=vname("testdata/index_module/index", _, _, "testdata/index_module/index", _)
 import {foo} from './index_module';

--- a/kythe/typescript/testdata/module.ts
+++ b/kythe/typescript/testdata/module.ts
@@ -2,7 +2,7 @@
 // The signature is 'module' and the path is the module path (the filename
 // without an extension).  See the discussion of "Module name" in README.md.
 
-//- Mod=vname("module", _, _, "testdata/module", _).node/kind record
+//- Mod=vname("testdata/module", _, _, "testdata/module", _).node/kind record
 
 // The first letter in the module is tagged as defining the module.
 // See discussion in emitModuleAnchor().

--- a/kythe/typescript/testdata/reexport/reexport.ts
+++ b/kythe/typescript/testdata/reexport/reexport.ts
@@ -19,5 +19,5 @@ export {
   //- @#0someFunction ref SomeFunction
   //- @someFunctionAlias ref SomeFunction
   someFunction as someFunctionAlias}
-//- @"'./main'" ref/imports vname("module", _, _, "testdata/reexport/main", _)
+//- @"'./main'" ref/imports vname("testdata/reexport/main", _, _, "testdata/reexport/main", _)
 from './main';

--- a/kythe/typescript/testdata/root_dirs.ts
+++ b/kythe/typescript/testdata/root_dirs.ts
@@ -9,6 +9,6 @@
 // "testdata/fake-genfiles/testdata/alt_module".
 // See the discussion of module names in README.md.
 
-//- @exported ref/imports _Alt=vname("exported", _, _, "testdata/alt_module", _)
-//- @"'./alt_module'" ref/imports _ModRef=vname("module", _, _, "testdata/alt_module", _)
+//- @exported ref/imports _Alt=vname("testdata/alt_module/exported", _, _, "testdata/alt_module", _)
+//- @"'./alt_module'" ref/imports _ModRef=vname("testdata/alt_module", _, _, "testdata/alt_module", _)
 import {exported} from './alt_module';

--- a/kythe/typescript/testdata/rvalue.ts
+++ b/kythe/typescript/testdata/rvalue.ts
@@ -1,18 +1,18 @@
 // Tests that expression rvalues do not name a new scope a VName signature.
 
 const a = class A {
-  //- @foo defines/binding vname("a.foo", _, _, _, _)
+  //- @foo defines/binding vname("testdata/rvalue/a.foo", _, _, _, _)
   foo = 0;
 };
 
 class BB {
-  //- @cc defines/binding vname("BB.cc", _, _, _, _)
+  //- @cc defines/binding vname("testdata/rvalue/BB.cc", _, _, _, _)
   static cc = class C {
-    //- @d defines/binding vname("BB.cc.d", _, _, _, _)
+    //- @d defines/binding vname("testdata/rvalue/BB.cc.d", _, _, _, _)
     d: number;
   };
   static ee = {
-    //- @f defines/binding vname("BB.ee.f", _, _, _, _)
+    //- @f defines/binding vname("testdata/rvalue/BB.ee.f", _, _, _, _)
     f: 0
   };
 }

--- a/kythe/typescript/testdata/schema.ts
+++ b/kythe/typescript/testdata/schema.ts
@@ -1,94 +1,94 @@
 // Tests TypeScript indexer VName schema.
 
 // SourceFile
-//- FileModule=VName("module", _, _, "testdata/schema", "typescript").node/kind record
+//- FileModule=VName("testdata/schema", _, _, "testdata/schema", "typescript").node/kind record
 //- FileModuleAnchor.node/kind anchor
 //- FileModuleAnchor./kythe/loc/start 0
 //- FileModuleAnchor./kythe/loc/end 1
 //- FileModuleAnchor defines/binding FileModule
 
 // NamespaceImport
-//- @NspI defines/binding VName("NspI", _, _, "testdata/schema", "typescript")
+//- @NspI defines/binding VName("testdata/schema/NspI", _, _, "testdata/schema", "typescript")
 import * as NspI from './declaration';
 
 // ExportAssignment
-//- @default defines/binding VName("default", _, _, "testdata/schema", "typescript")
+//- @default defines/binding VName("testdata/schema/default", _, _, "testdata/schema", "typescript")
 export default NspI;
 
 // ClassDeclaration
-//- @C defines/binding VName("C#type", _, _, "testdata/schema", "typescript")
-//- @C defines/binding VName("C", _, _, "testdata/schema", "typescript")
+//- @C defines/binding VName("testdata/schema/C#type", _, _, "testdata/schema", "typescript")
+//- @C defines/binding VName("testdata/schema/C", _, _, "testdata/schema", "typescript")
 class C {
   // PropertyDeclaration instance member
-  //- @property defines/binding VName("C#type.property", _, _, "testdata/schema", "typescript")
+  //- @property defines/binding VName("testdata/schema/C#type.property", _, _, "testdata/schema", "typescript")
   property = 0;
 
   // PropertyDeclarartion string literal
-  //- @"'propliteral'" defines/binding VName("C#type.\"propliteral\"", _, _, "testdata/schema", "typescript")
+  //- @"'propliteral'" defines/binding VName("testdata/schema/C#type.\"propliteral\"", _, _, "testdata/schema", "typescript")
   'propliteral' = 0;
 
   // PropertyDeclaration static member
-  //- @property defines/binding VName("C.property", _, _, "testdata/schema", "typescript")
+  //- @property defines/binding VName("testdata/schema/C.property", _, _, "testdata/schema", "typescript")
   static property = 0;
 
   // MethodDeclaration
-  //- @method defines/binding VName("C#type.method", _, _, "testdata/schema", "typescript")
+  //- @method defines/binding VName("testdata/schema/C#type.method", _, _, "testdata/schema", "typescript")
   method() {}
 
   // Constructor, ParameterPropertyDeclaration
-  //- @constructor defines/binding VName("C#type.constructor", _, _, "testdata/schema", "typescript")
-  //- @cprop defines/binding VName("C#type.cprop", _, _, "testdata/schema", "typescript")
+  //- @constructor defines/binding VName("testdata/schema/C#type.constructor", _, _, "testdata/schema", "typescript")
+  //- @cprop defines/binding VName("testdata/schema/C#type.cprop", _, _, "testdata/schema", "typescript")
   constructor(private cprop: number) {}
 
   // GetAccessor
-  //- @prop defines/binding VName("C#type.prop:getter", _, _, "testdata/schema", "typescript")
-  //- @prop defines/binding VName("C#type.prop", _, _, "testdata/schema", "typescript")
+  //- @prop defines/binding VName("testdata/schema/C#type.prop:getter", _, _, "testdata/schema", "typescript")
+  //- @prop defines/binding VName("testdata/schema/C#type.prop", _, _, "testdata/schema", "typescript")
   get prop() {
     return this.property;
   }
 
   // SetAccessor
-  //- @prop defines/binding VName("C#type.prop:setter", _, _, "testdata/schema", "typescript")
+  //- @prop defines/binding VName("testdata/schema/C#type.prop:setter", _, _, "testdata/schema", "typescript")
   set prop(nProp) {
     this.property = nProp;
   }
 }
 
 // ClassDeclaration with no ctor
-//- @CC defines/binding VName("CC#type", _, _, "testdata/schema", "typescript")
-//- @CC defines/binding VName("CC", _, _, "testdata/schema", "typescript")
+//- @CC defines/binding VName("testdata/schema/CC#type", _, _, "testdata/schema", "typescript")
+//- @CC defines/binding VName("testdata/schema/CC", _, _, "testdata/schema", "typescript")
 class CC {}
 
 // EnumDeclaration
-//- @E defines/binding VName("E", _, _, "testdata/schema", "typescript")
-//- @E defines/binding VName("E#type", _, _, "testdata/schema", "typescript")
+//- @E defines/binding VName("testdata/schema/E", _, _, "testdata/schema", "typescript")
+//- @E defines/binding VName("testdata/schema/E#type", _, _, "testdata/schema", "typescript")
 enum E {
   // EnumMember
-  //- @EnumMember defines/binding VName("E.EnumMember", _, _, "testdata/schema", "typescript")
+  //- @EnumMember defines/binding VName("testdata/schema/E.EnumMember", _, _, "testdata/schema", "typescript")
   EnumMember = 0
 }
 
 // FunctionDeclaration
-//- @#1"fun" defines/binding VName("fun", _, _, "testdata/schema", "typescript")
+//- @#1"fun" defines/binding VName("testdata/schema/fun", _, _, "testdata/schema", "typescript")
 function fun(
     // Parameter
-    //- @param defines/binding VName("fun.param", _, _, "testdata/schema", "typescript")
+    //- @param defines/binding VName("testdata/schema/fun.param", _, _, "testdata/schema", "typescript")
     param: number) {}
 
 // InterfaceDeclaration
-//- @B defines/binding VName("B#type", _, _, "testdata/schema", "typescript")
+//- @B defines/binding VName("testdata/schema/B#type", _, _, "testdata/schema", "typescript")
 interface B {
   // PropertySignature
-  //- @pSig defines/binding VName("B.pSig", _, _, "testdata/schema", "typescript")
+  //- @pSig defines/binding VName("testdata/schema/B.pSig", _, _, "testdata/schema", "typescript")
   pSig: number;
 
   // MethodSignature
-  //- @mSig defines/binding VName("B.mSig", _, _, "testdata/schema", "typescript")
+  //- @mSig defines/binding VName("testdata/schema/B.mSig", _, _, "testdata/schema", "typescript")
   mSig(): void;
 }
 
 // VariableDeclaration
-//- @v defines/binding VName("v", _, _, "testdata/schema", "typescript")
+//- @v defines/binding VName("testdata/schema/v", _, _, "testdata/schema", "typescript")
 let v = {
   // PropertyAssignment
   // TODO: the signature here should be something like `block0.prop`, but
@@ -98,13 +98,13 @@ let v = {
 };
 
 // TypeAliasDeclaration
-//- @AliasArray defines/binding VName("AliasArray#type", _, _, "testdata/schema", "typescript")
+//- @AliasArray defines/binding VName("testdata/schema/AliasArray#type", _, _, "testdata/schema", "typescript")
 type AliasArray<
     // TypeParameter
-    //- @#0"T" defines/binding VName("AliasArray.T#type", _, _, "testdata/schema", "typescript")
+    //- @#0"T" defines/binding VName("testdata/schema/AliasArray.T#type", _, _, "testdata/schema", "typescript")
     T> = Array<T>;
 
-//- @arrowFun defines/binding VName("arrowFun", _, _, "testdata/schema", "typescript")
+//- @arrowFun defines/binding VName("testdata/schema/arrowFun", _, _, "testdata/schema", "typescript")
 const arrowFun = () => {
   // Arrow function scope name is not well-defined.
   //- @anonArrowFunDecl defines/binding VName(_, _, _, "testdata/schema", "typescript")


### PR DESCRIPTION
Made a few changes to the Typescript Indexer so it's easier to index code across different modules:

- Module signatures are now the module name instead of the word `module`.
- Anchor signatures now include the file path instead of just having the offsets
- Symbol signatures now include their module
- Module names are now relative to `KYTHE_ROOT_DIRECTORY`
- Corpus is now set to `KYTHE_CORPUS`