### PR TITLE
feat: add lib for reading artifacts from bazel event streams

### DIFF
--- a/external.bzl
+++ b/external.bzl
@@ -33,9 +33,9 @@ def _proto_dependencies():
     maybe(
         build_event_stream_repository,
         name = "build_event_stream_proto",
-        revision = "2.1.0",
+        revision = "2.2.0",
         sha256s = {
-            "build_event_stream.proto": "6942888c75ef5e6ab94364604cdd297f207ab119b425681eb7bf523e206d96a7",
+            "build_event_stream.proto": "aa71ad693b7b474517ee3702318603d76baef35a6c13e9f8980f3962d91c2827",
             "command_line.proto": "a6fb6591aa50794431787169bc4fae16105ef5c401e7c30ecf0f775e0ab25c2c",
             "invocation_policy.proto": "5312a440a5d16e9bd72cd8561ad2f5d2b29579f19df7e13af1517c6ad9e7fa64",
             "option_filters.proto": "e3e8dfa9a4e05683bf1853a0be29fae46c753b18ad3d42b92bedcb412577f20f",

--- a/external.bzl
+++ b/external.bzl
@@ -1,6 +1,6 @@
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 load("@rules_java//java:repositories.bzl", "rules_java_dependencies")
 load("@rules_jvm_external//:defs.bzl", "maven_install")
@@ -10,6 +10,7 @@ load("@io_kythe//tools:build_rules/shims.bzl", "go_repository")
 load("@io_kythe//tools/build_rules/llvm:repo.bzl", "git_llvm_repository")
 load("@io_kythe//third_party/leiningen:lein_repo.bzl", "lein_repository")
 load("@io_kythe//tools/build_rules/lexyacc:lexyacc.bzl", "lexyacc_configure")
+load("@io_kythe//tools/build_rules/build_event_stream:repo.bzl", "build_event_stream_repository")
 load("@io_kythe//kythe/cxx/extractor:toolchain.bzl", cxx_extractor_register_toolchains = "register_toolchains")
 load("@rules_python//python:repositories.bzl", "py_repositories")
 load("@bazel_toolchains//repositories:repositories.bzl", bazel_toolchains_repositories = "repositories")
@@ -25,6 +26,21 @@ def _rule_dependencies():
 
 def _gazelle_ignore(**kwargs):
     """Dummy macro which causes gazelle to see a repository as already defined."""
+
+def _proto_dependencies():
+    # Rather than pull down the entire Bazel source repository for a single file,
+    # just grab the file we need and use it locally.
+    maybe(
+        build_event_stream_repository,
+        name = "build_event_stream_proto",
+        revision = "1.1.0",
+        sha256s = {
+            "build_event_stream.proto": "6942888c75ef5e6ab94364604cdd297f207ab119b425681eb7bf523e206d96a7",
+            "command_line.proto": "a6fb6591aa50794431787169bc4fae16105ef5c401e7c30ecf0f775e0ab25c2c",
+            "invocation_policy.proto": "5312a440a5d16e9bd72cd8561ad2f5d2b29579f19df7e13af1517c6ad9e7fa64",
+            "option_filters.proto": "e3e8dfa9a4e05683bf1853a0be29fae46c753b18ad3d42b92bedcb412577f20f",
+        },
+    )
 
 def _cc_dependencies():
     maybe(
@@ -1141,6 +1157,8 @@ def kythe_dependencies(sample_ui = True):
 
     Call this once in your WORKSPACE file to load all @io_kythe dependencies.
     """
+    _proto_dependencies()
+    _py_dependencies()
     _cc_dependencies()
     _go_dependencies()
     _java_dependencies()

--- a/external.bzl
+++ b/external.bzl
@@ -1,6 +1,6 @@
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 load("@rules_java//java:repositories.bzl", "rules_java_dependencies")
 load("@rules_jvm_external//:defs.bzl", "maven_install")
@@ -1158,7 +1158,6 @@ def kythe_dependencies(sample_ui = True):
     Call this once in your WORKSPACE file to load all @io_kythe dependencies.
     """
     _proto_dependencies()
-    _py_dependencies()
     _cc_dependencies()
     _go_dependencies()
     _java_dependencies()

--- a/external.bzl
+++ b/external.bzl
@@ -33,7 +33,7 @@ def _proto_dependencies():
     maybe(
         build_event_stream_repository,
         name = "build_event_stream_proto",
-        revision = "1.1.0",
+        revision = "2.1.0",
         sha256s = {
             "build_event_stream.proto": "6942888c75ef5e6ab94364604cdd297f207ab119b425681eb7bf523e206d96a7",
             "command_line.proto": "a6fb6591aa50794431787169bc4fae16105ef5c401e7c30ecf0f775e0ab25c2c",

--- a/kythe/cxx/extractor/BUILD
+++ b/kythe/cxx/extractor/BUILD
@@ -257,6 +257,71 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "bazel_event_reader",
+    srcs = ["bazel_event_reader.cc"],
+    hdrs = ["bazel_event_reader.h"],
+    deps = [
+        "@build_event_stream_proto//:build_event_stream_cc_proto",
+        "@com_github_google_glog//:glog",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/types:variant",
+        "@com_google_protobuf//:protobuf",
+    ],
+)
+
+cc_test(
+    name = "bazel_event_reader_test",
+    srcs = ["bazel_event_reader_test.cc"],
+    deps = [
+        ":bazel_event_reader",
+        "//third_party:gtest_main",
+        "@build_event_stream_proto//:build_event_stream_cc_proto",
+        "@com_google_absl//absl/strings",
+        "@com_google_protobuf//:protobuf",
+    ],
+)
+
+cc_library(
+    name = "bazel_artifact_reader",
+    srcs = ["bazel_artifact_reader.cc"],
+    hdrs = ["bazel_artifact_reader.h"],
+    deps = [
+        ":bazel_event_reader",
+        "@build_event_stream_proto//:build_event_stream_cc_proto",
+        "@com_github_google_glog//:glog",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/types:variant",
+    ],
+)
+
+cc_test(
+    name = "bazel_artifact_reader_test",
+    srcs = ["bazel_artifact_reader_test.cc"],
+    deps = [
+        ":bazel_artifact_reader",
+        ":bazel_event_reader",
+        "//third_party:gtest_main",
+        "@build_event_stream_proto//:build_event_stream_cc_proto",
+        "@com_google_absl//absl/strings",
+        "@com_google_protobuf//:protobuf",
+    ],
+)
+
+cc_binary(
+    name = "dump_bazel_artifacts",
+    srcs = ["dump_bazel_artifacts.cc"],
+    deps = [
+        ":bazel_artifact_reader",
+        "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/flags:parse",
+        "@com_google_protobuf//:protobuf",
+    ],
+)
+
 sh_binary(
     name = "xcode_wrapper",
     srcs = ["xcode_wrapper.sh"],

--- a/kythe/cxx/extractor/bazel_artifact_reader.cc
+++ b/kythe/cxx/extractor/bazel_artifact_reader.cc
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2020 The Kythe Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "kythe/cxx/extractor/bazel_artifact_reader.h"
+
+#include <string>
+
+#include "absl/strings/escaping.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/string_view.h"
+#include "src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.pb.h"
+
+namespace kythe {
+namespace {
+
+std::string AsUri(const build_event_stream::File& primary_output) {
+  switch (primary_output.file_case()) {
+    case build_event_stream::File::kUri:
+      return primary_output.uri();
+    case build_event_stream::File::kContents:
+      // We expect inline data to be rare and small, so always base64 encode it.
+      return absl::StrCat(
+          "data:base64,",
+          // data URIs use regualr base64, not "web safe" base64.
+          absl::Base64Escape(primary_output.contents()));
+    case build_event_stream::File::FILE_NOT_SET:
+      break;
+  }
+  LOG(FATAL) << "Unexpected build_event_stream::File case!"
+             << primary_output.file_case();
+}
+
+std::vector<std::string> FileSetIds(
+    const google::protobuf::RepeatedPtrField<
+        build_event_stream::BuildEventId::NamedSetOfFilesId>& children) {
+  std::vector<std::string> result;
+  result.reserve(children.size());
+  for (const auto& child : children) {
+    result.push_back(child.id());
+  }
+  return result;
+}
+}  // namespace
+
+void BazelArtifactReader::Next() {
+  if (event_reader_->Done()) return;
+  event_reader_->Next();
+  Select();
+}
+
+void BazelArtifactReader::Select() {
+  for (; !event_reader_->Done(); event_reader_->Next()) {
+    const auto& event = event_reader_->Ref();
+    for (auto& select : selectors_) {
+      if (select(event, &absl::get<value_type>(value_))) {
+        return;
+      }
+    }
+  }
+  // Both we and the underlying reader are done; propagate the status.
+  value_ = event_reader_->status();
+}
+
+/* static */
+std::vector<ArtifactSelector> BazelArtifactReader::DefaultSelectors() {
+  return {ExtraActionSelector{}};
+}
+
+bool ExtraActionSelector::operator()(
+    const build_event_stream::BuildEvent& event, BazelArtifact* result) const {
+  if (event.id().has_action_completed() && event.action().success() &&
+      (action_types.empty() || action_types.contains(event.action().type()))) {
+    result->label = event.id().action_completed().label();
+    result->uris = {AsUri(event.action().primary_output())};
+    return true;
+  }
+  return false;
+}
+
+bool OutputGroupSelector::operator()(
+    const build_event_stream::BuildEvent& event, BazelArtifact* result) {
+  if (event.id().has_named_set()) {
+    filesets_[event.id().named_set().id()] = event.named_set_of_files();
+    return false;
+  }
+  if (!event.id().has_target_completed()) {
+    return false;
+  }
+  std::vector<std::string> uris;
+  for (const auto& group : event.completed().output_group()) {
+    if (group_names_.contains(group.name())) {
+      FindNamedUris(FileSetIds(group.file_sets()), &uris);
+    }
+  }
+  if (!uris.empty()) {
+    result->label = event.id().target_completed().label();
+    result->uris = std::move(uris);
+    return true;
+  }
+  return false;
+}
+
+void OutputGroupSelector::FindNamedUris(std::vector<std::string> ids,
+                                        std::vector<std::string>* result) {
+  while (!ids.empty()) {
+    std::string id = std::move(ids.back());
+    ids.pop_back();
+    if (auto iter = filesets_.find(id); iter != filesets_.end()) {
+      result->reserve(result->size() + iter->second.files().size());
+      for (const auto& file : iter->second.files()) {
+        result->push_back(AsUri(file));
+      }
+
+      ids.reserve(ids.size() + iter->second.file_sets().size());
+      for (const auto& child : iter->second.file_sets()) {
+        ids.push_back(child.id());
+      }
+    }
+    // TODO(shahms): When do we want to remove visited file sets from the map?
+    // The build event stream doesn't generally give us a reliable signal on
+    // when it's safe to do so, but indefinitely tracking all seen filesets
+    // is neither scalable nor resumable.
+    // We can't drop them on first use, because that use might be from a file
+    // group we don't care about prior to one we do and only doing so for
+    // "selected" file groups solves neither problem.
+    // We might be able to restrict it to groups with known suffixes (".kzip"),
+    // and expire the groups on first visitation.
+    // We also want to find a reliable way of determinition when no more outputs
+    // will result from a particular target, but that doesn't seem possible with
+    // extra actions.
+  }
+}
+
+}  // namespace kythe

--- a/kythe/cxx/extractor/bazel_artifact_reader.h
+++ b/kythe/cxx/extractor/bazel_artifact_reader.h
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2020 The Kythe Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef KYTHE_CXX_EXTRACTOR_BAZEL_ARTIFACT_READER_H_
+#define KYTHE_CXX_EXTRACTOR_BAZEL_ARTIFACT_READER_H_
+
+#include <functional>
+#include <string>
+#include <vector>
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
+#include "absl/status/status.h"
+#include "absl/types/variant.h"
+#include "glog/logging.h"
+#include "kythe/cxx/extractor/bazel_event_reader.h"
+#include "src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.pb.h"
+
+namespace kythe {
+
+/// \brief A list of extracted compilation units and the target which owns them.
+struct BazelArtifact {
+  std::string label;  ///< The target from which these artifacts originate.
+  std::vector<std::string>
+      uris;  ///< A list of URIs at which the artifacts can be found. Clients
+             ///< should be able to handle `file:` and `data:` schemes.
+};
+
+/// \brief A callback which will be invoked on each BuildEvent in turn.  If the
+/// selector can supply a BazelArtifact as a result of this event, it should
+/// do so via the second parameter and return true.
+/// A return value of false indicates no match and the artifacts should be
+/// unmodified.
+using ArtifactSelector =
+    std::function<bool(const build_event_stream::BuildEvent&, BazelArtifact*)>;
+
+class BazelArtifactReader {
+ public:
+  using value_type = BazelArtifact;
+  using reference = value_type&;
+  using const_reference = const value_type&;
+
+  static std::vector<ArtifactSelector> DefaultSelectors();
+
+  explicit BazelArtifactReader(
+      BazelEventReader* event_reader,
+      std::vector<ArtifactSelector> selectors = DefaultSelectors())
+      : event_reader_(CHECK_NOTNULL(event_reader)),
+        selectors_(std::move(selectors)) {
+    Select();
+  }
+
+  void Next();
+
+  bool Done() const { return value_.index() != 0; }
+  reference Ref() { return absl::get<value_type>(value_); }
+  const_reference Ref() const { return absl::get<value_type>(value_); }
+  absl::Status status() const { return absl::get<absl::Status>(value_); }
+
+ private:
+  void Select();
+
+  absl::variant<value_type, absl::Status> value_;
+  BazelEventReader* event_reader_;
+  std::vector<ArtifactSelector> selectors_;
+};
+
+/// \brief An ArtifactSelector which selects artifacts emitted by extra
+/// actions.
+///
+/// This will select any successful ActionCompleted build event, but the
+/// selection can be restricted to an allowlist of action_types.
+struct ExtraActionSelector {
+  /// \brief Allowlist against which to match ActionCompleted events.
+  /// An empty set will select any successful action.
+  absl::flat_hash_set<std::string> action_types;
+
+  /// \brief Sets result from the primary output of a successful
+  /// ActionCompleted event.
+  bool operator()(const build_event_stream::BuildEvent& event,
+                  BazelArtifact* result) const;
+};
+
+/// \brief An ArtifactSelector which selects artifacts by output group.
+///
+/// This is a stateful selector as it needs to track the named sets of files
+/// from the output stream.
+class OutputGroupSelector {
+ public:
+  explicit OutputGroupSelector(absl::flat_hash_set<std::string> group_names)
+      : group_names_(std::move(group_names)) {}
+
+  bool operator()(const build_event_stream::BuildEvent& event,
+                  BazelArtifact* result);
+
+ private:
+  void FindNamedUris(std::vector<std::string> ids,
+                     std::vector<std::string>* result);
+
+  absl::flat_hash_set<std::string> group_names_;
+  absl::flat_hash_map<std::string, build_event_stream::NamedSetOfFiles>
+      filesets_;
+};
+
+}  // namespace kythe
+
+#endif  // KYTHE_CXX_EXTRACTOR_BAZEL_ARTIFACT_READER_H_

--- a/kythe/cxx/extractor/bazel_artifact_reader_test.cc
+++ b/kythe/cxx/extractor/bazel_artifact_reader_test.cc
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020 The Kythe Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "kythe/cxx/extractor/bazel_artifact_reader.h"
+
+#include <sstream>
+
+#include "absl/strings/str_cat.h"
+#include "google/protobuf/io/zero_copy_stream_impl.h"
+#include "google/protobuf/util/delimited_message_util.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "kythe/cxx/extractor/bazel_event_reader.h"
+#include "src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.pb.h"
+
+namespace kythe {
+namespace {
+using ::google::protobuf::io::IstreamInputStream;
+using ::google::protobuf::util::SerializeDelimitedToOstream;
+using ::testing::ElementsAre;
+
+template <typename T, typename U>
+auto Artifact(T&& t, U&& u) {
+  return ::testing::AllOf(
+      ::testing::Field(&BazelArtifact::label, std::forward<T>(t)),
+      ::testing::Field(&BazelArtifact::uris, std::forward<U>(u)));
+}
+
+TEST(BazelArtifactReaderTest, ReadsExpectedArtifacts) {
+  static constexpr int kArtifactCount = 5;
+  std::stringstream stream;
+  for (int i = 0; i < kArtifactCount; i++) {
+    build_event_stream::BuildEvent event;
+    auto* id = event.mutable_id()->mutable_action_completed();
+    id->set_primary_output("unused");
+    id->set_label(absl::StrCat("//id/label:", i));
+    auto* payload = event.mutable_action();
+    payload->set_success(true);
+    payload->set_type("extra_action");
+    payload->mutable_primary_output()->set_uri(
+        absl::StrCat("file:///dummy/", i, ".kzip"));
+    ASSERT_TRUE(SerializeDelimitedToOstream(event, &stream));
+  }
+
+  IstreamInputStream input(&stream);
+  BazelEventReader events(&input);
+  BazelArtifactReader reader(&events);
+  std::vector<BazelArtifact> artifacts;
+  for (; !reader.Done(); reader.Next()) {
+    artifacts.push_back(std::move(reader.Ref()));
+  }
+  ASSERT_TRUE(reader.status().ok()) << reader.status();
+  EXPECT_THAT(
+      artifacts,
+      ElementsAre(
+          Artifact("//id/label:0", ElementsAre("file:///dummy/0.kzip")),
+          Artifact("//id/label:1", ElementsAre("file:///dummy/1.kzip")),
+          Artifact("//id/label:2", ElementsAre("file:///dummy/2.kzip")),
+          Artifact("//id/label:3", ElementsAre("file:///dummy/3.kzip")),
+          Artifact("//id/label:4", ElementsAre("file:///dummy/4.kzip"))));
+}
+
+}  // namespace
+}  // namespace kythe

--- a/kythe/cxx/extractor/bazel_artifact_reader_test.cc
+++ b/kythe/cxx/extractor/bazel_artifact_reader_test.cc
@@ -18,9 +18,9 @@
 #include <sstream>
 
 #include "absl/strings/str_cat.h"
+#include "gmock/gmock.h"
 #include "google/protobuf/io/zero_copy_stream_impl.h"
 #include "google/protobuf/util/delimited_message_util.h"
-#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "kythe/cxx/extractor/bazel_event_reader.h"
 #include "src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.pb.h"

--- a/kythe/cxx/extractor/bazel_event_reader.cc
+++ b/kythe/cxx/extractor/bazel_event_reader.cc
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 The Kythe Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "kythe/cxx/extractor/bazel_event_reader.h"
+
+#include <utility>
+
+#include "absl/status/status.h"
+#include "google/protobuf/util/delimited_message_util.h"
+#include "src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.pb.h"
+
+namespace kythe {
+namespace {
+using ::build_event_stream::BuildEvent;
+using ::google::protobuf::io::CodedInputStream;
+using ::google::protobuf::io::ZeroCopyInputStream;
+using ::google::protobuf::util::ParseDelimitedFromCodedStream;
+using ::google::protobuf::util::ParseDelimitedFromZeroCopyStream;
+
+struct ParseEvent {
+  BuildEvent* event;
+  bool* clean_eof;
+
+  template <typename T>
+  bool From(T&& variant) {
+    return absl::visit(*this, std::forward<T>(variant));
+  }
+
+  bool operator()(ZeroCopyInputStream* stream) const {
+    return ParseDelimitedFromZeroCopyStream(event, stream, clean_eof);
+  }
+
+  bool operator()(CodedInputStream* stream) const {
+    return ParseDelimitedFromCodedStream(event, stream, clean_eof);
+  }
+};
+
+}  // namespace
+
+void BazelEventReader::Next() {
+  bool clean_eof = true;
+  BuildEvent event;
+  if (ParseEvent{&event, &clean_eof}.From(stream_)) {
+    value_ = std::move(event);
+  } else if (clean_eof) {
+    value_ = absl::OkStatus();
+  } else {
+    value_ = absl::UnknownError("Error decoding BuildEvent from stream");
+  }
+}
+
+}  // namespace kythe

--- a/kythe/cxx/extractor/bazel_event_reader.h
+++ b/kythe/cxx/extractor/bazel_event_reader.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 The Kythe Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef KYTHE_CXX_EXTRACTOR_BAZEL_EVENT_READER_H_
+#define KYTHE_CXX_EXTRACTOR_BAZEL_EVENT_READER_H_
+
+#include "absl/status/status.h"
+#include "absl/types/variant.h"
+#include "glog/logging.h"
+#include "google/protobuf/io/zero_copy_stream.h"
+#include "src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.pb.h"
+
+namespace kythe {
+
+/// \brief Reads BazelEvent messages from a binary Bazel event stream.
+class BazelEventReader {
+ public:
+  using value_type = ::build_event_stream::BuildEvent;
+  using reference = value_type&;
+  using const_reference = const value_type&;
+
+  /// \brief Constructs a new BazelEventReader
+  explicit BazelEventReader(google::protobuf::io::CodedInputStream* stream)
+      : stream_(stream) {
+    Next();
+  }
+
+  /// \brief Constructs a new BazelEventReader
+  explicit BazelEventReader(google::protobuf::io::ZeroCopyInputStream* stream)
+      : stream_(stream) {
+    Next();
+  }
+
+  void Next();
+
+  bool Done() const { return value_.index() != 0; }
+  reference Ref() { return absl::get<value_type>(value_); }
+  const_reference Ref() const { return absl::get<value_type>(value_); }
+  absl::Status status() const { return absl::get<absl::Status>(value_); }
+
+ private:
+  absl::variant<value_type, absl::Status> value_;
+  absl::variant<google::protobuf::io::CodedInputStream*,
+                google::protobuf::io::ZeroCopyInputStream*>
+      stream_;
+};
+
+}  // namespace kythe
+
+#endif  // KYTHE_CXX_EXTRACTOR_BAZEL_EVENT_READER_H_

--- a/kythe/cxx/extractor/bazel_event_reader_test.cc
+++ b/kythe/cxx/extractor/bazel_event_reader_test.cc
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 The Kythe Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "kythe/cxx/extractor/bazel_event_reader.h"
+
+#include <sstream>
+
+#include "absl/strings/str_cat.h"
+#include "gmock/gmock.h"
+#include "google/protobuf/io/zero_copy_stream_impl.h"
+#include "google/protobuf/util/delimited_message_util.h"
+#include "gtest/gtest.h"
+#include "src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.pb.h"
+
+namespace kythe {
+namespace {
+using ::google::protobuf::io::IstreamInputStream;
+using ::google::protobuf::util::SerializeDelimitedToOstream;
+using ::testing::ElementsAre;
+
+TEST(BazelEventReaderTest, ReadsExpectedEvents) {
+  std::stringstream stream;
+  for (int i = 0; i < 5; i++) {
+    build_event_stream::BuildEvent event;
+    event.mutable_id()->mutable_unknown()->set_details(absl::StrCat(i));
+    ASSERT_TRUE(SerializeDelimitedToOstream(event, &stream));
+  }
+  IstreamInputStream input_stream(&stream);
+
+  std::vector<std::string> events;
+  BazelEventReader reader(&input_stream);
+  for (; !reader.Done(); reader.Next()) {
+    events.push_back(reader.Ref().id().unknown().details());
+  }
+  ASSERT_TRUE(reader.status().ok()) << reader.status();
+  EXPECT_THAT(events, ElementsAre("0", "1", "2", "3", "4"));
+}
+
+}  // namespace
+}  // namespace kythe

--- a/kythe/cxx/extractor/dump_bazel_artifacts.cc
+++ b/kythe/cxx/extractor/dump_bazel_artifacts.cc
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 The Kythe Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "absl/flags/flag.h"
+#include "absl/flags/parse.h"
+#include "absl/strings/string_view.h"
+#include "glog/logging.h"
+#include "google/protobuf/io/zero_copy_stream_impl.h"
+#include "kythe/cxx/extractor/bazel_artifact_reader.h"
+
+ABSL_FLAG(std::string, build_event_binary_file, "",
+          "Bazel event protocol file to read");
+
+namespace kythe {
+namespace {
+
+absl::string_view Basename(absl::string_view path) {
+  if (auto pos = path.rfind('/'); pos != path.npos) {
+    return path.substr(pos + 1);
+  }
+  return path;
+}
+
+int DumpArtifacts(const std::string filename) {
+  std::ifstream file(filename);
+  if (!file.is_open()) {
+    LOG(ERROR) << "Error opening " << filename << ": " << std::strerror(errno);
+    return 1;
+  }
+
+  google::protobuf::io::IstreamInputStream input(&file);
+  BazelEventReader events(&input);
+  BazelArtifactReader artifacts(&events);
+  for (; !artifacts.Done(); artifacts.Next()) {
+    std::cout << artifacts.Ref().label << std::endl;
+    for (const auto& uri : artifacts.Ref().uris) {
+      std::cout << "  " << Basename(uri) << std::endl;
+    }
+  }
+  if (!artifacts.status().ok()) {
+    LOG(ERROR) << artifacts.status();
+  }
+
+  return !artifacts.status().ok();
+}
+}  // namespace
+}  // namespace kythe
+
+int main(int argc, char** argv) {
+  absl::ParseCommandLine(argc, argv);
+  return kythe::DumpArtifacts(absl::GetFlag(FLAGS_build_event_binary_file));
+}

--- a/tools/build_rules/build_event_stream/BUILD
+++ b/tools/build_rules/build_event_stream/BUILD
@@ -1,0 +1,1 @@
+exports_files(["repo.bzl"])

--- a/tools/build_rules/build_event_stream/repo.bzl
+++ b/tools/build_rules/build_event_stream/repo.bzl
@@ -1,0 +1,71 @@
+"""An external repository for fetching build_event_stream protobufs."""
+
+load("@bazel_skylib//lib:paths.bzl", "paths")
+
+_FILES = [
+    "src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.proto",
+    "src/main/protobuf/command_line.proto",
+    "src/main/protobuf/invocation_policy.proto",
+    "src/main/protobuf/option_filters.proto",
+]
+
+_URL_TEMPLATE = "https://raw.githubusercontent.com/bazelbuild/bazel/{revision}/{path}"
+
+_BUILD_FILE_TEMPLATE = """
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+proto_library(
+    name = "build_event_stream_proto",
+    srcs = [
+        {filenames},
+    ],
+)
+
+cc_proto_library(
+    name = "build_event_stream_cc_proto",
+    deps = [":build_event_stream_proto"],
+    visibility = ["//visibility:public"],
+)
+"""
+
+def _bes_repo(repository_ctx):
+    attrs = {
+        "name": repository_ctx.attr.name,
+        "revision": repository_ctx.attr.revision,
+        "sha256s": dict(repository_ctx.attr.sha256s),
+    }
+    proto_srcs = []
+    for path in _FILES:
+        filename = paths.basename(path)
+        output = paths.join("src/main/protobuf", filename)
+        proto_srcs.append("\"%s\"" % output)
+        attrs["sha256s"][filename] = repository_ctx.download(
+            _URL_TEMPLATE.format(
+                revision = repository_ctx.attr.revision,
+                path = path,
+            ),
+            output = output,
+            sha256 = repository_ctx.attr.sha256s.get(filename, ""),
+        ).sha256
+
+    repository_ctx.file(
+        "BUILD.bazel",
+        _BUILD_FILE_TEMPLATE.format(
+            filenames = ",\n        ".join(proto_srcs),
+        ),
+    )
+
+    return attrs
+
+build_event_stream_repository = repository_rule(
+    implementation = _bes_repo,
+    attrs = {
+        "revision": attr.string(
+            doc = "A tag, commit or branch string at which to fetch the required files.",
+            default = "master",
+        ),
+        "sha256s": attr.string_dict(
+            doc = "A mapping of basename to sha256 for the fetched files",
+        ),
+    },
+)

--- a/tools/build_rules/build_event_stream/repo.bzl
+++ b/tools/build_rules/build_event_stream/repo.bzl
@@ -36,14 +36,16 @@ def _bes_repo(repository_ctx):
     }
     proto_srcs = []
     for path in _FILES:
+        url = _URL_TEMPLATE.format(
+            revision = repository_ctx.attr.revision,
+            path = path,
+        )
         filename = paths.basename(path)
         proto_srcs.append("\"%s\"" % path)
         attrs["sha256s"][filename] = repository_ctx.download(
-            _URL_TEMPLATE.format(
-                revision = repository_ctx.attr.revision,
-                path = path,
-            ),
+            url,
             output = path,
+            canonical_id = url,
             sha256 = repository_ctx.attr.sha256s.get(filename, ""),
         ).sha256
 

--- a/tools/build_rules/build_event_stream/repo.bzl
+++ b/tools/build_rules/build_event_stream/repo.bzl
@@ -37,14 +37,13 @@ def _bes_repo(repository_ctx):
     proto_srcs = []
     for path in _FILES:
         filename = paths.basename(path)
-        output = paths.join("src/main/protobuf", filename)
-        proto_srcs.append("\"%s\"" % output)
+        proto_srcs.append("\"%s\"" % path)
         attrs["sha256s"][filename] = repository_ctx.download(
             _URL_TEMPLATE.format(
                 revision = repository_ctx.attr.revision,
                 path = path,
             ),
-            output = output,
+            output = path,
             sha256 = repository_ctx.attr.sha256s.get(filename, ""),
         ).sha256
 


### PR DESCRIPTION
In the short term, this paves the way for Bazel extraction using the build event stream, rather than groveling around in `bazel-out` for .kzip files.  In the medium term it will allow for aspect-based extraction (via output_group).