### PR TITLE
Don't attempt to extract compilation from assembly

### DIFF
--- a/kythe/cxx/extractor/BUILD
+++ b/kythe/cxx/extractor/BUILD
@@ -177,6 +177,7 @@ cc_binary(
         "@com_github_google_glog//:glog",
         "@com_google_absl//absl/flags:flag",
         "@com_google_absl//absl/flags:parse",
+        "@com_google_absl//absl/strings",
         "@com_google_protobuf//:protobuf",
         "@com_googlesource_code_re2//:re2",
     ],

--- a/kythe/cxx/extractor/cxx_extractor_bazel_main.cc
+++ b/kythe/cxx/extractor/cxx_extractor_bazel_main.cc
@@ -20,8 +20,8 @@
 #include <fcntl.h>
 #include <sys/stat.h>
 
-#include <string>
 #include <fstream>
+#include <string>
 
 #include "absl/flags/flag.h"
 #include "absl/flags/parse.h"
@@ -69,7 +69,6 @@ int main(int argc, char* argv[]) {
                   remain[0]);
     return 1;
   }
-
   std::string extra_action_file = remain[1];
   std::string output_file = remain[2];
   std::string vname_config = remain[3];


### PR DESCRIPTION
CppCompile actions (created by cc_* rules or Starlark rules using
cc_common.compile) can accept a variety of types of files in srcs,
including assembly (".s" or ".asm"). However, those source files
don't actually result in compiler jobs, so there's nothing to
extract. Attempting to run the extractor on e.g. cc_* targets
with only ".s" srcs results in an error like:

error: unable to handle compilation, expected exactly one compiler job in ''

Instead, the extractor should write an empty output in those cases and
exit, since there are no C/C++ cross-references to extract from those
sources.