### PR TITLE
fix(build): remove jq dependency

### DIFF
--- a/kythe/go/platform/tools/kzip/metadatacmd/BUILD
+++ b/kythe/go/platform/tools/kzip/metadatacmd/BUILD
@@ -22,7 +22,6 @@ shell_tool_test(
     name = "test",
     scriptfile = "test.sh",
     tools = {
-        "JQ": "@com_github_stedolan_jq//:jq",
         "KZIP": "//kythe/go/platform/tools/kzip",
     },
 )

--- a/kythe/go/platform/tools/kzip/metadatacmd/test.sh
+++ b/kythe/go/platform/tools/kzip/metadatacmd/test.sh
@@ -29,4 +29,4 @@ $KZIP create_metadata \
     --corpus test_corpus \
     --commit_timestamp "$TIMESTAMP"
 
-$KZIP view meta.kzip | $JQ .
+$KZIP view meta.kzip


### PR DESCRIPTION
It's much easier to get this test running in google3 without the jq dependency.