### PR TITLE
fix(typescript_indexer): don't emit defines/binding for computed properties

### DIFF
--- a/kythe/typescript/README.md
+++ b/kythe/typescript/README.md
@@ -29,6 +29,21 @@ Run `yarn test` to run the test suite. (You'll need to have built first.)
 Run `yarn run fmt` to autoformat the source code. (Better, configure your editor
 to run clang-format on save.)
 
+### Running tests
+
+To run tests use:
+
+```shell
+cd kythe/typescript
+bazel test :indexer_test
+```
+
+To run single test from file `testdata/foo.ts`:
+
+```shell
+bazel test --test_arg=foo :indexer_test
+```
+
 ### Writing tests
 
 By default in TypeScript, files are "scripts", where every declaration is in the

--- a/kythe/typescript/testdata/function.ts
+++ b/kythe/typescript/testdata/function.ts
@@ -39,14 +39,13 @@ test(
 //- @#0"fn" defines/binding OFnStr
 const fn = 'fn';
 let o = {
-  //- @"[fn]" defines/binding OFn
-  //- OFn.node/kind function
+  //- !{@"[fn]" defines/binding _}
   //- @fn ref OFnStr
   [fn]() {},
 };
 
-//- @fn ref OFn
-o.fn();
+//- @fn ref OFnStr
+o[fn]();
 
 // Test arrow functions
 //- @x defines/binding X

--- a/kythe/typescript/testdata/object.ts
+++ b/kythe/typescript/testdata/object.ts
@@ -14,8 +14,7 @@ const Object = {
   //- ShortProperty.node/kind variable
   shortProperty,
 
-  //- @"[computed]" defines/binding ComputedProperty
-  //- ComputedProperty.node/kind variable
+  //- !{@"[computed]" defines/binding _}
   //- @computed ref Computed
   [computed]: 0,
 
@@ -34,8 +33,10 @@ const Object = {
 
 //- @property ref Property
 //- @shortProperty ref ShortProperty
-//- @computed ref ComputedProperty
-const x = Object.property || Object.shortProperty || Object.computed;
+const x = Object.property || Object.shortProperty;
+
+//- @computed ref Computed
+Object[computed];
 
 //- @"'string#literal'" ref SLiteralProperty
 Object['string#literal'];


### PR DESCRIPTION
From developer point of view computed properties themselves don't
represent a separate entity that you can click. Instead they are
just expressions and identifiers in that expression should be
xrefed.

Current behavior (which is being fixed in this commit) is the
following:

```typescript
const k = {
  [foo]: 123,
};
```

Currently `[foo]` considered a definition and it overlaps `foo`
making it impossible to click on `foo`.

Tested:
  unit tests