### PR TITLE
fix(java_indexer): blame instance/static callsites on ctor/cinit methods

### DIFF
--- a/kythe/java/com/google/devtools/kythe/analyzers/java/JavaEntrySets.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/JavaEntrySets.java
@@ -185,7 +185,7 @@ public class JavaEntrySets extends KytheEntrySets {
         newNode(NodeKind.FUNCTION)
             .setCorpusPath(CorpusPath.fromVName(classNode))
             .addSignatureSalt(classNode)
-            .addSignatureSalt("cinit")
+            .addSignatureSalt("clinit")
             .build());
   }
 

--- a/kythe/java/com/google/devtools/kythe/analyzers/java/JavaEntrySets.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/JavaEntrySets.java
@@ -179,6 +179,16 @@ public class JavaEntrySets extends KytheEntrySets {
             .addSignatureSalt("" + filePositions.getSpan(lambda)));
   }
 
+  /** Emits and returns a new {@link EntrySet} representing a static class initializer. */
+  public EntrySet newClassInitAndEmit(VName classNode) {
+    return emitAndReturn(
+        newNode(NodeKind.FUNCTION)
+            .setCorpusPath(CorpusPath.fromVName(classNode))
+            .addSignatureSalt(classNode)
+            .addSignatureSalt("cinit")
+            .build());
+  }
+
   /**
    * Emits and returns a new {@link EntrySet} representing a Java comment with an optional subkind.
    */

--- a/kythe/java/com/google/devtools/kythe/analyzers/java/JavaNode.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/JavaNode.java
@@ -19,6 +19,8 @@ package com.google.devtools.kythe.analyzers.java;
 import com.google.common.collect.ImmutableList;
 import com.google.devtools.kythe.analyzers.base.EntrySet;
 import com.google.devtools.kythe.proto.Storage.VName;
