### PR TITLE
Fix invalid escape sequences

### DIFF
--- a/kythe/data/vnames.bzl
+++ b/kythe/data/vnames.bzl
@@ -28,7 +28,7 @@ def _construct_vnames_config_impl(ctx):
         command = "\n".join([
             "set -e -o pipefail",
             "cat " + " ".join([src.path for src in srcs]) + " | " +
-            "tr -d '\n' | sed 's/\]\[/,/g' > " + merged.path,
+            "tr -d '\n' | sed 's/\\]\\[/,/g' > " + merged.path,
         ]),
     )
     ctx.actions.expand_template(


### PR DESCRIPTION
`\]` and `\[` are invalid escape sequences in Starlark. This used to be silently ignored but now throws an error (see https://github.com/bazelbuild/bazel/commit/73402fa4aa5b9de46c9a4042b75e6fb332ad4a7f).