### PR TITLE
fix(runextractor): set --build_file default to build.gradle

### DIFF
--- a/kythe/go/extractors/config/runextractor/gradlecmd/gradlecmd.go
+++ b/kythe/go/extractors/config/runextractor/gradlecmd/gradlecmd.go
@@ -51,7 +51,7 @@ func New() subcommands.Command {
 // flags for gradle extraction.
 func (g *gradleCommand) SetFlags(fs *flag.FlagSet) {
 	fs.StringVar(&g.javacWrapper, "javac_wrapper", "", "A required executable that wraps javac for Kythe extraction.")
-	fs.StringVar(&g.buildFile, "build_file", "gradle.build", "The config file for a gradle repo, defaults to 'gradle.build'")
+	fs.StringVar(&g.buildFile, "build_file", "build.gradle", "The config file for a gradle repo, defaults to 'gradle.build'")
 }
 
 func (g gradleCommand) verifyFlags() error {


### PR DESCRIPTION
this is the file name most projects use and is recommended by:
https://guides.gradle.org/creating-new-gradle-builds/