### PR TITLE
fix(rust): Fix small bugs in the Rust implementation

### DIFF
--- a/kythe/rust/extractor/src/bin/extractor.rs
+++ b/kythe/rust/extractor/src/bin/extractor.rs
@@ -47,6 +47,7 @@ fn main() -> Result<()> {
     let kzip_file = File::create(&config.output_path)
         .with_context(|| format!("Failed to create kzip file at path {:?}", config.output_path))?;
     let mut kzip = ZipWriter::new(kzip_file);
+    kzip.add_directory("root/", FileOptions::default())?;
 
     // Get KYTHE_CORPUS variable
     let corpus = std::env::var("KYTHE_CORPUS")

--- a/kythe/rust/indexer/testdata/struct.rs
+++ b/kythe/rust/indexer/testdata/struct.rs
@@ -20,3 +20,5 @@ impl TestStruct {
     //- TestFn childof Struct
     fn _test() {}
 }
+
+fn main(){}


### PR DESCRIPTION
This PR fixes the following bugs:
- Previously, the Rust extractor didn't emit an explicit root directory. This meant that the kzips produced by the extractor were incompatible with the `kzip` tool. This has been fixed.
- The struct verifier test for the indexer was missing a main function and not working properly. The main function has now been added.