### PR TITLE
fix(rust): Update author for Rust example package

### DIFF
--- a/kythe/rust/examples/hello_world/cargo/Cargo.toml
+++ b/kythe/rust/examples/hello_world/cargo/Cargo.toml
@@ -17,7 +17,7 @@
 [package]
 name = "hello_world"
 version = "0.1.0"
-authors = ["Wyatt Calandro <wcalandro@google.com>"]
+authors = ["The Kythe Authors"]
 edition = "2018"
 
 # Mandatory (or Cargo tooling is unhappy)


### PR DESCRIPTION
This PR fixes the author field in the Rust example package to be "The Kythe Authors"