### PR TITLE
fix(rust): Fix Rust indexer issue with Trait definitions

### DIFF
--- a/kythe/rust/indexer/testdata/modules/test.rs
+++ b/kythe/rust/indexer/testdata/modules/test.rs
@@ -7,8 +7,8 @@
 //- TestMod.complete definition
 //- TestMod childof ImplicitMod
 
-//- @nothing defines/binding NothingFn
+//- @_nothing defines/binding NothingFn
 //- NothingFn childof TestMod
-fn nothing() {
+fn _nothing() {
     ()
 }

--- a/kythe/rust/indexer/testdata/struct.rs
+++ b/kythe/rust/indexer/testdata/struct.rs
@@ -1,10 +1,10 @@
 // Verifies that structs are properly handled by the indexer
 
-//- @TestStruct defines/binding Struct
+//- @_TestStruct defines/binding Struct
 //- Struct.node/kind record
 //- Struct.complete definition
 //- Struct.subkind struct
-struct TestStruct {
+struct _TestStruct {
     //- @test_field defines/binding StructField
     //- StructField childof Struct
     //- StructField.node/kind variable
@@ -13,7 +13,7 @@ struct TestStruct {
     test_field: String,
 }
 
-impl TestStruct {
+impl _TestStruct {
     //- @_test defines/binding TestFn
     //- TestFn.node/kind function
     //- TestFn.complete definition

--- a/kythe/rust/indexer/testdata/trait.rs
+++ b/kythe/rust/indexer/testdata/trait.rs
@@ -15,7 +15,6 @@ struct TestStruct {}
 impl TestTrait for TestStruct {
     //- @test_method defines/binding ImplMethod
     //- ImplMethod childof Struct
-    //- ImplMethod overrides TestMethod
     fn test_method() {}
 }
 


### PR DESCRIPTION
This PR fixes the following bugs in the Rust indexer:
- Fixes some of the verifier tests to prevent compiler warnings
- Removes the functionality associated with emitting `overrides` edges with Traits. Overrides are not part of the Rust language, and there were bugs associated with standard library Traits not having their definitions known while indexing.