+import java.util.List;
+import java.util.Optional;
 
 /** Kythe graph node representing a Java language construct. */
 class JavaNode {
@@ -26,6 +28,9 @@ class JavaNode {
   // (i.e. types and abstractions)
   private final VName vName;
   private JavaNode type;
+
+  private List<VName> classConstructors = ImmutableList.of();
+  private Optional<VName> classInit = Optional.empty();
 
   // I think order matters for the wildcards because the abs node will be connected to them with
   // param edges, which are numbered. If order doesn't matter, we should change this to something
@@ -64,5 +69,23 @@ class JavaNode {
 
   JavaNode getType() {
     return type;
+  }
+
+  JavaNode setClassConstructors(List<VName> constructors) {
+    this.classConstructors = constructors;
+    return this;
+  }
+
+  List<VName> getClassConstructors() {
+    return classConstructors;
+  }
+
+  JavaNode setClassInit(VName classInit) {
+    this.classInit = Optional.ofNullable(classInit);
+    return this;
+  }
+
+  Optional<VName> getClassInit() {
+    return classInit;
   }
 }

--- a/kythe/java/com/google/devtools/kythe/analyzers/java/TreeContext.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/TreeContext.java
@@ -20,6 +20,7 @@ import com.google.common.base.Joiner;
 import com.google.devtools.kythe.analyzers.java.SourceText.Positions;
 import com.google.devtools.kythe.util.Span;
 import com.sun.tools.javac.tree.JCTree;
+import com.sun.tools.javac.tree.JCTree.JCBlock;
 import com.sun.tools.javac.tree.JCTree.JCClassDecl;
 import com.sun.tools.javac.tree.JCTree.JCCompilationUnit;
 import com.sun.tools.javac.tree.JCTree.JCMethodDecl;
@@ -92,10 +93,12 @@ class TreeContext {
     return parent;
   }
 
-  public TreeContext getClassOrMethodParent() {
+  public TreeContext getScope() {
     TreeContext parent = up();
     while (parent != null
-        && !(parent.getTree() instanceof JCMethodDecl || parent.getTree() instanceof JCClassDecl)) {
+        && !(parent.getTree() instanceof JCMethodDecl
+            || parent.getTree() instanceof JCClassDecl
+            || parent.getTree() instanceof JCBlock)) {
       parent = parent.up();
     }
     return parent;

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Callgraph.java
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Callgraph.java
@@ -3,32 +3,53 @@ package pkg;
 //- @Callgraph defines/binding Class
 public class Callgraph {
 
+  // Implicit static class initializer
+  //- ClassInit.node/kind function
+  //- ClassInit childof Class
+  //- !{ ClassInit.subkind "constructor" }
+
   //- StaticGCall.loc/start @^"g()"
   //- StaticGCall.loc/end @$"g()"
   //- StaticGCall ref/call G
-  //- StaticGCall childof Class
+  //- StaticGCall childof ECtor
+  //- StaticGCall childof SCtor
+  //- !{ StaticGCall childof Class }
+  //- !{ StaticGCall childof ClassInit }
   final int ZERO = g();
 
   static {
     //- StaticBlockGCall.loc/start @^"g()"
     //- StaticBlockGCall.loc/end @$"g()"
     //- StaticBlockGCall ref/call G
-    //- StaticBlockGCall childof Class
+    //- StaticBlockGCall childof ClassInit
+    //- !{ StaticBlockGCall childof ECtor }
+    //- !{ StaticBlockGCall childof SCtor }
     int zero = g();
+
+    {
+      //- NestedStaticBlockGCall.loc/start @^"g()"
+      //- NestedStaticBlockGCall.loc/end @$"g()"
+      //- NestedStaticBlockGCall ref/call G
+      //- NestedStaticBlockGCall childof ClassInit
+      //- NestedStaticBlockGCall childof ClassInit
+      g();
+    }
   }
 
   {
     //- BlockGCall.loc/start @^"g()"
     //- BlockGCall.loc/end @$"g()"
     //- BlockGCall ref/call G
-    //- BlockGCall childof Class
+    //- BlockGCall childof ECtor
+    //- BlockGCall childof SCtor
     int zero = g();
   }
 
-  //- StaticCtorCall.loc/start @^"new Callgraph()"
-  //- StaticCtorCall.loc/end @$"new Callgraph()"
-  //- StaticCtorCall ref/call ECtor
-  //- StaticCtorCall childof Class
+  //- CtorCall.loc/start @^"new Callgraph()"
+  //- CtorCall.loc/end @$"new Callgraph()"
+  //- CtorCall ref/call ECtor
+  //- CtorCall childof ECtor
+  //- CtorCall childof SCtor
   final Callgraph INSTANCE = new Callgraph();
 
   //- @Callgraph defines/binding ECtor
@@ -71,5 +92,31 @@ public class Callgraph {
     //- CallAnchor ref/call F
     //- CallAnchor childof  G
     return 0;
+  }
+
+  //- @Nested defines/binding NestedClass
+  static class Nested {
+    //- NestedInit.node/kind function
+    //- NestedInit childof NestedClass
+    //- !{ NestedInit.subkind "constructor" }
+
+    //- ImplicitConstructor.node/kind function
+    //- ImplicitConstructor.subkind "constructor"
+    //- ImplicitConstructor childof NestedClass
+
+    //- NestedClassCall.loc/start @^"g()"
+    //- NestedClassCall.loc/end   @$"g()"
+    //- NestedClassCall  childof  ImplicitConstructor
+    final int INT = g();
+
+    static {
+      //- NestedClassStaticCall.loc/start @^"g()"
+      //- NestedClassStaticCall.loc/end   @$"g()"
+      //- NestedClassStaticCall  childof  NestedInit
+      g();
+    }
+
+    //- !{ NestedClassCall childof NestedInit
+    //-    NestedClassStaticCall childof ImplicitConstructor }
   }
 }

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Classes.java
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Classes.java
@@ -77,10 +77,13 @@ public class Classes {
     class LocalClass {};
   }
 
-
+  //- ClassInit.node/kind function
+  //- ClassInit childof N
+  // !{ ClassInit.subkind "constructor" }
+  
   static {
     //- @LocalClassInStaticInitializer defines/binding LCISI
-    //- LCISI childof N
+    //- LCISI childof ClassInit
     class LocalClassInStaticInitializer {};
   }
 }


### PR DESCRIPTION
This matches the C++ indexer's existing behavior and better represents the actual callgraph.

The cinit function is newly represented in this commit as a bare function node per class.