### PR TITLE
feat(textproto): expose DescriptorPool in plugin api

### DIFF
--- a/kythe/cxx/indexer/textproto/analyzer.cc
+++ b/kythe/cxx/indexer/textproto/analyzer.cc
@@ -171,6 +171,10 @@ class TextprotoAnalyzer : public PluginApi {
         descriptor, [this](auto path) { return VNameForRelPath(path); });
   }
 
+  const DescriptorPool* ProtoDescriptorPool() const override {
+    return descriptor_pool_;
+  }
+
  private:
   absl::Status AnalyzeField(const proto::VName& file_vname,
                             const Message& proto,

--- a/kythe/cxx/indexer/textproto/plugin.h
+++ b/kythe/cxx/indexer/textproto/plugin.h
@@ -55,7 +55,7 @@ class PluginApi {
   virtual proto::VName VNameForRelPath(
       absl::string_view simplified_path) const = 0;
 
-  // Returns a reference to the descriptor pool built from the .proto files
+  // Returns a pointer to the descriptor pool built from the .proto files
   // included as dependencies in the textproto's compilation unit.
   virtual const google::protobuf::DescriptorPool* ProtoDescriptorPool()
       const = 0;

--- a/kythe/cxx/indexer/textproto/plugin.h
+++ b/kythe/cxx/indexer/textproto/plugin.h
@@ -54,6 +54,11 @@ class PluginApi {
   // required_inputs.
   virtual proto::VName VNameForRelPath(
       absl::string_view simplified_path) const = 0;
+
+  // Returns a reference to the descriptor pool built from the .proto files
+  // included as dependencies in the textproto's compilation unit.
+  virtual const google::protobuf::DescriptorPool* ProtoDescriptorPool()
+      const = 0;
 };
 
 struct StringToken {


### PR DESCRIPTION
plugins can use this to lookup proto descriptors based on qualified names