### PR TITLE
fix(java_indexer): only apply jdk override for non-source symbols

### DIFF
--- a/kythe/java/com/google/devtools/kythe/analyzers/java/JavaEntrySets.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/JavaEntrySets.java
@@ -361,16 +361,19 @@ public class JavaEntrySets extends KytheEntrySets {
   }
 
   static boolean fromJDK(@Nullable Symbol sym) {
-    if (sym == null
-        || sym.enclClass() == null
-        || sym.enclClass().classfile == null
-        || sym.enclClass().sourcefile != null) {
+    if (sym == null) {
       return false;
     }
-    String cls = sym.enclClass().className();
+    ClassSymbol enclClass = sym.enclClass();
+    if (enclClass == null
+        || enclClass.classfile == null
+        || enclClass.classfile.getKind() == JavaFileObject.Kind.SOURCE) {
+      return false;
+    }
+    String cls = enclClass.className();
     // For performance, first check common package prefixes, then delegate
     // to the slower loadedByJDKClassLoader() method.
-    return SignatureGenerator.isArrayHelperClass(sym.enclClass())
+    return SignatureGenerator.isArrayHelperClass(enclClass)
         || cls.startsWith("java.")
         || cls.startsWith("javax.")
         || cls.startsWith("com.sun.")

--- a/kythe/java/com/google/devtools/kythe/analyzers/java/JavaEntrySets.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/JavaEntrySets.java
@@ -361,7 +361,10 @@ public class JavaEntrySets extends KytheEntrySets {
   }
 
   static boolean fromJDK(@Nullable Symbol sym) {
-    if (sym == null || sym.enclClass() == null) {
+    if (sym == null
+        || sym.enclClass() == null
+        || sym.enclClass().classfile == null
+        || sym.enclClass().sourcefile != null) {
       return false;
     }
     String cls = sym.enclClass().className();

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/sun/BUILD
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/sun/BUILD
@@ -1,0 +1,8 @@
+load("//tools/build_rules/verifier_test:java_verifier_test.bzl", "java_verifier_test")
+
+java_verifier_test(
+    name = "jdk_tests",
+    size = "small",
+    srcs = ["SunSource.java"],
+    indexer_opts = ["--override_jdk_corpus=override"],
+)

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/sun/SunSource.java
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/sun/SunSource.java
@@ -1,0 +1,23 @@
+package sun;
+
+// Check that we correctly detect classes provided by the JDK,
+// regardless of package name.
+
+import org.xml.sax.SAXException;
+
+public class SunSource {
+
+  class SomeUserClass {};
+
+  //- @s defines/binding S
+  //- S typed vname(_,"override","","","java")
+  String s;
+
+  //- @se defines/binding SE
+  //- SE typed vname(_,"override","","","java")
+  SAXException se;
+
+  //- @suc defines/binding SUC
+  //- !{ SUC typed vname(_,"override","","","java") }
+  SomeUserClass suc;
+}


### PR DESCRIPTION
I don't believe this is a complete solution, which will involve checking the enclosing class's classfile against file manager locations, but it's a good low-risk initial change.