### PR TITLE
Support deprecated tags in TS marked source

### DIFF
--- a/kythe/typescript/indexer.ts
+++ b/kythe/typescript/indexer.ts
@@ -1979,7 +1979,10 @@ class Visitor {
     this.emitFact(doc, FactName.TEXT, jsdoc);
   }
 
-  /** Tags a node as deprecated if its JSDoc marks it as so. */
+  /**
+   * Tags a node as deprecated if its JSDoc marks it as so.
+   * TODO(TS 4.0): TS 4.0 exposes a JSDocDeprecatedTag.
+   */
   maybeTagDeprecated(node: ts.Node, nodeVName: VName) {
     const deprecatedTag =
         ts.getJSDocTags(node).find(tag => tag.tagName.text === 'deprecated');

--- a/kythe/typescript/indexer.ts
+++ b/kythe/typescript/indexer.ts
@@ -1950,6 +1950,8 @@ class Visitor {
    * for JSDoc comments.
    */
   visitJSDoc(node: ts.Node, target: VName) {
+    this.maybeTagDeprecated(node, target);
+
     const text = node.getFullText();
     const comments = ts.getLeadingCommentRanges(text, 0);
     if (!comments) return;
@@ -1975,6 +1977,16 @@ class Visitor {
     this.emitNode(doc, NodeKind.DOC);
     this.emitEdge(doc, EdgeKind.DOCUMENTS, target);
     this.emitFact(doc, FactName.TEXT, jsdoc);
+  }
+
+  /** Tags a node as deprecated if its JSDoc marks it as so. */
+  maybeTagDeprecated(node: ts.Node, nodeVName: VName) {
+    const deprecatedTag =
+        ts.getJSDocTags(node).find(tag => tag.tagName.text === 'deprecated');
+    if (deprecatedTag) {
+      this.emitFact(
+          nodeVName, FactName.TAG_DEPRECATED, deprecatedTag.comment || '');
+    }
   }
 
   /** visit is the main dispatch for visiting AST nodes. */

--- a/kythe/typescript/kythe.ts
+++ b/kythe/typescript/kythe.ts
@@ -155,6 +155,7 @@ export enum FactName {
   SNIPPET_END = '/kythe/snippet/end',
   SNIPPET_START = '/kythe/snippet/start',
   SUBKIND = '/kythe/subkind',
+  TAG_DEPRECATED = '/kythe/tag/deprecated',
   TEXT = '/kythe/text',
   TEXT_ENCODING = '/kythe/text/encoding',
   VISIBILITY = '/kythe/visibility',

--- a/kythe/typescript/testdata/jsdoc.ts
+++ b/kythe/typescript/testdata/jsdoc.ts
@@ -55,3 +55,17 @@ class Class {
 //- FunctionDoc.text "Function doc."
 /** Function doc. */
 function myFunc() {}
+
+interface String {
+//- @:66"fontsize" defines/binding FontSize
+//- FontSize.tag/deprecated "The <font> element has been removed in HTML5.\nPrefer using CSS properties."
+  /**
+   * @deprecated The <font> element has been removed in HTML5.
+   *             Prefer using CSS properties.
+   */
+  fontsize: (size: number) => string;
+//- @:70"big" defines/binding Big
+//- Big.tag/deprecated ""
+  /** @deprecated */
+  big: () => string;
+}


### PR DESCRIPTION
While reading the [TS 4.0 release notes](https://devblogs.microsoft.com/typescript/announcing-typescript-4-0-beta/),
I realized that the TS indexer currently doesn't tag entities that are
marked as deprecated. There's a formal API for this in TS 4.0, but we
accurately determine whether a node is deprecated (and why) by scanning
the JSDoc tags of that node.