### PR TITLE
Remove layering_check and parse_headers from cxx/intexer/proto package

### DIFF
--- a/kythe/cxx/indexer/proto/BUILD
+++ b/kythe/cxx/indexer/proto/BUILD
@@ -1,10 +1,3 @@
-package(
-    features = [
-        "layering_check",
-        "parse_headers",
-    ],
-)
-
 cc_library(
     name = "proto_graph_builder",
     srcs = ["proto_graph_builder.cc"],


### PR DESCRIPTION
Bazel will start supporting layering check in the next version and then
this package will start failing
(https://github.com/bazelbuild/bazel/issues/11501). This PR removes
enabled  freatures from this packages until the violations are fixed.