### PR TITLE
feat(cxx_indexer): annotate edges we know are writes to vars and ivars

### DIFF
--- a/kythe/cxx/common/indexing/KytheGraphRecorder.cc
+++ b/kythe/cxx/common/indexing/KytheGraphRecorder.cc
@@ -81,6 +81,8 @@ static const std::string* kEdgeKindSpellings[] = {
     new std::string("/kythe/edge/property/writes"),
     new std::string("/clang/usr"),
     new std::string("/kythe/edge/ref/id"),
+    new std::string("/kythe/edge/ref/writes"),
+    new std::string("/kythe/edge/ref/writes/implicit"),
 };
 
 bool of_spelling(absl::string_view str, EdgeKindID* edge_id) {

--- a/kythe/cxx/common/indexing/KytheGraphRecorder.h
+++ b/kythe/cxx/common/indexing/KytheGraphRecorder.h
@@ -122,7 +122,9 @@ enum class EdgeKindID {
   kPropertyReads,
   kPropertyWrites,
   kClangUsr,
-  kRefId
+  kRefId,
+  kRefWrites,
+  kRefWritesImplicit
 };
 
 /// \brief Returns the Kythe spelling of `node_kind_id`

--- a/kythe/cxx/indexer/cxx/BUILD
+++ b/kythe/cxx/indexer/cxx/BUILD
@@ -82,6 +82,7 @@ cc_library(
         "-Wno-implicit-fallthrough",
     ],
     deps = [
+        ":indexed_parent_map",
         "//third_party/llvm/src:clang_builtin_headers",
         "@com_github_google_glog//:glog",
         "@org_llvm//:LLVMSupport",

--- a/kythe/cxx/indexer/cxx/GraphObserver.h
+++ b/kythe/cxx/indexer/cxx/GraphObserver.h
@@ -828,9 +828,9 @@ class GraphObserver {
   /// \brief Classifies a use site.
   enum class UseKind {
     /// No specific determination. Similar to a read.
-    Unknown,
+    kUnknown,
     /// This use site is a write.
-    Write
+    kWrite
   };
 
   /// \brief Records a use site for some decl with additional semantic

--- a/kythe/cxx/indexer/cxx/GraphObserver.h
+++ b/kythe/cxx/indexer/cxx/GraphObserver.h
@@ -825,6 +825,20 @@ class GraphObserver {
                                    const NodeId& BlameId, Claimability Cl,
                                    Implicit I) {}
 
+  /// \brief Classifies a use site.
+  enum class UseKind {
+    /// No specific determination. Similar to a read.
+    Unknown,
+    /// This use site is a write.
+    Write
+  };
+
+  /// \brief Records a use site for some decl with additional semantic
+  /// information.
+  virtual void recordSemanticDeclUseLocation(const Range& SourceRange,
+                                             const NodeId& DeclId, UseKind K,
+                                             Claimability Cl, Implicit I) {}
+
   /// \brief Records an init site for some decl.
   virtual void recordInitLocation(const Range& SourceRange,
                                   const NodeId& DeclId, Claimability Cl,

--- a/kythe/cxx/indexer/cxx/IndexerASTHooks.cc
+++ b/kythe/cxx/indexer/cxx/IndexerASTHooks.cc
@@ -2034,11 +2034,10 @@ bool IndexerASTVisitor::VisitDeclRefOrIvarRefExpr(
         }
       }
       auto semantic = IsUsedAsWrite(*getAllParents(), Expr)
-                          ? GraphObserver::UseKind::Write
-                          : GraphObserver::UseKind::Unknown;
+                          ? GraphObserver::UseKind::kWrite
+                          : GraphObserver::UseKind::kUnknown;
       Observer.recordSemanticDeclUseLocation(
-          *RCC, DeclId, semantic,
-          GraphObserver::Claimability::Unclaimable,
+          *RCC, DeclId, semantic, GraphObserver::Claimability::Unclaimable,
           this->IsImplicit(*RCC));
       for (const auto& S : Supports) {
         S->InspectDeclRef(*this, SL, *RCC, DeclId, FoundDecl);

--- a/kythe/cxx/indexer/cxx/IndexerASTHooks.cc
+++ b/kythe/cxx/indexer/cxx/IndexerASTHooks.cc
@@ -2033,9 +2033,13 @@ bool IndexerASTVisitor::VisitDeclRefOrIvarRefExpr(
           }
         }
       }
-      Observer.recordDeclUseLocation(*RCC, DeclId,
-                                     GraphObserver::Claimability::Unclaimable,
-                                     this->IsImplicit(*RCC));
+      auto semantic = IsUsedAsWrite(*getAllParents(), Expr)
+                          ? GraphObserver::UseKind::Write
+                          : GraphObserver::UseKind::Unknown;
+      Observer.recordSemanticDeclUseLocation(
+          *RCC, DeclId, semantic,
+          GraphObserver::Claimability::Unclaimable,
+          this->IsImplicit(*RCC));
       for (const auto& S : Supports) {
         S->InspectDeclRef(*this, SL, *RCC, DeclId, FoundDecl);
       }

--- a/kythe/cxx/indexer/cxx/KytheGraphObserver.cc
+++ b/kythe/cxx/indexer/cxx/KytheGraphObserver.cc
@@ -1071,6 +1071,23 @@ void KytheGraphObserver::recordBlameLocation(
                Claimability::Claimable);
 }
 
+void KytheGraphObserver::recordSemanticDeclUseLocation(
+    const GraphObserver::Range& source_range, const NodeId& node, UseKind kind,
+    Claimability claimability, Implicit i) {
+  EdgeKindID edge_kind;
+  switch (kind) {
+    case UseKind::Unknown:
+      edge_kind =
+          (i == Implicit::Yes ? EdgeKindID::kRefImplicit : EdgeKindID::kRef);
+      break;
+    case UseKind::Write:
+      edge_kind = (i == Implicit::Yes ? EdgeKindID::kRefWritesImplicit
+                                      : EdgeKindID::kRefWrites);
+      break;
+  }
+  RecordAnchor(source_range, node, edge_kind, claimability);
+}
+
 void KytheGraphObserver::recordInitLocation(
     const GraphObserver::Range& source_range, const NodeId& node,
     Claimability claimability, Implicit i) {

--- a/kythe/cxx/indexer/cxx/KytheGraphObserver.h
+++ b/kythe/cxx/indexer/cxx/KytheGraphObserver.h
@@ -243,6 +243,10 @@ class KytheGraphObserver : public GraphObserver {
                            GraphObserver::Claimability cl,
                            GraphObserver::Implicit i) override;
 
+  void recordSemanticDeclUseLocation(const Range& SourceRange,
+                                     const NodeId& DeclId, UseKind K,
+                                     Claimability Cl, Implicit I) override;
+
   void recordInitLocation(const Range& source_range, const NodeId& node,
                           GraphObserver::Claimability cl,
                           GraphObserver::Implicit i) override;

--- a/kythe/cxx/indexer/cxx/clang_utils.cc
+++ b/kythe/cxx/indexer/cxx/clang_utils.cc
@@ -93,4 +93,25 @@ bool ShouldHaveBlameContext(const clang::Decl* decl) {
       return false;
   }
 }
+
+bool IsUsedAsWrite(const IndexedParentMap& map, const clang::Stmt* stmt) {
+  // TODO(zarko): Improve coverage (or get rid of this entirely and maintain
+  // traversal state in the AST walker; this would be more of a maintenance
+  // and correctness burden, but may be required for richer representations.)
+  if (stmt == nullptr) return false;
+  const auto* indexed_parent = map.GetIndexedParent(*stmt);
+  if (indexed_parent == nullptr) return false;
+  const auto* parent_stmt = indexed_parent->parent.get<clang::Stmt>();
+  if (parent_stmt == nullptr) return false;
+  switch (parent_stmt->getStmtClass()) {
+    case clang::Stmt::StmtClass::BinaryOperatorClass: {
+      const auto* binop = clang::dyn_cast<clang::BinaryOperator>(parent_stmt);
+      if (binop == nullptr) return false;
+      return binop->getOpcode() == clang::BinaryOperator::Opcode::BO_Assign &&
+             binop->getLHS() == stmt;
+    }
+    default:
+      return false;
+  }
+}
 }  // namespace kythe

