### PR TITLE
feat(textproto): put example plugin behind a flag

### DIFF
--- a/kythe/cxx/indexer/textproto/BUILD
+++ b/kythe/cxx/indexer/textproto/BUILD
@@ -68,6 +68,7 @@ cc_library(
     deps = [
         ":plugin",
         "//kythe/cxx/indexer/textproto/plugins/example:plugin",
+        "@com_google_absl//absl/flags:flag",
         "@com_google_absl//absl/strings",
         "@com_google_protobuf//:protobuf",
     ],

--- a/kythe/cxx/indexer/textproto/plugin_registry.cc
+++ b/kythe/cxx/indexer/textproto/plugin_registry.cc
@@ -16,7 +16,11 @@
 
 #include "plugin_registry.h"
 
+#include "absl/flags/flag.h"
 #include "kythe/cxx/indexer/textproto/plugins/example/plugin.h"
+
+ABSL_FLAG(bool, enable_example_plugin, false,
+          "Enable the 'example' textproto plugin");
 
 namespace kythe {
 namespace lang_textproto {
@@ -25,7 +29,8 @@ std::vector<std::unique_ptr<Plugin>> LoadRegisteredPlugins(
     const google::protobuf::Message& proto) {
   std::vector<std::unique_ptr<Plugin>> plugins;
   std::string msg_name = proto.GetDescriptor()->full_name();
-  if (msg_name == "kythe_plugin_example.Person") {
+  if (absl::GetFlag(FLAGS_enable_example_plugin) &&
+      msg_name == "kythe_plugin_example.Person") {
     plugins.push_back(
         std::make_unique<kythe::lang_textproto::ExamplePlugin>(proto));
   }

--- a/kythe/cxx/indexer/textproto/plugins/example/testdata/BUILD
+++ b/kythe/cxx/indexer/textproto/plugins/example/testdata/BUILD
@@ -6,6 +6,7 @@ package(
 
 textproto_verifier_test(
     name = "cross_file_test",
+    indexer_opts = ["--enable_example_plugin"],
     protos = [":example_proto"],
     textprotos = [
         "test1.pbtxt",
@@ -15,6 +16,7 @@ textproto_verifier_test(
 
 textproto_verifier_test(
     name = "syntax_test",
+    indexer_opts = ["--enable_example_plugin"],
     protos = [":example_proto"],
     textprotos = [
         "syntax_test.pbtxt",

--- a/kythe/cxx/indexer/textproto/testdata/textproto_verifier_test.bzl
+++ b/kythe/cxx/indexer/textproto/testdata/textproto_verifier_test.bzl
@@ -82,6 +82,7 @@ def textproto_verifier_test(
         protos,
         size = "small",
         tags = [],
+        indexer_opts = [],
         verifier_opts = [],
         convert_marked_source = False,
         vnames_config = None,
@@ -94,6 +95,7 @@ def textproto_verifier_test(
       protos: Proto libraries that define the textproto's schema
       size: Test size
       tags: Test tags
+      indexer_opts: List of options passed to the textproto indexer
       verifier_opts: List of options passed to the verifier tool
       convert_marked_source: Whether the verifier should convert marked source.
       vnames_config: Optional path to a VName configuration file
@@ -125,7 +127,7 @@ def textproto_verifier_test(
             name = rule_prefix + "_entries",
             testonly = True,
             indexer = "//kythe/cxx/indexer/textproto:textproto_indexer",
-            opts = ["--index_file"],
+            opts = indexer_opts + ["--index_file"],
             tags = tags,
             visibility = visibility,
             deps = [textproto_kzip],


### PR DESCRIPTION
This also adds an `indexer_opts` param to textproto_verifier_test, so
tests can enable specific plugins.