### PR TITLE
fix(rust): Handles different roots for Fuchsia

### DIFF
--- a/kythe/rust/cargo/BUILD
+++ b/kythe/rust/cargo/BUILD
@@ -79,6 +79,11 @@ alias(
     tags = ["cargo-raze"],
 )
 alias(
+    name = "serial_test",
+    actual = "@raze__serial_test__0_4_0//:serial_test",
+    tags = ["cargo-raze"],
+)
+alias(
     name = "tempdir",
     actual = "@raze__tempdir__0_3_7//:tempdir",
     tags = ["cargo-raze"],

--- a/kythe/rust/cargo/Cargo.toml
+++ b/kythe/rust/cargo/Cargo.toml
@@ -42,6 +42,7 @@ lazy_static = "1.4.0"
 [dev-dependencies]
 assert_cmd = "1.0.1"
 predicates = "1.0.5"
+serial_test = "0.4.0"
 
 [raze]
 workspace_path = "//kythe/rust/cargo"

--- a/kythe/rust/cargo/crates.bzl
+++ b/kythe/rust/cargo/crates.bzl
@@ -143,6 +143,14 @@ def raze_fetch_remote_crates():
     )
 
     _new_http_archive(
+        name = "raze__cloudabi__0_0_3",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/cloudabi/cloudabi-0.0.3.crate",
+        type = "tar.gz",
+        strip_prefix = "cloudabi-0.0.3",
+        build_file = Label("//kythe/rust/cargo/remote:cloudabi-0.0.3.BUILD"),
+    )
+
+    _new_http_archive(
         name = "raze__colored__2_0_0",
         url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/colored/colored-2.0.0.crate",
         type = "tar.gz",
@@ -296,6 +304,14 @@ def raze_fetch_remote_crates():
     )
 
     _new_http_archive(
+        name = "raze__lock_api__0_3_4",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/lock_api/lock_api-0.3.4.crate",
+        type = "tar.gz",
+        strip_prefix = "lock_api-0.3.4",
+        build_file = Label("//kythe/rust/cargo/remote:lock_api-0.3.4.BUILD"),
+    )
+
+    _new_http_archive(
         name = "raze__log__0_4_11",
         url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/log/log-0.4.11.crate",
         type = "tar.gz",
@@ -338,6 +354,22 @@ def raze_fetch_remote_crates():
         sha256 = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611",
         strip_prefix = "num-traits-0.2.12",
         build_file = Label("//kythe/rust/cargo/remote:num-traits-0.2.12.BUILD"),
+    )
+
+    _new_http_archive(
+        name = "raze__parking_lot__0_10_2",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/parking_lot/parking_lot-0.10.2.crate",
+        type = "tar.gz",
+        strip_prefix = "parking_lot-0.10.2",
+        build_file = Label("//kythe/rust/cargo/remote:parking_lot-0.10.2.BUILD"),
+    )
+
+    _new_http_archive(
+        name = "raze__parking_lot_core__0_7_2",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/parking_lot_core/parking_lot_core-0.7.2.crate",
+        type = "tar.gz",
+        strip_prefix = "parking_lot_core-0.7.2",
+        build_file = Label("//kythe/rust/cargo/remote:parking_lot_core-0.7.2.BUILD"),
     )
 
     _new_http_archive(
@@ -473,6 +505,14 @@ def raze_fetch_remote_crates():
     )
 
     _new_http_archive(
+        name = "raze__redox_syscall__0_1_57",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/redox_syscall/redox_syscall-0.1.57.crate",
+        type = "tar.gz",
+        strip_prefix = "redox_syscall-0.1.57",
+        build_file = Label("//kythe/rust/cargo/remote:redox_syscall-0.1.57.BUILD"),
+    )
+
+    _new_http_archive(
         name = "raze__regex__1_3_9",
         url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/regex/regex-1.3.9.crate",
         type = "tar.gz",
@@ -554,6 +594,14 @@ def raze_fetch_remote_crates():
     )
 
     _new_http_archive(
+        name = "raze__scopeguard__1_1_0",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/scopeguard/scopeguard-1.1.0.crate",
+        type = "tar.gz",
+        strip_prefix = "scopeguard-1.1.0",
+        build_file = Label("//kythe/rust/cargo/remote:scopeguard-1.1.0.BUILD"),
+    )
+
+    _new_http_archive(
         name = "raze__serde__1_0_114",
         url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/serde/serde-1.0.114.crate",
         type = "tar.gz",
@@ -569,6 +617,30 @@ def raze_fetch_remote_crates():
         sha256 = "164eacbdb13512ec2745fb09d51fd5b22b0d65ed294a1dcf7285a360c80a675c",
         strip_prefix = "serde_json-1.0.57",
         build_file = Label("//kythe/rust/cargo/remote:serde_json-1.0.57.BUILD"),
+    )
+
+    _new_http_archive(
+        name = "raze__serial_test__0_4_0",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/serial_test/serial_test-0.4.0.crate",
+        type = "tar.gz",
+        strip_prefix = "serial_test-0.4.0",
+        build_file = Label("//kythe/rust/cargo/remote:serial_test-0.4.0.BUILD"),
+    )
+
+    _new_http_archive(
+        name = "raze__serial_test_derive__0_4_0",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/serial_test_derive/serial_test_derive-0.4.0.crate",
+        type = "tar.gz",
+        strip_prefix = "serial_test_derive-0.4.0",
+        build_file = Label("//kythe/rust/cargo/remote:serial_test_derive-0.4.0.BUILD"),
+    )
+
+    _new_http_archive(
+        name = "raze__smallvec__1_4_2",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/smallvec/smallvec-1.4.2.crate",
+        type = "tar.gz",
+        strip_prefix = "smallvec-1.4.2",
+        build_file = Label("//kythe/rust/cargo/remote:smallvec-1.4.2.BUILD"),
     )
 
     _new_http_archive(

--- a/kythe/rust/cargo/remote/cloudabi-0.0.3.BUILD
+++ b/kythe/rust/cargo/remote/cloudabi-0.0.3.BUILD
@@ -12,7 +12,7 @@ package(default_visibility = [
 ])
 
 licenses([
-  "notice", # MIT from expression "MIT OR Apache-2.0"
+  "restricted", # BSD-2-Clause from expression "BSD-2-Clause"
 ])
 
 load(
@@ -23,39 +23,24 @@ load(
 )
 
 
-# Unsupported target "build-script-build" with type "custom-build" omitted
 
 rust_library(
-    name = "winapi",
+    name = "cloudabi",
     crate_type = "lib",
     deps = [
+        "@raze__bitflags__1_2_1//:bitflags",
     ],
     srcs = glob(["**/*.rs"]),
-    crate_root = "src/lib.rs",
+    crate_root = "cloudabi.rs",
     edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",
     ],
-    version = "0.3.9",
+    version = "0.0.3",
     tags = ["cargo-raze"],
     crate_features = [
-        "consoleapi",
-        "errhandlingapi",
-        "fileapi",
-        "handleapi",
-        "minwinbase",
-        "minwindef",
-        "ntdef",
-        "ntsecapi",
-        "ntstatus",
-        "processenv",
-        "profileapi",
-        "std",
-        "sysinfoapi",
-        "timezoneapi",
-        "winbase",
-        "winerror",
-        "winnt",
+        "bitflags",
+        "default",
     ],
 )
 

--- a/kythe/rust/cargo/remote/lock_api-0.3.4.BUILD
+++ b/kythe/rust/cargo/remote/lock_api-0.3.4.BUILD
@@ -12,7 +12,7 @@ package(default_visibility = [
 ])
 
 licenses([
-  "notice", # MIT from expression "MIT OR Apache-2.0"
+  "notice", # Apache-2.0 from expression "Apache-2.0 OR MIT"
 ])
 
 load(
@@ -23,39 +23,22 @@ load(
 )
 
 
-# Unsupported target "build-script-build" with type "custom-build" omitted
 
 rust_library(
-    name = "winapi",
+    name = "lock_api",
     crate_type = "lib",
     deps = [
+        "@raze__scopeguard__1_1_0//:scopeguard",
     ],
     srcs = glob(["**/*.rs"]),
     crate_root = "src/lib.rs",
-    edition = "2015",
+    edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",
     ],
-    version = "0.3.9",
+    version = "0.3.4",
     tags = ["cargo-raze"],
     crate_features = [
-        "consoleapi",
-        "errhandlingapi",
-        "fileapi",
-        "handleapi",
-        "minwinbase",
-        "minwindef",
-        "ntdef",
-        "ntsecapi",
-        "ntstatus",
-        "processenv",
-        "profileapi",
-        "std",
-        "sysinfoapi",
-        "timezoneapi",
-        "winbase",
-        "winerror",
-        "winnt",
     ],
 )
 

--- a/kythe/rust/cargo/remote/parking_lot-0.10.2.BUILD
+++ b/kythe/rust/cargo/remote/parking_lot-0.10.2.BUILD
@@ -12,7 +12,7 @@ package(default_visibility = [
 ])
 
 licenses([
-  "notice", # MIT from expression "MIT OR Apache-2.0"
+  "notice", # Apache-2.0 from expression "Apache-2.0 OR MIT"
 ])
 
 load(
@@ -23,39 +23,25 @@ load(
 )
 
 
-# Unsupported target "build-script-build" with type "custom-build" omitted
+# Unsupported target "issue_203" with type "test" omitted
 
 rust_library(
-    name = "winapi",
+    name = "parking_lot",
     crate_type = "lib",
     deps = [
+        "@raze__lock_api__0_3_4//:lock_api",
+        "@raze__parking_lot_core__0_7_2//:parking_lot_core",
     ],
     srcs = glob(["**/*.rs"]),
     crate_root = "src/lib.rs",
-    edition = "2015",
+    edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",
     ],
-    version = "0.3.9",
+    version = "0.10.2",
     tags = ["cargo-raze"],
     crate_features = [
-        "consoleapi",
-        "errhandlingapi",
-        "fileapi",
-        "handleapi",
-        "minwinbase",
-        "minwindef",
-        "ntdef",
-        "ntsecapi",
-        "ntstatus",
-        "processenv",
-        "profileapi",
-        "std",
-        "sysinfoapi",
-        "timezoneapi",
-        "winbase",
-        "winerror",
-        "winnt",
+        "default",
     ],
 )
 

--- a/kythe/rust/cargo/remote/parking_lot_core-0.7.2.BUILD
+++ b/kythe/rust/cargo/remote/parking_lot_core-0.7.2.BUILD
@@ -12,7 +12,7 @@ package(default_visibility = [
 ])
 
 licenses([
-  "notice", # MIT from expression "MIT OR Apache-2.0"
+  "notice", # Apache-2.0 from expression "Apache-2.0 OR MIT"
 ])
 
 load(
@@ -23,39 +23,24 @@ load(
 )
 
 
-# Unsupported target "build-script-build" with type "custom-build" omitted
 
 rust_library(
-    name = "winapi",
+    name = "parking_lot_core",
     crate_type = "lib",
     deps = [
+        "@raze__cfg_if__0_1_10//:cfg_if",
+        "@raze__libc__0_2_74//:libc",
+        "@raze__smallvec__1_4_2//:smallvec",
     ],
     srcs = glob(["**/*.rs"]),
     crate_root = "src/lib.rs",
-    edition = "2015",
+    edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",
     ],
-    version = "0.3.9",
+    version = "0.7.2",
     tags = ["cargo-raze"],
     crate_features = [
-        "consoleapi",
-        "errhandlingapi",
-        "fileapi",
-        "handleapi",
-        "minwinbase",
-        "minwindef",
-        "ntdef",
-        "ntsecapi",
-        "ntstatus",
-        "processenv",
-        "profileapi",
-        "std",
-        "sysinfoapi",
-        "timezoneapi",
-        "winbase",
-        "winerror",
-        "winnt",
     ],
 )
 

--- a/kythe/rust/cargo/remote/redox_syscall-0.1.57.BUILD
+++ b/kythe/rust/cargo/remote/redox_syscall-0.1.57.BUILD
@@ -12,7 +12,7 @@ package(default_visibility = [
 ])
 
 licenses([
-  "notice", # MIT from expression "MIT OR Apache-2.0"
+  "notice", # MIT from expression "MIT"
 ])
 
 load(
@@ -23,10 +23,14 @@ load(
 )
 
 
-# Unsupported target "build-script-build" with type "custom-build" omitted
+alias(
+  name = "redox_syscall",
+  actual = ":syscall",
+  tags = ["cargo-raze"],
+)
 
 rust_library(
-    name = "winapi",
+    name = "syscall",
     crate_type = "lib",
     deps = [
     ],
@@ -36,26 +40,9 @@ rust_library(
     rustc_flags = [
         "--cap-lints=allow",
     ],
-    version = "0.3.9",
+    version = "0.1.57",
     tags = ["cargo-raze"],
     crate_features = [
-        "consoleapi",
-        "errhandlingapi",
-        "fileapi",
-        "handleapi",
-        "minwinbase",
-        "minwindef",
-        "ntdef",
-        "ntsecapi",
-        "ntstatus",
-        "processenv",
-        "profileapi",
-        "std",
-        "sysinfoapi",
-        "timezoneapi",
-        "winbase",
-        "winerror",
-        "winnt",
     ],
 )
 

--- a/kythe/rust/cargo/remote/scopeguard-1.1.0.BUILD
+++ b/kythe/rust/cargo/remote/scopeguard-1.1.0.BUILD
@@ -23,10 +23,10 @@ load(
 )
 
 
-# Unsupported target "build-script-build" with type "custom-build" omitted
+# Unsupported target "readme" with type "example" omitted
 
 rust_library(
-    name = "winapi",
+    name = "scopeguard",
     crate_type = "lib",
     deps = [
     ],
@@ -36,26 +36,9 @@ rust_library(
     rustc_flags = [
         "--cap-lints=allow",
     ],
-    version = "0.3.9",
+    version = "1.1.0",
     tags = ["cargo-raze"],
     crate_features = [
-        "consoleapi",
-        "errhandlingapi",
-        "fileapi",
-        "handleapi",
-        "minwinbase",
-        "minwindef",
-        "ntdef",
-        "ntsecapi",
-        "ntstatus",
-        "processenv",
-        "profileapi",
-        "std",
-        "sysinfoapi",
-        "timezoneapi",
-        "winbase",
-        "winerror",
-        "winnt",
     ],
 )
 

--- a/kythe/rust/cargo/remote/serial_test-0.4.0.BUILD
+++ b/kythe/rust/cargo/remote/serial_test-0.4.0.BUILD
@@ -12,7 +12,7 @@ package(default_visibility = [
 ])
 
 licenses([
-  "notice", # MIT from expression "MIT OR Apache-2.0"
+  "notice", # MIT from expression "MIT"
 ])
 
 load(
@@ -23,39 +23,27 @@ load(
 )
 
 
-# Unsupported target "build-script-build" with type "custom-build" omitted
 
 rust_library(
-    name = "winapi",
+    name = "serial_test",
     crate_type = "lib",
     deps = [
+        "@raze__lazy_static__1_4_0//:lazy_static",
+        "@raze__parking_lot__0_10_2//:parking_lot",
     ],
     srcs = glob(["**/*.rs"]),
     crate_root = "src/lib.rs",
-    edition = "2015",
+    edition = "2018",
+    proc_macro_deps = [
+        "@raze__serial_test_derive__0_4_0//:serial_test_derive",
+    ],
     rustc_flags = [
         "--cap-lints=allow",
     ],
-    version = "0.3.9",
+    version = "0.4.0",
     tags = ["cargo-raze"],
     crate_features = [
-        "consoleapi",
-        "errhandlingapi",
-        "fileapi",
-        "handleapi",
-        "minwinbase",
-        "minwindef",
-        "ntdef",
-        "ntsecapi",
-        "ntstatus",
-        "processenv",
-        "profileapi",
-        "std",
-        "sysinfoapi",
-        "timezoneapi",
-        "winbase",
-        "winerror",
-        "winnt",
     ],
 )
 
+# Unsupported target "tests" with type "test" omitted

--- a/kythe/rust/cargo/remote/serial_test_derive-0.4.0.BUILD
+++ b/kythe/rust/cargo/remote/serial_test_derive-0.4.0.BUILD
@@ -12,7 +12,7 @@ package(default_visibility = [
 ])
 
 licenses([
-  "notice", # MIT from expression "MIT OR Apache-2.0"
+  "notice", # MIT from expression "MIT"
 ])
 
 load(
@@ -23,39 +23,24 @@ load(
 )
 
 
-# Unsupported target "build-script-build" with type "custom-build" omitted
 
 rust_library(
-    name = "winapi",
-    crate_type = "lib",
+    name = "serial_test_derive",
+    crate_type = "proc-macro",
     deps = [
+        "@raze__proc_macro2__1_0_19//:proc_macro2",
+        "@raze__quote__1_0_7//:quote",
+        "@raze__syn__1_0_36//:syn",
     ],
     srcs = glob(["**/*.rs"]),
     crate_root = "src/lib.rs",
-    edition = "2015",
+    edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",
     ],
-    version = "0.3.9",
+    version = "0.4.0",
     tags = ["cargo-raze"],
     crate_features = [
-        "consoleapi",
-        "errhandlingapi",
-        "fileapi",
-        "handleapi",
-        "minwinbase",
-        "minwindef",
-        "ntdef",
-        "ntsecapi",
-        "ntstatus",
-        "processenv",
-        "profileapi",
-        "std",
-        "sysinfoapi",
-        "timezoneapi",
-        "winbase",
-        "winerror",
-        "winnt",
     ],
 )
 

--- a/kythe/rust/cargo/remote/smallvec-1.4.2.BUILD
+++ b/kythe/rust/cargo/remote/smallvec-1.4.2.BUILD
@@ -23,39 +23,23 @@ load(
 )
 
 
-# Unsupported target "build-script-build" with type "custom-build" omitted
+# Unsupported target "bench" with type "bench" omitted
+# Unsupported target "macro" with type "test" omitted
 
 rust_library(
-    name = "winapi",
+    name = "smallvec",
     crate_type = "lib",
     deps = [
     ],
     srcs = glob(["**/*.rs"]),
     crate_root = "src/lib.rs",
-    edition = "2015",
+    edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",
     ],
-    version = "0.3.9",
+    version = "1.4.2",
     tags = ["cargo-raze"],
     crate_features = [
-        "consoleapi",
-        "errhandlingapi",
-        "fileapi",
-        "handleapi",
-        "minwinbase",
-        "minwindef",
-        "ntdef",
-        "ntsecapi",
-        "ntstatus",
-        "processenv",
-        "profileapi",
-        "std",
-        "sysinfoapi",
-        "timezoneapi",
-        "winbase",
-        "winerror",
-        "winnt",
     ],
 )
 

--- a/kythe/rust/cargo/remote/syn-1.0.36.BUILD
+++ b/kythe/rust/cargo/remote/syn-1.0.36.BUILD
@@ -47,6 +47,7 @@ rust_library(
         "clone-impls",
         "default",
         "derive",
+        "full",
         "parsing",
         "printing",
         "proc-macro",

--- a/kythe/rust/fuchsia_extractor/BUILD
+++ b/kythe/rust/fuchsia_extractor/BUILD
@@ -54,6 +54,7 @@ rust_binary(
         "//kythe/rust/cargo:rls_data",
         "//kythe/rust/cargo:rust_crypto",
         "//kythe/rust/cargo:serde_json",
+        "//kythe/rust/cargo:tempdir",
     ],
     rustc_flags = select({
         ":if_opt": [ "-Crelocation-model=static" ],
@@ -66,6 +67,7 @@ rust_test(
     crate = ":fuchsia_extractor",
     deps = [
       "//kythe/rust/cargo:zip",
+      "//kythe/rust/cargo:serial_test",
     ],
     edition = "2018",
     # See https://github.com/bazelbuild/rules_rust/issues/118.  Without this,

--- a/kythe/rust/fuchsia_extractor/testdata/test_dir_2/compilation-root/out/terminal.x64/gen/third_party/rust_crates/vendor/nom/dir/file.rs
+++ b/kythe/rust/fuchsia_extractor/testdata/test_dir_2/compilation-root/out/terminal.x64/gen/third_party/rust_crates/vendor/nom/dir/file.rs
@@ -1,0 +1,1 @@
+fn _file_test_fn() {}

--- a/kythe/rust/fuchsia_extractor/testdata/test_dir_2/compilation-root/out/terminal.x64/gen/third_party/rust_crates/vendor/nom/dummy
+++ b/kythe/rust/fuchsia_extractor/testdata/test_dir_2/compilation-root/out/terminal.x64/gen/third_party/rust_crates/vendor/nom/dummy
@@ -1,0 +1,1 @@
+dummy file

--- a/kythe/rust/fuchsia_extractor/testdata/test_dir_2/compilation-root/out/terminal.x64/gen/third_party/rust_crates/vendor/nom/lib.rs
+++ b/kythe/rust/fuchsia_extractor/testdata/test_dir_2/compilation-root/out/terminal.x64/gen/third_party/rust_crates/vendor/nom/lib.rs
@@ -1,0 +1,1 @@
+fn _lib_test_fn() {}

--- a/kythe/rust/fuchsia_extractor/testdata/test_dir_2/compilation-root/out/terminal.x64/save-analysis-temp/nom.json
+++ b/kythe/rust/fuchsia_extractor/testdata/test_dir_2/compilation-root/out/terminal.x64/save-analysis-temp/nom.json
@@ -1,0 +1,84 @@
+{
+  "config": {
+    "output_file": null,
+    "full_docs": false,
+    "pub_only": false,
+    "reachable_only": false,
+    "distro_crate": false,
+    "signatures": false,
+    "borrow_data": false
+  },
+  "version": "0.19.0",
+  "compilation": {
+    "directory": "../../out/terminal.x64",
+    "program": "../../prebuilt/third_party/rust/linux-x64/bin/rustc",
+    "arguments": [
+      "--extern",
+      "lazy_static=x64-shared/obj/third_party/rust_crates/liblazy_static-cdf593bd3fb3d68f.rlib",
+      "--extern",
+      "memchr=x64-shared/obj/third_party/rust_crates/libmemchr-523a962cdfbcb111.rlib",
+      "--extern",
+      "regex=x64-shared/obj/third_party/rust_crates/libregex-be3eec66bf66867d.rlib"
+    ],
+    "output": "x64-shared/obj/third_party/rust_crates/libnom-75597d9e6590c988.rlib"
+  },
+  "prelude": {
+    "crate_id": {
+      "name": "nom",
+      "disambiguator": [
+        6567607726669606000,
+        5026429877498273000
+      ]
+    },
+    "crate_root": "gen/third_party/rust_crates/vendor/nom/src",
+    "external_crates": [
+      {
+        "file_name": "../../out/terminal.x64/gen/third_party/rust_crates/vendor/nom/src/lib.rs",
+        "num": 1,
+        "id": {
+          "name": "std",
+          "disambiguator": [
+            8850744928711379000,
+            8674301700331227000
+          ]
+        }
+      }
+    ],
+    "span": {
+      "file_name": "gen/third_party/rust_crates/vendor/nom/src/lib.rs",
+      "byte_start": 0,
+      "byte_end": 16643,
+      "line_start": 1,
+      "line_end": 512,
+      "column_start": 1,
+      "column_end": 16
+    }
+  },
+  "imports": [
+    {
+      "kind": "ExternCrate",
+      "ref_id": null,
+      "span": {
+        "file_name": "gen/third_party/rust_crates/vendor/nom/src/lib.rs",
+        "byte_start": 14587,
+        "byte_end": 14598,
+        "line_start": 414,
+        "line_end": 414,
+        "column_start": 14,
+        "column_end": 25
+      },
+      "alias_span": null,
+      "name": "lazy_static",
+      "value": "",
+      "parent": {
+        "krate": 0,
+        "index": 0
+      }
+    }
+  ],
+  "defs": [],
+  "impls": [],
+  "refs": [],
+  "macro_refs": [],
+  "relations": []
+}

--- a/kythe/rust/fuchsia_extractor/testdata/test_dir_2/compilation-root/out/terminal.x64/x64-shared/obj/third_party/rust_crates/liblazy_static-cdf593bd3fb3d68f.rlib
+++ b/kythe/rust/fuchsia_extractor/testdata/test_dir_2/compilation-root/out/terminal.x64/x64-shared/obj/third_party/rust_crates/liblazy_static-cdf593bd3fb3d68f.rlib
@@ -1,0 +1,1 @@
+dummy file

--- a/kythe/rust/fuchsia_extractor/testdata/test_dir_2/compilation-root/out/terminal.x64/x64-shared/obj/third_party/rust_crates/libmemchr-523a962cdfbcb111.rlib
+++ b/kythe/rust/fuchsia_extractor/testdata/test_dir_2/compilation-root/out/terminal.x64/x64-shared/obj/third_party/rust_crates/libmemchr-523a962cdfbcb111.rlib
@@ -1,0 +1,1 @@
+dummy file 2

--- a/kythe/rust/fuchsia_extractor/testdata/test_dir_2/compilation-root/out/terminal.x64/x64-shared/obj/third_party/rust_crates/libregex-be3eec66bf66867d.rlib
+++ b/kythe/rust/fuchsia_extractor/testdata/test_dir_2/compilation-root/out/terminal.x64/x64-shared/obj/third_party/rust_crates/libregex-be3eec66bf66867d.rlib
@@ -1,0 +1,1 @@
+dummy file 3


### PR DESCRIPTION
Adds sorting code that bins all the Fuchsia source
files into separate roots, based on the relative
path of a file with respect to the directory the
root builds in.

There are about a dozen different roots, some of which
are "" (the "default" source, which is the "in-tree" code),
the "gen" (source code generated by build rules), "fidling_gen"
(the source code generated by the FIDL compiler) and so on.

Regression test added to confirm that the paths are set as
expected.