### PR TITLE
fix(java_common): keep rooted URI paths rooted

### DIFF
--- a/kythe/go/util/kytheuri/uri_test.go
+++ b/kythe/go/util/kytheuri/uri_test.go
@@ -194,6 +194,23 @@ func TestRoundTripURI(t *testing.T) {
 	}
 }
 
+func TestToString(t *testing.T) {
+	tests := []struct {
+		VName    *spb.VName
+		Expected string
+	}{
+		{&spb.VName{Corpus: "kythe", Path: "unrooted/path"}, "kythe://kythe?path=unrooted/path"},
+		{&spb.VName{Corpus: "kythe", Path: "/rooted/path"}, "kythe://kythe?path=/rooted/path"},
+		{&spb.VName{Corpus: "kythe", Path: "//rooted//path"}, "kythe://kythe?path=/rooted/path"},
+	}
+
+	for _, test := range tests {
+		if found := ToString(test.VName); found != test.Expected {
+			t.Errorf("kytheuri.ToString(%#v): found %q, want %q", test.VName, found, test.Expected)
+		}
+	}
+}
+
 func TestRoundTripVName(t *testing.T) {
 	// Verify that converting a VName to a Kythe URI and then back preserves
 	// equivalence.

--- a/kythe/java/com/google/devtools/kythe/util/KytheURI.java
+++ b/kythe/java/com/google/devtools/kythe/util/KytheURI.java
@@ -282,6 +282,9 @@ public class KytheURI implements Serializable {
    */
   private static String cleanPath(String path) {
     ArrayList<String> clean = new ArrayList<>();
+    if (!path.isEmpty() && path.charAt(0) == '/') {
+      clean.add("");
+    }
     for (String part : PATH_SPLITTER.split(path)) {
       if (part.isEmpty() || part.equals(".")) {
         continue; // skip empty path components and "here" markers.

--- a/kythe/javatests/com/google/devtools/kythe/util/KytheURITest.java
+++ b/kythe/javatests/com/google/devtools/kythe/util/KytheURITest.java
@@ -114,6 +114,13 @@ public class KytheURITest extends TestCase {
     assertThat(builder().setCorpus("kythe").setSignature("a=").build().toString())
         .isEqualTo("kythe://kythe#a%3D");
     assertThat(builder().setSignature("広").build().toString()).isEqualTo("kythe:#%E5%BA%83");
+
+    assertThat(builder().setCorpus("kythe").setPath("unrooted/path").build().toString())
+        .isEqualTo("kythe://kythe?path=unrooted/path");
+    assertThat(builder().setCorpus("kythe").setPath("/rooted/path").build().toString())
+        .isEqualTo("kythe://kythe?path=/rooted/path");
+    assertThat(builder().setCorpus("kythe").setPath("//rooted//path").build().toString())
+        .isEqualTo("kythe://kythe?path=/rooted/path");
   }
 
   private void checkToString(String expected, String... cases) throws URISyntaxException {


### PR DESCRIPTION
This makes the Java KytheURI implementation match the canonical Go implementation.