### PR TITLE
fix(bazel_go_extractor): record canonical importpath for archives

### DIFF
--- a/kythe/go/extractors/cmd/bazel/bazel_go_extractor/BUILD
+++ b/kythe/go/extractors/cmd/bazel/bazel_go_extractor/BUILD
@@ -7,6 +7,7 @@ go_binary(
     srcs = ["bazel_go_extractor.go"],
     deps = [
         "//kythe/go/extractors/bazel",
+        "//kythe/go/util/ptypes",
         "//kythe/go/extractors/govname",
         "//kythe/go/util/vnameutil",
         "//kythe/proto:analysis_go_proto",

--- a/kythe/go/extractors/cmd/bazel/bazel_go_extractor/bazel_go_extractor.go
+++ b/kythe/go/extractors/cmd/bazel/bazel_go_extractor/bazel_go_extractor.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 The Kythe Authors. All rights reserved.
+ * Copyright 2020 The Kythe Authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kythe/go/extractors/cmd/bazel/bazel_go_extractor/bazel_go_extractor.go
+++ b/kythe/go/extractors/cmd/bazel/bazel_go_extractor/bazel_go_extractor.go
@@ -200,8 +200,8 @@ type compileArgs struct {
 
 func parseCompileArgs(args []string) *compileArgs {
 	c := &compileArgs{
-		original:  args,
-		importMap: make(map[string]string),
+		original:         args,
+		importMap:        make(map[string]string),
 		archiveImportMap: make(map[string]string),
 	}
 

--- a/kythe/go/extractors/cmd/bazel/bazel_go_extractor/bazel_go_extractor.go
+++ b/kythe/go/extractors/cmd/bazel/bazel_go_extractor/bazel_go_extractor.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Kythe Authors. All rights reserved.
+ * Copyright 2016 The Kythe Authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kythe/go/extractors/cmd/bazel/bazel_go_extractor/bazel_go_extractor.go
+++ b/kythe/go/extractors/cmd/bazel/bazel_go_extractor/bazel_go_extractor.go
@@ -28,6 +28,7 @@ import (
 
 	"kythe.io/kythe/go/extractors/bazel"
 	"kythe.io/kythe/go/extractors/govname"
+	"kythe.io/kythe/go/util/ptypes"
 	"kythe.io/kythe/go/util/vnameutil"
 
 	apb "kythe.io/kythe/proto/analysis_go_proto"
@@ -154,6 +155,19 @@ func (*extractor) isSource(name string) bool { return filepath.Ext(name) == ".go
 func (*extractor) checkEnv(name, _ string) bool { return name != "PATH" }
 
 func (e *extractor) fixup(unit *apb.CompilationUnit) error {
+	// Add GoPackageInfo to record canonical import paths of packages.
+	for _, ri := range unit.RequiredInput {
+		if ip, ok := e.compileArgs.archiveImportMap[ri.Info.Path]; ok {
+			any, err := ptypes.MarshalAny(&gopb.GoPackageInfo{
+				ImportPath: ip,
+			})
+			if err != nil {
+				return fmt.Errorf("error adding GoPackageInfo details: %v", err)
+			}
+			ri.Details = append(ri.Details, any)
+		}
+	}
+
 	// Try to infer a unit vname from the output.
 	if vname, ok := e.rules.Apply(e.compileArgs.outputPath); ok {
 		vname.Language = govname.Language
@@ -171,22 +185,24 @@ func (e *extractor) fixup(unit *apb.CompilationUnit) error {
 // compileArgs records the build information extracted from the GoCompilePkg
 // action's argument list.
 type compileArgs struct {
-	original    []string          // the original args, as provided
-	srcs        []string          // source file to be compiled
-	deps        []string          // import paths of direct dependencies
-	tags        []string          // build tags to assert
-	importMap   map[string]string // import map for direct dependencies
-	outputPath  string            // output object file
-	packageList string            // file containing the list of standard library packages
-	include     []string          // additional include directories
-	importPath  string            // output package import path
-	trimPrefix  string            // prefix to trim from source paths
+	original         []string          // the original args, as provided
+	srcs             []string          // source file to be compiled
+	deps             []string          // import paths of direct dependencies
+	tags             []string          // build tags to assert
+	importMap        map[string]string // import map for direct dependencies
+	archiveImportMap map[string]string // import map for direct dependencies of archives
+	outputPath       string            // output object file
+	packageList      string            // file containing the list of standard library packages
+	include          []string          // additional include directories
+	importPath       string            // output package import path
+	trimPrefix       string            // prefix to trim from source paths
 }
 
 func parseCompileArgs(args []string) *compileArgs {
 	c := &compileArgs{
 		original:  args,
 		importMap: make(map[string]string),
+		archiveImportMap: make(map[string]string),
 	}
 
 	var tail []string // left-over non-flag arguments
@@ -207,12 +223,23 @@ func parseCompileArgs(args []string) *compileArgs {
 		switch flag {
 		case "dep":
 			c.deps = append(c.deps, arg)
-		case "importmap", "arc":
+		case "importmap":
 			// Only record the mappings that change something.
 			ps := strings.SplitN(arg, "=", 2)
 			if len(ps) == 2 && ps[0] != ps[1] {
 				c.importMap[ps[0]] = ps[1]
 			}
+		case "arc":
+			// Example -arc arg:
+			//   "github.com/google/subcommands=github.com/google/subcommands=bazel-out/k8-fastbuild/bin/external/com_github_google_subcommands/linux_amd64_stripped/go_default_library%/github.com/google/subcommands.a=",
+			//
+			// Only record the mappings that change something.
+			ps := strings.SplitN(strings.TrimSuffix(arg, "="), "=", 3)
+			if len(ps) == 3 {
+				// map from file path to desired importpath
+				c.archiveImportMap[ps[2]] = ps[1]
+			}
+
 		case "o":
 			c.outputPath = arg
 		case "package_list":


### PR DESCRIPTION
This should fix cross-module linking for go code extracted through bazel.

Go package dependencies are pulled in as static archives (.a files) and are mentioned in the arguments like:

`-arc "github.com/google/subcommands=github.com/google/subcommands=bazel-out/k8-fastbuild/bin/external/com_github_google_subcommands/linux_amd64_stripped/go_default_library%/github.com/google/subcommands.a="`

This change parses the `-arc` arguments and builds a map of filepath -> importpath, which is then used to attach `GoPackageInfo` details messages to the corresponding required_inputs in the compilation unit. The indexer later picks these up and refers to package dependencies by the correct vname/importpath.