### PR TITLE
fix(rust): parallelize the extraction process

### DIFF
--- a/kythe/rust/cargo/BUILD
+++ b/kythe/rust/cargo/BUILD
@@ -49,6 +49,11 @@ alias(
     tags = ["cargo-raze"],
 )
 alias(
+    name = "rayon",
+    actual = "@raze__rayon__1_3_1//:rayon",
+    tags = ["cargo-raze"],
+)
+alias(
     name = "regex",
     actual = "@raze__regex__1_3_9//:regex",
     tags = ["cargo-raze"],

--- a/kythe/rust/cargo/Cargo.toml
+++ b/kythe/rust/cargo/Cargo.toml
@@ -38,6 +38,7 @@ serde_json = "1.0"
 tempdir = "0.3"
 zip = "0.5.6"
 lazy_static = "1.4.0"
+rayon = "1.3.1"
 
 [dev-dependencies]
 assert_cmd = "1.0.1"

--- a/kythe/rust/cargo/crates.bzl
+++ b/kythe/rust/cargo/crates.bzl
@@ -169,6 +169,38 @@ def raze_fetch_remote_crates():
     )
 
     _new_http_archive(
+        name = "raze__crossbeam_deque__0_7_3",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/crossbeam-deque/crossbeam-deque-0.7.3.crate",
+        type = "tar.gz",
+        strip_prefix = "crossbeam-deque-0.7.3",
+        build_file = Label("//kythe/rust/cargo/remote:crossbeam-deque-0.7.3.BUILD"),
+    )
+
+    _new_http_archive(
+        name = "raze__crossbeam_epoch__0_8_2",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/crossbeam-epoch/crossbeam-epoch-0.8.2.crate",
+        type = "tar.gz",
+        strip_prefix = "crossbeam-epoch-0.8.2",
+        build_file = Label("//kythe/rust/cargo/remote:crossbeam-epoch-0.8.2.BUILD"),
+    )
+
+    _new_http_archive(
+        name = "raze__crossbeam_queue__0_2_3",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/crossbeam-queue/crossbeam-queue-0.2.3.crate",
+        type = "tar.gz",
+        strip_prefix = "crossbeam-queue-0.2.3",
+        build_file = Label("//kythe/rust/cargo/remote:crossbeam-queue-0.2.3.BUILD"),
+    )
+
+    _new_http_archive(
+        name = "raze__crossbeam_utils__0_7_2",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/crossbeam-utils/crossbeam-utils-0.7.2.crate",
+        type = "tar.gz",
+        strip_prefix = "crossbeam-utils-0.7.2",
+        build_file = Label("//kythe/rust/cargo/remote:crossbeam-utils-0.7.2.BUILD"),
+    )
+
+    _new_http_archive(
         name = "raze__derive_new__0_5_8",
         url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/derive-new/derive-new-0.5.8.crate",
         type = "tar.gz",
@@ -321,12 +353,28 @@ def raze_fetch_remote_crates():
     )
 
     _new_http_archive(
+        name = "raze__maybe_uninit__2_0_0",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/maybe-uninit/maybe-uninit-2.0.0.crate",
+        type = "tar.gz",
+        strip_prefix = "maybe-uninit-2.0.0",
+        build_file = Label("//kythe/rust/cargo/remote:maybe-uninit-2.0.0.BUILD"),
+    )
+
+    _new_http_archive(
         name = "raze__memchr__2_3_3",
         url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/memchr/memchr-2.3.3.crate",
         type = "tar.gz",
         sha256 = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400",
         strip_prefix = "memchr-2.3.3",
         build_file = Label("//kythe/rust/cargo/remote:memchr-2.3.3.BUILD"),
+    )
+
+    _new_http_archive(
+        name = "raze__memoffset__0_5_5",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/memoffset/memoffset-0.5.5.crate",
+        type = "tar.gz",
+        strip_prefix = "memoffset-0.5.5",
+        build_file = Label("//kythe/rust/cargo/remote:memoffset-0.5.5.BUILD"),
     )
 
     _new_http_archive(
@@ -354,6 +402,14 @@ def raze_fetch_remote_crates():
         sha256 = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611",
         strip_prefix = "num-traits-0.2.12",
         build_file = Label("//kythe/rust/cargo/remote:num-traits-0.2.12.BUILD"),
+    )
+
+    _new_http_archive(
+        name = "raze__num_cpus__1_13_0",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/num_cpus/num_cpus-1.13.0.crate",
+        type = "tar.gz",
+        strip_prefix = "num_cpus-1.13.0",
+        build_file = Label("//kythe/rust/cargo/remote:num_cpus-1.13.0.BUILD"),
     )
 
     _new_http_archive(
@@ -493,6 +549,22 @@ def raze_fetch_remote_crates():
         sha256 = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc",
         strip_prefix = "rand_core-0.4.2",
         build_file = Label("//kythe/rust/cargo/remote:rand_core-0.4.2.BUILD"),
+    )
+
+    _new_http_archive(
+        name = "raze__rayon__1_3_1",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/rayon/rayon-1.3.1.crate",
+        type = "tar.gz",
+        strip_prefix = "rayon-1.3.1",
+        build_file = Label("//kythe/rust/cargo/remote:rayon-1.3.1.BUILD"),
+    )
+
+    _new_http_archive(
+        name = "raze__rayon_core__1_7_1",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/rayon-core/rayon-core-1.7.1.crate",
+        type = "tar.gz",
+        strip_prefix = "rayon-core-1.7.1",
+        build_file = Label("//kythe/rust/cargo/remote:rayon-core-1.7.1.BUILD"),
     )
 
     _new_http_archive(

--- a/kythe/rust/cargo/remote/crossbeam-deque-0.7.3.BUILD
+++ b/kythe/rust/cargo/remote/crossbeam-deque-0.7.3.BUILD
@@ -1,0 +1,50 @@
+"""
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+package(default_visibility = [
+  # Public for visibility by "@raze__crate__version//" targets.
+  #
+  # Prefer access through "//kythe/rust/cargo", which limits external
+  # visibility to explicit Cargo.toml dependencies.
+  "//visibility:public",
+])
+
+licenses([
+  "notice", # MIT from expression "MIT OR Apache-2.0"
+])
+
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_library",
+    "rust_binary",
+    "rust_test",
+)
+
+
+
+rust_library(
+    name = "crossbeam_deque",
+    crate_type = "lib",
+    deps = [
+        "@raze__crossbeam_epoch__0_8_2//:crossbeam_epoch",
+        "@raze__crossbeam_utils__0_7_2//:crossbeam_utils",
+        "@raze__maybe_uninit__2_0_0//:maybe_uninit",
+    ],
+    srcs = glob(["**/*.rs"]),
+    crate_root = "src/lib.rs",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    version = "0.7.3",
+    tags = ["cargo-raze"],
+    crate_features = [
+    ],
+)
+
+# Unsupported target "fifo" with type "test" omitted
+# Unsupported target "injector" with type "test" omitted
+# Unsupported target "lifo" with type "test" omitted
+# Unsupported target "steal" with type "test" omitted

--- a/kythe/rust/cargo/remote/crossbeam-epoch-0.8.2.BUILD
+++ b/kythe/rust/cargo/remote/crossbeam-epoch-0.8.2.BUILD
@@ -1,0 +1,58 @@
+"""
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+package(default_visibility = [
+  # Public for visibility by "@raze__crate__version//" targets.
+  #
+  # Prefer access through "//kythe/rust/cargo", which limits external
+  # visibility to explicit Cargo.toml dependencies.
+  "//visibility:public",
+])
+
+licenses([
+  "notice", # MIT from expression "MIT OR Apache-2.0"
+])
+
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_library",
+    "rust_binary",
+    "rust_test",
+)
+
+
+# Unsupported target "build-script-build" with type "custom-build" omitted
+
+rust_library(
+    name = "crossbeam_epoch",
+    crate_type = "lib",
+    deps = [
+        "@raze__cfg_if__0_1_10//:cfg_if",
+        "@raze__crossbeam_utils__0_7_2//:crossbeam_utils",
+        "@raze__lazy_static__1_4_0//:lazy_static",
+        "@raze__maybe_uninit__2_0_0//:maybe_uninit",
+        "@raze__memoffset__0_5_5//:memoffset",
+        "@raze__scopeguard__1_1_0//:scopeguard",
+    ],
+    srcs = glob(["**/*.rs"]),
+    crate_root = "src/lib.rs",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    version = "0.8.2",
+    tags = ["cargo-raze"],
+    crate_features = [
+        "default",
+        "lazy_static",
+        "std",
+    ],
+)
+
+# Unsupported target "defer" with type "bench" omitted
+# Unsupported target "flush" with type "bench" omitted
+# Unsupported target "pin" with type "bench" omitted
+# Unsupported target "sanitize" with type "example" omitted
+# Unsupported target "treiber_stack" with type "example" omitted

