### PR TITLE
feat(go extractor): relativize paths against KYTHE_ROOT_DIRECTORY

### DIFF
--- a/kythe/go/extractors/cmd/gotool/gotool.go
+++ b/kythe/go/extractors/cmd/gotool/gotool.go
@@ -120,6 +120,7 @@ func main() {
 			DefaultCorpus:             *corpus,
 			Rules:                     rules,
 			CanonicalizePackageCorpus: *canonicalizePackageCorpus,
+			RootDirectory:             os.Getenv("KYTHE_ROOT_DIRECTORY"),
 		},
 	}
 	if *extraFiles != "" {

--- a/kythe/go/extractors/golang/golang.go
+++ b/kythe/go/extractors/golang/golang.go
@@ -377,12 +377,21 @@ func (p *Package) EachUnit(ctx context.Context, f func(cu *apb.CompilationUnit, 
 // The digest will be the complete path as written -- this will be replaced
 // with the content digest in the fetcher.
 func (p *Package) addFiles(cu *apb.CompilationUnit, root, base string, names []string) {
+	// If a root directory is specified, use it instead of the the root from the
+	// go package loader.
+	if p.ext.RootDirectory != "" {
+		root = p.ext.RootDirectory
+	}
+	if !strings.HasSuffix(root, "/") {
+		root += "/"
+	}
+
 	for _, name := range names {
 		path := name
 		if base != "" {
 			path = filepath.Join(base, name)
 		}
-		trimmed := strings.TrimPrefix(path, root+"/")
+		trimmed := strings.TrimPrefix(path, root)
 		vn := &spb.VName{
 			Corpus: p.ext.DefaultCorpus,
 			Path:   trimmed,

--- a/kythe/go/extractors/govname/govname.go
+++ b/kythe/go/extractors/govname/govname.go
@@ -54,6 +54,11 @@ type PackageVNameOptions struct {
 	// Rules optionally provides a list of rules to apply to go package and file
 	// paths to customize output vnames. See the vnameutil package for details.
 	Rules vnameutil.Rules
+
+	// If set, file and package paths are made relative to this directory before
+	// applying vname rules (if any). If unset, the module root (if using
+	// modules) or the gopath directory is used instead.
+	RootDirectory string
 }
 
 // ForPackage returns a VName for a Go package.
@@ -97,9 +102,14 @@ type PackageVNameOptions struct {
 //   }
 func ForPackage(pkg *build.Package, opts *PackageVNameOptions) *spb.VName {
 	if !pkg.Goroot && opts != nil && opts.Rules != nil {
-		relpath, err := filepath.Rel(pkg.Root, pkg.Dir)
+		root := pkg.Root
+		if opts.RootDirectory != "" {
+			root = opts.RootDirectory
+		}
+
+		relpath, err := filepath.Rel(root, pkg.Dir)
 		if err != nil {
-			log.Fatalf("relativizing path %q against dir %q: %v", pkg.Dir, pkg.Root, err)
+			log.Fatalf("relativizing path %q against dir %q: %v", pkg.Dir, root, err)
 		}
 		if relpath == "." {
 			relpath = ""


### PR DESCRIPTION
By default, the go extractor makes source files relative to GOPATH or
the module root if using modules. This change extends the extractor to
use the KYTHE_ROOT_DIRECTORY environment variable instead if it is
provided.

This helps us handle extraction for go code in android better because their code uses multiple go modules, which are extracted separately. The extraction script is [here](https://cs.android.com/android/platform/superproject/+/master:build/soong/build_kzip.bash;l=30), but the golang part is roughly:

`cd build/soong && gotool --rules=./go.vnames.json ./...`
`cd build/blueprint && gotool --rules=./go.vnames.json ./...`

This extracts the `soong` and `blueprint` go modules, each using their own vnames.json mapping file. The `soong` module depends on `blueprint`, so `blueprint` code shows up in both runs of the extractor. Before this PR, the extractor relativized paths against their module root, so a package named "parser" from the `soong` module would get mapped to the same vname path as a "parser" module from the `blueprint` module. This breaks cross-module references because when `blueprint` was later extracted, it assigned different vname paths the same packages that were used by `soong`.

For reference, here are the two vnames.json files:

* https://cs.android.com/android/platform/superproject/+/master:build/soong/vnames.go.json
* https://cs.android.com/android/platform/superproject/+/master:build/blueprint/vnames.go.json

After this PR, we can switch to using a single vnames.go.json:

```
[
    {
        "pattern": "(.*)",
        "vname": {
            "corpus": "android.googlesource.com/platform/superproject",
            "path": "@1@"
        }
    }
]
```