### PR TITLE
feat(build): have arc run bazel test with named config

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -62,5 +62,7 @@ build:remote --extra_toolchains=@io_kythe//tools/build_rules/lexyacc:lexyacc_rem
 
 build:remote --action_env=LEIN_JAVA_CMD=
 
+test:prepush --verbose_failures --noshow_loading_progress --noshow_progress
+
 # Support user-provided user.bazelrc
 try-import user.bazelrc

--- a/tools/arc/unit/engine/BazelTestEngine.php
+++ b/tools/arc/unit/engine/BazelTestEngine.php
@@ -115,6 +115,7 @@ final class BazelTestEngine extends ArcanistUnitTestEngine {
 
     $tag_filters = join(",", array_map(function($s) { return "-$s"; }, self::$omit_tags));
     $future = new ExecFuture($this->bazelCommand("test", array_merge([
+        "--config=prepush",
         "--verbose_failures",
         "--test_tag_filters=$tag_filters",
         "--noshow_loading_progress",


### PR DESCRIPTION
This will allow folks (read: me) to optionally have the pre-push tests use the remote configuration without changing the default.