### PR TITLE
feat(java_indexer): experimentally emit named edges to JVM nodes

### DIFF
--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/BUILD
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/BUILD
@@ -383,7 +383,7 @@ java_verifier_test(
 
 java_verifier_test(
     name = "jvm_reference_tests",
-    size = "small",
+    size = "medium",
     srcs = ["JvmCrossFile.java"],
     indexer_opts = ["--emit_jvm_references"],
     verifier_deps = [":files_tests"],

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/CrossFile.java
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/CrossFile.java
@@ -28,7 +28,9 @@ public class CrossFile {
   //- @Inter ref Inter
   Inter i;
 
-  public static void main(String[] args) {
+  //- @Exception ref Exception
+  //- Exception named _JVMException=vname(_, _, _, _, "jvm")
+  public static void main(String[] args) throws Exception {
     //- @staticMethod ref StaticMethod
     Files.staticMethod();
     //- @staticMethod ref StaticMethod

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Files.java
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Files.java
@@ -42,6 +42,9 @@ public class Files {
   interface Inter<T> {}
 }
 
+//- FilesClass named JVMFiles=vname(_, _, _, _, "jvm")
+//- JVMFiles.node/kind record
+
 //- File=vname("","kythe","","kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Files.java","")
 //-   .node/kind file
 //- File.text/encoding "UTF-8"

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Jvm.java
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Jvm.java
@@ -5,32 +5,40 @@ import java.util.List;
 
 //- @Jvm defines/binding ClassJava
 //- ClassJava generates ClassJvm
+//- ClassJava named ClassJvm
 public class Jvm {
 
   //- @intField defines/binding IntFieldJava
   //- IntFieldJava generates IntFieldJvm
+  //- IntFieldJava named IntFieldJvm
   int intField;
 
   //- @Nested defines/binding NestedJava
   //- NestedJava generates NestedJvm
+  //- NestedJava named NestedJvm
   public static class Nested {
     //- @Nested defines/binding NestedCtorJava
     //- NestedCtorJava generates NestedCtorJvm
+    //- NestedCtorJava named NestedCtorJvm
     public Nested() {}
   }
 
   //- @Inner defines/binding InnerJava
   //- InnerJava generates InnerJvm
+  //- InnerJava named InnerJvm
   public class Inner {
     //- @Inner defines/binding InnerCtorJava
     //- InnerCtorJava generates InnerCtorJvm
+    //- InnerCtorJava named InnerCtorJvm
     public Inner() {}
 
     //- @InnerInner defines/binding InnerInnerJava
     //- InnerInnerJava generates InnerInnerJvm
+    //- InnerInnerJava named InnerInnerJvm
     public class InnerInner {
       //- @InnerInner defines/binding InnerInnerCtorJava
       //- InnerInnerCtorJava generates InnerInnerCtorJvm
+      //- InnerInnerCtorJava named InnerInnerCtorJvm
       public InnerInner() {}
     }
   }
@@ -38,14 +46,18 @@ public class Jvm {
   //- @methodWithInnerParam defines/binding MethodWithInnerParamJava
   //- MethodWithInnerParamJava.node/kind function
   //- MethodWithInnerParamJava generates MethodWithInnerParamJvm
+  //- MethodWithInnerParamJava named MethodWithInnerParamJvm
   private void methodWithInnerParam(Inner inner) {}
 
   //- @func defines/binding FuncJava
   //- FuncJava generates FuncJvm
+  //- FuncJava named FuncJvm
   //- @intParam defines/binding Param0Java
   //- @objectParam defines/binding Param1Java
   //- Param0Java generates Param0Jvm
   //- Param1Java generates Param1Jvm
+  //- Param0Java named Param0Jvm
+  //- Param1Java named Param1Jvm
   public static void func(int intParam, Object objectParam) {}
 
   //- @Generic defines/binding GenericAbs
@@ -53,25 +65,30 @@ public class Jvm {
   //- GenericClass childof GenericAbs
   //- GenericClass.node/kind record
   //- GenericClass generates GenericJvm
+  //- GenericClass named GenericJvm
   public static class Generic<T extends Integer> {
     //- @tfield defines/binding TFieldJava
     //- TFieldJava.node/kind variable
     //- TFieldJava generates TFieldJvm
+    //- TFieldJava named TFieldJvm
     private T tfield;
 
     //- @tmethod defines/binding TMethodJava
     //- TMethodJava.node/kind function
     //- TMethodJava generates TMethodJvm
+    //- TMethodJava named TMethodJvm
     private void tmethod(T targ) {}
 
     //- @tlistmethod defines/binding TListMethodJava
     //- TListMethodJava.node/kind function
     //- TListMethodJava generates TListMethodJvm
+    //- TListMethodJava named TListMethodJvm
     private void tlistmethod(List<T> targ) {}
 
     //- @tlistretmethod defines/binding TListRetMethodJava
     //- TListRetMethodJava.node/kind function
     //- TListRetMethodJava generates TListRetMethodJvm
+    //- TListRetMethodJava named TListRetMethodJvm
     private List<T> tlistretmethod() {
       return null;
     }
@@ -82,15 +99,18 @@ public class Jvm {
   //- MBGenericClass childof MBGenericAbs
   //- MBGenericClass.node/kind record
   //- MBGenericClass generates MBGenericJvm
+  //- MBGenericClass named MBGenericJvm
   public static class MultipleBoundGeneric<T extends Integer & Formattable> {
     //- @mbtmethod defines/binding MBTMethodJava
     //- MBTMethodJava.node/kind function
     //- MBTMethodJava generates MBTMethodJvm
+    //- MBTMethodJava named MBTMethodJvm
     private void mbtmethod(T targ) {}
   }
 
   //- @nope defines/binding NopeJava
   //- NopeJava generates NopeJvm
+  //- NopeJava named NopeJvm
   public static <T> T nope() {
     return null;
   }
@@ -105,6 +125,7 @@ public class Jvm {
 
   //- @g defines/binding GJava
   //- GJava generates GJvm
+  //- GJava named GJvm
   static void g(
       int[] arrayParam,
       boolean booleanParam,
@@ -118,5 +139,6 @@ public class Jvm {
 
   //- @ints defines/binding VarArgsParamJava
   //- VarArgsParamJava generates VarArgsParamJvm
+  //- VarArgsParamJava named VarArgsParamJvm
   static void varargs(int... ints) {}
 }

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/JvmCrossFile.java
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/JvmCrossFile.java
@@ -14,6 +14,14 @@ import static pkg.Files.INSTANCE;
 import pkg.Files.Inter;
 import pkg.Files.OtherDecl;
 
+//- ConstantMember named JvmConstantMember
+//- FilesClass named JvmFilesClass
+//- InnerClass named JvmInnerClass
+//- Inter named JvmInter
+//- ODecl named JvmODecl
+//- StaticMethod named JvmStaticMethod
+//- InstanceMember named JvmInstanceMember
+
 //- ConstantMember generates JvmConstantMember
 //- FilesClass generates JvmFilesClass
 //- InnerClass generates JvmInnerClass


### PR DESCRIPTION
Experiment with emitting edges into the JVM graph for both definitions
and references when --emit_jvm=SEMANTIC.  This allows post-processing to
decide whether to use the language-specific nodes or general JVM nodes
for cross-references.