### PR TITLE
fix(cxx_indexer): properly emit ref/init edges in all cases

### DIFF
--- a/kythe/cxx/indexer/cxx/IndexerASTHooks.cc
+++ b/kythe/cxx/indexer/cxx/IndexerASTHooks.cc
@@ -1864,7 +1864,7 @@ bool IndexerASTVisitor::TraverseInitListExpr(clang::InitListExpr* ILE) {
   // because only the syntactic form retains designated initializers while the
   // semantic form is required for mapping from initializing expression to the
   // field/base which it initializes.
-  // TODO(shahms): Supress the redundant visitation.
+  // TODO(shahms): Suppress the redundant visitation.
   return Base::TraverseInitListExpr(ILE);
 }
 

--- a/kythe/cxx/indexer/cxx/IndexerASTHooks.cc
+++ b/kythe/cxx/indexer/cxx/IndexerASTHooks.cc
@@ -278,7 +278,8 @@ struct FieldInit {
 
 llvm::SmallVector<FieldInit, 5> GetFieldInitializers(
     const clang::InitListExpr* ILE) {
-  CHECK(ILE->isSemanticForm());
+  // We need the resolved type of the InitListExpr and all of the fields.
+  ILE = ILE->isSemanticForm() ? ILE : ILE->getSemanticForm();
   if (const clang::FieldDecl* Field = ILE->getInitializedFieldInUnion()) {
     return {FieldInit{Field, ILE->inits().front()}};
   }
@@ -1839,8 +1840,6 @@ bool IndexerASTVisitor::VisitDesignatedInitExpr(
 }
 
 bool IndexerASTVisitor::VisitInitListExpr(const clang::InitListExpr* ILE) {
-  // We need the resolved type of the InitListExpr and all of the fields.
-  ILE = ILE->isSemanticForm() ? ILE : ILE->getSemanticForm();
   for (const auto& [Field, Init] : GetFieldInitializers(ILE)) {
     if (auto RCC =
             RangeInCurrentContext(BuildNodeIdForImplicitStmt(Init),

--- a/kythe/cxx/indexer/cxx/IndexerASTHooks.h
+++ b/kythe/cxx/indexer/cxx/IndexerASTHooks.h
@@ -115,7 +115,11 @@ class IndexerASTVisitor : public RecursiveTypeVisitor<IndexerASTVisitor> {
   bool VisitBindingDecl(const clang::BindingDecl* Decl);
   bool VisitSizeOfPackExpr(const clang::SizeOfPackExpr* Expr);
   bool VisitDeclRefExpr(const clang::DeclRefExpr* DRE);
+
+  bool TraverseInitListExpr(clang::InitListExpr* ILE);
+  bool VisitInitListExpr(const clang::InitListExpr* ILE);
   bool VisitDesignatedInitExpr(const clang::DesignatedInitExpr* DIE);
+
   bool VisitCXXConstructExpr(const clang::CXXConstructExpr* E);
   bool VisitCXXDeleteExpr(const clang::CXXDeleteExpr* E);
   bool VisitCXXNewExpr(const clang::CXXNewExpr* E);

--- a/kythe/cxx/indexer/cxx/testdata/BUILD
+++ b/kythe/cxx/indexer/cxx/testdata/BUILD
@@ -1611,6 +1611,9 @@ test_suite(
 cc_indexer_test(
     name = "rec_agg_init",
     srcs = ["rec/rec_agg_init.cc"],
+    # The compiler-generated move constructor inserts a DeclRefExpr to the enclosing class for each member at the class name.
+    # TODO(shahms): Suppress these spurious references.
+    ignore_dups = True,
     tags = ["rec"],
 )
 
@@ -1685,7 +1688,6 @@ cc_indexer_test(
 cc_indexer_test(
     name = "rec_designated_initializer",
     srcs = ["rec/rec_designated_initializer.c"],
-    ignore_dups = True,  # clang visits these expressions multiple times.
     std = "c99",
     tags = ["rec"],
 )

--- a/kythe/cxx/indexer/cxx/testdata/BUILD
+++ b/kythe/cxx/indexer/cxx/testdata/BUILD
@@ -1613,8 +1613,13 @@ cc_indexer_test(
     srcs = ["rec/rec_agg_init.cc"],
     # The compiler-generated move constructor inserts a DeclRefExpr to the enclosing class for each member at the class name.
     # TODO(shahms): Suppress these spurious references.
+    # Additionally, clang visits aggregate init twice; once as the syntactic form and once in the semantic.
     ignore_dups = True,
-    tags = ["rec"],
+    std = "c++17",
+    tags = [
+        "c++17",
+        "rec",
+    ],
 )
 
 cc_indexer_test(
@@ -1688,6 +1693,8 @@ cc_indexer_test(
 cc_indexer_test(
     name = "rec_designated_initializer",
     srcs = ["rec/rec_designated_initializer.c"],
+    # Clang visits aggregate init twice; once as the syntactic form and once in the semantic.
+    ignore_dups = True,
     std = "c99",
     tags = ["rec"],
 )

--- a/kythe/cxx/indexer/cxx/testdata/rec/rec_agg_init.cc
+++ b/kythe/cxx/indexer/cxx/testdata/rec/rec_agg_init.cc
@@ -1,14 +1,34 @@
 // Tests that aggregate initialization references struct.
 
 //- @S defines/binding StructS
-struct S {};
+struct S {
+  //- @a defines/binding FieldA
+  int a;
+  //- @b defines/binding FieldB
+  long b;
+};
+
+//- @U defines/binding UnionU
+union U {
+  //- @x defines/binding FieldX
+  int x;
+  //- @y defines/binding FieldY
+  long y;
+};
 
 template <typename...T>
 void fn(T&&...);
 
 void f() {
   //- @S ref StructS
-  auto s = S{};
+  //- @"1" ref/init FieldA
+  //- !{ _ ref/init FieldB }
+  auto s = S{1};
+
+  //- @U ref UnionU
+  //- @"1" ref/init FieldX
+  //- !{ _ ref/init FieldY }
+  auto u = U{1};
 
   //- @S ref StructS
   fn(S{});

--- a/kythe/cxx/indexer/cxx/testdata/rec/rec_agg_init.cc
+++ b/kythe/cxx/indexer/cxx/testdata/rec/rec_agg_init.cc
@@ -8,6 +8,20 @@ struct S {
   long b;
 };
 
+//- @T defines/binding StructT
+struct T : S {
+  union {
+    //- @j defines/binding FieldJ
+    int j;
+    //- @k defines/binding FieldK
+    long k;
+  };
+  //- @l defines/binding FieldL
+  int l;
+  //- @m defines/binding FieldM
+  char m;
+};
+
 //- @U defines/binding UnionU
 union U {
   //- @x defines/binding FieldX
@@ -22,12 +36,21 @@ void fn(T&&...);
 void f() {
   //- @S ref StructS
   //- @"1" ref/init FieldA
-  //- !{ _ ref/init FieldB }
   auto s = S{1};
+
+  //- @T ref StructT
+  //- @"1" ref/init FieldA
+  auto t = T{1};
+
+  //- @T ref StructT
+  //- @"{1,2}" ref/init StructS
+  //- @"3" ref/init FieldJ
+  //- @"4" ref/init FieldL
+  //- @"5" ref/init FieldM
+  auto full = T{{1,2},3,4,5};
 
   //- @U ref UnionU
   //- @"1" ref/init FieldX
-  //- !{ _ ref/init FieldY }
   auto u = U{1};
 
   //- @S ref StructS

--- a/kythe/cxx/indexer/cxx/testdata/rec/rec_agg_init.cc
+++ b/kythe/cxx/indexer/cxx/testdata/rec/rec_agg_init.cc
@@ -44,6 +44,8 @@ void f() {
 
   //- @T ref StructT
   //- @"{1,2}" ref/init StructS
+  //- @"1" ref/init FieldA
+  //- @"2" ref/init FieldB
   //- @"3" ref/init FieldJ
   //- @"4" ref/init FieldL
   //- @"5" ref/init FieldM

--- a/kythe/cxx/indexer/cxx/testdata/rec/rec_designated_initializer.c
+++ b/kythe/cxx/indexer/cxx/testdata/rec/rec_designated_initializer.c
@@ -23,3 +23,15 @@ struct ssz { struct sz outer; };
 //- @field ref Field
 //- @"2" ref/init Field
 static struct ssz k = { .outer = { .inner = { .field = 2 } } };
+
+
+union U {
+  //- @x defines/binding FieldX
+  int x;
+  //- @y defines/binding FieldY
+  long y;
+};
+
+//- @"1" ref/init FieldY
+//- !{ _ ref/init FieldX }
+static union U u = {.y = 1};


### PR DESCRIPTION
This matches the Go behavior and that documented in the schema.  Prior to this, we would only emit ref/init for the designated initializer case, which is less useful because we also emit a regular ref from the field name in the designated initializer itself.

This PR cuts out a redundant traversal and emits a ref/init edge to all fields initialized from a given initializer list, excluding those without an explicit initializing expression.