### PR TITLE
update examples.md

### DIFF
--- a/kythe/web/site/examples.md
+++ b/kythe/web/site/examples.md
@@ -175,7 +175,7 @@ Install Cayley if necessary:
 
 {% highlight bash %}
 # Convert GraphStore to nquads format
-bazel run //kythe/go/storage/tools/triples -- --graphstore /path/to/graphstore | \
+bazel run //kythe/go/storage/tools/triples --graphstore /path/to/graphstore | \
   gzip >kythe.nq.gz
 
 cayley repl --dbpath kythe.nq.gz # or cayley http --dbpath kythe.nq.gz


### PR DESCRIPTION
From the source of triples.go and the output of `triples --help` istm that `--graphstore` does not need to be separated by ` -- `.