### PR TITLE
chore(java_extractor): use SOURCE_OUTPUT rather than genSrcDir

### DIFF
--- a/kythe/java/com/google/devtools/kythe/extractors/java/bazel/JavaExtractor.java
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/bazel/JavaExtractor.java
@@ -121,8 +121,8 @@ public class JavaExtractor {
     javacOpts.add(output.toString());
 
     // Add the generated sources directory if any processors could be invoked.
-    Optional<Path> genSrcDir = Optional.empty();
     if (!jInfo.getProcessorList().isEmpty()) {
+      Optional<Path> genSrcDir = Optional.empty();
       try {
         genSrcDir = readGeneratedSourceDirParam(jInfo);
       } catch (IOException ioe) {
@@ -149,7 +149,6 @@ public class JavaExtractor {
                 sourcepaths,
                 jInfo.getProcessorpathList(),
                 jInfo.getProcessorList(),
-                genSrcDir,
                 javacOpts,
                 jInfo.getOutputjar());
 

--- a/kythe/java/com/google/devtools/kythe/extractors/java/standalone/Javac8Wrapper.java
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/standalone/Javac8Wrapper.java
@@ -26,12 +26,9 @@ import com.sun.tools.javac.main.Option;
 import com.sun.tools.javac.util.Context;
 import com.sun.tools.javac.util.Options;
 import java.io.File;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
-import java.util.Optional;
 import javax.tools.JavaFileObject;
 import javax.tools.StandardLocation;
 
@@ -100,9 +97,6 @@ public class Javac8Wrapper extends AbstractJavacWrapper {
       outputDirectory = ".";
     }
 
-    // Find generated source directory by the -s argument.
-    Optional<Path> genSrcDir = Optional.ofNullable(options.get(Option.S)).map(Paths::get);
-
     String analysisTarget =
         readEnvironmentVariable("KYTHE_ANALYSIS_TARGET", createTargetFromSourceFiles(sources));
     return javaCompilationUnitExtractor.extract(
@@ -113,7 +107,6 @@ public class Javac8Wrapper extends AbstractJavacWrapper {
         sourcePaths,
         processorPaths,
         processors,
-        genSrcDir,
         completeOptions,
         outputDirectory);
   }

--- a/kythe/java/com/google/devtools/kythe/extractors/java/standalone/Javac9Wrapper.java
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/standalone/Javac9Wrapper.java
@@ -26,12 +26,9 @@ import com.sun.tools.javac.main.Option;
 import com.sun.tools.javac.util.Context;
 import com.sun.tools.javac.util.Options;
 import java.io.File;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
-import java.util.Optional;
 import javax.tools.JavaFileObject;
 import javax.tools.StandardLocation;
 
@@ -115,9 +112,6 @@ public class Javac9Wrapper extends AbstractJavacWrapper {
       outputDirectory = ".";
     }
 
-    // Find generated source directory by the -s argument.
-    Optional<Path> genSrcDir = Optional.ofNullable(options.get(Option.S)).map(Paths::get);
-
     String analysisTarget =
         readEnvironmentVariable("KYTHE_ANALYSIS_TARGET", createTargetFromSourceFiles(sources));
 
@@ -129,7 +123,6 @@ public class Javac9Wrapper extends AbstractJavacWrapper {
         sourcePaths,
         processorPaths,
         processors,
-        genSrcDir,
         completeOptions,
         outputDirectory);
   }

--- a/kythe/java/com/google/devtools/kythe/platform/java/filemanager/ForwardingStandardJavaFileManager.java
+++ b/kythe/java/com/google/devtools/kythe/platform/java/filemanager/ForwardingStandardJavaFileManager.java
@@ -16,6 +16,7 @@
 package com.google.devtools.kythe.platform.java.filemanager;
 
 import com.google.common.base.Throwables;
+import com.google.common.collect.Iterables;
 import com.google.common.flogger.FluentLogger;
 import com.google.common.reflect.Reflection;
 import java.io.File;
@@ -223,7 +224,10 @@ public class ForwardingStandardJavaFileManager
     // TODO(shahms): return fileManager.getLocationAsPaths(location);
     try {
       return (Iterable<? extends Path>) getLocationAsPathsMethod.invoke(fileManager, location);
-    } catch (NullPointerException | ReflectiveOperationException e) {
+    } catch (NullPointerException npe) {
+      // Fall back to using getLocation from the underlying fileManager.
+      return Iterables.transform(fileManager.getLocation(location), File::toPath);
+    } catch (ReflectiveOperationException e) {
       throw propagateInvocationTargetErrorIfPossible("getLocationAsPaths", e);
     }
   }

--- a/kythe/javatests/com/google/devtools/kythe/extractors/java/JavaExtractorTest.java
+++ b/kythe/javatests/com/google/devtools/kythe/extractors/java/JavaExtractorTest.java
@@ -42,7 +42,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import junit.framework.TestCase;
@@ -76,8 +75,7 @@ public class JavaExtractorTest extends TestCase {
 
     // Index the specified sources
     CompilationDescription description =
-        java.extract(
-            TARGET1, sources, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, Optional.empty(), EMPTY, "output");
+        java.extract(TARGET1, sources, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, "output");
 
     CompilationUnit unit = description.getCompilationUnit();
     assertThat(unit.getVName().getCorpus()).isEqualTo(CORPUS);
@@ -119,8 +117,7 @@ public class JavaExtractorTest extends TestCase {
 
     // Index the specified sources
     CompilationDescription description =
-        java.extract(
-            TARGET1, sources, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, Optional.empty(), EMPTY, "output");
+        java.extract(TARGET1, sources, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, "output");
 
     CompilationUnit unit = description.getCompilationUnit();
     assertThat(unit.getVName().getCorpus()).isEmpty(); // source files are from different corpora
@@ -158,8 +155,7 @@ public class JavaExtractorTest extends TestCase {
 
     // Index the specified sources
     CompilationDescription description =
-        java.extract(
-            TARGET1, sources, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, Optional.empty(), EMPTY, "output");
+        java.extract(TARGET1, sources, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, "output");
 
     CompilationUnit unit = description.getCompilationUnit();
     assertThat(unit).isNotNull();
@@ -194,8 +190,7 @@ public class JavaExtractorTest extends TestCase {
 
     // Index the specified sources
     CompilationDescription description =
-        java.extract(
-            TARGET1, sources, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, Optional.empty(), EMPTY, "output");
+        java.extract(TARGET1, sources, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, "output");
 
     CompilationUnit unit = description.getCompilationUnit();
     assertThat(unit).isNotNull();
@@ -227,8 +222,7 @@ public class JavaExtractorTest extends TestCase {
 
     // Index the specified sources
     CompilationDescription description =
-        java.extract(
-            TARGET1, sources, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, Optional.empty(), EMPTY, "output");
+        java.extract(TARGET1, sources, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, "output");
 
     CompilationUnit unit = description.getCompilationUnit();
     assertThat(unit).isNotNull();
@@ -263,17 +257,7 @@ public class JavaExtractorTest extends TestCase {
 
     // Index the specified sources and classes from the classpath
     CompilationDescription description =
-        java.extract(
-            TARGET1,
-            sources,
-            classpath,
-            EMPTY,
-            EMPTY,
-            EMPTY,
-            EMPTY,
-            Optional.empty(),
-            EMPTY,
-            "output");
+        java.extract(TARGET1, sources, classpath, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, "output");
 
     CompilationUnit unit = description.getCompilationUnit();
     assertThat(unit).isNotNull();
@@ -306,17 +290,7 @@ public class JavaExtractorTest extends TestCase {
 
     // Index the specified sources and classes from inside jar on the classpath.
     CompilationDescription description =
-        java.extract(
-            TARGET1,
-            sources,
-            classpath,
-            EMPTY,
-            EMPTY,
-            EMPTY,
-            EMPTY,
-            Optional.empty(),
-            EMPTY,
-            "output");
+        java.extract(TARGET1, sources, classpath, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, "output");
 
     CompilationUnit unit = description.getCompilationUnit();
     assertThat(unit).isNotNull();
@@ -350,8 +324,7 @@ public class JavaExtractorTest extends TestCase {
 
     // Index the specified sources, reporting compilation failure.
     CompilationDescription description =
-        java.extract(
-            TARGET1, sources, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, Optional.empty(), EMPTY, "output");
+        java.extract(TARGET1, sources, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, "output");
 
     CompilationUnit unit = description.getCompilationUnit();
     assertThat(unit).isNotNull();
@@ -378,8 +351,7 @@ public class JavaExtractorTest extends TestCase {
 
     // Index the specified sources
     CompilationDescription description =
-        java.extract(
-            TARGET1, sources, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, Optional.empty(), EMPTY, "output");
+        java.extract(TARGET1, sources, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, "output");
 
     CompilationUnit unit = description.getCompilationUnit();
     assertThat(unit).isNotNull();
@@ -411,8 +383,7 @@ public class JavaExtractorTest extends TestCase {
 
     // Index the specified sources
     CompilationDescription description =
-        java.extract(
-            TARGET1, sources, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, Optional.empty(), EMPTY, "output");
+        java.extract(TARGET1, sources, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, "output");
 
     CompilationUnit unit = description.getCompilationUnit();
     assertThat(unit).isNotNull();
@@ -443,8 +414,7 @@ public class JavaExtractorTest extends TestCase {
 
     // Index the specified sources
     CompilationDescription description =
-        java.extract(
-            TARGET1, sources, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, Optional.empty(), EMPTY, "output");
+        java.extract(TARGET1, sources, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, "output");
 
     CompilationUnit unit = description.getCompilationUnit();
     assertThat(unit).isNotNull();
@@ -521,7 +491,6 @@ public class JavaExtractorTest extends TestCase {
             EMPTY,
             processorpath,
             processors,
-            Optional.empty(),
             options,
             "output");
 
@@ -575,7 +544,6 @@ public class JavaExtractorTest extends TestCase {
             EMPTY,
             processorpath,
             processors,
-            Optional.of(genSrcDir),
             options,
             "output");
 
@@ -610,17 +578,7 @@ public class JavaExtractorTest extends TestCase {
 
     // Index the specified sources
     CompilationDescription description =
-        java.extract(
-            TARGET1,
-            sources,
-            EMPTY,
-            bootclasspath,
-            EMPTY,
-            EMPTY,
-            EMPTY,
-            Optional.empty(),
-            EMPTY,
-            "output");
+        java.extract(TARGET1, sources, EMPTY, bootclasspath, EMPTY, EMPTY, EMPTY, EMPTY, "output");
 
     CompilationUnit unit = description.getCompilationUnit();
 
@@ -647,17 +605,7 @@ public class JavaExtractorTest extends TestCase {
 
     // Index the specified sources
     CompilationDescription description =
-        java.extract(
-            TARGET1,
-            sources,
-            EMPTY,
-            bootclasspath,
-            EMPTY,
-            EMPTY,
-            EMPTY,
-            Optional.empty(),
-            EMPTY,
-            "output");
+        java.extract(TARGET1, sources, EMPTY, bootclasspath, EMPTY, EMPTY, EMPTY, EMPTY, "output");
 
     CompilationUnit unit = description.getCompilationUnit();
     assertThat(unit).isNotNull();
@@ -688,17 +636,7 @@ public class JavaExtractorTest extends TestCase {
     List<String> classpath = ImmutableList.of(join(TEST_DATA_DIR, "src_in_jar/pack.jar"));
 
     CompilationDescription description =
-        java.extract(
-            TARGET1,
-            sources,
-            classpath,
-            EMPTY,
-            EMPTY,
-            EMPTY,
-            EMPTY,
-            Optional.empty(),
-            EMPTY,
-            "output");
+        java.extract(TARGET1, sources, classpath, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, "output");
 
     CompilationUnit unit = description.getCompilationUnit();
     assertThat(unit).isNotNull();
@@ -730,8 +668,7 @@ public class JavaExtractorTest extends TestCase {
     java.useSystemDirectory(join(TEST_DATA_DIR, "/system_modules"));
 
     CompilationDescription description =
-        java.extract(
-            TARGET1, sources, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, Optional.empty(), EMPTY, "output");
+        java.extract(TARGET1, sources, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, "output");
 
     CompilationUnit unit = description.getCompilationUnit();
     assertThat(unit).isNotNull();


### PR DESCRIPTION
Trying this again with internally-tested fallbacks for JDK8.