### PR TITLE
feat(cxx_extractor): cache symlink resolution in PathRealizer

### DIFF
--- a/kythe/cxx/common/BUILD
+++ b/kythe/cxx/common/BUILD
@@ -56,8 +56,10 @@ cc_library(
         ":status",
         ":status_or",
         "@com_github_google_glog//:glog",
+        "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/synchronization",
     ],
 )
 


### PR DESCRIPTION
If this is insufficient, I can try implementing realpath directly to cache intermediate symbolic links and further cut down on the redundant work, but for now just use a direct cache.