### PR TITLE
fix(cxx_indexer): don't emit ref/init for unspecified fields

### DIFF
--- a/kythe/cxx/indexer/cxx/IndexerASTHooks.cc
+++ b/kythe/cxx/indexer/cxx/IndexerASTHooks.cc
@@ -1899,6 +1899,13 @@ bool IndexerASTVisitor::VisitInitListExpr(const clang::InitListExpr* ILE) {
       break;
     }
     const clang::Expr* Init = *II++;
+    if (!Init->getEndLoc().isValid() || Init->getEndLoc() == ILE->getEndLoc()) {
+      // When visiting the semantic form initializers which aren't explicitly
+      // specified either have an invalid location (for uninitialized fields) or
+      // share a location with the end of the ILE (for default initialized
+      // fields).  Skip these.
+      continue;
+    }
     if (auto RCC =
             RangeInCurrentContext(BuildNodeIdForImplicitStmt(Init),
                                   NormalizeRange(Init->getSourceRange()))) {

--- a/kythe/cxx/indexer/cxx/IndexerASTHooks.cc
+++ b/kythe/cxx/indexer/cxx/IndexerASTHooks.cc
@@ -291,9 +291,8 @@ llvm::SmallVector<const clang::Decl*, 5> GetInitExprDecls(
     const clang::InitListExpr* ILE) {
   CHECK(ILE->isSemanticForm());
   QualType Type = ILE->getType();
-  if (!Type->isAggregateType() ||
-      // Ignore copy initialization.
-      (ILE->getNumInits() == 1 && ILE->getInit(0)->getType() == Type)) {
+  // Ignore non-aggregate and copy initialization.
+  if (!Type->isAggregateType() || ILE->isTransparent()) {
     return {};
   }
   if (const clang::FieldDecl* Field = ILE->getInitializedFieldInUnion()) {
@@ -314,7 +313,6 @@ llvm::SmallVector<const clang::Decl*, 5> GetInitExprDecls(
   }
   return result;
 }
-
 }  // anonymous namespace
 
 bool IsClaimableForTraverse(const clang::Decl* decl) {
@@ -1890,6 +1888,7 @@ bool IndexerASTVisitor::VisitInitListExpr(const clang::InitListExpr* ILE) {
   // We need the resolved type of the InitListExpr and all of the fields, but
   // don't want to do so redundantly for both syntactic and semantic forms.
   if (!ILE->isSemanticForm() || ILE->getNumInits() == 0) return true;
+  clang::SourceRange ListRange = NormalizeRange(ILE->getSourceRange());
 
   auto II = ILE->inits().begin();
   for (const clang::Decl* Decl : GetInitExprDecls(ILE)) {
@@ -1899,11 +1898,14 @@ bool IndexerASTVisitor::VisitInitListExpr(const clang::InitListExpr* ILE) {
       break;
     }
     const clang::Expr* Init = *II++;
-    if (!Init->getEndLoc().isValid() || Init->getEndLoc() == ILE->getEndLoc()) {
+    clang::SourceRange InitRange = NormalizeRange(Init->getSourceRange());
+    if (!InitRange.isValid() || (InitRange.getBegin() != ListRange.getBegin() &&
+                                 InitRange.getEnd() == ListRange.getEnd())) {
       // When visiting the semantic form initializers which aren't explicitly
       // specified either have an invalid location (for uninitialized fields) or
       // share a location with the end of the ILE (for default initialized
-      // fields).  Skip these.
+      // fields).  Skip these, but only if they don't share a start location as
+      // that indicates an implicit init list expr of only the contained value.
       continue;
     }
     if (auto RCC =

--- a/kythe/cxx/indexer/cxx/testdata/rec/rec_agg_init.cc
+++ b/kythe/cxx/indexer/cxx/testdata/rec/rec_agg_init.cc
@@ -1,11 +1,19 @@
 // Tests that aggregate initialization references struct.
 
+struct Default {
+  Default();
+};
+
 //- @S defines/binding StructS
 struct S {
   //- @a defines/binding FieldA
   int a;
   //- @b defines/binding FieldB
   long b;
+  //- @c defines/binding FieldC
+  bool c = false;
+  //- @d defines/binding FieldD
+  Default d;
 };
 
 //- @T defines/binding StructT
@@ -38,6 +46,9 @@ void fn(T&&...);
 void f() {
   //- @S ref StructS
   //- @"1" ref/init FieldA
+  //- !{ @"}" ref/init FieldB }
+  //- !{ @"}" ref/init FieldC }
+  //- !{ @"}" ref/init FieldD }
   auto s = S{1};
 
   //- @T ref StructT

--- a/kythe/cxx/indexer/cxx/testdata/rec/rec_agg_init.cc
+++ b/kythe/cxx/indexer/cxx/testdata/rec/rec_agg_init.cc
@@ -38,6 +38,14 @@ union U {
   long y;
 };
 
+//- @V defines/binding StructV
+struct V {
+  //- @s defines/binding FieldS
+  S s;
+  //- @t defines/binding FieldT
+  T t;
+};
+
 S FromValue();
 
 template <typename...T>
@@ -72,5 +80,14 @@ void f() {
   fn(S{});
 
   //- !{ @"FromValue()" ref/init _ }
-  S v{FromValue()};
+  S c{FromValue()};
+
+  //- V ref StructV
+  //- @"{1}" ref/init FieldS
+  //- @"1" ref/init FieldA
+  //- @"2" ref/init FieldT
+  //- @"2" ref/init FieldA
+  //- !{ @#0"}" ref/init _ }
+  //- !{ @#1"}" ref/init _ }
+  V v{{1}, 2};
 }


### PR DESCRIPTION
This would've been much easier if Clang consistently gave imaginary expressions invalid locations, but nooooo.