### PR TITLE
Support TypeScript 3.8 AST

### DIFF
--- a/kythe/typescript/indexer.ts
+++ b/kythe/typescript/indexer.ts
@@ -1249,7 +1249,7 @@ class Visitor {
    * and that case is handled as part of the ordinary declaration handling.
    */
   visitExportDeclaration(decl: ts.ExportDeclaration) {
-    if (decl.exportClause) {
+    if (decl.exportClause && ts.isNamedExports(decl.exportClause)) {
       for (const exp of decl.exportClause.elements) {
         const localSym = this.host.getSymbolAtLocation(exp.name);
         if (!localSym) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1883,9 +1883,9 @@
       }
     },
     "typescript": {
-      "version": "3.7.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
-      "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw=="
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w=="
     },
     "uglify-js": {
       "version": "3.8.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "source-map-support": "^0.5.16",
-    "typescript": "^3.7.5"
+    "typescript": "^3.8.3"
   },
   "license": "Apache-2.0"
 }


### PR DESCRIPTION
TypeScript 3.8 updated the AST so that a `ts.ExportDeclaration` can now either have a `NamedExports` or `NamespaceExport` as child ([example](https://ts-ast-viewer.com/#code/KYDwDg9gTgLgBAKjgQwM5wHboGZQgWzgHIsiBuAKFEljgG8BfOXA40soA)). This PR updates the current exports handing to only traverse into named exports and leave namespace exports alone. This is only meant to unblock building and running Kythe with TypeScript 3.8 and it's API's.