--- a/kythe/cxx/indexer/cxx/clang_utils.h
+++ b/kythe/cxx/indexer/cxx/clang_utils.h
@@ -21,6 +21,7 @@
 #include "clang/AST/DeclarationName.h"
 #include "clang/Basic/LangOptions.h"
 #include "clang/Basic/SourceManager.h"
+#include "kythe/cxx/indexer/cxx/indexed_parent_map.h"
 
 namespace kythe {
 /// \return true if `DN` is an Objective-C selector.

--- a/kythe/cxx/indexer/cxx/clang_utils.h
+++ b/kythe/cxx/indexer/cxx/clang_utils.h
@@ -34,6 +34,10 @@ const clang::Decl* FindSpecializedTemplate(const clang::Decl* decl);
 /// \return true if a reference to `decl` should be given blame context.
 bool ShouldHaveBlameContext(const clang::Decl* decl);
 
+/// \return true if `stmt` is being used in a write position according to
+/// `map`.
+bool IsUsedAsWrite(const IndexedParentMap& map, const clang::Stmt* stmt);
+
 }  // namespace kythe
 
 #endif  // KYTHE_CXX_INDEXER_CXX_CLANG_UTILS_H_

--- a/kythe/cxx/indexer/cxx/testdata/BUILD
+++ b/kythe/cxx/indexer/cxx/testdata/BUILD
@@ -3240,6 +3240,12 @@ cc_indexer_test(
     tags = ["df"],
 )
 