--- a/kythe/rust/cargo/remote/crossbeam-queue-0.2.3.BUILD
+++ b/kythe/rust/cargo/remote/crossbeam-queue-0.2.3.BUILD
@@ -1,0 +1,50 @@
+"""
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+package(default_visibility = [
+  # Public for visibility by "@raze__crate__version//" targets.
+  #
+  # Prefer access through "//kythe/rust/cargo", which limits external
+  # visibility to explicit Cargo.toml dependencies.
+  "//visibility:public",
+])
+
+licenses([
+  "notice", # MIT from expression "MIT OR (Apache-2.0 AND BSD-2-Clause)"
+])
+
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_library",
+    "rust_binary",
+    "rust_test",
+)
+
+
+# Unsupported target "array_queue" with type "test" omitted
+
+rust_library(
+    name = "crossbeam_queue",
+    crate_type = "lib",
+    deps = [
+        "@raze__cfg_if__0_1_10//:cfg_if",
+        "@raze__crossbeam_utils__0_7_2//:crossbeam_utils",
+        "@raze__maybe_uninit__2_0_0//:maybe_uninit",
+    ],
+    srcs = glob(["**/*.rs"]),
+    crate_root = "src/lib.rs",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    version = "0.2.3",
+    tags = ["cargo-raze"],
+    crate_features = [
+        "default",
+        "std",
+    ],
+)
+
+# Unsupported target "seg_queue" with type "test" omitted

--- a/kythe/rust/cargo/remote/crossbeam-utils-0.7.2.BUILD
+++ b/kythe/rust/cargo/remote/crossbeam-utils-0.7.2.BUILD
@@ -1,0 +1,56 @@
+"""
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+package(default_visibility = [
+  # Public for visibility by "@raze__crate__version//" targets.
+  #
+  # Prefer access through "//kythe/rust/cargo", which limits external
+  # visibility to explicit Cargo.toml dependencies.
+  "//visibility:public",
+])
+
+licenses([
+  "notice", # MIT from expression "MIT OR Apache-2.0"
+])
+
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_library",
+    "rust_binary",
+    "rust_test",
+)
+
+
+# Unsupported target "atomic_cell" with type "bench" omitted
+# Unsupported target "atomic_cell" with type "test" omitted
+# Unsupported target "build-script-build" with type "custom-build" omitted
+# Unsupported target "cache_padded" with type "test" omitted
+
+rust_library(
+    name = "crossbeam_utils",
+    crate_type = "lib",
+    deps = [
+        "@raze__cfg_if__0_1_10//:cfg_if",
+        "@raze__lazy_static__1_4_0//:lazy_static",
+    ],
+    srcs = glob(["**/*.rs"]),
+    crate_root = "src/lib.rs",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    version = "0.7.2",
+    tags = ["cargo-raze"],
+    crate_features = [
+        "default",
+        "lazy_static",
+        "std",
+    ],
+)
+
+# Unsupported target "parker" with type "test" omitted
+# Unsupported target "sharded_lock" with type "test" omitted
+# Unsupported target "thread" with type "test" omitted
+# Unsupported target "wait_group" with type "test" omitted

