### PR TITLE
fix(release): don't include the current working directory in release

### DIFF
--- a/kythe/release/package_release.sh
+++ b/kythe/release/package_release.sh
@@ -119,6 +119,6 @@ while [[ $# -gt 0 ]]; do
   shift
 done
 
-tar czf "$OUT" -C "$OUT.dir" .
+tar czf "$OUT" -C "$OUT.dir" "$(basename "$PBASE")"
 
 $SHASUM_TOOL "$OUT" > "$OUT.sha256"


### PR DESCRIPTION
Having tar try to modify the current working directory is rude, don't.  Also fixes https://github.com/kythe/kythe/issues/4430