### PR TITLE
fix(rust): Ensure that Rust extractor creates a top-level folder

### DIFF
--- a/.arclint
+++ b/.arclint
@@ -2,7 +2,7 @@
   "linters": {
     "spelling": {
       "type": "spelling",
-      "exclude": "(^third_party)"
+      "exclude": "(^third_party|kythe/java/com/google/devtools/kythe/platform/java/helpers/SignatureGenerator.java)"
     },
     "chmod": {
       "type": "chmod",

--- a/kythe/rust/extractor/src/bin/extractor.rs
+++ b/kythe/rust/extractor/src/bin/extractor.rs
@@ -89,7 +89,7 @@ fn main() -> Result<()> {
         .with_context(|| "Failed to serialize IndexedCompilation to bytes".to_string())?;
     let indexed_compilation_digest = sha256digest(&indexed_compilation_bytes);
     kzip_add_file(
-        format!("pbunits/{}", indexed_compilation_digest),
+        format!("root/pbunits/{}", indexed_compilation_digest),
         &indexed_compilation_bytes,
         &mut kzip,
     )?;
@@ -180,7 +180,7 @@ fn kzip_add_required_input(
         .read_to_end(&mut source_file_contents)
         .with_context(|| format!("Failed read file {:?}", file_path_string))?;
     let digest = sha256digest(&source_file_contents);
-    kzip_add_file(format!("files/{}", digest), &source_file_contents, zip_writer)?;
+    kzip_add_file(format!("root/files/{}", digest), &source_file_contents, zip_writer)?;
 
     // Generate FileInput and add it to the list of required inputs
     let mut file_input = CompilationUnit_FileInput::new();

--- a/kythe/rust/extractor/tests/integration_test.rs
+++ b/kythe/rust/extractor/tests/integration_test.rs
@@ -143,7 +143,7 @@ fn correct_arguments_succeed(
     let mut kzip = zip::ZipArchive::new(kzip_file).expect("Couldn't read kzip archive");
 
     // Ensure the source file from the test macro is in the kzip
-    kzip.by_name("files/7cb3b3c74ecdf86f434548ba15c1651c92bf03b6690fd0dfc053ab09d094cf03").unwrap();
+    kzip.by_name("root/files/7cb3b3c74ecdf86f434548ba15c1651c92bf03b6690fd0dfc053ab09d094cf03").unwrap();
 
     // Ensure protobuf is in the kzip
     let mut cu_path_str = String::from("");

--- a/kythe/rust/indexer/src/providers.rs
+++ b/kythe/rust/indexer/src/providers.rs
@@ -80,7 +80,7 @@ impl KzipFileProvider {
             }
             // Safe to unwrap because kzip read would have failed if the internal paths
             // weren't UTF-8
-            path.to_str().unwrap().to_owned()
+            path.to_str().unwrap().to_owned().replace("/", "")
         };
 
         Ok(Self { zip_archive, root_name })

--- a/kythe/rust/indexer/src/providers.rs
+++ b/kythe/rust/indexer/src/providers.rs
@@ -113,9 +113,7 @@ impl KzipFileProvider {
 impl FileProvider for KzipFileProvider {
     /// Given a file hash, returns whether the file exists in the kzip.
     fn exists(&mut self, file_hash: &str) -> bool {
-        // root_name contains a trailing forward-slash, so it's needed in the format
-        // string. For example, the extractor kzip that will have a root name of "root/"
-        let name = format!("{}files/{}", self.root_name, file_hash);
+        let name = format!("{}/files/{}", self.root_name, file_hash);
         self.zip_archive.by_name(&name).is_ok()
     }
 
@@ -127,7 +125,7 @@ impl FileProvider for KzipFileProvider {
     /// An error will be returned if the file does not exist or cannot be read.
     fn contents(&mut self, file_hash: &str) -> Result<Vec<u8>, KytheError> {
         // Ensure the file exists in the kzip
-        let name = format!("{}files/{}", self.root_name, file_hash);
+        let name = format!("{}/files/{}", self.root_name, file_hash);
         let file = self.zip_archive.by_name(&name).map_err(|_| KytheError::FileNotFoundError)?;
         let mut reader = BufReader::new(file);
         let mut file_contents: Vec<u8> = Vec::new();


### PR DESCRIPTION
This PR fixes a bug in the Rust extractor where a top-level folder was not being created in the kzips, causing them to be invalid. The extractor will now create a top-level folder named "root". The indexer has been fixed to properly detect the root folder name. 

This PR adds an exclusion for `kythe/java/com/google/devtools/kythe/platform/java/helpers/SignatureGenerator.java` from the arcanist spellchecker. This prevents the linter from failing due to a false-positive.