### PR TITLE
Add property/reads and property/writes edge kinds to KytheGraphRecorder.

### DIFF
--- a/kythe/cxx/common/indexing/KytheGraphRecorder.cc
+++ b/kythe/cxx/common/indexing/KytheGraphRecorder.cc
@@ -77,6 +77,8 @@ static const std::string* kEdgeKindSpellings[] = {
     new std::string("/kythe/edge/ref/init/implicit"),
     new std::string("/kythe/edge/imputes"),
     new std::string("/kythe/edge/tagged"),
+    new std::string("/kythe/edge/property/reads"),
+    new std::string("/kythe/edge/property/writes"),
     new std::string("/clang/usr"),
 };
 

--- a/kythe/cxx/common/indexing/KytheGraphRecorder.h
+++ b/kythe/cxx/common/indexing/KytheGraphRecorder.h
@@ -119,6 +119,8 @@ enum class EdgeKindID {
   kRefInitImplicit,
   kImputes,
   kTagged,
+  kPropertyReads,
+  kPropertyWrites,
   kClangUsr
 };
 


### PR DESCRIPTION
C++ doesn't have a notion of properties, so the edge kinds didn't previously exist; however KytheGraphRecorder is in common C++ code that could be used for other languages whose indexer can be written in C++.