### PR TITLE
fix(java extractor): include r4174.jar in release

### DIFF
--- a/kythe/java/com/google/devtools/kythe/extractors/java/standalone/BUILD
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/standalone/BUILD
@@ -16,6 +16,7 @@ java_binary(
         "//kythe/proto:storage_java_proto",
         "//third_party/guava",
         "//third_party/javac",
+        "//third_party/javac:javac-9+181-r4173-1.jar",
     ],
 )
 


### PR DESCRIPTION
without this, the extractor fails to find certain com/sun/tools/javac* classes when building for jdk8. See #4392 .