### PR TITLE
feat(runextractor): Pass flags to the compdb extractor

### DIFF
--- a/kythe/go/extractors/config/runextractor/cmakecmd/cmakecmd.go
+++ b/kythe/go/extractors/config/runextractor/cmakecmd/cmakecmd.go
@@ -121,7 +121,7 @@ func (c *cmakeCommand) Execute(ctx context.Context, fs *flag.FlagSet, args ...in
 		return c.Fail("Error building repository: %v", err)
 	}
 
-	if err := compdb.ExtractCompilations(ctx, extractor, filepath.Join(buildDir, "compile_commands.json")); err != nil {
+	if err := compdb.ExtractCompilations(ctx, extractor, filepath.Join(buildDir, "compile_commands.json"), nil); err != nil {
 		return c.Fail("Error extracting repository: %v", err)
 	}
 	return subcommands.ExitSuccess

--- a/kythe/go/extractors/config/runextractor/compdb/compdb_test.go
+++ b/kythe/go/extractors/config/runextractor/compdb/compdb_test.go
@@ -64,7 +64,7 @@ func TestExtractCompilationsEndToEnd(t *testing.T) {
 	if err := os.Chdir(filepath.Join(root, testPath, "testdata")); err != nil {
 		t.Fatalf("Unable to change working directory: %v", err)
 	}
-	if err := ExtractCompilations(context.Background(), extractor, "compilation_database.json"); err != nil {
+	if err := ExtractCompilations(context.Background(), extractor, "compilation_database.json", nil); err != nil {
 		t.Fatalf("Error running ExtractCompilations: %v", err)
 	}
 	err = filepath.Walk(os.Getenv("KYTHE_OUTPUT_DIRECTORY"), func(path string, info os.FileInfo, err error) error {

--- a/kythe/go/extractors/config/runextractor/compdbcmd/compdbcmd.go
+++ b/kythe/go/extractors/config/runextractor/compdbcmd/compdbcmd.go
@@ -40,7 +40,11 @@ type compdbCommand struct {
 // New creates a new subcommand for running compdb extraction.
 func New() subcommands.Command {
 	return &compdbCommand{
-		Info: cmdutil.NewInfo("compdb", "extract a repo from compile_commands.json", `documight`),
+		Info: cmdutil.NewInfo("compdb", "extract a repo from compile_commands.json",
+			`runextractor compdb [OPTIONS] -- [extractor_args...]
+
+Any flags specified in [extractor_args...] will be passed verbatim to the chosen extractor binary.
+`),
 	}
 }
 
@@ -73,7 +77,7 @@ func (c *compdbCommand) Execute(ctx context.Context, fs *flag.FlagSet, args ...i
 	if err != nil {
 		return c.Fail("Unable to resolve path to extractor: %v", err)
 	}
-	if err := compdb.ExtractCompilations(ctx, extractor, c.path); err != nil {
+	if err := compdb.ExtractCompilations(ctx, extractor, c.path, fs.Args()); err != nil {
 		return c.Fail("Error extracting repository: %v", err)
 	}
 	return subcommands.ExitSuccess


### PR DESCRIPTION
Adds the ability to pass arbitrary additional flags to the
extractor binary ran by `runextractor`.  This allows for example
specifying custom include library paths for `cxx_extractor`, which
allows the extractor access to include library paths for a custom
compiler if used.

Example:

```bash
runextractor compdb -extractor cxx_extractor -- -cxx-isystem=../some/dir
```