### PR TITLE
Convert PackAny's parameter to absl::string_view.

### DIFF
--- a/kythe/cxx/common/json_proto.cc
+++ b/kythe/cxx/common/json_proto.cc
@@ -234,9 +234,9 @@ absl::Status ParseFromJsonString(absl::string_view input,
   return ParseFromJsonString(input, DefaultParseOptions(), message);
 }
 
-void PackAny(const google::protobuf::Message& message, const char* type_uri,
-             google::protobuf::Any* out) {
-  out->set_type_url(type_uri);
+void PackAny(const google::protobuf::Message& message,
+             absl::string_view type_uri, google::protobuf::Any* out) {
+  out->set_type_url(type_uri.data(), type_uri.size());
   google::protobuf::io::StringOutputStream stream(out->mutable_value());
   google::protobuf::io::CodedOutputStream coded_output_stream(&stream);
   message.SerializeToCodedStream(&coded_output_stream);

--- a/kythe/cxx/common/json_proto.h
+++ b/kythe/cxx/common/json_proto.h
@@ -99,8 +99,8 @@ StatusOr<std::string> WriteMessageAsJsonToString(
 /// \param message The message to wrap.
 /// \param type_uri The URI of the message type.
 /// \param out The resulting Any.
-void PackAny(const google::protobuf::Message& message, const char* type_uri,
-             google::protobuf::Any* out);
+void PackAny(const google::protobuf::Message& message,
+             absl::string_view type_uri, google::protobuf::Any* out);
 
 /// \brief Unpack a protobuf from an Any.
 /// \param any The Any to unpack.


### PR DESCRIPTION
Modernizing the API by replacing `const char *` parameter type with `string_view`.