--- a/kythe/rust/cargo/remote/maybe-uninit-2.0.0.BUILD
+++ b/kythe/rust/cargo/remote/maybe-uninit-2.0.0.BUILD
@@ -1,0 +1,45 @@
+"""
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+package(default_visibility = [
+  # Public for visibility by "@raze__crate__version//" targets.
+  #
+  # Prefer access through "//kythe/rust/cargo", which limits external
+  # visibility to explicit Cargo.toml dependencies.
+  "//visibility:public",
+])
+
+licenses([
+  "notice", # Apache-2.0 from expression "Apache-2.0 OR MIT"
+])
+
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_library",
+    "rust_binary",
+    "rust_test",
+)
+
+
+# Unsupported target "build-script-build" with type "custom-build" omitted
+# Unsupported target "doesnt_drop" with type "test" omitted
+
+rust_library(
+    name = "maybe_uninit",
+    crate_type = "lib",
+    deps = [
+    ],
+    srcs = glob(["**/*.rs"]),
+    crate_root = "src/lib.rs",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    version = "2.0.0",
+    tags = ["cargo-raze"],
+    crate_features = [
+    ],
+)
+

--- a/kythe/rust/cargo/remote/memoffset-0.5.5.BUILD
+++ b/kythe/rust/cargo/remote/memoffset-0.5.5.BUILD
@@ -1,0 +1,45 @@
+"""
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+package(default_visibility = [
+  # Public for visibility by "@raze__crate__version//" targets.
+  #
+  # Prefer access through "//kythe/rust/cargo", which limits external
+  # visibility to explicit Cargo.toml dependencies.
+  "//visibility:public",
+])
+
+licenses([
+  "notice", # MIT from expression "MIT"
+])
+
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_library",
+    "rust_binary",
+    "rust_test",
+)
+
+
+# Unsupported target "build-script-build" with type "custom-build" omitted
+
+rust_library(
+    name = "memoffset",
+    crate_type = "lib",
+    deps = [
+    ],
+    srcs = glob(["**/*.rs"]),
+    crate_root = "src/lib.rs",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    version = "0.5.5",
+    tags = ["cargo-raze"],
+    crate_features = [
+        "default",
+    ],
+)
+

