### PR TITLE
feat(cxx_indexer): trace influence through function calls

### DIFF
--- a/kythe/cxx/indexer/cxx/IndexerASTHooks.cc
+++ b/kythe/cxx/indexer/cxx/IndexerASTHooks.cc
@@ -1976,7 +1976,8 @@ bool IndexerASTVisitor::TraverseCallExpr(clang::CallExpr* CE) {
   auto callee = CE->getDirectCallee();
   auto callee_exp = CE->getCallee();
   bool valid = callee != nullptr && callee_exp != nullptr &&
-               callee->param_size() == CE->getNumArgs();
+               CE->getNumArgs() <= callee->param_size();
+  // TODO(zarko): deal with parameter packs and varargs.
   for (unsigned arg = 0; valid && arg < CE->getNumArgs(); ++arg) {
     valid = CE->getArg(arg) != nullptr && callee->getParamDecl(arg) != nullptr;
   }

--- a/kythe/cxx/indexer/cxx/IndexerASTHooks.h
+++ b/kythe/cxx/indexer/cxx/IndexerASTHooks.h
@@ -117,6 +117,8 @@ class IndexerASTVisitor : public RecursiveTypeVisitor<IndexerASTVisitor> {
   bool VisitSizeOfPackExpr(const clang::SizeOfPackExpr* Expr);
   bool VisitDeclRefExpr(const clang::DeclRefExpr* DRE);
 
+  bool TraverseCallExpr(clang::CallExpr* CE);
+  bool TraverseReturnStmt(clang::ReturnStmt* RS);
   bool TraverseBinaryOperator(clang::BinaryOperator* BO);
 
   bool TraverseInitListExpr(clang::InitListExpr* ILE);

--- a/kythe/cxx/indexer/cxx/testdata/BUILD
+++ b/kythe/cxx/indexer/cxx/testdata/BUILD
@@ -3242,6 +3242,13 @@ cc_indexer_test(
 )
 
 cc_indexer_test(
+    name = "df_fncall_influence",
+    srcs = ["df/df_fncall_influence.cc"],
+    ignore_dups = True,
+    tags = ["df"],
+)
+
+cc_indexer_test(
     name = "df_var_ref_blame",
     srcs = ["df/df_var_ref_blame.cc"],
     tags = ["df"],

--- a/kythe/cxx/indexer/cxx/testdata/BUILD
+++ b/kythe/cxx/indexer/cxx/testdata/BUILD
@@ -3249,6 +3249,27 @@ cc_indexer_test(
 )
 
 cc_indexer_test(
+    name = "df_fncall_influence_defaultargs",
+    srcs = ["df/df_fncall_influence_defaultargs.cc"],
+    ignore_dups = True,
+    tags = ["df"],
+)
+
+cc_indexer_test(
+    name = "df_fncall_influence_pack",
+    srcs = ["df/df_fncall_influence_pack.cc"],
+    ignore_dups = True,
+    tags = ["df"],
+)
+
+cc_indexer_test(
+    name = "df_fncall_influence_vararg",
+    srcs = ["df/df_fncall_influence_vararg.cc"],
+    ignore_dups = True,
+    tags = ["df"],
+)
+
+cc_indexer_test(
     name = "df_var_ref_blame",
     srcs = ["df/df_var_ref_blame.cc"],
     tags = ["df"],

--- a/kythe/cxx/indexer/cxx/testdata/df/df_fncall_influence.cc
+++ b/kythe/cxx/indexer/cxx/testdata/df/df_fncall_influence.cc
@@ -1,0 +1,31 @@
+// Checks that influence is recorded for simple function calls.
+
+//- @a defines/binding VarA
+//- @b defines/binding VarB
+//- @f defines/binding FDecl
+int f(int a, int b);
+
+//- @c defines/binding VarC
+//- @d defines/binding VarD
+//- @f defines/binding FDefn
+//- @f completes/uniquely FDecl
+//- VarA influences VarC
+//- VarB influences VarD
+int f(int c, int d) {
+  //- VarC influences FDefn
+  //- VarD influences FDefn
+  return c + d;
+}
+
+void g() {
+  //- @e defines/binding VarE
+  //- @h defines/binding VarH
+  int e = 0, h = 1,
+  //- @i defines/binding VarI
+      i = 2;
+  //- @f ref FDefn
+  //- VarE influences VarC
+  //- VarH influences VarD
+  //- FDefn influences VarI
+  i = f(e, h);
+}

--- a/kythe/cxx/indexer/cxx/testdata/df/df_fncall_influence_defaultargs.cc
+++ b/kythe/cxx/indexer/cxx/testdata/df/df_fncall_influence_defaultargs.cc
@@ -1,0 +1,17 @@
+// Checks that influence is recorded for function calls with default arguments.
+
+//- @a defines/binding VarA
+//- @b defines/binding VarB
+void f(int a, int b = 2);
+
+void g() {
+    //- @c defines/binding VarC
+    //- @d defines/binding VarD
+    //- @e defines/binding VarE
+    int c = 3, d = 4, e = 5;
+    //- VarC influences VarA
+    f(c);
+    //- VarD influences VarA
+    //- VarE influences VarB
+    f(d, e);
+}

--- a/kythe/cxx/indexer/cxx/testdata/df/df_fncall_influence_pack.cc
+++ b/kythe/cxx/indexer/cxx/testdata/df/df_fncall_influence_pack.cc
@@ -1,0 +1,22 @@
+// Checks that recording influence doesn't cause problems for packs.
+template<class ... Ts>
+void h(int a, Ts ... ts) { }
+
+void g() {
+    //- @b defines/binding VarB
+    //- @c defines/binding VarC
+    //- @d defines/binding VarD
+    //- @e defines/binding VarE
+    //- @f defines/binding VarF
+    //- @g defines/binding VarG
+    int b = 1, c = 2, d = 3, e = 4, f = 5, g = 6;
+    //- VarB influences _VarA
+    h(b);
+    //- VarC influences _VarAPrime
+    //- VarD influences _
+    h(c, d);
+    //- VarE influences _VarAPrimePrime
+    //- VarF influences _
+    //- VarG influences _
+    h(e, f, g);
+}

--- a/kythe/cxx/indexer/cxx/testdata/df/df_fncall_influence_vararg.cc
+++ b/kythe/cxx/indexer/cxx/testdata/df/df_fncall_influence_vararg.cc
@@ -1,0 +1,23 @@
+// Checks that recording influence doesn't cause problems for varargs.
+
+//- @a defines/binding VarA
+void h(int a, ...);
+
+void g() {
+    //- @b defines/binding VarB
+    //- @c defines/binding VarC
+    //- @d defines/binding VarD
+    //- @e defines/binding VarE
+    //- @f defines/binding VarF
+    //- @g defines/binding VarG
+    int b = 1, c = 2, d = 3, e = 4, f = 5, g = 6;
+    //- VarB influences VarA
+    h(b);
+    //- !{VarC influences VarA}
+    //- !{VarD influences _}
+    h(c, d);
+    //- !{VarE influences VarA}
+    //- !{VarF influences _}
+    //- !{VarG influences _}
+    h(e, f, g);
+}


### PR DESCRIPTION
This PR adds influence edges for function calls. In particular:

  * argument expressions influence parameter variables
  * parameter variables on incomplete functions influence the
    parameter variables on functions that complete them
  * return expressions influence their containing (complete)
    functions
  * a function call results in that function being included
    in the current influence set.

It should not be necessary to make complete functions influence
the functions they complete as they are already related through
clustering. Parameters on incomplete definitions are not clustered
with the corresponding parameters on complete definitions.

Note: it may be necessary to implement the new traverse functions
using data recursion should we start running out of stack. I have not
observed this behavior yet, but it's worth mentioning now rather than
discovering later.

Related to #4688.