### PR TITLE
feat(extractors): add a passthrough bazel extractor

### DIFF
--- a/kythe/go/extractors/cmd/bazel/copy_kzip/BUILD
+++ b/kythe/go/extractors/cmd/bazel/copy_kzip/BUILD
@@ -7,5 +7,6 @@ go_binary(
     srcs = ["copy_kzip.go"],
     deps = [
         "//kythe/go/extractors/bazel",
+        "//kythe/go/platform/vfs",
     ],
 )

--- a/kythe/go/extractors/cmd/bazel/copy_kzip/BUILD
+++ b/kythe/go/extractors/cmd/bazel/copy_kzip/BUILD
@@ -1,0 +1,11 @@
+load("//tools:build_rules/shims.bzl", "go_binary")
+
+package(default_visibility = ["//kythe:default_visibility"])
+
+go_binary(
+    name = "copy_kzip",
+    srcs = ["copy_kzip.go"],
+    deps = [
+        "//kythe/go/extractors/bazel",
+    ],
+)

--- a/kythe/go/extractors/cmd/bazel/copy_kzip/copy_kzip.go
+++ b/kythe/go/extractors/cmd/bazel/copy_kzip/copy_kzip.go
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2020 The Kythe Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Program copy_kzip implements a Bazel extra action that directly copies a Kythe
+// compilation record produced by a "spawn" action.
+package main
+
+import (
+	"flag"
+	"io"
+	"log"
+	"os"
+	"time"
+
+	"kythe.io/kythe/go/extractors/bazel"
+)
+
+var (
+	outputPath  = flag.String("output", "", "Path of output index file (required)")
+	extraAction = flag.String("extra_action", "", "Path of the SpawnAction file (required)")
+)
+
+func main() {
+	flag.Parse()
+
+	// Verify that required flags are set.
+	if *outputPath == "" {
+		log.Fatal("You must provide a non-empty --output file path")
+	}
+	if *extraAction == "" {
+		log.Fatal("You must provide a non-empty --extra_action file path")
+	}
+
+	info, err := bazel.LoadAction(*extraAction)
+	if err != nil {
+		log.Fatalf("Unable to load extra action: %v", err)
+	}
+	start := time.Now()
+	ai, err := bazel.SpawnAction(info)
+	if len(ai.Outputs) != 1 {
+		log.Fatalf("Can only copy a single output kzip, not %d", len(ai.Outputs))
+	}
+
+	if err := os.Link(ai.Outputs[0], *outputPath); err != nil {
+		log.Printf("Unable to link input to output, falling back to copy: %v", err)
+		if err := copyFile(ai.Outputs[0], *outputPath); err != nil {
+			log.Fatalf("Unable to copy input to output: %v", err)
+		}
+	}
+
+	log.Printf("Finished extracting [%v elapsed]", time.Since(start))
+}
+
+func copyFile(input, output string) error {
+	f, err := os.Open(input)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	o, err := os.Create(output)
+	if err != nil {
+		return err
+	}
+
+	if _, err := io.Copy(o, f); err != nil {
+		return err
+	}
+
+	if err := o.Close(); o != nil {
+		return err
+	}
+	return nil
+}

--- a/kythe/go/extractors/cmd/bazel/copy_kzip/copy_kzip.go
+++ b/kythe/go/extractors/cmd/bazel/copy_kzip/copy_kzip.go
@@ -19,6 +19,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"io"
 	"log"
@@ -26,6 +27,7 @@ import (
 	"time"
 
 	"kythe.io/kythe/go/extractors/bazel"
+	"kythe.io/kythe/go/platform/vfs"
 )
 
 var (
@@ -65,23 +67,22 @@ func main() {
 }
 
 func copyFile(input, output string) error {
-	f, err := os.Open(input)
+	ctx := context.Background()
+	f, err := vfs.Open(ctx, input)
 	if err != nil {
 		return err
 	}
 	defer f.Close()
 
-	o, err := os.Create(output)
+	o, err := vfs.Create(ctx, output)
 	if err != nil {
 		return err
 	}
 
 	if _, err := io.Copy(o, f); err != nil {
+		o.Close()
 		return err
 	}
 
-	if err := o.Close(); o != nil {
-		return err
-	}
-	return nil
+	return o.Close()
 }


### PR DESCRIPTION
In order to integrate in-build extracted object with extra-action based pipelines, this extractor just copies a single SpawnAction output to the specified path.