### PR TITLE
Replace `stream::iterator` with alternatives in enhanced for loops.

### DIFF
--- a/kythe/java/com/google/devtools/kythe/platform/java/filemanager/CompilationUnitPathFileManager.java
+++ b/kythe/java/com/google/devtools/kythe/platform/java/filemanager/CompilationUnitPathFileManager.java
@@ -357,6 +357,8 @@ public final class CompilationUnitPathFileManager extends ForwardingStandardJava
               .toAbsolutePath();
       Path systemRoot = Files.createDirectory(temporaryDirectory.resolve("system"));
       try (Stream<Path> stream = Files.walk(sys.resolve("lib"))) {
+        // While this is ugly, it's safer in general than converting to a one-shot Iterable
+        // using ::iterator.
         Iterator<Path> it = stream.iterator();
         while (it.hasNext()) {
           Path path = it.next();

--- a/kythe/java/com/google/devtools/kythe/platform/java/filemanager/CompilationUnitPathFileManager.java
+++ b/kythe/java/com/google/devtools/kythe/platform/java/filemanager/CompilationUnitPathFileManager.java
@@ -357,7 +357,9 @@ public final class CompilationUnitPathFileManager extends ForwardingStandardJava
               .toAbsolutePath();
       Path systemRoot = Files.createDirectory(temporaryDirectory.resolve("system"));
       try (Stream<Path> stream = Files.walk(sys.resolve("lib"))) {
-        for (Path path : (Iterable<Path>) stream::iterator) {
+        Iterator<Path> it = stream.iterator();
+        while (it.hasNext()) {
+          Path path = it.next();
           Path p =
               Files.copy(
                   path,


### PR DESCRIPTION
Stream::iterator is an unsafe way to create an Iterable, and will soon be banned by an ErrorProne check.