### PR TITLE
fix(cxx_indexer): refactor TypeLoc visitation into separate class

### DIFF
--- a/kythe/cxx/indexer/cxx/BUILD
+++ b/kythe/cxx/indexer/cxx/BUILD
@@ -182,6 +182,7 @@ cc_library(
         ":kythe_claim_client",
         ":marked_source",
         ":node_set",
+        ":recursive_type_visitor",
         ":semantic_hash",
         ":type_map",
         "//kythe/cxx/common:lib",

--- a/kythe/cxx/indexer/cxx/BUILD
+++ b/kythe/cxx/indexer/cxx/BUILD
@@ -499,7 +499,9 @@ cc_test(
 cc_library(
     name = "recursive_type_visitor",
     hdrs = ["recursive_type_visitor.h"],
-    deps = ["//third_party/llvm"],
+    deps = [
+        "@org_llvm//:clangAST",
+    ],
 )
 
 cc_test(

--- a/kythe/cxx/indexer/cxx/BUILD
+++ b/kythe/cxx/indexer/cxx/BUILD
@@ -501,7 +501,6 @@ cc_library(
     name = "recursive_type_visitor",
     hdrs = ["recursive_type_visitor.h"],
     deps = [
-        "//kythe/cxx/common:scope_guard",
         "@org_llvm//:clangAST",
     ],
 )

--- a/kythe/cxx/indexer/cxx/BUILD
+++ b/kythe/cxx/indexer/cxx/BUILD
@@ -500,6 +500,7 @@ cc_library(
     name = "recursive_type_visitor",
     hdrs = ["recursive_type_visitor.h"],
     deps = [
+        "//kythe/cxx/common:scope_guard",
         "@org_llvm//:clangAST",
     ],
 )

--- a/kythe/cxx/indexer/cxx/BUILD
+++ b/kythe/cxx/indexer/cxx/BUILD
@@ -496,6 +496,21 @@ cc_test(
     ],
 )
 
+cc_library(
+    name = "recursive_type_visitor",
+    hdrs = ["recursive_type_visitor.h"],
+    deps = ["//third_party/llvm"],
+)
+
+cc_test(
+    name = "recursive_type_visitor_test",
+    srcs = ["recursive_type_visitor_test.cc"],
+    deps = [
+        ":recursive_type_visitor",
+        "//third_party:gtest_main",
+    ],
+)
+
 config_setting(
     name = "darwin",
     values = {"cpu": "darwin"},

--- a/kythe/cxx/indexer/cxx/IndexerASTHooks.cc
+++ b/kythe/cxx/indexer/cxx/IndexerASTHooks.cc
@@ -1954,11 +1954,11 @@ bool IndexerASTVisitor::VisitDesignatedInitExpr(
   return true;
 }
 
-bool IndexerASTVisitor::RecordTypeLocSpellingLocation(clang::TypeLoc TL) {
+NodeSet IndexerASTVisitor::RecordTypeLocSpellingLocation(clang::TypeLoc TL) {
   return RecordTypeLocSpellingLocation(TL, TL.getTypePtr());
 }
 
-bool IndexerASTVisitor::RecordTypeLocSpellingLocation(
+NodeSet IndexerASTVisitor::RecordTypeLocSpellingLocation(
     clang::TypeLoc Written, const clang::Type* Resolved) {
   if (auto RCC = ExpandedRangeInCurrentContext(Written.getSourceRange())) {
     // TODO(shahms): This is correct, except the nested use of EmitRanges causes

--- a/kythe/cxx/indexer/cxx/IndexerASTHooks.cc
+++ b/kythe/cxx/indexer/cxx/IndexerASTHooks.cc
@@ -18,6 +18,7 @@
 
 #include <algorithm>
 #include <tuple>
+#include <type_traits>
 
 #include "GraphObserver.h"
 #include "absl/flags/flag.h"

--- a/kythe/cxx/indexer/cxx/IndexerASTHooks.h
+++ b/kythe/cxx/indexer/cxx/IndexerASTHooks.h
@@ -87,6 +87,7 @@ class PruneCheck;
 /// writes it to a `GraphObserver`.
 class IndexerASTVisitor : public RecursiveTypeVisitor<IndexerASTVisitor> {
   using Base = RecursiveTypeVisitor;
+
  public:
   IndexerASTVisitor(clang::ASTContext& C, BehaviorOnUnimplemented B,
                     BehaviorOnTemplates T, Verbosity V,
@@ -135,12 +136,14 @@ class IndexerASTVisitor : public RecursiveTypeVisitor<IndexerASTVisitor> {
   bool VisitSubstTemplateTypeParmTypeLoc(
       clang::SubstTemplateTypeParmTypeLoc TL);
 
-  template <typename T>
-  bool VisitTemplateSpecializationTypeLocHelper(T TL);
+  template <typename TypeLoc, typename Type>
+  bool VisitTemplateSpecializationTypePairHelper(TypeLoc Written,
+                                                 const Type* Resolved);
   bool VisitTemplateSpecializationTypeLoc(
       clang::TemplateSpecializationTypeLoc TL);
-  bool VisitDeducedTemplateSpecializationTypeLoc(
-      clang::DeducedTemplateSpecializationTypeLoc TL);
+  bool VisitDeducedTemplateSpecializationTypePair(
+      clang::DeducedTemplateSpecializationTypeLoc TL,
+      const clang::DeducedTemplateSpecializationType* T);
 
   bool VisitAutoTypePair(clang::AutoTypeLoc TL, const clang::AutoType* T);
 
@@ -161,7 +164,8 @@ class IndexerASTVisitor : public RecursiveTypeVisitor<IndexerASTVisitor> {
 
   // Emit edges for an anchor pointing to the indicated type.
   NodeSet RecordTypeLocSpellingLocation(clang::TypeLoc TL);
-  NodeSet RecordTypeLocSpellingLocation(clang::TypeLoc Written, const clang::Type* Resolved);
+  NodeSet RecordTypeLocSpellingLocation(clang::TypeLoc Written,
+                                        const clang::Type* Resolved);
 
   bool TraverseDeclarationNameInfo(clang::DeclarationNameInfo NameInfo);
 

--- a/kythe/cxx/indexer/cxx/IndexerASTHooks.h
+++ b/kythe/cxx/indexer/cxx/IndexerASTHooks.h
@@ -784,19 +784,6 @@ class IndexerASTVisitor : public RecursiveTypeVisitor<IndexerASTVisitor> {
   GraphObserver::NodeId ApplyBuiltinTypeConstructor(
       const char* BuiltinName, const GraphObserver::NodeId& Param);
 
-  /// \brief Ascribes a type to `AscribeTo`.
-  /// \param Type The `TypeLoc` referring to the type
-  /// \param DType A possibly deduced type (or simply Type->getType()).
-  /// \param AscribeTo The node to which the type should be ascribed.
-  ///
-  /// `auto` does not update TypeSourceInfo records after deduction, so
-  /// a deduced `auto` in the source text will appear to be undeduced.
-  /// In this case, it's useful to query the object being ascribed for its
-  /// unlocated QualType, as this does get updated.
-  void AscribeSpelledType(const clang::TypeLoc& Type,
-                          const clang::QualType& TrueType,
-                          const GraphObserver::NodeId& AscribeTo);
-
   /// \brief Returns the parent of the given node, along with the index
   /// at which the node appears underneath each parent.
   ///

--- a/kythe/cxx/indexer/cxx/recursive_type_visitor.h
+++ b/kythe/cxx/indexer/cxx/recursive_type_visitor.h
@@ -84,13 +84,13 @@ class RecursiveTypeVisitor : public clang::RecursiveASTVisitor<Derived> {
   bool TraverseTypePair(clang::TypeLoc TL, clang::QualType T);
 
   // Declare Traverse*() for all concrete TypeLoc classes.
-  // Note: We're using TypeNodes.def as QualifiedTypeLoc needs to be handled
+  // Note: We're using TypeNodes.inc as QualifiedTypeLoc needs to be handled
   // specially.
 #define ABSTRACT_TYPE(CLASS, BASE)
 #define TYPE(CLASS, BASE)                                  \
   bool Traverse##CLASS##TypePair(clang::CLASS##TypeLoc TL, \
                                  const clang::CLASS##Type* T);
-#include "clang/AST/TypeNodes.def"
+#include "clang/AST/TypeNodes.inc"
 
   bool TraverseQualifiedTypePair(clang::QualifiedTypeLoc TL, clang::QualType T);
 
@@ -111,7 +111,7 @@ class RecursiveTypeVisitor : public clang::RecursiveASTVisitor<Derived> {
                               const clang::CLASS##Type* T) {      \
     return getDerived().Visit##CLASS##TypeLoc(TL);                \
   }
-#include "clang/AST/TypeNodes.def"
+#include "clang/AST/TypeNodes.inc"
 
  private:
   bool ShouldInterceptTypeLoc(clang::TypeLoc TL) const {
@@ -157,7 +157,7 @@ bool RecursiveTypeVisitor<Derived>::TraverseTypePair(clang::TypeLoc TL,
         clang::isa<clang::CLASS##Type>(T.getTypePtr())        \
             ? clang::cast<clang::CLASS##Type>(T.getTypePtr()) \
             : TL.castAs<clang::CLASS##TypeLoc>().getTypePtr());
-#include "clang/AST/TypeNodes.def"
+#include "clang/AST/TypeNodes.inc"
   }
 
   return true;

--- a/kythe/cxx/indexer/cxx/recursive_type_visitor.h
+++ b/kythe/cxx/indexer/cxx/recursive_type_visitor.h
@@ -339,6 +339,9 @@ DEF_TRAVERSE_TYPEPAIR(InjectedClassNameType, {});
 DEF_TRAVERSE_TYPEPAIR(ParenType, {
   return getDerived().TraverseTypePair(TL.getInnerLoc(), T->getInnerType());
 });
+DEF_TRAVERSE_TYPEPAIR(MacroQualifiedType, {
+  return getDerived().TraverseTypePair(TL.getInnerLoc(), T->getUnderlyingType());
+});
 DEF_TRAVERSE_TYPEPAIR(AttributedType, {
   return getDerived().TraverseTypePair(TL.getModifiedLoc(),
                                        T->getModifiedType());

--- a/kythe/cxx/indexer/cxx/recursive_type_visitor.h
+++ b/kythe/cxx/indexer/cxx/recursive_type_visitor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 The Kythe Authors. All rights reserved.
+ * Copyright 2020 The Kythe Authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kythe/cxx/indexer/cxx/recursive_type_visitor.h
+++ b/kythe/cxx/indexer/cxx/recursive_type_visitor.h
@@ -21,7 +21,6 @@
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/AST/Type.h"
 #include "clang/AST/TypeLoc.h"
-#include "kythe/cxx/common/scope_guard.h"
 
 namespace kythe {
 

--- a/kythe/cxx/indexer/cxx/recursive_type_visitor.h
+++ b/kythe/cxx/indexer/cxx/recursive_type_visitor.h
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2018 The Kythe Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef KYTHE_CXX_INDEXER_CXX_RECURSIVE_TYPE_VISITOR_H_
+#define KYTHE_CXX_INDEXER_CXX_RECURSIVE_TYPE_VISITOR_H_
+
+#include "clang/AST/Type.h"
+#include "clang/AST/TypeLoc.h"
+
+namespace kythe {
+
+// RecursiveTypeVisitor is a parallel type to clang::RecursiveASTVisitor which
+// uses the same visitation strategy, but visits type-as-written and resolved
+// type in parallel.
+template <typename Derived>
+class RecursiveTypeVisitor {
+ public:
+  Derived& getDerived() { return *static_cast<Derived*>(this); }
+  /// Recursively vist a type-as-written with location in parallel
+  /// with the derived type, by dispatching to Traverse*TypeLocType()
+  /// based on the TypeLoc argument's getTypeClass() property.
+  ///
+  /// \returns false if the visitation was terminated early,
+  /// true otherwise (including when the argument is a Null type location).
+  bool TraverseTypeLocType(clang::TypeLoc TL, clang::QualType T);
+
+  // Declare Traverse*() for all concrete TypeLoc classes.
+  // Note: We're using TypeNodes.def as QualifiedTypeLoc needs to be handled
+  // specially.
+#define ABSTRACT_TYPE(CLASS, BASE)
+#define TYPE(CLASS, BASE)                                     \
+  bool Traverse##CLASS##TypeLocType(clang::CLASS##TypeLoc TL, \
+                                    const clang::CLASS##Type* T);
+#include "clang/AST/TypeNodes.def"
+
+  bool TraverseQualifiedTypeLocType(clang::QualifiedTypeLoc TL,
+                                    clang::QualType T);
+
+  // Define WalkUpFrom*() and empty Visit*() for all TypeLoc classes.
+  bool WalkUpFromTypeLocType(clang::TypeLoc TL, const clang::Type* T) {
+    return getDerived().VisitTypeLocType(TL, T);
+  }
+  bool VisitTypeLocType(clang::TypeLoc TL, const clang::Type* T) {
+    return true;
+  }
+
+  // QualifiedTypeLoc and UnqualTypeLoc are not declared in
+  // TypeNodes.def and thus need to be handled specially.
+  bool WalkUpFromQualifiedTypeLoc(clang::QualifiedTypeLoc TL) {
+    return getDerived().VisitUnqualTypeLoc(TL.getUnqualifiedLoc());
+  }
+  bool VisitQualifiedTypeLoc(clang::QualifiedTypeLoc TL) { return true; }
+  bool WalkUpFromUnqualTypeLoc(clang::UnqualTypeLoc TL) {
+    return getDerived().VisitUnqualTypeLoc(TL.getUnqualifiedLoc());
+  }
+  bool VisitUnqualTypeLoc(clang::UnqualTypeLoc TL) { return true; }
+
+  // Note that BASE includes trailing 'Type' which CLASS doesn't.
+#define TYPE(CLASS, BASE)                                            \
+  bool WalkUpFrom##CLASS##TypeLocType(clang::CLASS##TypeLoc TL,      \
+                                      const clang::CLASS##Type* T) { \
+    return getDerived().WalkUpFrom##BASE##LocType(TL, T) &&          \
+           getDerived().Visit##CLASS##TypeLocType(TL, T);            \
+  }                                                                  \
+  bool Visit##CLASS##TypeLocType(clang::CLASS##TypeLoc TL,           \
+                                 const clang::CLASS##Type* T) {      \
+    return true;                                                     \
+  }
+#include "clang/AST/TypeNodes.def"
+
+ private:
+#define ABSTRACT_TYPE(CLASS, BASE)
+#define TYPE(CLASS, BASE)                                                      \
+  bool Traverse##CLASS##TypeLocTypeHelper(clang::CLASS##TypeLoc TL,            \
+                                          const clang::CLASS##Type* T) {       \
+    return getDerived().Traverse##CLASS##TypeLocType(TL,                       \
+                                                     T ? T : TL.getTypePtr()); \
+  }
+#include "clang/AST/TypeNodes.def"
+};
+
+template <typename Derived>
+bool RecursiveTypeVisitor<Derived>::TraverseTypeLocType(clang::TypeLoc TL,
+                                                        clang::QualType T) {
+  if (TL.isNull()) return true;
+  if (T.isNull()) {
+    T = TL.getType();
+  }
+
+  switch (TL.getTypeLocClass()) {
+    case clang::TypeLoc::Qualified:
+      return getDerived().TraverseQualifiedTypeLocType(
+          TL.castAs<clang::QualifiedTypeLoc>(), T);
+#define ABSTRACT_TYPE(CLASS, BASE)
+#define TYPE(CLASS, BASE)                      \
+  case clang::TypeLoc::CLASS:                  \
+    return Traverse##CLASS##TypeLocTypeHelper( \
+        TL.castAs<clang::CLASS##TypeLoc>(),    \
+        clang::dyn_cast<clang::CLASS##Type>(T.getTypePtr()));
+#include "clang/AST/TypeNodes.def"
+  }
+
+  return true;
+}
+
+template <typename Derived>
+bool RecursiveTypeVisitor<Derived>::TraverseQualifiedTypeLocType(
+    clang::QualifiedTypeLoc TL, clang::QualType T) {
+  // See RecursiveASTVisitor<Derived>::TraverseQualifiedTypeLoc notes for why
+  // we're doing this, but essentially we pretend to have never seen the locally
+  // qualified version to avoid redundant visitation.
+  return TraverseTypeLocType(TL.getUnqualifiedLoc(),
+                             T.getLocalUnqualifiedType());
+}
+
+#define DEF_TRAVERSE_TYPELOC(TYPE, CODE)                          \
+  template <typename Derived>                                     \
+  bool RecursiveTypeVisitor<Derived>::Traverse##TYPE##LocType(    \
+      clang::TYPE##Loc TL, const clang::TYPE* T) {                \
+    return getDerived().WalkUpFrom##TYPE##LocType(TL, T) && [&] { \
+      CODE;                                                       \
+      return true;                                                \
+    }();                                                          \
+  }
+
+DEF_TRAVERSE_TYPELOC(BuiltinType, {});
+// TODO(shahms): Finish ComplexType.
+DEF_TRAVERSE_TYPELOC(ComplexType, {});
+DEF_TRAVERSE_TYPELOC(PointerType, {
+  return getDerived().TraverseTypeLocType(TL.getPointeeLoc(),
+                                          T->getPointeeType());
+});
+DEF_TRAVERSE_TYPELOC(BlockPointerType, {
+  return getDerived().TraverseTypeLocType(TL.getPointeeLoc(),
+                                          T->getPointeeType());
+});
+DEF_TRAVERSE_TYPELOC(LValueReferenceType, {
+  return getDerived().TraverseTypeLocType(TL.getPointeeLoc(),
+                                          T->getPointeeType());
+});
+DEF_TRAVERSE_TYPELOC(RValueReferenceType, {
+  return getDerived().TraverseTypeLocType(TL.getPointeeLoc(),
+                                          T->getPointeeType());
+});
+DEF_TRAVERSE_TYPELOC(MemberPointerType, {
+  return getDerived().TraverseTypeLocType(TL.getPointeeLoc(),
+                                          T->getPointeeType());
+});
+DEF_TRAVERSE_TYPELOC(AdjustedType, {
+  return getDerived().TraverseTypeLocType(TL.getOriginalLoc(),
+                                          T->getOriginalType());
+});
+DEF_TRAVERSE_TYPELOC(DecayedType, {
+  return getDerived().TraverseTypeLocType(TL.getOriginalLoc(),
+                                          T->getOriginalType());
+});
+DEF_TRAVERSE_TYPELOC(ConstantArrayType, {
+  return getDerived().TraverseTypeLocType(TL.getElementLoc(),
+                                          T->getElementType());
+});
+DEF_TRAVERSE_TYPELOC(IncompleteArrayType, {
+  return getDerived().TraverseTypeLocType(TL.getElementLoc(),
+                                          T->getElementType());
+});
+DEF_TRAVERSE_TYPELOC(VariableArrayType, {
+  return getDerived().TraverseTypeLocType(TL.getElementLoc(),
+                                          T->getElementType());
+});
+DEF_TRAVERSE_TYPELOC(DependentSizedArrayType, {
+  return getDerived().TraverseTypeLocType(TL.getElementLoc(),
+                                          T->getElementType());
+});
+DEF_TRAVERSE_TYPELOC(DependentAddressSpaceType, {});
+
+#undef DEF_TRAVERSE_TYPELOC
+
+}  // namespace kythe
+
+#endif  // KYTHE_CXX_INDEXER_CXX_RECURSIVE_TYPE_VISITOR_H_

--- a/kythe/cxx/indexer/cxx/recursive_type_visitor.h
+++ b/kythe/cxx/indexer/cxx/recursive_type_visitor.h
@@ -16,6 +16,7 @@
 #ifndef KYTHE_CXX_INDEXER_CXX_RECURSIVE_TYPE_VISITOR_H_
 #define KYTHE_CXX_INDEXER_CXX_RECURSIVE_TYPE_VISITOR_H_
 
+#include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/AST/Type.h"
 #include "clang/AST/TypeLoc.h"
 
@@ -25,36 +26,34 @@ namespace kythe {
 // uses the same visitation strategy, but visits type-as-written and resolved
 // type in parallel.
 template <typename Derived>
-class RecursiveTypeVisitor {
+class RecursiveTypeVisitor : public clang::RecursiveASTVisitor<Derived> {
  public:
   Derived& getDerived() { return *static_cast<Derived*>(this); }
+
   /// Recursively vist a type-as-written with location in parallel
-  /// with the derived type, by dispatching to Traverse*TypeLocType()
+  /// with the derived type, by dispatching to Traverse*TypePair()
   /// based on the TypeLoc argument's getTypeClass() property.
   ///
   /// \returns false if the visitation was terminated early,
   /// true otherwise (including when the argument is a Null type location).
-  bool TraverseTypeLocType(clang::TypeLoc TL, clang::QualType T);
+  bool TraverseTypePair(clang::TypeLoc TL, clang::QualType T);
 
   // Declare Traverse*() for all concrete TypeLoc classes.
   // Note: We're using TypeNodes.def as QualifiedTypeLoc needs to be handled
   // specially.
 #define ABSTRACT_TYPE(CLASS, BASE)
-#define TYPE(CLASS, BASE)                                     \
-  bool Traverse##CLASS##TypeLocType(clang::CLASS##TypeLoc TL, \
-                                    const clang::CLASS##Type* T);
+#define TYPE(CLASS, BASE)                                  \
+  bool Traverse##CLASS##TypePair(clang::CLASS##TypeLoc TL, \
+                                 const clang::CLASS##Type* T);
 #include "clang/AST/TypeNodes.def"
 
-  bool TraverseQualifiedTypeLocType(clang::QualifiedTypeLoc TL,
-                                    clang::QualType T);
+  bool TraverseQualifiedTypePair(clang::QualifiedTypeLoc TL, clang::QualType T);
 
   // Define WalkUpFrom*() and empty Visit*() for all TypeLoc classes.
-  bool WalkUpFromTypeLocType(clang::TypeLoc TL, const clang::Type* T) {
-    return getDerived().VisitTypeLocType(TL, T);
+  bool WalkUpFromTypePair(clang::TypeLoc TL, const clang::Type* T) {
+    return getDerived().VisitTypePair(TL, T);
   }
-  bool VisitTypeLocType(clang::TypeLoc TL, const clang::Type* T) {
-    return true;
-  }
+  bool VisitTypePair(clang::TypeLoc TL, const clang::Type* T) { return true; }
 
   // QualifiedTypeLoc and UnqualTypeLoc are not declared in
   // TypeNodes.def and thus need to be handled specially.
@@ -68,32 +67,32 @@ class RecursiveTypeVisitor {
   bool VisitUnqualTypeLoc(clang::UnqualTypeLoc TL) { return true; }
 
   // Note that BASE includes trailing 'Type' which CLASS doesn't.
-#define TYPE(CLASS, BASE)                                            \
-  bool WalkUpFrom##CLASS##TypeLocType(clang::CLASS##TypeLoc TL,      \
-                                      const clang::CLASS##Type* T) { \
-    return getDerived().WalkUpFrom##BASE##LocType(TL, T) &&          \
-           getDerived().Visit##CLASS##TypeLocType(TL, T);            \
-  }                                                                  \
-  bool Visit##CLASS##TypeLocType(clang::CLASS##TypeLoc TL,           \
-                                 const clang::CLASS##Type* T) {      \
-    return true;                                                     \
+#define TYPE(CLASS, BASE)                                         \
+  bool WalkUpFrom##CLASS##TypePair(clang::CLASS##TypeLoc TL,      \
+                                   const clang::CLASS##Type* T) { \
+    return getDerived().WalkUpFrom##BASE##Pair(TL, T) &&          \
+           getDerived().Visit##CLASS##TypePair(TL, T);            \
+  }                                                               \
+  bool Visit##CLASS##TypePair(clang::CLASS##TypeLoc TL,           \
+                              const clang::CLASS##Type* T) {      \
+    return true;                                                  \
   }
 #include "clang/AST/TypeNodes.def"
 
  private:
 #define ABSTRACT_TYPE(CLASS, BASE)
-#define TYPE(CLASS, BASE)                                                      \
-  bool Traverse##CLASS##TypeLocTypeHelper(clang::CLASS##TypeLoc TL,            \
-                                          const clang::CLASS##Type* T) {       \
-    return getDerived().Traverse##CLASS##TypeLocType(TL,                       \
-                                                     T ? T : TL.getTypePtr()); \
+#define TYPE(CLASS, BASE)                                                   \
+  bool Traverse##CLASS##TypePairHelper(clang::CLASS##TypeLoc TL,            \
+                                       const clang::CLASS##Type* T) {       \
+    return getDerived().Traverse##CLASS##TypePair(TL,                       \
+                                                  T ? T : TL.getTypePtr()); \
   }
 #include "clang/AST/TypeNodes.def"
 };
 
 template <typename Derived>
-bool RecursiveTypeVisitor<Derived>::TraverseTypeLocType(clang::TypeLoc TL,
-                                                        clang::QualType T) {
+bool RecursiveTypeVisitor<Derived>::TraverseTypePair(clang::TypeLoc TL,
+                                                     clang::QualType T) {
   if (TL.isNull()) return true;
   if (T.isNull()) {
     T = TL.getType();
@@ -101,13 +100,13 @@ bool RecursiveTypeVisitor<Derived>::TraverseTypeLocType(clang::TypeLoc TL,
 
   switch (TL.getTypeLocClass()) {
     case clang::TypeLoc::Qualified:
-      return getDerived().TraverseQualifiedTypeLocType(
+      return getDerived().TraverseQualifiedTypePair(
           TL.castAs<clang::QualifiedTypeLoc>(), T);
 #define ABSTRACT_TYPE(CLASS, BASE)
-#define TYPE(CLASS, BASE)                      \
-  case clang::TypeLoc::CLASS:                  \
-    return Traverse##CLASS##TypeLocTypeHelper( \
-        TL.castAs<clang::CLASS##TypeLoc>(),    \
+#define TYPE(CLASS, BASE)                   \
+  case clang::TypeLoc::CLASS:               \
+    return Traverse##CLASS##TypePairHelper( \
+        TL.castAs<clang::CLASS##TypeLoc>(), \
         clang::dyn_cast<clang::CLASS##Type>(T.getTypePtr()));
 #include "clang/AST/TypeNodes.def"
   }
@@ -116,75 +115,161 @@ bool RecursiveTypeVisitor<Derived>::TraverseTypeLocType(clang::TypeLoc TL,
 }
 
 template <typename Derived>
-bool RecursiveTypeVisitor<Derived>::TraverseQualifiedTypeLocType(
+bool RecursiveTypeVisitor<Derived>::TraverseQualifiedTypePair(
     clang::QualifiedTypeLoc TL, clang::QualType T) {
   // See RecursiveASTVisitor<Derived>::TraverseQualifiedTypeLoc notes for why
   // we're doing this, but essentially we pretend to have never seen the locally
   // qualified version to avoid redundant visitation.
-  return TraverseTypeLocType(TL.getUnqualifiedLoc(),
-                             T.getLocalUnqualifiedType());
+  return TraverseTypePair(TL.getUnqualifiedLoc(), T.getLocalUnqualifiedType());
 }
 
-#define DEF_TRAVERSE_TYPELOC(TYPE, CODE)                          \
-  template <typename Derived>                                     \
-  bool RecursiveTypeVisitor<Derived>::Traverse##TYPE##LocType(    \
-      clang::TYPE##Loc TL, const clang::TYPE* T) {                \
-    return getDerived().WalkUpFrom##TYPE##LocType(TL, T) && [&] { \
-      CODE;                                                       \
-      return true;                                                \
-    }();                                                          \
+#define DEF_TRAVERSE_TYPEPAIR(TYPE, CODE)                      \
+  template <typename Derived>                                  \
+  bool RecursiveTypeVisitor<Derived>::Traverse##TYPE##Pair(    \
+      clang::TYPE##Loc TL, const clang::TYPE* T) {             \
+    return getDerived().WalkUpFrom##TYPE##Pair(TL, T) && [&] { \
+      CODE;                                                    \
+      return true;                                             \
+    }();                                                       \
   }
 
-DEF_TRAVERSE_TYPELOC(BuiltinType, {});
+DEF_TRAVERSE_TYPEPAIR(BuiltinType, {});
 // TODO(shahms): Finish ComplexType.
-DEF_TRAVERSE_TYPELOC(ComplexType, {});
-DEF_TRAVERSE_TYPELOC(PointerType, {
-  return getDerived().TraverseTypeLocType(TL.getPointeeLoc(),
-                                          T->getPointeeType());
+DEF_TRAVERSE_TYPEPAIR(ComplexType, {});
+DEF_TRAVERSE_TYPEPAIR(PointerType, {
+  return getDerived().TraverseTypePair(TL.getPointeeLoc(), T->getPointeeType());
 });
-DEF_TRAVERSE_TYPELOC(BlockPointerType, {
-  return getDerived().TraverseTypeLocType(TL.getPointeeLoc(),
-                                          T->getPointeeType());
+DEF_TRAVERSE_TYPEPAIR(BlockPointerType, {
+  return getDerived().TraverseTypePair(TL.getPointeeLoc(), T->getPointeeType());
 });
-DEF_TRAVERSE_TYPELOC(LValueReferenceType, {
-  return getDerived().TraverseTypeLocType(TL.getPointeeLoc(),
-                                          T->getPointeeType());
+DEF_TRAVERSE_TYPEPAIR(LValueReferenceType, {
+  return getDerived().TraverseTypePair(TL.getPointeeLoc(), T->getPointeeType());
 });
-DEF_TRAVERSE_TYPELOC(RValueReferenceType, {
-  return getDerived().TraverseTypeLocType(TL.getPointeeLoc(),
-                                          T->getPointeeType());
+DEF_TRAVERSE_TYPEPAIR(RValueReferenceType, {
+  return getDerived().TraverseTypePair(TL.getPointeeLoc(), T->getPointeeType());
 });
-DEF_TRAVERSE_TYPELOC(MemberPointerType, {
-  return getDerived().TraverseTypeLocType(TL.getPointeeLoc(),
-                                          T->getPointeeType());
+DEF_TRAVERSE_TYPEPAIR(MemberPointerType, {
+  return getDerived().TraverseTypePair(TL.getClassTInfo()->getTypeLoc(),
+                                       clang::QualType(T->getClass(), 0)) &&
+         getDerived().TraverseTypePair(TL.getPointeeLoc(), T->getPointeeType());
 });
-DEF_TRAVERSE_TYPELOC(AdjustedType, {
-  return getDerived().TraverseTypeLocType(TL.getOriginalLoc(),
-                                          T->getOriginalType());
+DEF_TRAVERSE_TYPEPAIR(AdjustedType, {
+  return getDerived().TraverseTypePair(TL.getOriginalLoc(),
+                                       T->getOriginalType());
 });
-DEF_TRAVERSE_TYPELOC(DecayedType, {
-  return getDerived().TraverseTypeLocType(TL.getOriginalLoc(),
-                                          T->getOriginalType());
+DEF_TRAVERSE_TYPEPAIR(DecayedType, {
+  return getDerived().TraverseTypePair(TL.getOriginalLoc(),
+                                       T->getOriginalType());
 });
-DEF_TRAVERSE_TYPELOC(ConstantArrayType, {
-  return getDerived().TraverseTypeLocType(TL.getElementLoc(),
-                                          T->getElementType());
+DEF_TRAVERSE_TYPEPAIR(ConstantArrayType, {
+  return getDerived().TraverseTypePair(TL.getElementLoc(),
+                                       T->getElementType()) &&
+         getDerived().TraverseStmt(TL.getSizeExpr());
 });
-DEF_TRAVERSE_TYPELOC(IncompleteArrayType, {
-  return getDerived().TraverseTypeLocType(TL.getElementLoc(),
-                                          T->getElementType());
+DEF_TRAVERSE_TYPEPAIR(IncompleteArrayType, {
+  return getDerived().TraverseTypePair(TL.getElementLoc(),
+                                       T->getElementType()) &&
+         getDerived().TraverseStmt(TL.getSizeExpr());
 });
-DEF_TRAVERSE_TYPELOC(VariableArrayType, {
-  return getDerived().TraverseTypeLocType(TL.getElementLoc(),
-                                          T->getElementType());
+DEF_TRAVERSE_TYPEPAIR(VariableArrayType, {
+  return getDerived().TraverseTypePair(TL.getElementLoc(),
+                                       T->getElementType()) &&
+         getDerived().TraverseStmt(TL.getSizeExpr());
 });
-DEF_TRAVERSE_TYPELOC(DependentSizedArrayType, {
-  return getDerived().TraverseTypeLocType(TL.getElementLoc(),
-                                          T->getElementType());
+DEF_TRAVERSE_TYPEPAIR(DependentSizedArrayType, {
+  return getDerived().TraverseTypePair(TL.getElementLoc(),
+                                       T->getElementType()) &&
+         getDerived().TraverseStmt(TL.getSizeExpr());
 });
-DEF_TRAVERSE_TYPELOC(DependentAddressSpaceType, {});
+DEF_TRAVERSE_TYPEPAIR(DependentAddressSpaceType, {
+  return getDerived().TraverseStmt(TL.getTypePtr()->getAddrSpaceExpr()) &&
+         getDerived().TraverseTypePair(TL.getPointeeTypeLoc(),
+                                       T->getPointeeType());
+});
+DEF_TRAVERSE_TYPEPAIR(DependentSizedExtVectorType, {
+  if (auto* Expr = TL.getTypePtr()->getSizeExpr()) {
+    if (!getDerived().TraverseStmt(Expr)) {
+      return false;
+    }
+  }
+  return getDerived().TraverseType(TL.getTypePtr()->getElementType());
+});
+DEF_TRAVERSE_TYPEPAIR(VectorType, {
+  return getDerived().TraverseType(TL.getTypePtr()->getElementType());
+});
+DEF_TRAVERSE_TYPEPAIR(DependentVectorType, {
+  if (auto* Expr = TL.getTypePtr()->getSizeExpr()) {
+    if (!getDerived().TraverseStmt(Expr)) {
+      return false;
+    }
+  }
+  return getDerived().TraverseType(TL.getTypePtr()->getElementType());
+});
+DEF_TRAVERSE_TYPEPAIR(ExtVectorType, {
+  return getDerived().TraverseType(TL.getTypePtr()->getElementType());
+});
+DEF_TRAVERSE_TYPEPAIR(FunctionNoProtoType, {
+  return getDerived().TraverseTypePair(TL.getReturnLoc(), T->getReturnType());
+});
+DEF_TRAVERSE_TYPEPAIR(FunctionProtoType, {
+  if (!getDerived().TraverseTypePair(TL.getReturnLoc(), T->getReturnType())) {
+    return false;
+  }
+  for (unsigned I = 0, E = TL.getNumParams(); I != E; ++I) {
+    if (auto P = TL.getParam(I)) {
+      if (!getDerived().TraverseDecl(P)) {
+        return false;
+      }
+    } else if (I < T->getNumParams()) {
+      if (!getDerived().TraverseType(T->getParamType(I))) {
+        return false;
+      }
+    }
+  }
+  for (const auto& E : T->exceptions()) {
+    if (!getDerived().TraverseType(E)) {
+      return false;
+    }
+  }
+  if (auto* NE = T->getNoexceptExpr()) {
+    return getDerived().TraverseStmt(NE);
+  }
+  return true;
+});
+DEF_TRAVERSE_TYPEPAIR(UnresolvedUsingType, {});
+DEF_TRAVERSE_TYPEPAIR(TypedefType, {});
+DEF_TRAVERSE_TYPEPAIR(TypeOfExprType, {
+  return getDerived().TraverseStmt(TL.getUnderlyingExpr());
+});
+DEF_TRAVERSE_TYPEPAIR(TypeOfType, {
+  return getDerived().TraverseTypePair(TL.getUnderlyingTInfo()->getTypeLoc(),
+                                       T->getUnderlyingType());
+});
+DEF_TRAVERSE_TYPEPAIR(DecltypeType, {});
+DEF_TRAVERSE_TYPEPAIR(UnaryTransformType, {});
+DEF_TRAVERSE_TYPEPAIR(AutoType, {});
+DEF_TRAVERSE_TYPEPAIR(DeducedTemplateSpecializationType, {});
+DEF_TRAVERSE_TYPEPAIR(RecordType, {});
+DEF_TRAVERSE_TYPEPAIR(EnumType, {});
+DEF_TRAVERSE_TYPEPAIR(TemplateTypeParmType, {});
+DEF_TRAVERSE_TYPEPAIR(SubstTemplateTypeParmType, {});
+DEF_TRAVERSE_TYPEPAIR(SubstTemplateTypeParmPackType, {});
+DEF_TRAVERSE_TYPEPAIR(TemplateSpecializationType, {});
+DEF_TRAVERSE_TYPEPAIR(InjectedClassNameType, {});
+DEF_TRAVERSE_TYPEPAIR(ParenType, {});
+DEF_TRAVERSE_TYPEPAIR(AttributedType, {});
+DEF_TRAVERSE_TYPEPAIR(ElaboratedType, {});
+DEF_TRAVERSE_TYPEPAIR(DependentNameType, {});
+DEF_TRAVERSE_TYPEPAIR(DependentTemplateSpecializationType, {});
+DEF_TRAVERSE_TYPEPAIR(PackExpansionType, {});
+DEF_TRAVERSE_TYPEPAIR(ObjCTypeParamType, {});
+DEF_TRAVERSE_TYPEPAIR(ObjCInterfaceType, {});
+DEF_TRAVERSE_TYPEPAIR(ObjCObjectType, {});
+DEF_TRAVERSE_TYPEPAIR(ObjCObjectPointerType, {});
+DEF_TRAVERSE_TYPEPAIR(AtomicType, {});
+DEF_TRAVERSE_TYPEPAIR(PipeType, {});
 
-#undef DEF_TRAVERSE_TYPELOC
+#undef DEF_TRAVERSE_TYPEPAIR
 
 }  // namespace kythe
 

--- a/kythe/cxx/indexer/cxx/recursive_type_visitor_test.cc
+++ b/kythe/cxx/indexer/cxx/recursive_type_visitor_test.cc
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018 The Kythe Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "kythe/cxx/indexer/cxx/recursive_type_visitor.h"
+
+#include "gtest/gtest.h"
+
+namespace kythe {
+namespace {
+
+TEST(RecursiveTypeVisitorTest, TrivialImplementationWorks) {
+  struct TestVisitor : RecursiveTypeVisitor<TestVisitor> {
+  } visitor;
+  ASSERT_TRUE(visitor.TraverseTypeLocType(clang::TypeLoc(), clang::QualType()));
+}
+
+}  // namespace
+}  // namespace kythe

--- a/kythe/cxx/indexer/cxx/recursive_type_visitor_test.cc
+++ b/kythe/cxx/indexer/cxx/recursive_type_visitor_test.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 The Kythe Authors. All rights reserved.
+ * Copyright 2020 The Kythe Authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kythe/cxx/indexer/cxx/recursive_type_visitor_test.cc
+++ b/kythe/cxx/indexer/cxx/recursive_type_visitor_test.cc
@@ -24,7 +24,7 @@ namespace {
 TEST(RecursiveTypeVisitorTest, TrivialImplementationWorks) {
   struct TestVisitor : RecursiveTypeVisitor<TestVisitor> {
   } visitor;
-  ASSERT_TRUE(visitor.TraverseTypeLocType(clang::TypeLoc(), clang::QualType()));
+  ASSERT_TRUE(visitor.TraverseTypePair(clang::TypeLoc(), clang::QualType()));
 }
 
 }  // namespace

--- a/kythe/cxx/indexer/cxx/testdata/BUILD
+++ b/kythe/cxx/indexer/cxx/testdata/BUILD
@@ -2015,6 +2015,13 @@ cc_indexer_test(
 )
 
 cc_indexer_test(
+    name = "template/template_dependent_name_ref",
+    srcs = ["template/template_dependent_name_ref.cc"],
+    ignore_dups = True,
+    tags = ["template"],
+)
+
+cc_indexer_test(
     name = "template_dependent_sized_array",
     srcs = ["template/template_dependent_sized_array.cc"],
     tags = ["template"],

--- a/kythe/cxx/indexer/cxx/testdata/template/template_dependent_name_ref.cc
+++ b/kythe/cxx/indexer/cxx/testdata/template/template_dependent_name_ref.cc
@@ -1,0 +1,8 @@
+
+template<typename T>
+void fn() {
+  //- @value_type ref DependentName
+  typename T::value_type a;
+  //- @value_type ref DependentName
+  typename T::value_type b;
+}


### PR DESCRIPTION
Rather than using the current hack for visiting types when the type-as-written differs from the resolved type, factor that logic into a separate visitation hierarchy that visits the type-as-written in parallel with the resolved type.

This is closer to the old logic, but implemented using the same visitation approach as the rest of RecursiveASTVisitor.