--- a/kythe/rust/cargo/remote/num_cpus-1.13.0.BUILD
+++ b/kythe/rust/cargo/remote/num_cpus-1.13.0.BUILD
@@ -1,0 +1,45 @@
+"""
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+package(default_visibility = [
+  # Public for visibility by "@raze__crate__version//" targets.
+  #
+  # Prefer access through "//kythe/rust/cargo", which limits external
+  # visibility to explicit Cargo.toml dependencies.
+  "//visibility:public",
+])
+
+licenses([
+  "notice", # MIT from expression "MIT OR Apache-2.0"
+])
+
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_library",
+    "rust_binary",
+    "rust_test",
+)
+
+
+
+rust_library(
+    name = "num_cpus",
+    crate_type = "lib",
+    deps = [
+        "@raze__libc__0_2_74//:libc",
+    ],
+    srcs = glob(["**/*.rs"]),
+    crate_root = "src/lib.rs",
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    version = "1.13.0",
+    tags = ["cargo-raze"],
+    crate_features = [
+    ],
+)
+
+# Unsupported target "values" with type "example" omitted

--- a/kythe/rust/cargo/remote/rayon-1.3.1.BUILD
+++ b/kythe/rust/cargo/remote/rayon-1.3.1.BUILD
@@ -1,0 +1,61 @@
+"""
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+package(default_visibility = [
+  # Public for visibility by "@raze__crate__version//" targets.
+  #
+  # Prefer access through "//kythe/rust/cargo", which limits external
+  # visibility to explicit Cargo.toml dependencies.
+  "//visibility:public",
+])
+
+licenses([
+  "notice", # Apache-2.0 from expression "Apache-2.0 OR MIT"
+])
+
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_library",
+    "rust_binary",
+    "rust_test",
+)
+
+
+# Unsupported target "build-script-build" with type "custom-build" omitted
+# Unsupported target "clones" with type "test" omitted
+# Unsupported target "collect" with type "test" omitted
+# Unsupported target "cpu_monitor" with type "example" omitted
+# Unsupported target "cross-pool" with type "test" omitted
+# Unsupported target "debug" with type "test" omitted
+# Unsupported target "intersperse" with type "test" omitted
+# Unsupported target "issue671" with type "test" omitted
+# Unsupported target "issue671-unzip" with type "test" omitted
+# Unsupported target "iter_panic" with type "test" omitted
+# Unsupported target "named-threads" with type "test" omitted
+# Unsupported target "octillion" with type "test" omitted
+# Unsupported target "producer_split_at" with type "test" omitted
+
+rust_library(
+    name = "rayon",
+    crate_type = "lib",
+    deps = [
+        "@raze__crossbeam_deque__0_7_3//:crossbeam_deque",
+        "@raze__either__1_5_3//:either",
+        "@raze__rayon_core__1_7_1//:rayon_core",
+    ],
+    srcs = glob(["**/*.rs"]),
+    crate_root = "src/lib.rs",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    version = "1.3.1",
+    tags = ["cargo-raze"],
+    crate_features = [
+    ],
+)
+
+# Unsupported target "sort-panic-safe" with type "test" omitted
+# Unsupported target "str" with type "test" omitted