+cc_indexer_test(
+    name = "df_var_rw",
+    srcs = ["df/df_var_rw.cc"],
+    tags = ["df"],
+)
+
 test_suite(
     name = "indexer_df",
     tags = ["df"],

--- a/kythe/cxx/indexer/cxx/testdata/df/df_var_ref_blame.cc
+++ b/kythe/cxx/indexer/cxx/testdata/df/df_var_ref_blame.cc
@@ -4,7 +4,7 @@
 void f() {
   //- @x defines/binding VarX
 	int x;
-  //- @x ref VarX
+  //- @x ref/writes VarX
   //- @x childof FnF
 	x = 3;
 }

--- a/kythe/cxx/indexer/cxx/testdata/df/df_var_rw.cc
+++ b/kythe/cxx/indexer/cxx/testdata/df/df_var_rw.cc
@@ -1,0 +1,10 @@
+// Variable writes are distinguished from reads.
+
+int f() {
+  //- @x defines/binding VarX
+  int x = 3;  // Definition site.
+  //- @x ref/writes VarX
+  x = 4;  // Write site.
+  //- @x ref VarX
+  return x;  // Read site.
+}

--- a/kythe/cxx/indexer/cxx/testdata/objc/categories/extension_property.m
+++ b/kythe/cxx/indexer/cxx/testdata/objc/categories/extension_property.m
@@ -29,7 +29,7 @@
 @synthesize val = data;
 
 -(int) foo {
-  //- @data ref Data
+  //- @data ref/writes Data
   self->data = 300;
 
   //- @x defines/binding XVar

--- a/kythe/cxx/indexer/cxx/testdata/objc/ivar_decl.m
+++ b/kythe/cxx/indexer/cxx/testdata/objc/ivar_decl.m
@@ -15,7 +15,7 @@
 //- @Box defines/binding BoxImpl
 @implementation Box
 -(int)foo {
-  //- @data ref Data
+  //- @data ref/writes Data
   self->data = 300;
   return self->data;
 }

--- a/kythe/cxx/indexer/cxx/testdata/objc/property_decl_defn_synth.m
+++ b/kythe/cxx/indexer/cxx/testdata/objc/property_decl_defn_synth.m
@@ -45,7 +45,7 @@
 @synthesize d = newvar;
 
 -(void) foo {
-  //- @width ref WidthIVarDecl
+  //- @width ref/writes WidthIVarDecl
   self->width = 100;
 
   //- @a ref ADecl
@@ -53,17 +53,17 @@
 
   //- @b ref BDecl
   self.b = 300;
-  //- @"_b" ref BIvarDecl
+  //- @"_b" ref/writes BIvarDecl
   self->_b = 301;
 
   //- @c ref CDecl
   self.c = 400;
-  //- @c ref CIvarDecl
+  //- @c ref/writes CIvarDecl
   self->c = 401;
 
   //- @d ref DDecl
   self.d = 500;
-  //- @newvar ref NewvarIVarDecl
+  //- @newvar ref/writes NewvarIVarDecl
   self->newvar = 501;
 }
 @end

--- a/kythe/cxx/indexer/cxx/testdata/rec/rec_class_member_ptr.cc
+++ b/kythe/cxx/indexer/cxx/testdata/rec/rec_class_member_ptr.cc
@@ -15,6 +15,6 @@ void fn() {
   int C::* mptr;
   //- @C ref CDecl
   //- @member ref MemberDecl
-  //- @mptr ref PtrDecl
+  //- @mptr ref/writes PtrDecl
   mptr = &C::member;
 }


### PR DESCRIPTION
This PR marks a subset of ref edges known to be writes (currently using the primitive operator = with vars or ivars on the lhs) as `ref/writes` (or `ref/writes/implicit`).