### PR TITLE
fix(cxx_indexer): avoid an assert check in Clang, silence errors

### DIFF
--- a/kythe/cxx/indexer/cxx/BUILD
+++ b/kythe/cxx/indexer/cxx/BUILD
@@ -351,6 +351,7 @@ cc_library(
         ":clang_utils",
         ":graph_observer",
         ":kythe_claim_client",
+        "//kythe/cxx/common:scope_guard",
         "//third_party/llvm/src:clang_builtin_headers",
         "@com_github_google_glog//:glog",
         "@com_google_absl//absl/flags:flag",

--- a/kythe/cxx/indexer/cxx/marked_source.cc
+++ b/kythe/cxx/indexer/cxx/marked_source.cc
@@ -596,11 +596,10 @@ void MarkedSourceGenerator::ReplaceMarkedSourceWithTemplateArgumentList(
   // diagnostics from the typechecker.
   clang::IgnoringDiagConsumer consumer;
   auto* diags = &cache_->source_manager().getDiagnostics();
-  bool owned = diags->ownsClient();
-  auto* client = diags->getClient();
+  auto guard = MakeScopeGuard(
+      [diags = diags, client = diags->getClient(),
+       owned = diags->ownsClient()] { diags->setClient(client, owned); });
   diags->setClient(&consumer, false);
-  auto guard = MakeScopeGuard([=] { diags->setClient(client, owned); });
-
   auto* template_decl = decl->getSpecializedTemplate();
   auto* template_params = template_decl->getTemplateParameters();
   auto cached_default = cache_->first_default_template_argument()->find(decl);


### PR DESCRIPTION
For some reason, in recent versions of Clang, integer template arguments (when fed into Sema as we do in MarkedSource) reach an assert that fails. To avoid tripping the assert, this PR stops trying to infer information about default template arguments if it encounters an integer template argument.

This PR also disables diagnostics while inferring which arguments are defaults. Previously, the indexer would report spurious diagnostics that were raised during inference.