### PR TITLE
chore(proto_indexer): remove unused FileVNameGenerator

### DIFF
--- a/kythe/cxx/indexer/proto/indexer_frontend.cc
+++ b/kythe/cxx/indexer/proto/indexer_frontend.cc
@@ -30,7 +30,6 @@ namespace kythe {
 std::string IndexProtoCompilationUnit(const proto::CompilationUnit& unit,
                                       const std::vector<proto::FileData>& files,
                                       KytheOutputStream* output) {
-  FileVNameGenerator file_vnames;
   KytheGraphRecorder recorder(output);
 
   std::vector<std::string> unprocessed_args;
@@ -49,8 +48,8 @@ std::string IndexProtoCompilationUnit(const proto::CompilationUnit& unit,
   for (const auto& file_data : files) {
     file_reader.AddFile(file_data.info().path(), file_data.content());
   }
-  lang_proto::ProtoAnalyzer analyzer(&unit, &descriptor_db, &file_vnames,
-                                     &recorder, &file_substitution_cache);
+  lang_proto::ProtoAnalyzer analyzer(&unit, &descriptor_db, &recorder,
+                                     &file_substitution_cache);
   if (unit.source_file().empty()) {
     return "Error: no source_files in CompilationUnit.";
   }

--- a/kythe/cxx/indexer/proto/proto_analyzer.cc
+++ b/kythe/cxx/indexer/proto/proto_analyzer.cc
@@ -39,10 +39,9 @@ using ::kythe::proto::VName;
 ProtoAnalyzer::ProtoAnalyzer(
     const proto::CompilationUnit* unit,
     google::protobuf::DescriptorDatabase* descriptor_db,
-    FileVNameGenerator* file_vnames, KytheGraphRecorder* recorder,
+    KytheGraphRecorder* recorder,
     absl::flat_hash_map<std::string, std::string>* path_substitution_cache)
     : unit_(unit),
-      file_vnames_(file_vnames),
       recorder_(recorder),
       path_substitution_cache_(path_substitution_cache),
       descriptor_db_(descriptor_db) {}
@@ -116,7 +115,7 @@ VName ProtoAnalyzer::VNameFromFullPath(const std::string& path) const {
       return input.v_name();
     }
   }
-  return file_vnames_->LookupVName(path);
+  return VName{};
 }
 
 }  // namespace lang_proto

--- a/kythe/cxx/indexer/proto/proto_analyzer.h
+++ b/kythe/cxx/indexer/proto/proto_analyzer.h
@@ -46,7 +46,7 @@ class ProtoAnalyzer {
   ProtoAnalyzer(
       const proto::CompilationUnit* unit,
       google::protobuf::DescriptorDatabase* descriptor_db,
-      FileVNameGenerator* file_vnames, KytheGraphRecorder* recorder,
+      KytheGraphRecorder* recorder,
       absl::flat_hash_map<std::string, std::string>* path_substitution_cache);
 
   // disallow copy and assign
@@ -72,14 +72,11 @@ class ProtoAnalyzer {
   absl::node_hash_set<std::string> visited_files_;
 
   // Returns the VName associated with `path` in unit_'s required inputs, or
-  // a VName created from file_vnames_ if none is found.
+  // an empty vname if none is found.
   proto::VName VNameFromFullPath(const std::string& path) const;
 
   // Compilation unit to be analyzed.
   const proto::CompilationUnit* unit_;
-
-  // A generator for consistently mapping file paths to VNames.
-  FileVNameGenerator* file_vnames_;
 
   // Where we output Kythe artifacts.
   KytheGraphRecorder* recorder_;


### PR DESCRIPTION
The FileVNameGenerator only produces useful VName lookups if given a
vname config file or if other defaults are set. In this case it was just
being used empty.

Because the proto indexer only needs file vnames for .proto files and
these all have vnames specified in the compilation unit, there isn't
need for other configuration.

In the case that a proto is referenced, but not in the compilation unit,
an empty vname would be used. This shouldn't happen though because the
proto parser itself would fail and the indexing code wouldn't get run.

We could consider changing the lookup functions to return a StatusOr to
handle that case better.