### PR TITLE
chore: generate partial compile_commands.json

### DIFF
--- a/tools/cpp/generate_compilation_database.sh
+++ b/tools/cpp/generate_compilation_database.sh
@@ -1,25 +1,27 @@
 #!/bin/bash
 
 # Generates a compile_commands.json file at $(bazel info execution_root) for
-# your Clang tooling needs.
+# the given file path.
 
 set -e
 
+FILENAME=${1:?Missing required source path}
 bazel build \
   --experimental_action_listener=//kythe/cxx/tools/generate_compile_commands:extract_json \
-  --noshow_progress \
-  --noshow_loading_progress \
-  $(bazel query 'kind(cc_.*, //...) - attr(tags, manual, //...)') > /dev/null
+  --output_groups=compilation_outputs \
+  --compile_one_dependency \
+  "$FILENAME" > /dev/null
 
 BAZEL_ROOT="$(bazel info execution_root)"
 pushd "$BAZEL_ROOT" > /dev/null
-echo "[" > compile_commands.json
-COUNT=0
 find . -name '*.compile_command.json' -print0 | while read -r -d '' fname; do
-  if ((COUNT++)); then
-    echo ',' >> compile_commands.json
-  fi
   sed -e "s|@BAZEL_ROOT@|$BAZEL_ROOT|g" < "$fname" >> compile_commands.json
+  echo "" >> compile_commands.json
 done
-echo "]" >> compile_commands.json
+# Decompose, insert and keep the most recent entry for a given file, then
+# recombine.
+sed 's/\(^[[]\)\|\([],]$\)//;/^$/d;' < compile_commands.json \
+  | tac | sort -u -t, -k1,1 \
+  | sed '1s/^./[\0/;s/}$/},/;$s/,$/]/' > compile_commands.json.tmp
+mv compile_commands.json{.tmp,}
 popd > /dev/null

--- a/tools/cpp/generate_compilation_database.sh
+++ b/tools/cpp/generate_compilation_database.sh
@@ -8,6 +8,8 @@ set -e
 FILENAME=${1:?Missing required source path}
 bazel build \
   --experimental_action_listener=//kythe/cxx/tools/generate_compile_commands:extract_json \
+  --noshow_progress \
+  --noshow_loading_progress \
   --output_groups=compilation_outputs \
   --compile_one_dependency \
   "$FILENAME" > /dev/null


### PR DESCRIPTION
Rather than re-generating compile_commands.json all in one go, use `--compile_one_dependency` to insert new entries and reformat.