--- a/kythe/rust/cargo/remote/rayon-core-1.7.1.BUILD
+++ b/kythe/rust/cargo/remote/rayon-core-1.7.1.BUILD
@@ -1,0 +1,55 @@
+"""
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+package(default_visibility = [
+  # Public for visibility by "@raze__crate__version//" targets.
+  #
+  # Prefer access through "//kythe/rust/cargo", which limits external
+  # visibility to explicit Cargo.toml dependencies.
+  "//visibility:public",
+])
+
+licenses([
+  "notice", # Apache-2.0 from expression "Apache-2.0 OR MIT"
+])
+
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_library",
+    "rust_binary",
+    "rust_test",
+)
+
+
+# Unsupported target "build-script-build" with type "custom-build" omitted
+# Unsupported target "double_init_fail" with type "test" omitted
+# Unsupported target "init_zero_threads" with type "test" omitted
+
+rust_library(
+    name = "rayon_core",
+    crate_type = "lib",
+    deps = [
+        "@raze__crossbeam_deque__0_7_3//:crossbeam_deque",
+        "@raze__crossbeam_queue__0_2_3//:crossbeam_queue",
+        "@raze__crossbeam_utils__0_7_2//:crossbeam_utils",
+        "@raze__lazy_static__1_4_0//:lazy_static",
+        "@raze__num_cpus__1_13_0//:num_cpus",
+    ],
+    srcs = glob(["**/*.rs"]),
+    crate_root = "src/lib.rs",
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    version = "1.7.1",
+    tags = ["cargo-raze"],
+    crate_features = [
+    ],
+)
+
+# Unsupported target "scope_join" with type "test" omitted
+# Unsupported target "scoped_threadpool" with type "test" omitted
+# Unsupported target "simple_panic" with type "test" omitted
+# Unsupported target "stack_overflow_crash" with type "test" omitted

--- a/kythe/rust/fuchsia_extractor/BUILD
+++ b/kythe/rust/fuchsia_extractor/BUILD
@@ -50,6 +50,7 @@ rust_binary(
         "//kythe/rust/cargo:clap",
         "//kythe/rust/cargo:lazy_static",
         "//kythe/rust/cargo:protobuf",
+        "//kythe/rust/cargo:rayon",
         "//kythe/rust/cargo:regex",
         "//kythe/rust/cargo:rls_data",
         "//kythe/rust/cargo:rust_crypto",


### PR DESCRIPTION
The Fuchsia compilation extraction is easy to parallelize, so
we do so.  The rayon library farms out the extraction process,
and the extraction workers won't interfere with each other as
they only read inputs, and are guaranteed not to step over
each other.

This should speed up the extraction significantly.