### PR TITLE
Revert "chore: remove redudnant genSrcDir parameter and ask fileManag…

### DIFF
--- a/kythe/java/com/google/devtools/kythe/extractors/java/bazel/JavaExtractor.java
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/bazel/JavaExtractor.java
@@ -120,9 +120,9 @@ public class JavaExtractor {
     Path output = Files.createTempDirectory("output");
     javacOpts.add(output.toString());
 
+    // Add the generated sources directory if any processors could be invoked.
+    Optional<Path> genSrcDir = Optional.empty();
     if (!jInfo.getProcessorList().isEmpty()) {
-      // Add the generated sources directory if any processors could be invoked.
-      Optional<Path> genSrcDir = Optional.empty();
       try {
         genSrcDir = readGeneratedSourceDirParam(jInfo);
       } catch (IOException ioe) {
@@ -149,6 +149,7 @@ public class JavaExtractor {
                 sourcepaths,
                 jInfo.getProcessorpathList(),
                 jInfo.getProcessorList(),
+                genSrcDir,
                 javacOpts,
                 jInfo.getOutputjar());
 

--- a/kythe/java/com/google/devtools/kythe/extractors/java/standalone/Javac8Wrapper.java
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/standalone/Javac8Wrapper.java
@@ -26,9 +26,12 @@ import com.sun.tools.javac.main.Option;
 import com.sun.tools.javac.util.Context;
 import com.sun.tools.javac.util.Options;
 import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Optional;
 import javax.tools.JavaFileObject;
 import javax.tools.StandardLocation;
 
@@ -97,6 +100,9 @@ public class Javac8Wrapper extends AbstractJavacWrapper {
       outputDirectory = ".";
     }
 
+    // Find generated source directory by the -s argument.
+    Optional<Path> genSrcDir = Optional.ofNullable(options.get(Option.S)).map(Paths::get);
+
     String analysisTarget =
         readEnvironmentVariable("KYTHE_ANALYSIS_TARGET", createTargetFromSourceFiles(sources));
     return javaCompilationUnitExtractor.extract(
@@ -107,6 +113,7 @@ public class Javac8Wrapper extends AbstractJavacWrapper {
         sourcePaths,
         processorPaths,
         processors,
+        genSrcDir,
         completeOptions,
         outputDirectory);
   }

--- a/kythe/java/com/google/devtools/kythe/extractors/java/standalone/Javac9Wrapper.java
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/standalone/Javac9Wrapper.java
@@ -26,9 +26,12 @@ import com.sun.tools.javac.main.Option;
 import com.sun.tools.javac.util.Context;
 import com.sun.tools.javac.util.Options;
 import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Optional;
 import javax.tools.JavaFileObject;
 import javax.tools.StandardLocation;
 
@@ -112,6 +115,9 @@ public class Javac9Wrapper extends AbstractJavacWrapper {
       outputDirectory = ".";
     }
 
+    // Find generated source directory by the -s argument.
+    Optional<Path> genSrcDir = Optional.ofNullable(options.get(Option.S)).map(Paths::get);
+
     String analysisTarget =
         readEnvironmentVariable("KYTHE_ANALYSIS_TARGET", createTargetFromSourceFiles(sources));
 
@@ -123,6 +129,7 @@ public class Javac9Wrapper extends AbstractJavacWrapper {
         sourcePaths,
         processorPaths,
         processors,
+        genSrcDir,
         completeOptions,
         outputDirectory);
   }

--- a/kythe/javatests/com/google/devtools/kythe/extractors/java/JavaExtractorTest.java
+++ b/kythe/javatests/com/google/devtools/kythe/extractors/java/JavaExtractorTest.java
@@ -42,6 +42,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import junit.framework.TestCase;
@@ -75,7 +76,8 @@ public class JavaExtractorTest extends TestCase {
 
     // Index the specified sources
     CompilationDescription description =
-        java.extract(TARGET1, sources, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, "output");
+        java.extract(
+            TARGET1, sources, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, Optional.empty(), EMPTY, "output");
 
     CompilationUnit unit = description.getCompilationUnit();
     assertThat(unit.getVName().getCorpus()).isEqualTo(CORPUS);
@@ -117,7 +119,8 @@ public class JavaExtractorTest extends TestCase {
 
     // Index the specified sources
     CompilationDescription description =
-        java.extract(TARGET1, sources, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, "output");
+        java.extract(
+            TARGET1, sources, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, Optional.empty(), EMPTY, "output");
 
     CompilationUnit unit = description.getCompilationUnit();
     assertThat(unit.getVName().getCorpus()).isEmpty(); // source files are from different corpora
@@ -155,7 +158,8 @@ public class JavaExtractorTest extends TestCase {
 
     // Index the specified sources
     CompilationDescription description =
-        java.extract(TARGET1, sources, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, "output");
+        java.extract(
+            TARGET1, sources, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, Optional.empty(), EMPTY, "output");
 
     CompilationUnit unit = description.getCompilationUnit();
     assertThat(unit).isNotNull();
@@ -190,7 +194,8 @@ public class JavaExtractorTest extends TestCase {
 
     // Index the specified sources
     CompilationDescription description =
-        java.extract(TARGET1, sources, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, "output");
+        java.extract(
+            TARGET1, sources, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, Optional.empty(), EMPTY, "output");
 
     CompilationUnit unit = description.getCompilationUnit();
     assertThat(unit).isNotNull();
@@ -222,7 +227,8 @@ public class JavaExtractorTest extends TestCase {
 
     // Index the specified sources
     CompilationDescription description =
-        java.extract(TARGET1, sources, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, "output");
+        java.extract(
+            TARGET1, sources, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, Optional.empty(), EMPTY, "output");
 
     CompilationUnit unit = description.getCompilationUnit();
     assertThat(unit).isNotNull();
@@ -257,7 +263,17 @@ public class JavaExtractorTest extends TestCase {
 
     // Index the specified sources and classes from the classpath
     CompilationDescription description =
-        java.extract(TARGET1, sources, classpath, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, "output");
+        java.extract(
+            TARGET1,
+            sources,
+            classpath,
+            EMPTY,
+            EMPTY,
+            EMPTY,
+            EMPTY,
+            Optional.empty(),
+            EMPTY,
+            "output");
 
     CompilationUnit unit = description.getCompilationUnit();
     assertThat(unit).isNotNull();
@@ -290,7 +306,17 @@ public class JavaExtractorTest extends TestCase {
 
     // Index the specified sources and classes from inside jar on the classpath.
     CompilationDescription description =
-        java.extract(TARGET1, sources, classpath, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, "output");
+        java.extract(
+            TARGET1,
+            sources,
+            classpath,
+            EMPTY,
+            EMPTY,
+            EMPTY,
+            EMPTY,
+            Optional.empty(),
+            EMPTY,
+            "output");
 
     CompilationUnit unit = description.getCompilationUnit();
     assertThat(unit).isNotNull();
@@ -324,7 +350,8 @@ public class JavaExtractorTest extends TestCase {
 
     // Index the specified sources, reporting compilation failure.
     CompilationDescription description =
-        java.extract(TARGET1, sources, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, "output");
+        java.extract(
+            TARGET1, sources, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, Optional.empty(), EMPTY, "output");
 
     CompilationUnit unit = description.getCompilationUnit();
     assertThat(unit).isNotNull();
@@ -351,7 +378,8 @@ public class JavaExtractorTest extends TestCase {
 
     // Index the specified sources
     CompilationDescription description =
-        java.extract(TARGET1, sources, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, "output");
+        java.extract(
+            TARGET1, sources, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, Optional.empty(), EMPTY, "output");
 
     CompilationUnit unit = description.getCompilationUnit();
     assertThat(unit).isNotNull();
@@ -383,7 +411,8 @@ public class JavaExtractorTest extends TestCase {
 
     // Index the specified sources
     CompilationDescription description =
-        java.extract(TARGET1, sources, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, "output");
+        java.extract(
+            TARGET1, sources, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, Optional.empty(), EMPTY, "output");
 
     CompilationUnit unit = description.getCompilationUnit();
     assertThat(unit).isNotNull();
@@ -414,7 +443,8 @@ public class JavaExtractorTest extends TestCase {
 
     // Index the specified sources
     CompilationDescription description =
-        java.extract(TARGET1, sources, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, "output");
+        java.extract(
+            TARGET1, sources, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, Optional.empty(), EMPTY, "output");
 
     CompilationUnit unit = description.getCompilationUnit();
     assertThat(unit).isNotNull();
@@ -491,6 +521,7 @@ public class JavaExtractorTest extends TestCase {
             EMPTY,
             processorpath,
             processors,
+            Optional.empty(),
             options,
             "output");
 
@@ -544,6 +575,7 @@ public class JavaExtractorTest extends TestCase {
             EMPTY,
             processorpath,
             processors,
+            Optional.of(genSrcDir),
             options,
             "output");
 
@@ -578,7 +610,17 @@ public class JavaExtractorTest extends TestCase {
 
     // Index the specified sources
     CompilationDescription description =
-        java.extract(TARGET1, sources, EMPTY, bootclasspath, EMPTY, EMPTY, EMPTY, EMPTY, "output");
+        java.extract(
+            TARGET1,
+            sources,
+            EMPTY,
+            bootclasspath,
+            EMPTY,
+            EMPTY,
+            EMPTY,
+            Optional.empty(),
+            EMPTY,
+            "output");
 
     CompilationUnit unit = description.getCompilationUnit();
 
@@ -605,7 +647,17 @@ public class JavaExtractorTest extends TestCase {
 
     // Index the specified sources
     CompilationDescription description =
-        java.extract(TARGET1, sources, EMPTY, bootclasspath, EMPTY, EMPTY, EMPTY, EMPTY, "output");
+        java.extract(
+            TARGET1,
+            sources,
+            EMPTY,
+            bootclasspath,
+            EMPTY,
+            EMPTY,
+            EMPTY,
+            Optional.empty(),
+            EMPTY,
+            "output");
 
     CompilationUnit unit = description.getCompilationUnit();
     assertThat(unit).isNotNull();
@@ -636,7 +688,17 @@ public class JavaExtractorTest extends TestCase {
     List<String> classpath = ImmutableList.of(join(TEST_DATA_DIR, "src_in_jar/pack.jar"));
 
     CompilationDescription description =
-        java.extract(TARGET1, sources, classpath, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, "output");
+        java.extract(
+            TARGET1,
+            sources,
+            classpath,
+            EMPTY,
+            EMPTY,
+            EMPTY,
+            EMPTY,
+            Optional.empty(),
+            EMPTY,
+            "output");
 
     CompilationUnit unit = description.getCompilationUnit();
     assertThat(unit).isNotNull();
@@ -668,7 +730,8 @@ public class JavaExtractorTest extends TestCase {
     java.useSystemDirectory(join(TEST_DATA_DIR, "/system_modules"));
 
     CompilationDescription description =
-        java.extract(TARGET1, sources, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, "output");
+        java.extract(
+            TARGET1, sources, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, Optional.empty(), EMPTY, "output");
 
     CompilationUnit unit = description.getCompilationUnit();
     assertThat(unit).isNotNull();


### PR DESCRIPTION
…er (#4405)"

This reverts commit 3413ca7ee72a9416bdec1a9e32a06526c292c001.

Despite testing locally on JDK8, this fails when imported and run under JDK8.