### PR TITLE
docs: update minimum Clang version to 8

### DIFF
--- a/kythe/web/site/getting-started.md
+++ b/kythe/web/site/getting-started.md
@@ -57,7 +57,7 @@ apt-get update
 
 apt-get install \
     asciidoc asciidoctor source-highlight graphviz \
-    gcc uuid-dev libncurses-dev flex clang-3.8 bison \
+    gcc uuid-dev libncurses-dev flex clang-8 bison \
     openjdk-8-jdk \
     parallel \
     wget
@@ -72,14 +72,14 @@ You must either have `/usr/bin/clang` aliased properly, or the `CC` env var set
 for Bazel:
 
 {% highlight bash %}
-echo 'build --client_env=CC=/usr/bin/clang-3.8' >>~/.bazelrc
+echo 'build --client_env=CC=/usr/bin/clang-8' >>~/.bazelrc
 {% endhighlight %}
 
 OR:
 
 {% highlight bash %}
-sudo ln -s /usr/bin/clang-3.8 /usr/bin/clang
-sudo ln -s /usr/bin/clang++-3.8 /usr/bin/clang++
+sudo ln -s /usr/bin/clang-8 /usr/bin/clang
+sudo ln -s /usr/bin/clang++-8 /usr/bin/clang++
 {% endhighlight %}
 
 OR:

--- a/kythe/web/site/getting-started.md
+++ b/kythe/web/site/getting-started.md
@@ -31,7 +31,7 @@ Kythe relies on the following external dependencies:
 
 * asciidoc
 * bison-3.0.4
-* clang >= 3.8
+* clang >= 8
 * [docker](https://www.docker.com/) (for release images `//kythe/release/...` and `//buildtools/docker`)
 * flex-2.5
 * go >= 1.7


### PR DESCRIPTION
The recent changes to enable -std=c++17 are not supported in Clang 3.8.