### PR TITLE
feat(cxx_indexer): add blame scopes for field references

### DIFF
--- a/kythe/cxx/common/init.cc
+++ b/kythe/cxx/common/init.cc
@@ -26,6 +26,11 @@ namespace kythe {
 
 #if defined(KYTHE_OVERRIDE_ASSERT_FAIL)
 extern "C" {
+
+#ifndef __THROW
+#define __THROW throw()
+#endif
+
 // Make sure we get a legible stack trace when assert from <assert.h> fails.
 // This works around https://github.com/abseil/abseil-cpp/issues/769.
 //

--- a/kythe/cxx/indexer/cxx/IndexerASTHooks.h
+++ b/kythe/cxx/indexer/cxx/IndexerASTHooks.h
@@ -677,6 +677,11 @@ class IndexerASTVisitor : public RecursiveTypeVisitor<IndexerASTVisitor> {
   void RecordCallEdges(const GraphObserver::Range& Range,
                        const GraphObserver::NodeId& Callee);
 
+  // Blames the use of a `Decl` at a particular `Range` on everything at the
+  // top of `BlameStack`. If there is nothing at the top of `BlameStack`,
+  // blames the use on the file.
+  void RecordBlame(const clang::Decl* Decl, const GraphObserver::Range& Range);
+
   /// \return whether `range` should be considered to be implicit under the
   /// current context.
   GraphObserver::Implicit IsImplicit(const GraphObserver::Range& range);

--- a/kythe/cxx/indexer/cxx/clang_utils.cc
+++ b/kythe/cxx/indexer/cxx/clang_utils.cc
@@ -87,6 +87,7 @@ const clang::Decl* FindSpecializedTemplate(const clang::Decl* decl) {
 bool ShouldHaveBlameContext(const clang::Decl* decl) {
   // TODO(zarko): introduce more blameable decls.
   switch (decl->getKind()) {
+    case clang::Decl::Kind::Field:
     case clang::Decl::Kind::Var:
       return true;
     default:

--- a/kythe/cxx/indexer/cxx/testdata/BUILD
+++ b/kythe/cxx/indexer/cxx/testdata/BUILD
@@ -3229,6 +3229,13 @@ test_suite(
 )
 
 cc_indexer_test(
+    name = "df_field_ref_blame",
+    srcs = ["df/df_field_ref_blame.cc"],
+    ignore_dups = True,
+    tags = ["df"],
+)
+
+cc_indexer_test(
     name = "df_var_ref_blame",
     srcs = ["df/df_var_ref_blame.cc"],
     tags = ["df"],

--- a/kythe/cxx/indexer/cxx/testdata/df/df_field_ref_blame.cc
+++ b/kythe/cxx/indexer/cxx/testdata/df/df_field_ref_blame.cc
@@ -1,0 +1,12 @@
+// Checks that field references in a function are blamed on that function.
+
+//- @f defines/binding FieldF
+struct S { int f; };
+
+//- @f defines/binding FnF
+void f() {
+  S s;
+  //- @f ref FieldF
+  //- @f childof FnF
+  s.f = 3;
+}


### PR DESCRIPTION
This PR pulls out blame assignment into a separate function.
It also fixes init.cc on macOSx (and presumably other platforms
that fail to define __THROW).