### PR TITLE
fix: require flex version 2.6 or newer

### DIFF
--- a/kythe/web/site/getting-started.md
+++ b/kythe/web/site/getting-started.md
@@ -33,7 +33,7 @@ Kythe relies on the following external dependencies:
 * bison-3.0.4
 * clang >= 8
 * [docker](https://www.docker.com/) (for release images `//kythe/release/...` and `//buildtools/docker`)
-* flex-2.5
+* flex-2.6
 * go >= 1.7
 * graphviz
 * jdk >= 8

--- a/tools/build_rules/lexyacc/lexyacc.bzl
+++ b/tools/build_rules/lexyacc/lexyacc.bzl
@@ -1,3 +1,5 @@
+load("@bazel_skylib//lib:versions.bzl", "versions")
+
 def genlex(name, src, out, includes = []):
     """Generate a C++ lexer from a lex file using Flex.
 
@@ -83,10 +85,22 @@ def lexyacc_toolchain(name, lex, yacc):
         toolchain_type = "@io_kythe//tools/build_rules/lexyacc:toolchain_type",
     )
 
-def _local_lexyacc(repository_ctx):
+def _check_flex_version(repository_ctx, min_version):
     flex = repository_ctx.which("flex")
     if flex == None:
         fail("Unable to find flex binary")
+    flex_result = repository_ctx.execute([flex, "--version"])
+    if flex_result.return_code:
+        fail("Unable to determine flex version: " + flex_result.stderr)
+    flex_version = flex_result.stdout.split(" ")
+    if len(flex_version) < 2:
+        fail("Too few components in flex version: " + flex_result.stdout)
+    if not versions.is_at_least(min_version, flex_version[1]):
+        fail("Flex too old (%s < %s)" % (flex_version[1], min_version))
+    return flex
+
+def _local_lexyacc(repository_ctx):
+    flex = _check_flex_version(repository_ctx, "2.6")
     bison = repository_ctx.os.environ.get("BISON", repository_ctx.which("bison"))
     if not bison:
         fail("Unable to find bison binary")


### PR DESCRIPTION
Fixes #4455 (by requiring a version of flex that omits the `register` keyword).