### PR TITLE
fix(textproto tests): use relative path in `proto-file` schema comment

### DIFF
--- a/kythe/cxx/extractor/textproto/testdata/custom_corpus.UNIT
+++ b/kythe/cxx/extractor/textproto/testdata/custom_corpus.UNIT
@@ -20,7 +20,7 @@
         },
         {
             "info": {
-                "digest": "6d48481a83f2e236fcb4afafe363b54af9377d9ec9deacc382930ef7c52e163a",
+                "digest": "40e64606167c9bea6f8c2a60f489901565aca97c6a676d25db195d4af91bcb9f",
                 "path": "kythe/cxx/extractor/textproto/testdata/simple.pbtxt"
             },
             "v_name": {

--- a/kythe/cxx/extractor/textproto/testdata/extra_imports.UNIT
+++ b/kythe/cxx/extractor/textproto/testdata/extra_imports.UNIT
@@ -28,7 +28,7 @@
         },
         {
             "info": {
-                "digest": "1df9b906fcc53691e0dae75488f4f7f9474f868c3c7190f6f5b555ba129a1acb",
+                "digest": "b3462a501dafa3eea3d3fd7e8ed1ae6be6b3fba38849b20effeeea4cd8448c3e",
                 "path": "kythe/cxx/extractor/textproto/testdata/extra_imports.pbtxt"
             },
             "v_name": {

--- a/kythe/cxx/extractor/textproto/testdata/extra_imports.pbtxt
+++ b/kythe/cxx/extractor/textproto/testdata/extra_imports.pbtxt
@@ -1,4 +1,4 @@
-# proto-file: kythe/cxx/extractor/textproto/testdata/example.proto
+# proto-file: example.proto
 # proto-message: textproto_test.MyMessage
 # proto-import: dep.proto
 

--- a/kythe/cxx/extractor/textproto/testdata/simple.UNIT
+++ b/kythe/cxx/extractor/textproto/testdata/simple.UNIT
@@ -19,7 +19,7 @@
         },
         {
             "info": {
-                "digest": "6d48481a83f2e236fcb4afafe363b54af9377d9ec9deacc382930ef7c52e163a",
+                "digest": "40e64606167c9bea6f8c2a60f489901565aca97c6a676d25db195d4af91bcb9f",
                 "path": "kythe/cxx/extractor/textproto/testdata/simple.pbtxt"
             },
             "v_name": {

--- a/kythe/cxx/extractor/textproto/testdata/simple.pbtxt
+++ b/kythe/cxx/extractor/textproto/testdata/simple.pbtxt
@@ -1,4 +1,4 @@
-# proto-file: kythe/cxx/extractor/textproto/testdata/example.proto
+# proto-file: example.proto
 # proto-message: textproto_test.MyMessage
 
 str_field: "testing, testing..."


### PR DESCRIPTION
this makes import into google easier because if the path in the .pbtxt needs to be updated at import, the digest in the .UNIT golden file needs to be recomputed