### PR TITLE
feat(cxx_indexer): record var-to-var influence

### DIFF
--- a/kythe/cxx/common/indexing/KytheGraphRecorder.cc
+++ b/kythe/cxx/common/indexing/KytheGraphRecorder.cc
@@ -83,7 +83,7 @@ static const std::string* kEdgeKindSpellings[] = {
     new std::string("/kythe/edge/ref/id"),
     new std::string("/kythe/edge/ref/writes"),
     new std::string("/kythe/edge/ref/writes/implicit"),
-};
+    new std::string("/kythe/edge/influences")};
 
 bool of_spelling(absl::string_view str, EdgeKindID* edge_id) {
   size_t edge_index = 0;

--- a/kythe/cxx/common/indexing/KytheGraphRecorder.h
+++ b/kythe/cxx/common/indexing/KytheGraphRecorder.h
@@ -124,7 +124,8 @@ enum class EdgeKindID {
   kClangUsr,
   kRefId,
   kRefWrites,
-  kRefWritesImplicit
+  kRefWritesImplicit,
+  kInfluences
 };
 
 /// \brief Returns the Kythe spelling of `node_kind_id`

--- a/kythe/cxx/indexer/cxx/BUILD
+++ b/kythe/cxx/indexer/cxx/BUILD
@@ -194,6 +194,7 @@ cc_library(
         "//kythe/cxx/extractor:supported_language",
         "//third_party/llvm/src:clang_builtin_headers",
         "@com_github_google_glog//:glog",
+        "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/flags:flag",
         "@com_google_absl//absl/memory",
         "@org_llvm//:LLVMSupport",

--- a/kythe/cxx/indexer/cxx/GraphObserver.h
+++ b/kythe/cxx/indexer/cxx/GraphObserver.h
@@ -715,6 +715,10 @@ class GraphObserver {
   virtual void recordTypeEdge(const NodeId& TermNodeId,
                               const NodeId& TypeNodeId) {}
 
+  /// \brief Records that `Influencer` influences `Influenced`.
+  virtual void recordInfluences(const NodeId& Influencer,
+                                const NodeId& Influenced) {}
+
   /// \brief Records an upper bound for the type of a node as an edge in the
   /// graph.
   /// \param TypeNodeId The identifier for the node to given a bounded type.

--- a/kythe/cxx/indexer/cxx/IndexerASTHooks.cc
+++ b/kythe/cxx/indexer/cxx/IndexerASTHooks.cc
@@ -1948,8 +1948,7 @@ bool IndexerASTVisitor::TraverseBinAssign(clang::BinaryOperator* BO) {
       lhs != nullptr && rhs != nullptr) {
     if (!WalkUpFromBinAssign(BO)) return false;
     if (!TraverseStmt(lhs)) return false;
-    auto scope_guard = PushScope(Job->InfluenceSets,
-                                 absl::flat_hash_set<const clang::Decl*>());
+    auto scope_guard = PushScope(Job->InfluenceSets, {});
     if (!TraverseStmt(rhs)) {
       return false;
     }

--- a/kythe/cxx/indexer/cxx/IndexerASTHooks.h
+++ b/kythe/cxx/indexer/cxx/IndexerASTHooks.h
@@ -26,7 +26,6 @@
 
 #include "GraphObserver.h"
 #include "IndexerLibrarySupport.h"
-#include "absl/container/flat_hash_set.h"
 #include "absl/memory/memory.h"
 #include "absl/types/optional.h"
 #include "clang/AST/ASTContext.h"
@@ -981,9 +980,6 @@ class IndexerASTVisitor : public RecursiveTypeVisitor<IndexerASTVisitor> {
   /// \brief The number of (raw) bytes to use to represent a USR. If 0,
   /// no USRs will be recorded.
   int UsrByteSize = 0;
-
-  /// \brief The current stack of influence sets.
-  std::vector<absl::flat_hash_set<const clang::Decl*>> influence_sets_;
 };
 
 /// \brief An `ASTConsumer` that passes events to a `GraphObserver`.

--- a/kythe/cxx/indexer/cxx/IndexerASTHooks.h
+++ b/kythe/cxx/indexer/cxx/IndexerASTHooks.h
@@ -26,6 +26,7 @@
 
 #include "GraphObserver.h"
 #include "IndexerLibrarySupport.h"
+#include "absl/container/flat_hash_set.h"
 #include "absl/memory/memory.h"
 #include "absl/types/optional.h"
 #include "clang/AST/ASTContext.h"
@@ -115,6 +116,8 @@ class IndexerASTVisitor : public RecursiveTypeVisitor<IndexerASTVisitor> {
   bool VisitBindingDecl(const clang::BindingDecl* Decl);
   bool VisitSizeOfPackExpr(const clang::SizeOfPackExpr* Expr);
   bool VisitDeclRefExpr(const clang::DeclRefExpr* DRE);
+
+  bool TraverseBinAssign(clang::BinaryOperator* BO);
 
   bool TraverseInitListExpr(clang::InitListExpr* ILE);
   bool VisitInitListExpr(const clang::InitListExpr* ILE);
@@ -978,6 +981,9 @@ class IndexerASTVisitor : public RecursiveTypeVisitor<IndexerASTVisitor> {
   /// \brief The number of (raw) bytes to use to represent a USR. If 0,
   /// no USRs will be recorded.
   int UsrByteSize = 0;
+
+  /// \brief The current stack of influence sets.
+  std::vector<absl::flat_hash_set<const clang::Decl*>> influence_sets_;
 };
 
 /// \brief An `ASTConsumer` that passes events to a `GraphObserver`.

--- a/kythe/cxx/indexer/cxx/KytheGraphObserver.cc
+++ b/kythe/cxx/indexer/cxx/KytheGraphObserver.cc
@@ -647,6 +647,12 @@ void KytheGraphObserver::recordTypeEdge(const NodeId& term_id,
                      VNameRefFromNodeId(type_id));
 }
 
+void KytheGraphObserver::recordInfluences(const NodeId& influencer,
+                                          const NodeId& influenced) {
+  recorder_->AddEdge(VNameRefFromNodeId(influencer), EdgeKindID::kInfluences,
+                     VNameRefFromNodeId(influenced));
+}
+
 void KytheGraphObserver::recordUpperBoundEdge(const NodeId& TypeNodeId,
                                               const NodeId& TypeBoundNodeId) {
   recorder_->AddEdge(VNameRefFromNodeId(TypeNodeId), EdgeKindID::kBoundedUpper,

--- a/kythe/cxx/indexer/cxx/KytheGraphObserver.h
+++ b/kythe/cxx/indexer/cxx/KytheGraphObserver.h
@@ -304,6 +304,9 @@ class KytheGraphObserver : public GraphObserver {
 
   void recordTypeEdge(const NodeId& term_id, const NodeId& type_id) override;
 
+  void recordInfluences(const NodeId& influencer,
+                        const NodeId& influenced) override;
+
   void recordUpperBoundEdge(const NodeId& TypeNodeId,
                             const NodeId& TypeBoundNodeId) override;
 

--- a/kythe/cxx/indexer/cxx/indexer_worklist.h
+++ b/kythe/cxx/indexer/cxx/indexer_worklist.h
@@ -21,6 +21,7 @@
 #include <utility>
 #include <vector>
 
+#include "absl/container/flat_hash_set.h"
 #include "clang/AST/Decl.h"
 #include "clang/Sema/Template.h"
 #include "kythe/cxx/indexer/cxx/GraphObserver.h"
@@ -101,6 +102,9 @@ struct IndexJob {
 
   /// \brief A stack of CXXConstructExprs we've already visited.
   std::vector<const clang::CXXConstructExpr*> ConstructorStack;
+
+  /// \brief The current stack of influence sets.
+  std::vector<absl::flat_hash_set<const clang::Decl*>> InfluenceSets;
 };
 
 class IndexerASTVisitor;

--- a/kythe/cxx/indexer/cxx/testdata/BUILD
+++ b/kythe/cxx/indexer/cxx/testdata/BUILD
@@ -3246,6 +3246,13 @@ cc_indexer_test(
     tags = ["df"],
 )
 
+cc_indexer_test(
+    name = "df_var_influence",
+    srcs = ["df/df_var_influence.cc"],
+    ignore_dups = True,
+    tags = ["df"],
+)
+
 test_suite(
     name = "indexer_df",
     tags = ["df"],

--- a/kythe/cxx/indexer/cxx/testdata/df/df_var_influence.cc
+++ b/kythe/cxx/indexer/cxx/testdata/df/df_var_influence.cc
@@ -1,0 +1,17 @@
+// Basic var to var influence.
+void f() {
+  //- @x defines/binding VarX
+  //- @y defines/binding VarY
+  //- @z defines/binding VarZ
+  int x = 0, y = 1, z = 2;
+  //- VarZ influences VarY
+  //- VarY influences VarX
+  //- !{VarZ influences VarX}
+  //- !{VarY influences VarZ}
+  x = y = z;
+  //- @w defines/binding VarW
+  int w = 3;
+  //- VarX influences VarW
+  //- VarY influences VarW
+  w = x + y;
+}

--- a/kythe/docs/schema/schema.txt
+++ b/kythe/docs/schema/schema.txt
@@ -615,6 +615,38 @@ specification of that service. The specification and its generated artifacts
 may be joined by the *generates* edge.  Either both the specification and its
 generated artifact are file nodes or both are semantic nodes.
 
+[[influences]]
+influences
+~~~~~~~~~~
+
+Brief description::
+  A *influences* B if A directly affects B during the evaluation of a program.
+Commonly arises from::
+  assignment
+Points from::
+  semantic nodes
+Points toward::
+  semantic nodes
+Ordinals are used::
+  never
+Notes::
+  This is an experimental definition and is expected to undergo refinement.
+
+[kythe,C++,"Assignment causes influence"]
+--------------------------------------------------------------------------------
+void f() {
+  //- @x defines/binding VarX
+  //- @y defines/binding VarY
+  //- @z defines/binding VarZ
+  int x = 0, y = 1, z = 2;
+  //- VarZ influences VarY
+  //- VarY influences VarX
+  //- !{VarZ influences VarX}
+  //- !{VarY influences VarZ}
+  x = y = z;
+}
+--------------------------------------------------------------------------------
+
 [[instantiates]]
 instantiates
 ~~~~~~~~~~~~


### PR DESCRIPTION
This PR introduces the `influences` relation on variables, which
is meant as a primitive (and still experimental) way to track
dataflow in the semantic graph. Influence is currently limited
only to the primitive assignment operator =.