### PR TITLE
docs: install flex via Homebrew for macOS

### DIFF
--- a/kythe/web/site/getting-started-macos.md
+++ b/kythe/web/site/getting-started-macos.md
@@ -59,7 +59,7 @@ rest of these instructions assume you have it.
 To install most of the [external dependencies][ext], run
 
 {% highlight bash %}
-for pkg in asciidoc bison brotli go graphviz leveldb node openjdk parallel source-highlight wget ; do
+for pkg in asciidoc bison brotli flex go graphviz leveldb node openjdk parallel source-highlight wget ; do
    brew install $pkg
 done
 
@@ -72,9 +72,11 @@ brew tap bazelbuild/tap
 brew tap-pin bazelbuild/tap
 brew install bazelbuild/tap/bazel
 
-# Bison. The stock version is too old, but Bison is keg-only and Bazel uses
-# a restricted PATH, so we need to tell Bazel where to find bison (see #3514):
+# Bison and Flex. The stock versions are too old, but these tools are keg-only
+# and Bazel uses a restricted PATH, so we need to tell Bazel where to find
+# them (see #3514, #4455).
 export BISON=/usr/local/opt/bison/bin/bison
+export FLEX=/usr/local/opt/flex/bin/flex
 
 # Java (OpenJDK). By default macOS does not have a JDK installed, so we use the
 # openjdk package from Homebrew.  We need to set JAVA_HOME so the command-line

--- a/tools/build_rules/lexyacc/lexyacc.bzl
+++ b/tools/build_rules/lexyacc/lexyacc.bzl
@@ -86,7 +86,7 @@ def lexyacc_toolchain(name, lex, yacc):
     )
 
 def _check_flex_version(repository_ctx, min_version):
-    flex = repository_ctx.which("flex")
+    flex = repository_ctx.os.environ.get("FLEX", repository_ctx.which("flex"))
     if flex == None:
         fail("Unable to find flex binary")
     flex_result = repository_ctx.execute([flex, "--version"])

--- a/tools/build_rules/lexyacc/lexyacc.bzl
+++ b/tools/build_rules/lexyacc/lexyacc.bzl
@@ -125,7 +125,7 @@ def _local_lexyacc(repository_ctx):
 local_lexyacc_repository = repository_rule(
     implementation = _local_lexyacc,
     local = True,
-    environ = ["PATH", "BISON"],
+    environ = ["PATH", "BISON", "FLEX"],
 )
 
 def lexyacc_configure():


### PR DESCRIPTION
This is a follow-up to #4455 and #4456. Because macOS ships with flex 2.5 and
homebrew will not link it to avoid confusing the system build tools, this
change also adds a FLEX environment variable to allow it to be overridden
without diddling the user's PATH.