### PR TITLE
deprecation(java_indexer): remove --emit_jvm_references feature

### DIFF
--- a/kythe/java/com/google/devtools/kythe/analyzers/java/JavaIndexerConfig.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/JavaIndexerConfig.java
@@ -52,13 +52,6 @@ public class JavaIndexerConfig extends IndexerConfig {
   private String overrideJdkCorpus;
 
   @Parameter(
-      names = "--emit_jvm_references",
-      description =
-          "Whether to reference the JVM graph when encountering nodes from outside the analyzed"
-              + " compilation unit")
-  private boolean jvmReferences = false;
-
-  @Parameter(
       names = "--emit_anchor_scopes",
       description =
           "Whether to emit childof edges from anchors to their lexical scope's semantic node")
@@ -96,10 +89,6 @@ public class JavaIndexerConfig extends IndexerConfig {
     return emitJvmSignatures;
   }
 
-  public boolean getEmitJvmReferences() {
-    return jvmReferences;
-  }
-
   public boolean getEmitAnchorScopes() {
     return emitAnchorScopes;
   }
@@ -124,11 +113,6 @@ public class JavaIndexerConfig extends IndexerConfig {
 
   public JavaIndexerConfig setOverrideJdkCorpus(String overrideJdkCorpus) {
     this.overrideJdkCorpus = overrideJdkCorpus;
-    return this;
-  }
-
-  public JavaIndexerConfig setEmitJvmReferences(boolean jvmReferences) {
-    this.jvmReferences = jvmReferences;
     return this;
   }
 

--- a/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
@@ -1100,12 +1100,6 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
       entrySets.emitEdge(node.getVName(), EdgeKind.NAMED, jvmNode);
     }
 
-    if (jvmNode != null && config.getEmitJvmReferences() && isExternal(sym)) {
-      // Symbol is external to the analyzed compilation and may not be defined in Java.  Return the
-      // related JVM node to accommodate cross-language references.
-      return new JavaNode(jvmNode);
-    }
-
     return node;
   }
 
@@ -1131,15 +1125,6 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
       return JvmGraph.getReferenceVName(corpusPath, referenceType(sym.type));
     }
     return null;
-  }
-
-  private boolean isExternal(Symbol sym) {
-    // TODO(schroederc): research other methods to hueristically determine if a Symbol is defined in
-    //                   a Java compilation (vs. some other JVM language)
-    ClassSymbol cls = sym.enclClass();
-    return cls != null
-        && (cls.sourcefile == null || cls.sourcefile.getKind() != JavaFileObject.Kind.SOURCE)
-        && !JavaEntrySets.fromJDK(sym);
   }
 
   private void visitAnnotations(

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/BUILD
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/BUILD
@@ -377,7 +377,6 @@ java_verifier_test(
     name = "jvm_reference_tests",
     timeout = "long",
     srcs = ["JvmCrossFile.java"],
-    indexer_opts = ["--emit_jvm_references"],
     verifier_deps = [":files_tests"],
 )
 

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/JvmCrossFile.java
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/JvmCrossFile.java
@@ -2,13 +2,13 @@ package pkg;
 
 // Check that nodes unify across file/compilation boundaries
 
-//- @CONSTANT ref/imports JvmConstantMember
+//- @CONSTANT ref/imports ConstantMember
 import static pkg.Files.CONSTANT;
-//- @Inner ref/imports JvmInnerClass
+//- @Inner ref/imports InnerClass
 import static pkg.Files.Inner;
-//- @staticMethod ref/imports JvmStaticMethod
+//- @staticMethod ref/imports StaticMethod
 import static pkg.Files.staticMethod;
-//- @INSTANCE ref/imports JvmInstanceMember
+//- @INSTANCE ref/imports InstanceMember
 import static pkg.Files.INSTANCE;
 
 import pkg.Files.Inter;
@@ -33,30 +33,30 @@ import pkg.Files.OtherDecl;
 //- @pkg ref/doc Package
 /** Tests JVM references within the {@link pkg} package.*/
 public class JvmCrossFile {
-  //- @Files ref JvmFilesClass
+  //- @Files ref FilesClass
   Files f1;
 
-  //- @Files ref JvmFilesClass
-  //- @Inner ref JvmInnerClass
+  //- @Files ref FilesClass
+  //- @Inner ref InnerClass
   Files.Inner f2;
 
-  //- @OtherDecl ref JvmODecl
+  //- @OtherDecl ref ODecl
   OtherDecl f3;
 
-  //- @Inter ref JvmInter
+  //- @Inter ref Inter
   Inter i;
 
   //- @InterSub defines/binding InterSub
   //- InterSub.node/kind interface
-  //- InterSub extends JvmInter
+  //- InterSub extends Inter
   interface InterSub extends Inter {}
 
   public static void main(String[] args) {
-    //- @staticMethod ref JvmStaticMethod
+    //- @staticMethod ref StaticMethod
     Files.staticMethod();
-    //- @staticMethod ref JvmStaticMethod
+    //- @staticMethod ref StaticMethod
     staticMethod();
-    //- @CONSTANT ref JvmConstantMember
+    //- @CONSTANT ref ConstantMember
     System.out.println(Files.CONSTANT);
   }
 }


### PR DESCRIPTION
This functionality is superseded by #4505.