### PR TITLE
fix(bazel): align options between `query` and `build`

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -6,6 +6,7 @@ build --strategy=TypeScriptCompile=sandboxed,local
 
 # Compatibility flags to avoid regressions.
 build --incompatible_disallow_empty_glob
+query --incompatible_disallow_empty_glob
 
 build --workspace_status_command tools/buildstamp/get_workspace_status
 build --auto_cpu_environment_group=//buildenv:cpu

--- a/.bazelrc
+++ b/.bazelrc
@@ -5,8 +5,7 @@ startup --host_jvm_args=-Dbazel.DigestFunction=SHA256
 build --strategy=TypeScriptCompile=sandboxed,local
 
 # Compatibility flags to avoid regressions.
-build --incompatible_disallow_empty_glob
-query --incompatible_disallow_empty_glob
+common --incompatible_disallow_empty_glob
 
 build --workspace_status_command tools/buildstamp/get_workspace_status
 build --auto_cpu_environment_group=//buildenv:cpu


### PR DESCRIPTION
This flag seems to invalidate the build graph cache and causes bazel to re-fetch and re-analyze a lot of dependencies when switching between `bazel query` and `bazel build`.

I frequently use `ibazel` and this change makes the experience *significantly* better as it often runs bazel queries.