### PR TITLE
feat(textproto): move plugin loader to a library

### DIFF
--- a/kythe/cxx/indexer/textproto/BUILD
+++ b/kythe/cxx/indexer/textproto/BUILD
@@ -6,11 +6,11 @@ cc_binary(
     visibility = ["//visibility:public"],
     deps = [
         ":analyzer",
+        ":plugin_registry",
         "//kythe/cxx/common:init",
         "//kythe/cxx/common:kzip_reader",
         "//kythe/cxx/common/indexing:caching_output",
         "//kythe/cxx/common/indexing:output",
-        "//kythe/cxx/indexer/textproto/plugins/example:plugin",
         "//kythe/proto:analysis_cc_proto",
         "//kythe/proto:buildinfo_cc_proto",
         "@com_google_absl//absl/flags:flag",
@@ -57,5 +57,17 @@ cc_library(
         "//kythe/proto:analysis_cc_proto",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",
+    ],
+)
+
+cc_library(
+    name = "plugin_registry",
+    srcs = ["plugin_registry.cc"],
+    hdrs = ["plugin_registry.h"],
+    deps = [
+        ":plugin",
+        "//kythe/cxx/indexer/textproto/plugins/example:plugin",
+        "@com_google_absl//absl/strings",
+        "@com_google_protobuf//:protobuf",
     ],
 )

--- a/kythe/cxx/indexer/textproto/plugin_registry.cc
+++ b/kythe/cxx/indexer/textproto/plugin_registry.cc
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 The Kythe Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "plugin_registry.h"
+
+namespace kythe {
+namespace lang_textproto {
+
+std::vector<std::unique_ptr<Plugin>> LoadRegisteredPlugins(
+    absl::string_view msg_name, const google::protobuf::Message& proto) {
+  std::vector<std::unique_ptr<Plugin>> plugins;
+  if (msg_name == "kythe_plugin_example.Message") {
+    plugins.push_back(
+        std::make_unique<kythe::lang_textproto::ExamplePlugin>(proto));
+  }
+  return plugins;
+}
+
+}  // namespace lang_textproto
+}  // namespace kythe

--- a/kythe/cxx/indexer/textproto/plugin_registry.cc
+++ b/kythe/cxx/indexer/textproto/plugin_registry.cc
@@ -16,6 +16,8 @@
 
 #include "plugin_registry.h"
 
+#include "kythe/cxx/indexer/textproto/plugins/example/plugin.h"
+
 namespace kythe {
 namespace lang_textproto {
 

--- a/kythe/cxx/indexer/textproto/plugin_registry.h
+++ b/kythe/cxx/indexer/textproto/plugin_registry.h
@@ -19,6 +19,7 @@
 
 #include "absl/strings/string_view.h"
 #include "google/protobuf/descriptor.h"
+#include "kythe/cxx/indexer/textproto/plugin.h"
 
 namespace kythe {
 namespace lang_textproto {

--- a/kythe/cxx/indexer/textproto/plugin_registry.h
+++ b/kythe/cxx/indexer/textproto/plugin_registry.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 The Kythe Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef KYTHE_CXX_INDEXER_TEXTPROTO_PLUGIN_REGISTRY_H_
+#define KYTHE_CXX_INDEXER_TEXTPROTO_PLUGIN_REGISTRY_H_
+
+#include "absl/strings/string_view.h"
+#include "google/protobuf/descriptor.h"
+
+namespace kythe {
+namespace lang_textproto {
+
+// Simple PluginLoadCallback function that loads plugins relevant to the given
+// proto message. New plugins should be added to the implementation of this
+// function.
+std::vector<std::unique_ptr<Plugin>> LoadRegisteredPlugins(
+    absl::string_view msg_name, const google::protobuf::Message& proto);
+
+}  // namespace lang_textproto
+}  // namespace kythe
+
+#endif  // KYTHE_CXX_INDEXER_TEXTPROTO_PLUGIN_REGISTRY_H_


### PR DESCRIPTION
this will allow for easily swapping to a different loader in google3