### PR TITLE
chore(cxx_indexer): centralize and unittest some range handling

### DIFF
--- a/kythe/cxx/indexer/cxx/BUILD
+++ b/kythe/cxx/indexer/cxx/BUILD
@@ -91,6 +91,23 @@ cc_library(
     ],
 )
 
+cc_test(
+    name = "clang_utils_test",
+    srcs = [
+        "clang_utils_test.cc",
+    ],
+    deps = [
+        ":clang_utils",
+        "//third_party:gtest_main",
+        "@com_github_google_glog//:glog",
+        "@com_google_absl//absl/strings",
+        "@org_llvm//:LLVMSupport",
+        "@org_llvm//:clangAST",
+        "@org_llvm//:clangFrontend",
+        "@org_llvm//:clangTooling",
+    ],
+)
+
 cc_library(
     name = "google_flags_library_support",
     srcs = [

--- a/kythe/cxx/indexer/cxx/BUILD
+++ b/kythe/cxx/indexer/cxx/BUILD
@@ -193,6 +193,8 @@ cc_library(
         "-Wno-implicit-fallthrough",
     ],
     deps = [
+        ":clang_range_finder",
+        ":clang_utils",
         ":graph_observer",
         ":indexed_parent_iterator",
         ":indexed_parent_map",
@@ -529,6 +531,39 @@ cc_test(
     deps = [
         ":recursive_type_visitor",
         "//third_party:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "clang_range_finder",
+    srcs = ["clang_range_finder.cc"],
+    hdrs = ["clang_range_finder.h"],
+    deps = [
+        ":clang_utils",
+        "@com_github_google_glog//:glog",
+        "@org_llvm//:LLVMSupport",
+        "@org_llvm//:clangAST",
+        "@org_llvm//:clangBasic",
+        "@org_llvm//:clangLex",
+    ],
+)
+
+cc_test(
+    name = "clang_range_finder_test",
+    srcs = [
+        "clang_range_finder_test.cc",
+    ],
+    deps = [
+        ":clang_range_finder",
+        "//third_party:gtest_main",
+        "@com_github_google_glog//:glog",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
+        "@org_llvm//:LLVMSupport",
+        "@org_llvm//:clangAST",
+        "@org_llvm//:clangFrontend",
+        "@org_llvm//:clangLex",
+        "@org_llvm//:clangTooling",
     ],
 )
 

--- a/kythe/cxx/indexer/cxx/IndexerASTHooks.cc
+++ b/kythe/cxx/indexer/cxx/IndexerASTHooks.cc
@@ -50,6 +50,7 @@
 #include "clang/Sema/Lookup.h"
 #include "indexed_parent_iterator.h"
 #include "kythe/cxx/common/scope_guard.h"
+#include "kythe/cxx/indexer/cxx/clang_range_finder.h"
 #include "kythe/cxx/indexer/cxx/clang_utils.h"
 #include "kythe/cxx/indexer/cxx/marked_source.h"
 #include "kythe/cxx/indexer/cxx/node_set.h"
@@ -448,91 +449,11 @@ bool IndexerASTVisitor::IsDefinition(const clang::VarDecl* VD) {
   return VD->isThisDeclarationADefinition() != VarDecl::DeclarationOnly;
 }
 
-SourceRange IndexerASTVisitor::ConsumeToken(
-    SourceLocation StartLocation, clang::tok::TokenKind ExpectedKind) const {
-  clang::Token Token;
-  if (getRawToken(StartLocation, Token) == LexerResult::Success) {
-    // We can't use findLocationAfterToken() as that also uses "raw" lexing,
-    // which does not respect |lang_opts_.CXXOperatorNames| and will happily
-    // give |tok::raw_identifier| for tokens such as "compl" and then decide
-    // that "compl" doesn't match tok::tilde.  We want raw lexing so that
-    // macro expansion is suppressed, but then we need to manually re-map
-    // C++'s "alternative tokens" to the correct token kinds.
-    clang::tok::TokenKind ActualKind = Token.getKind();
-    if (Token.is(clang::tok::raw_identifier)) {
-      llvm::StringRef TokenSpelling(Token.getRawIdentifier());
-      const clang::IdentifierInfo& II =
-          Observer.getPreprocessor()->getIdentifierTable().get(TokenSpelling);
-      ActualKind = II.getTokenID();
-    }
-    if (ActualKind == ExpectedKind) {
-      const SourceLocation Begin = Token.getLocation();
-      return SourceRange(
-          Begin, GetLocForEndOfToken(*Observer.getSourceManager(),
-                                     *Observer.getLangOptions(), Begin));
-    }
-  }
-  return SourceRange();  // invalid location signals error/mismatch.
-}
-
 clang::SourceRange IndexerASTVisitor::RangeForNameOfDeclaration(
     const clang::NamedDecl* Decl) const {
-  const SourceLocation StartLocation = Decl->getLocation();
-  if (StartLocation.isInvalid()) {
-    return SourceRange();
-  }
-  if (StartLocation.isFileID()) {
-    if (isa<clang::CXXDestructorDecl>(Decl)) {
-      // If the first token is "~" (or its alternate spelling, "compl") and
-      // the second is the name of class (rather than the name of a macro),
-      // then span two tokens.  Otherwise span just one.
-      const SourceLocation NextLocation =
-          ConsumeToken(StartLocation, clang::tok::tilde).getEnd();
-
-      if (NextLocation.isValid()) {
-        // There was a tilde (or its alternate token, "compl", which is
-        // technically valid for a destructor even if it's awful style).
-        // The "name" of the destructor is "~Type" even if the source
-        // code says "compl Type".
-        clang::Token SecondToken;
-        if (getRawToken(NextLocation, SecondToken) == LexerResult::Success &&
-            SecondToken.is(clang::tok::raw_identifier) &&
-            ("~" + std::string(SecondToken.getRawIdentifier())) ==
-                Decl->getNameAsString()) {
-          const SourceLocation EndLocation = GetLocForEndOfToken(
-              *Observer.getSourceManager(), *Observer.getLangOptions(),
-              SecondToken.getLocation());
-          return clang::SourceRange(StartLocation, EndLocation);
-        }
-      }
-    } else if (auto* M = dyn_cast<clang::ObjCMethodDecl>(Decl)) {
-      // Only take the first selector (if we have one). This simplifies what
-      // consumers of this data have to do but it is not correct.
-
-      if (M->getNumSelectorLocs() == 0) {
-        // Take the whole declaration. For decls this goes up to but does not
-        // include the ";". For definitions this goes up to but does not include
-        // the "{". This range will include other fields, such as the return
-        // type, parameter types, and parameter names.
-
-        auto S = M->getSelectorStartLoc();
-        auto E = M->getDeclaratorEndLoc();
-        return SourceRange(S, E);
-      }
-      // TODO(salguarnieri) Return multiple ranges, one for each portion of the
-      // selector.
-      const SourceLocation& Loc = M->getSelectorLoc(0);
-      if (Loc.isValid() && Loc.isFileID()) {
-        return RangeForSingleToken(Loc);
-      }
-
-      // If the selector location is not valid or is not a file, return the
-      // whole range of the selector and hope for the best.
-      LogErrorWithASTDump("Could not get source range", M);
-      return M->getSourceRange();
-    }
-  }
-  return RangeForASTEntity(StartLocation);
+  return ClangRangeFinder(Observer.getSourceManager(),
+                          Observer.getLangOptions())
+      .RangeForNameOf(Decl);
 }
 
 clang::SourceRange IndexerASTVisitor::RangeForASTEntity(
@@ -2192,22 +2113,7 @@ bool IndexerASTVisitor::VisitNamespaceDecl(const clang::NamespaceDecl* Decl) {
   auto Marks = MarkedSources.Generate(Decl);
   GraphObserver::NodeId DeclNode(BuildNodeIdForDecl(Decl));
   // Use the range covering `namespace` for anonymous namespaces.
-  SourceRange NameRange;
-  if (Decl->isAnonymousNamespace()) {
-    SourceLocation Loc = Decl->getBeginLoc();
-    if (Decl->isInline() && Loc.isValid() && Loc.isFileID()) {
-      // Skip the `inline` keyword.
-      Loc = RangeForSingleToken(Loc).getEnd();
-      if (Loc.isValid() && Loc.isFileID()) {
-        SkipWhitespace(*Observer.getSourceManager(), &Loc);
-      }
-    }
-    if (Loc.isValid() && Loc.isFileID()) {
-      NameRange = RangeForASTEntity(Loc);
-    }
-  } else {
-    NameRange = RangeForNameOfDeclaration(Decl);
-  }
+  SourceRange NameRange = RangeForNameOfDeclaration(Decl);
   // Namespaces are never defined; they are only invoked.
   if (auto RCC =
           RangeInCurrentContext(Decl->isImplicit(), DeclNode, NameRange)) {
@@ -3670,13 +3576,17 @@ GraphObserver::NodeId IndexerASTVisitor::BuildNodeIdForDecl(
       // for enums and records because of the code above.
       Ostream << "#D";
     }
+  } else if (const auto* OD = dyn_cast<clang::ObjCInterfaceDecl>(Decl)) {
+    if (OD->isThisDeclarationADefinition()) {
+      // TODO(zarko): Investigate why Clang colocates incomplete and
+      // definition instances of VarDecls. This may have been masked
+      // for enums and records because of the code above.
+      Ostream << "#D";
+    }
   }
   clang::SourceRange DeclRange;
   if (const auto* named_decl = dyn_cast<NamedDecl>(Decl)) {
-    // RangeForNameOfDeclaration doesn't work well with some ObjCInterfaceDecls.
-    if (!isa<ObjCInterfaceDecl>(Decl)) {
-      DeclRange = RangeForNameOfDeclaration(named_decl);
-    }
+    DeclRange = RangeForNameOfDeclaration(named_decl);
   }
   if (!DeclRange.isValid()) {
     DeclRange = clang::SourceRange(Decl->getBeginLoc(), Decl->getEndLoc());
@@ -4675,20 +4585,19 @@ bool IndexerASTVisitor::VisitObjCCompatibleAliasDecl(
   // not give them to us. We expect something of the form:
   // @compatibility_alias AliasName OriginalClassName
   // Note that this does not work in the presence of macros with parameters.
-  SourceRange AtSign = RangeForNameOfDeclaration(Decl);
-  const auto KeywordRange(
-      ConsumeToken(AtSign.getEnd(), clang::tok::identifier));
-  const auto AliasRange(
-      ConsumeToken(KeywordRange.getEnd(), clang::tok::identifier));
-  const auto OrgClassRange(
-      ConsumeToken(AliasRange.getEnd(), clang::tok::identifier));
+  const auto AliasRange = RangeForNameOfDeclaration(Decl);
 
   // Record a ref to the original type
-  if (const auto& ERCC = ExplicitRangeInCurrentContext(OrgClassRange)) {
-    const auto& ID = BuildNodeIdForDecl(Decl->getClassInterface());
-    Observer.recordDeclUseLocation(ERCC.value(), ID,
-                                   GraphObserver::Claimability::Claimable,
-                                   IsImplicit(ERCC.value()));
+  if (const auto OrigClass = clang::Lexer::findNextToken(
+          AliasRange.getEnd(), *Observer.getSourceManager(),
+          *Observer.getLangOptions())) {
+    if (const auto& ERCC = ExplicitRangeInCurrentContext(clang::SourceRange(
+            OrigClass->getLocation(), OrigClass->getEndLoc()))) {
+      const auto& ID = BuildNodeIdForDecl(Decl->getClassInterface());
+      Observer.recordDeclUseLocation(ERCC.value(), ID,
+                                     GraphObserver::Claimability::Claimable,
+                                     IsImplicit(ERCC.value()));
+    }
   }
 
   // Record the type alias

--- a/kythe/cxx/indexer/cxx/IndexerASTHooks.h
+++ b/kythe/cxx/indexer/cxx/IndexerASTHooks.h
@@ -606,20 +606,6 @@ class IndexerASTVisitor : public RecursiveTypeVisitor<IndexerASTVisitor> {
   /// \brief Returns the ASTContext.
   const clang::ASTContext& getASTContext() { return Context; }
 
-  /// If `SR` is empty (getBegin() == getEnd()) and a valid file id, expands the
-  /// range. Otherwise, returns the input unmodified.
-  clang::SourceRange ExpandRangeIfEmptyFileID(const clang::SourceRange& SR);
-
-  // If `SR` is a valid macro id, attempt to map it to a file range,
-  // otherwise returns the input unmodified.
-  clang::SourceRange MapRangeToFileIfMacroID(const clang::SourceRange& SR);
-
-  /// Returns `SR` as a `Range` in this `RecursiveASTVisitor`'s current
-  /// RangeContext after expanding empty ranges and mapping macros to a file
-  /// location.
-  absl::optional<GraphObserver::Range> ExpandedFileRangeInCurrentContext(
-      const clang::SourceRange& SR);
-
   /// Returns `SR` as a `Range` in this `RecursiveASTVisitor`'s current
   /// RangeContext.
   absl::optional<GraphObserver::Range> ExplicitRangeInCurrentContext(
@@ -631,6 +617,8 @@ class IndexerASTVisitor : public RecursiveTypeVisitor<IndexerASTVisitor> {
   /// via RangeForASTEntityFromSourceLocation.
   absl::optional<GraphObserver::Range> ExpandedRangeInCurrentContext(
       clang::SourceRange SR);
+  /// Returns `SR` as a character-based file range.
+  clang::SourceRange NormalizeRange(clang::SourceRange SR) const;
 
   /// If `Implicit` is true, returns `Id` as an implicit Range; otherwise,
   /// returns `SR` as a `Range` in this `RecursiveASTVisitor`'s current

--- a/kythe/cxx/indexer/cxx/IndexerASTHooks.h
+++ b/kythe/cxx/indexer/cxx/IndexerASTHooks.h
@@ -553,16 +553,6 @@ class IndexerASTVisitor : public RecursiveTypeVisitor<IndexerASTVisitor> {
   clang::SourceRange RangeForSingleToken(
       clang::SourceLocation start_location) const;
 
-  /// Consume a token of the `ExpectedKind` from the `StartLocation`,
-  /// returning the range for that token on success and an invalid
-  /// range otherwise.
-  ///
-  /// The begin location for the returned range may be different than
-  /// StartLocation. For example, this can happen if StartLocation points to
-  /// whitespace before the start of the token.
-  clang::SourceRange ConsumeToken(clang::SourceLocation StartLocation,
-                                  clang::tok::TokenKind ExpectedKind) const;
-
   bool TraverseClassTemplateDecl(clang::ClassTemplateDecl* TD);
   bool TraverseClassTemplateSpecializationDecl(
       clang::ClassTemplateSpecializationDecl* TD);

--- a/kythe/cxx/indexer/cxx/clang_range_finder.cc
+++ b/kythe/cxx/indexer/cxx/clang_range_finder.cc
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2020 The Kythe Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "kythe/cxx/indexer/cxx/clang_range_finder.h"
+
+#include <string>
+
+#include "clang/AST/Decl.h"
+#include "clang/AST/DeclCXX.h"
+#include "clang/AST/DeclObjC.h"
+#include "clang/AST/NestedNameSpecifier.h"
+#include "clang/Basic/SourceLocation.h"
+#include "clang/Lex/Lexer.h"
+#include "glog/logging.h"
+#include "kythe/cxx/indexer/cxx/clang_utils.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace kythe {
+namespace {
+using ::clang::dyn_cast;
+using ::clang::SourceLocation;
+using ::clang::SourceRange;
+
+std::string DumpString(const clang::Decl& decl) {
+  std::string result;
+  llvm::raw_string_ostream out(result);
+  decl.dump(out);
+  return out.str();
+}
+}  // namespace
+
+SourceRange ClangRangeFinder::RangeForEntityAt(SourceLocation start) const {
+  // TODO(shahms): Move the implementations of these here.
+  return RangeForASTEntityFromSourceLocation(source_manager(), lang_options(),
+                                             start);
+}
+
+SourceRange ClangRangeFinder::RangeForTokenAt(SourceLocation start) const {
+  return ExpansionRange(SourceRange(start, start));
+}
+
+SourceRange ClangRangeFinder::RangeForNameOf(
+    const clang::NamedDecl* decl) const {
+  if (decl == nullptr) {
+    return SourceRange();
+  }
+  if (auto dtor = dyn_cast<clang::CXXDestructorDecl>(decl)) {
+    return RangeForNameOfDtor(*dtor);
+  } else if (auto alias = dyn_cast<clang::ObjCCompatibleAliasDecl>(decl)) {
+    return RangeForNameOfAlias(*alias);
+  } else if (auto method = dyn_cast<clang::ObjCMethodDecl>(decl)) {
+    return RangeForNameOfMethod(*method);
+  } else if (auto ns = dyn_cast<clang::NamespaceDecl>(decl)) {
+    return RangeForNamespace(*ns);
+  }
+  return RangeForEntityAt(decl->getLocation());
+}
+
+SourceRange ClangRangeFinder::RangeForNameOfDtor(
+    const clang::CXXDestructorDecl& decl) const {
+  if (SourceLocation loc = decl.getLocation();
+      loc.isValid() && loc.isFileID()) {
+    // TODO(shahms): The prior implementation checked this token against
+    // the name of the class and only used it if they matched.
+    // Do we want to replicate that or not?
+    if (auto next = clang::Lexer::findNextToken(loc, source_manager(),
+                                                lang_options())) {
+      return SourceRange(loc, next->getEndLoc());
+    }
+  }
+  return RangeForEntityAt(decl.getLocation());
+}
+
+SourceRange ClangRangeFinder::RangeForNameOfAlias(
+    const clang::ObjCCompatibleAliasDecl& decl) const {
+  // Ugliness to get the ranges for the tokens in this decl since clang does
+  // not give them to us. We expect something of the form:
+  // @compatibility_alias AliasName OriginalClassName
+  // But all of the locations stored in the decl point to @ alone.
+  if (auto loc = decl.getLocation(); loc.isValid() && loc.isFileID()) {
+    // Use an offset because the immediately following token is
+    // "compatibility_alias" and we want the name.
+    if (auto next = clang::Lexer::findNextToken(
+            loc.getLocWithOffset(1), source_manager(), lang_options())) {
+      return SourceRange(next->getLocation(), next->getEndLoc());
+    }
+  }
+  return RangeForEntityAt(decl.getLocation());
+}
+
+SourceRange ClangRangeFinder::RangeForNameOfMethod(
+    const clang::ObjCMethodDecl& decl) const {
+  // TODO(salguarnieri): Return multiple ranges, one for each portion of the
+  // selector.
+  if (decl.getNumSelectorLocs() > 0) {
+    if (auto loc = decl.getSelectorLoc(0); loc.isValid() && loc.isFileID()) {
+      // Only take the first selector (if we have one). This simplifies what
+      // consumers of this data have to do but it is not correct.
+      return RangeForTokenAt(loc);
+    }
+  } else {
+    // Take the whole declaration. For decls this goes up to but does not
+    // include the ";". For definitions this goes up to but does not include
+    // the "{". This range will include other fields, such as the return
+    // type, parameter types, and parameter names.
+    return SourceRange(decl.getSelectorStartLoc(), decl.getDeclaratorEndLoc());
+  }
+
+  // If the selector location is not valid or is not a file, return the
+  // whole range of the selector and hope for the best.
+  LOG(ERROR) << "Unable to determine source range for: " << DumpString(decl);
+  return decl.getSourceRange();
+}
+
+SourceRange ClangRangeFinder::RangeForNamespace(
+    const clang::NamespaceDecl& decl) const {
+  if (decl.isAnonymousNamespace()) {
+    if (decl.isInline()) {
+      if (auto next = clang::Lexer::findNextToken(
+              decl.getBeginLoc(), source_manager(), lang_options())) {
+        return SourceRange(next->getLocation(), next->getEndLoc());
+      }
+    }
+    return RangeForTokenAt(decl.getBeginLoc());
+  }
+  return RangeForEntityAt(decl.getLocation());
+}
+
+SourceRange ClangRangeFinder::ExpansionRange(SourceRange range) const {
+  return clang::Lexer::getAsCharRange(source_manager().getExpansionRange(range),
+                                      source_manager(), lang_options())
+      .getAsRange();
+}
+}  // namespace kythe

--- a/kythe/cxx/indexer/cxx/clang_range_finder.h
+++ b/kythe/cxx/indexer/cxx/clang_range_finder.h
@@ -37,8 +37,19 @@ class ClangRangeFinder {
       : source_manager_(CHECK_NOTNULL(source_manager)),
         lang_options_(CHECK_NOTNULL(lang_options)) {}
 
+  /// \brief Returns a suitable range for the entity beginning at `start`.
+  clang::SourceRange RangeForEntityAt(clang::SourceLocation start) const;
+  /// \brief Returns a range for the single token beginning at `start`.
+  clang::SourceRange RangeForTokenAt(clang::SourceLocation start) const;
   /// \brief Returns a range encompassing the name of the decl.
   clang::SourceRange RangeForNameOf(const clang::NamedDecl* decl) const;
+
+  /// \brief Retruns a range of characters between start and end in the ultimate
+  /// file.
+  clang::SourceRange NormalizeRange(clang::SourceRange range) const;
+  clang::SourceRange NormalizeRange(clang::SourceLocation start) const;
+  clang::SourceRange NormalizeRange(clang::SourceLocation start,
+                                    clang::SourceLocation end) const;
 
   const clang::SourceManager& source_manager() const {
     return *source_manager_;
@@ -46,11 +57,6 @@ class ClangRangeFinder {
   const clang::LangOptions& lang_options() const { return *lang_options_; }
 
  private:
-  /// \brief Returns a suitable range for the entity beginning at `start`.
-  clang::SourceRange RangeForEntityAt(clang::SourceLocation start) const;
-  /// \brief Returns a range for the single token beginning at `start`.
-  clang::SourceRange RangeForTokenAt(clang::SourceLocation start) const;
-
   clang::SourceRange RangeForNameOfDtor(
       const clang::CXXDestructorDecl& decl) const;
   clang::SourceRange RangeForNameOfAlias(
@@ -61,9 +67,8 @@ class ClangRangeFinder {
   // TODO(shahms): If possible, treat all "anonymous" declarations alike.
   clang::SourceRange RangeForNamespace(const clang::NamespaceDecl& decl) const;
 
-  /// \brief For a possibly token oriented range, returns a char range in the
-  /// ultimate file.
-  clang::SourceRange ExpansionRange(clang::SourceRange range) const;
+  /// \brief Converts a CharSourceRange to a character-oriented SourceRange.
+  clang::SourceRange ToCharRange(clang::CharSourceRange range) const;
 
   const clang::SourceManager* source_manager_;
   const clang::LangOptions* lang_options_;

--- a/kythe/cxx/indexer/cxx/clang_range_finder.h
+++ b/kythe/cxx/indexer/cxx/clang_range_finder.h
@@ -19,6 +19,7 @@
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclCXX.h"
 #include "clang/AST/DeclObjC.h"
+#include "clang/AST/DeclarationName.h"
 #include "clang/Basic/LangOptions.h"
 #include "clang/Basic/SourceLocation.h"
 #include "clang/Basic/SourceManager.h"
@@ -57,8 +58,8 @@ class ClangRangeFinder {
   const clang::LangOptions& lang_options() const { return *lang_options_; }
 
  private:
-  clang::SourceRange RangeForNameOfDtor(
-      const clang::CXXDestructorDecl& decl) const;
+  clang::SourceRange RangeForNameInfo(
+      const clang::DeclarationNameInfo& info) const;
   clang::SourceRange RangeForNameOfAlias(
       const clang::ObjCCompatibleAliasDecl& decl) const;
   clang::SourceRange RangeForNameOfMethod(

--- a/kythe/cxx/indexer/cxx/clang_range_finder.h
+++ b/kythe/cxx/indexer/cxx/clang_range_finder.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020 The Kythe Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef KYTHE_CXX_INDEXER_CXX_CLANG_RANGE_FINDER_H_
+#define KYTHE_CXX_INDEXER_CXX_CLANG_RANGE_FINDER_H_
+
+#include "clang/AST/Decl.h"
+#include "clang/AST/DeclCXX.h"
+#include "clang/AST/DeclObjC.h"
+#include "clang/Basic/LangOptions.h"
+#include "clang/Basic/SourceLocation.h"
+#include "clang/Basic/SourceManager.h"
+#include "glog/logging.h"
+
+namespace kythe {
+
+/// \brief Class responsible for finding suitable ranges for entities.
+///
+/// All valid ranges correspond to a concrete character-based location in a file
+/// which is most suitable location to attribute to that entity.
+class ClangRangeFinder {
+ public:
+  explicit ClangRangeFinder(const clang::SourceManager* source_manager,
+                            const clang::LangOptions* lang_options)
+      : source_manager_(CHECK_NOTNULL(source_manager)),
+        lang_options_(CHECK_NOTNULL(lang_options)) {}
+
+  /// \brief Returns a range encompassing the name of the decl.
+  clang::SourceRange RangeForNameOf(const clang::NamedDecl* decl) const;
+
+  const clang::SourceManager& source_manager() const {
+    return *source_manager_;
+  }
+  const clang::LangOptions& lang_options() const { return *lang_options_; }
+
+ private:
+  /// \brief Returns a suitable range for the entity beginning at `start`.
+  clang::SourceRange RangeForEntityAt(clang::SourceLocation start) const;
+  /// \brief Returns a range for the single token beginning at `start`.
+  clang::SourceRange RangeForTokenAt(clang::SourceLocation start) const;
+
+  clang::SourceRange RangeForNameOfDtor(
+      const clang::CXXDestructorDecl& decl) const;
+  clang::SourceRange RangeForNameOfAlias(
+      const clang::ObjCCompatibleAliasDecl& decl) const;
+  clang::SourceRange RangeForNameOfMethod(
+      const clang::ObjCMethodDecl& decl) const;
+
+  // TODO(shahms): If possible, treat all "anonymous" declarations alike.
+  clang::SourceRange RangeForNamespace(const clang::NamespaceDecl& decl) const;
+
+  /// \brief For a possibly token oriented range, returns a char range in the
+  /// ultimate file.
+  clang::SourceRange ExpansionRange(clang::SourceRange range) const;
+
+  const clang::SourceManager* source_manager_;
+  const clang::LangOptions* lang_options_;
+};
+
+}  // namespace kythe
+
+#endif  // KYTHE_CXX_INDEXER_CXX_CLANG_RANGE_FINDER_H_

--- a/kythe/cxx/indexer/cxx/clang_range_finder_test.cc
+++ b/kythe/cxx/indexer/cxx/clang_range_finder_test.cc
@@ -159,7 +159,7 @@ TEST_F(ClangRangeFinderTest, CXXNamedDecl) {
 TEST_F(ClangRangeFinderTest, CXXMacroDecls) {
   std::vector<NamedDeclTestCase> decls = {
       {"#define CLASS(X) class X\nCLASS(%s) ;"},
-      {"#define FUN(T) T ()\nstruct Type { FUN(%sType); };", "~",
+      {"#define FUN(T) T ()\nstruct Type { FUN(%s); };", "~Type",
        &FindLastDeclOf<clang::CXXDestructorDecl>},
       {"#define  T Type\nstruct Type { %s (); };", "~ T",
        &FindLastDeclOf<clang::CXXDestructorDecl>},

--- a/kythe/cxx/indexer/cxx/clang_range_finder_test.cc
+++ b/kythe/cxx/indexer/cxx/clang_range_finder_test.cc
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2020 The Kythe Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "kythe/cxx/indexer/cxx/clang_range_finder.h"
+
+#include <functional>
+#include <memory>
+
+#include "absl/strings/str_format.h"
+#include "absl/strings/string_view.h"
+#include "clang/AST/Decl.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Frontend/ASTUnit.h"
+#include "clang/Lex/Lexer.h"
+#include "clang/Tooling/Tooling.h"
+#include "glog/logging.h"
+#include "gtest/gtest.h"
+
+namespace kythe {
+namespace {
+using ::clang::ASTUnit;
+using ::clang::tooling::buildASTFromCode;
+
+class ClangRangeFinderTest : public ::testing::Test {
+ public:
+  clang::ASTUnit& Parse(llvm::StringRef code,
+                        llvm::StringRef filename = "input.cc") {
+    ast_ = buildASTFromCode(code, filename);
+    return *CHECK_NOTNULL(ast_);
+  }
+
+  absl::string_view GetSourceText(clang::SourceRange range) {
+    CHECK(range.isValid());
+    bool invalid = false;
+    auto text =
+        clang::Lexer::getSourceText(clang::CharSourceRange::getCharRange(range),
+                                    source_manager(), lang_options(), &invalid);
+    CHECK(!invalid);
+    return absl::string_view(text.data(), text.size());
+  }
+
+  const clang::Decl* top_level_back() { return *(ast_->top_level_end() - 1); }
+
+  clang::SourceManager& source_manager() { return ast_->getSourceManager(); }
+  const clang::LangOptions& lang_options() const { return ast_->getLangOpts(); }
+
+ private:
+  std::unique_ptr<clang::ASTUnit> ast_;
+};
+
+const clang::NamedDecl* FindLastDecl(clang::ASTUnit& ast) {
+  CHECK(!ast.top_level_empty());
+  return clang::dyn_cast<clang::NamedDecl>(*(ast.top_level_end() - 1));
+}
+
+template <typename T>
+T* FindLastDeclOf(clang::ASTUnit& ast) {
+  struct DeclFinder : clang::RecursiveASTVisitor<DeclFinder> {
+    bool TraverseDecl(clang::Decl* decl) {
+      if (decl == nullptr) {
+        return true;
+      }
+      if (auto found = clang::dyn_cast<T>(decl)) {
+        result = found;
+      }
+      return this->RecursiveASTVisitor::TraverseDecl(decl);
+    }
+
+    T* result = nullptr;
+  } visitor;
+  for (auto iter = ast.top_level_begin(); iter != ast.top_level_end(); iter++) {
+    visitor.TraverseDecl(*iter);
+  }
+  return visitor.result;
+}
+
+class NamedDeclTestCase {
+ public:
+  using DeclFinder = std::function<const clang::NamedDecl*(clang::ASTUnit&)>;
+  NamedDeclTestCase(absl::string_view format, absl::string_view name = "entity",
+                    DeclFinder find_decl = &FindLastDecl)
+      : format_(CHECK_NOTNULL(absl::ParsedFormat<'s'>::New(format))),
+        name_(name),
+        find_decl_(std::move(find_decl)) {}
+  NamedDeclTestCase(absl::string_view format, DeclFinder find_decl)
+      : NamedDeclTestCase(format, "entity", std::move(find_decl)) {}
+
+  std::string SourceText() const { return absl::StrFormat(*format_, name_); }
+
+  const clang::NamedDecl* FindDecl(clang::ASTUnit& ast) const {
+    return find_decl_(ast);
+  }
+
+  absl::string_view name() const { return name_; }
+
+ private:
+  std::shared_ptr<absl::ParsedFormat<'s'>> format_;
+  std::string name_;
+  DeclFinder find_decl_;
+};
+
+TEST_F(ClangRangeFinderTest, CXXNamedDecl) {
+  // These should all use the same name for the entity and that entity should be
+  // more than a single character and include a variety of spaces after the
+  // name, but before the next token.
+  std::vector<NamedDeclTestCase> decls = {
+      {"class %s ;"},
+      {"struct %s ;"},
+      {"union %s ;"},                 // class objects with different keys.
+      {"enum %s {};"},                // enumerations.
+      {"typedef void ( *%s )();"},    // legacy typedefs.
+      {"using %s = int;"},            // using typedef.
+      {"namespace %s {}"},            // namespace declarations.
+      {"inline namespace %s {}"},     // namespace declarations.
+      {"%s {}", "namespace"},         // anonymous namespace.
+      {"inline %s {}", "namespace"},  // anonymous inline namespace.
+      {"%s {};", "struct"},           // anonymous struct.
+      {"int %s ;"},                   // simple var decls.
+      {"void %s ();"},                // trivial function decl.
+      {"namespace ns {} namespace %s = ::ns;"},  // namespace alias.
+      {"template <typename> struct %s {};"},     // template class.
+      {"template <typename> void %s () {}"},     // function template.
+      {"enum { %s };",
+       &FindLastDeclOf<clang::EnumConstantDecl>},         // enum constants.
+      {"struct T; void %s (T&, T&);", "operator    <<"},  // operator overloads.
+      {"struct T { %s(); };", "~T",  // standard destructor.
+       &FindLastDeclOf<clang::CXXDestructorDecl>},
+      {"struct Type { %s(); };", "~Type",  // standard destructor.
+       &FindLastDeclOf<clang::CXXDestructorDecl>},
+      {"struct Type { %s   (); };", "~ Type",  // standard destructor.
+       &FindLastDeclOf<clang::CXXDestructorDecl>},
+      {"struct Type { %s   (); };", "compl   Type",  // awkward destructor.
+       &FindLastDeclOf<clang::CXXDestructorDecl>},
+  };
+  for (const auto& test : decls) {
+    ASTUnit& ast = Parse(test.SourceText());
+    ClangRangeFinder finder(&source_manager(), &lang_options());
+
+    EXPECT_EQ(GetSourceText(finder.RangeForNameOf(test.FindDecl(ast))),
+              test.name());
+  }
+}
+
+TEST_F(ClangRangeFinderTest, ObjCNamedDecl) {
+  std::vector<NamedDeclTestCase> decls = {
+      {"@interface Original\n@end\n@compatibility_alias %s Original;", "Alias",
+       &FindLastDecl},
+      {"@interface Selector\n  -(int)%s;\n@end\n", "count",
+       &FindLastDeclOf<clang::ObjCMethodDecl>},
+      {"@interface Selector\n  -(int)%s:(int)a other:(int)b;\n@end\n", "name",
+       &FindLastDeclOf<clang::ObjCMethodDecl>},
+  };
+  for (const auto& test : decls) {
+    // Trigger ObjectiveC mode.
+    ASTUnit& ast = Parse(test.SourceText(), "input.m");
+    ClangRangeFinder finder(&source_manager(), &lang_options());
+
+    EXPECT_EQ(GetSourceText(finder.RangeForNameOf(test.FindDecl(ast))),
+              test.name());
+  }
+}
+}  // namespace
+}  // namespace kythe

--- a/kythe/cxx/indexer/cxx/clang_utils_test.cc
+++ b/kythe/cxx/indexer/cxx/clang_utils_test.cc
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2020 The Kythe Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "kythe/cxx/indexer/cxx/clang_utils.h"
+
+#include <memory>
+
+#include "absl/strings/string_view.h"
+#include "clang/AST/Decl.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Frontend/ASTUnit.h"
+#include "clang/Tooling/Tooling.h"
+#include "glog/logging.h"
+#include "gtest/gtest.h"
+
+namespace kythe {
+namespace {
+using ::clang::ASTUnit;
+using ::clang::tooling::buildASTFromCode;
+
+class ClangUtilsTest : public ::testing::Test {
+ public:
+  clang::ASTUnit& Parse(llvm::StringRef code) {
+    ast_ = buildASTFromCode(code);
+    return *CHECK_NOTNULL(ast_);
+  }
+
+  absl::string_view GetCharacterData(clang::SourceRange range) {
+    CHECK(range.isValid());
+    return absl::string_view(
+        source_manager().getCharacterData(range.getBegin()),
+        source_manager().getFileOffset(range.getEnd()) -
+            source_manager().getFileOffset(range.getBegin()));
+  }
+
+  const clang::Decl* top_level_back() { return *(ast_->top_level_end() - 1); }
+
+  clang::SourceManager& source_manager() { return ast_->getSourceManager(); }
+  const clang::LangOptions& lang_options() const { return ast_->getLangOpts(); }
+
+ private:
+  std::unique_ptr<clang::ASTUnit> ast_;
+};
+
+template <typename T>
+T* FindLastDecl(clang::ASTUnit& ast) {
+  struct DeclFinder : clang::RecursiveASTVisitor<DeclFinder> {
+    bool TraverseDecl(clang::Decl* decl) {
+      if (decl == nullptr) {
+        return true;
+      }
+      decl->dump();
+      if (auto found = clang::dyn_cast<T>(decl)) {
+        result = found;
+      }
+      return this->RecursiveASTVisitor::TraverseDecl(decl);
+    }
+
+    T* result = nullptr;
+  } visitor;
+  for (auto iter = ast.top_level_begin(); iter != ast.top_level_end(); iter++) {
+    visitor.TraverseDecl(*iter);
+  }
+  return visitor.result;
+}
+
+using SkipWhitespaceTest = ClangUtilsTest;
+TEST_F(SkipWhitespaceTest, AdvancesLocationUntilNonWhitespace) {
+  ASTUnit& ast = Parse("    \t\n \nclass X;");
+  clang::SourceLocation loc = ast.getStartOfMainFileID();
+  SkipWhitespace(source_manager(), &loc);
+  ASSERT_TRUE(loc.isValid());
+  EXPECT_EQ(source_manager().getCharacterData(loc),
+            absl::string_view("class X;"));
+}
+
+using RangeForASTEntityFromSourceLocationTest = ClangUtilsTest;
+TEST_F(RangeForASTEntityFromSourceLocationTest, SimpleNamedDecl) {
+  // These should all use the same name for the entity and that entity should be
+  // more than a single character. The test is done of the last top-level
+  // declaration found in the text, should any setup be needed.
+  std::vector<std::string> decls = {
+      "class entity ;",
+      "struct entity ;",
+      "union entity;",              // class objects with different keys.
+      "enum entity {};",            // enumerations.
+      "typedef void (*entity)();",  // legacy typedefs.
+      "using entity = int;",        // using typedef.
+      "namespace entity{}",         // namespace declarations.
+      "int entity;",                // simple var decls.
+      "void entity();",             // trivial function decl.
+      "namespace ns {} namespace entity = ::ns;",  // namespace alias.
+      "template <typename> struct entity {};",     // template class.
+      "template <typename> void entity() {}",      // function template.
+  };
+  for (const auto& decl : decls) {
+    ASTUnit& ast = Parse(decl);
+    ASSERT_GE(ast.top_level_size(), 1);
+    clang::SourceRange range = RangeForASTEntityFromSourceLocation(
+        source_manager(), lang_options(), top_level_back()->getLocation());
+    EXPECT_EQ(GetCharacterData(range), "entity");
+  }
+}
+
+TEST_F(RangeForASTEntityFromSourceLocationTest, EnumConstantName) {
+  ASTUnit& ast = Parse(R"(enum { entity };)");
+  auto entity = FindLastDecl<clang::EnumConstantDecl>(ast);
+  ASSERT_NE(entity, nullptr);
+  ASSERT_TRUE(entity->getLocation().isValid());
+  clang::SourceRange range = RangeForASTEntityFromSourceLocation(
+      source_manager(), lang_options(), entity->getLocation());
+  EXPECT_EQ(GetCharacterData(range), "entity");
+}
+
+TEST_F(RangeForASTEntityFromSourceLocationTest, OperatorName) {
+  Parse(R"(struct T; void operator     <<(T&, T&);)");
+  clang::SourceRange range = RangeForASTEntityFromSourceLocation(
+      source_manager(), lang_options(), top_level_back()->getLocation());
+  EXPECT_EQ(GetCharacterData(range), "operator     <<");
+}
+
+}  // namespace
+}  // namespace kythe

--- a/kythe/cxx/indexer/cxx/testdata/BUILD
+++ b/kythe/cxx/indexer/cxx/testdata/BUILD
@@ -1118,7 +1118,6 @@ cc_indexer_test(
     name = "function_operator_overload_names",
     size = "small",
     srcs = ["function/function_operator_overload_names.cc"],
-    ignore_dups = True,
     tags = ["function"],
 )
 

--- a/kythe/cxx/indexer/cxx/testdata/basic/new_operator.cc
+++ b/kythe/cxx/indexer/cxx/testdata/basic/new_operator.cc
@@ -1,4 +1,4 @@
-//- @"operator" defines/binding OpNew
+//- @"operator new" defines/binding OpNew
 void *operator new(__SIZE_TYPE__);
 
 void f() {

--- a/kythe/cxx/indexer/cxx/testdata/function/function_operator_overload_names.cc
+++ b/kythe/cxx/indexer/cxx/testdata/function/function_operator_overload_names.cc
@@ -1,5 +1,4 @@
 // Checks how we link operator overload functions.
-// Needs --ignore_dups=true because of noncanonicalized function types.
 struct S {
 //- @"operator=" defines/binding OpEq
   void operator=(int);
@@ -10,13 +9,13 @@ struct S {
 //- @"operator->" defines/binding OpArrow
   void operator->();
 };
-//- @"operator" defines/binding OpNew
+//- @"operator new" defines/binding OpNew
 void* operator new(unsigned long);
-//- @"operator" defines/binding OpDelete
+//- @"operator delete" defines/binding OpDelete
 void operator delete(void*);
-//- @"operator" defines/binding OpNewArray
+//- @"operator new[]" defines/binding OpNewArray
 void* operator new[](unsigned long);
-//- @"operator" defines/binding OpDeleteArray
+//- @"operator delete[]" defines/binding OpDeleteArray
 void operator delete[](void*);
 //- @"operator+" defines/binding OpPlus
 void operator+(S a, S b);


### PR DESCRIPTION
I'm 95% certain that all of the current uses of `getLocWithOffset()` come down to a confusion between character and token oriented ranges and can be cleaned up.  This PR is somewhat cleanup and somewhat proof-of-concept for writing unittests of specific behavior in the indexer, rather than relying on verifier tests to accomplish everything.  Verifier tests are great at saying when something fails, but can be challenging to use to determine *why* something failed.