### PR TITLE
Remove deprecated flag from bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -7,9 +7,6 @@ build --strategy=TypeScriptCompile=sandboxed,local
 # Compatibility flags to avoid regressions.
 build --incompatible_disallow_empty_glob
 
-# Required for build_bazel_rules_nodejs
-common --experimental_allow_incremental_repository_updates
-
 build --workspace_status_command tools/buildstamp/get_workspace_status
 build --auto_cpu_environment_group=//buildenv:cpu
 


### PR DESCRIPTION
--experimental_allow_incremental_repository_updates has been deleted in https://github.com/bazelbuild/bazel/commit/fdf10c34c82c563fb7fc7f262de32e1f7af59e2d