### PR TITLE
fix(bazel-extractor): update docker image for c++17

### DIFF
--- a/kythe/extractors/bazel/Dockerfile
+++ b/kythe/extractors/bazel/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2019 The Kythe Authors. All rights reserved.
+# Copyright 2020 The Kythe Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,17 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/cloud-builders/bazel
+FROM debian:sid
 
 # Install C++ compilers for cc_* rule support.
 RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y gcc clang-6.0 && \
+    apt-get install -y git clang-8 build-essential && \
     apt-get clean
 
 # Create clang symlinks
-RUN ln -s /usr/bin/clang-6.0 /usr/bin/clang && \
-    ln -s /usr/bin/clang++-6.0 /usr/bin/clang++
+RUN ln -s /usr/bin/clang-8 /usr/bin/clang && \
+    ln -s /usr/bin/clang++-8 /usr/bin/clang++
+
+RUN echo 'build --client_env=CC=/usr/bin/clang' >> ~/.bazelrc
+RUN echo 'build --client_env=CXX=/usr/bin/clang++' >> ~/.bazelrc
 
 # Extract the Kythe release archive to /kythe
 COPY kythe/release/kythe-v*.tar.gz /tmp/
@@ -38,5 +40,12 @@ ADD kythe/release/base/fix_permissions.sh /kythe/
 # Bazelisk
 ADD external/com_github_bazelbuild_bazelisk/linux_amd64_stripped/bazelisk /kythe/
 
+RUN mkdir -p /workspace
+WORKDIR /workspace
+
+# copied from gcr.io bazel image
+# Store the Bazel outputs under /workspace so that the symlinks under bazel-bin
+# (et al) are accessible to downstream build steps.
+RUN echo 'startup --output_base=/workspace/.bazel' >> ~/.bazelrc
 
 ENTRYPOINT ["/kythe/extract.sh"]


### PR DESCRIPTION
we can't get a new enough clang/libstdc++ using the gcr.io bazel image,
so I switched to debian sid.