### PR TITLE
Make the verifier library publicly visible

### DIFF
--- a/kythe/cxx/verifier/BUILD
+++ b/kythe/cxx/verifier/BUILD
@@ -69,6 +69,7 @@ cc_library(
         "-Wno-unused-variable",
         "-Wno-implicit-fallthrough",
     ],
+    visibility = [PUBLIC_VISIBILITY],
     deps = [
         ":lexparse",
         "//kythe/cxx/common:file_utils",


### PR DESCRIPTION
Change //kythe/cxx/verifier:lib visibility to public. That will allow Kythe users to build verification tests as simple unit tests without the need to compile-in the Kythe verification binary.