### PR TITLE
fix(rust): Fix definition anchors and xrefs in the indexer

### DIFF
--- a/kythe/rust/indexer/BUILD
+++ b/kythe/rust/indexer/BUILD
@@ -125,5 +125,5 @@ rust_indexer_test(
 
 rust_indexer_test(
     name = "xrefs_test",
-    srcs = ["testdata/xrefs.rs"],
+    srcs = glob(["testdata/xrefs/*.rs"]),
 )

--- a/kythe/rust/indexer/src/indexer/analyzers.rs
+++ b/kythe/rust/indexer/src/indexer/analyzers.rs
@@ -424,7 +424,12 @@ impl<'a, 'b> CrateAnalyzer<'a, 'b> {
 
     /// Emit all of the Kythe graph nodes and edges, including anchors for the
     /// definition using the provided VName
-    fn emit_definition_node(&mut self, def_vname: &VName, def: &Def, file_vname: &VName) -> Result<(), KytheError> {
+    fn emit_definition_node(
+        &mut self,
+        def_vname: &VName,
+        def: &Def,
+        file_vname: &VName,
+    ) -> Result<(), KytheError> {
         // For Fields, we always emit childof edges to their
         // parent because TupleVariant definitions don't have their fields as children.
         // Structs and Unions have their fields listed as children so the facts would

--- a/kythe/rust/indexer/src/indexer/analyzers.rs
+++ b/kythe/rust/indexer/src/indexer/analyzers.rs
@@ -393,11 +393,11 @@ impl<'a, 'b> CrateAnalyzer<'a, 'b> {
                 })?;
 
             // Generate node based on definition type
-            let mut def_vname = file_vname.clone();
+            let mut def_vname = self.krate_vname.clone();
             let def_signature = format!("{}_def_{}", krate_signature, def.id.index);
             def_vname.set_signature(def_signature.clone());
             def_vname.set_language("rust".to_string());
-            self.emit_definition_node(&def_vname, &def)?;
+            self.emit_definition_node(&def_vname, &def, &file_vname)?;
         }
 
         // Normally you'd want to have a catch-all here where you emit childof edges
@@ -423,7 +423,7 @@ impl<'a, 'b> CrateAnalyzer<'a, 'b> {
 
     /// Emit all of the Kythe graph nodes and edges, including anchors for the
     /// definition using the provided VName
-    fn emit_definition_node(&mut self, def_vname: &VName, def: &Def) -> Result<(), KytheError> {
+    fn emit_definition_node(&mut self, def_vname: &VName, def: &Def, file_vname: &VName) -> Result<(), KytheError> {
         // For Fields, we always emit childof edges to their
         // parent because TupleVariant definitions don't have their fields as children.
         // Structs and Unions have their fields listed as children so the facts would
@@ -612,7 +612,7 @@ impl<'a, 'b> CrateAnalyzer<'a, 'b> {
         // Calculate the byte_start and byte_end using the OffsetIndex
         let byte_start = self
             .offset_index
-            .get_byte_offset(def_vname.get_path(), def.span.line_start.0, def.span.column_start.0)
+            .get_byte_offset(file_vname.get_path(), def.span.line_start.0, def.span.column_start.0)
             .ok_or_else(|| {
                 KytheError::IndexerError(format!(
                     "Failed to get starting offset for definition {:?}",
@@ -621,7 +621,7 @@ impl<'a, 'b> CrateAnalyzer<'a, 'b> {
             })?;
         let byte_end = self
             .offset_index
-            .get_byte_offset(def_vname.get_path(), def.span.line_end.0, def.span.column_end.0)
+            .get_byte_offset(file_vname.get_path(), def.span.line_end.0, def.span.column_end.0)
             .ok_or_else(|| {
                 KytheError::IndexerError(format!(
                     "Failed to get ending offset for definition {:?}",
@@ -715,7 +715,7 @@ impl<'a, 'b> CrateAnalyzer<'a, 'b> {
                 ))
             })?;
 
-            let mut target_vname = reference_vname.clone();
+            let mut target_vname = template_vname.clone();
             target_vname
                 .set_signature(format!("{}_def_{}", disambiguators, reference.ref_id.index));
             target_vname.set_language("rust".to_string());

--- a/kythe/rust/indexer/src/indexer/analyzers.rs
+++ b/kythe/rust/indexer/src/indexer/analyzers.rs
@@ -394,7 +394,7 @@ impl<'a, 'b> CrateAnalyzer<'a, 'b> {
             }
 
             // Generate node based on definition type
-            let mut def_vname = file_vname.unwrap().clone();
+            let mut def_vname = self.krate_vname.clone();
             let def_signature = format!("{}_def_{}", krate_signature, def.id.index);
             def_vname.set_signature(def_signature.clone());
             def_vname.set_language("rust".to_string());

--- a/kythe/rust/indexer/src/indexer/analyzers.rs
+++ b/kythe/rust/indexer/src/indexer/analyzers.rs
@@ -398,7 +398,8 @@ impl<'a, 'b> CrateAnalyzer<'a, 'b> {
             let def_signature = format!("{}_def_{}", krate_signature, def.id.index);
             def_vname.set_signature(def_signature.clone());
             def_vname.set_language("rust".to_string());
-            self.emit_definition_node(&def_vname, &def, &file_vname)?;
+            def_vname.clear_path();
+            self.emit_definition_node(&def_vname, &def, &file_vname.unwrap())?;
         }
 
         // Normally you'd want to have a catch-all here where you emit childof edges
@@ -637,6 +638,8 @@ impl<'a, 'b> CrateAnalyzer<'a, 'b> {
 
         let mut anchor_vname = def_vname.clone();
         anchor_vname.set_signature(format!("{}_anchor", def_vname.get_signature()));
+        anchor_vname.set_path(file_vname.get_path().to_string());
+
         // Module definitions need special logic if they are implicit
         if def.kind == DefKind::Mod && self.is_module_implicit(def) {
             // Emit a 0-length anchor and defines edge at the top of the file

--- a/kythe/rust/indexer/testdata/xrefs/log.rs
+++ b/kythe/rust/indexer/testdata/xrefs/log.rs
@@ -1,0 +1,14 @@
+//- LogModAnchor.node/kind anchor
+//- LogModAnchor.loc/start 0
+//- LogModAnchor.loc/end 0
+//- LogModAnchor defines/implicit LogMod
+//- LogMod.node/kind record
+//- LogMod.subkind module
+//- LogMod.complete definition
+
+//- @hello_world defines/binding HelloWorldFn
+//- HelloWorldFn.node/kind function
+//- HelloWorldFn.complete definition
+pub fn hello_world() {
+    println!("Hello, verifier!");
+}

--- a/kythe/rust/indexer/testdata/xrefs/main.rs
+++ b/kythe/rust/indexer/testdata/xrefs/main.rs
@@ -1,0 +1,105 @@
+// Verifies that cross-references work properly
+
+//- MainModAnchor.node/kind anchor
+//- MainModAnchor.loc/start 0
+//- MainModAnchor.loc/end 0
+//- MainModAnchor defines/implicit MainMod
+//- MainMod.node/kind record
+//- MainMod.subkind module
+//- MainMod.complete definition
+
+////- @log ref LogMod
+mod log;
+
+//- @NUM defines/binding NumConst
+//- NumConst.node/kind constant
+const NUM: u32 = 0;
+
+//- @KYTHE_STR defines/binding Static
+//- Static.node/kind constant
+static KYTHE_STR: &str = "Kythe";
+
+//- @CustomType defines/binding Type
+//- Type.node/kind talias
+type CustomType = u32;
+
+//- @arg1 defines/binding Arg1
+//- Arg1.node/kind variable
+//- Arg1.subkind local
+//- @arg2 defines/binding Arg2
+//- Arg2.node/kind variable
+//- Arg2.subkind local
+//- @add defines/binding AddFn
+//- AddFn.node/kind function
+//- AddFn.complete definition
+fn add(arg1: u32, arg2: u32) -> u32 {
+    //- @arg1 ref Arg1
+    //- @arg2 ref Arg2
+    arg1 + arg2
+}
+
+//- @TestTrait defines/binding Trait
+trait TestTrait {
+    //- @hello defines/binding TraitHelloFn
+    fn hello(){}
+}
+
+//- @TestStruct defines/binding Struct
+struct TestStruct {
+    //- @test_field defines/binding Field
+    //- @CustomType ref Type
+    pub test_field: CustomType,
+}
+
+//- @TestTrait ref Trait
+//- @TestStruct ref Struct
+impl TestTrait for TestStruct {
+    //- @hello defines/binding HelloFn
+    //- HelloFn.node/kind function
+    fn hello() {
+        println!("Hello, Rust xrefs!");
+    }
+}
+
+fn main() {
+    //- @var1 defines/binding Var1
+    let var1 = 1;
+    //- @var2 defines/binding Var2
+    let var2 = 2;
+    //- @var3 defines/binding Var3
+    //- @var1 ref Var1
+    //- @var2 ref Var2
+    //- @add ref AddFn
+    let var3 = add(var1, var2);
+
+    //- @var3 ref Var3
+    println!("{}", var3);
+
+    //- @var3 ref Var3
+    //- @NUM ref NumConst
+    let var4 = var3 + NUM;
+
+    //- @KYTHE_STR ref Static
+    println!("{}", KYTHE_STR);
+
+    //- @TestStruct ref Struct
+    //- @var5 defines/binding Var5
+    let var5 = TestStruct {
+        //- @test_field ref Field
+        test_field: var4,
+    };
+
+    //- @var5 ref Var5
+    //- @test_field ref Field
+    println!("{}", var5.test_field);
+
+    // TODO: Make this reference the implementation on the method,
+    // not the trait definition.
+    //- @"hello" ref TraitHelloFn
+    //- @TestStruct ref Struct
+    TestStruct::hello();
+
+    ////- @log ref LogMod
+    //- @hello_world ref HelloWorldFn
+    log::hello_world();
+}

--- a/tools/rust/extra_action/src/main.rs
+++ b/tools/rust/extra_action/src/main.rs
@@ -74,10 +74,18 @@ fn main() -> Result<()> {
     let source_files: Vec<String> =
         matches.value_of("src_files").unwrap().split(',').map(String::from).collect();
     let crate_name = matches.value_of("crate_name").unwrap();
+    let main_source_file = if source_files.len() == 1 {
+        &source_files[0]
+    } else {
+        &source_files[source_files
+            .iter()
+            .position(|file_path| file_path.contains(&"main.rs") || file_path.contains(&"lib.rs"))
+            .unwrap()]
+    };
     let arguments: Vec<String> = vec![
         "--".to_string(),
         // Only the main source file gets passed to the compiler
-        source_files[0].to_string(),
+        main_source_file.to_string(),
         format!("-L{}", matches.value_of("sysroot").unwrap()),
         format!("--codegen=linker={}", matches.value_of("linker").unwrap()),
         format!("--crate-name={}", crate_name),


### PR DESCRIPTION
This PR does the following:
- Runs rustfmt on the Rust code
- Removes the path field from the VName of emitted definitions nodes
- Removes emitting definitions that are in files we didn't emit file nodes for
- Makes verifier test for xrefs more complex