### PR TITLE
feat(verifier): build a souffle frontend that can read an entrystream

### DIFF
--- a/autotools.bzl
+++ b/autotools.bzl
@@ -14,11 +14,14 @@
 
 # Originally from google/sandboxed-api; added 'bootstrap'.
 
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "patch")
+
 """Repository rule that runs autotools' configure after extraction."""
 
 def _configure(ctx):
     bash_exe = ctx.os.environ["BAZEL_SH"] if "BAZEL_SH" in ctx.os.environ else "bash"
     ctx.report_progress("Running configure script...")
+
     # Run bootstrap script if it exists.
     ctx.execute(
         [bash_exe, "-c", "./bootstrap"],
@@ -42,6 +45,7 @@ def _buildfile(ctx):
     elif ctx.attr.build_file_content:
         ctx.execute([bash_exe, "-c", "rm -f BUILD.bazel"])
         ctx.file("BUILD.bazel", ctx.attr.build_file_content)
+    patch(ctx)
 
 def _autotools_repository_impl(ctx):
     if ctx.attr.build_file and ctx.attr.build_file_content:
@@ -74,6 +78,12 @@ autotools_repository = repository_rule(
         ),
         "quiet": attr.bool(
             default = True,
+        ),
+        "patches": attr.label_list(
+            default = [],
+        ),
+        "patch_args": attr.string_list(
+            default = ["-p0"],
         ),
     },
     implementation = _autotools_repository_impl,

--- a/external.bzl
+++ b/external.bzl
@@ -72,6 +72,10 @@ def _cc_dependencies():
         build_file = "@io_kythe//third_party:souffle.BUILD",
         sha256 = "654c1b33b2b3f20fdc1f0983dfed562c24a0baa230fd431401cc0004464c6b4d",
         strip_prefix = "souffle-fbb4c4b967bf58cccb7aca58e3d200a799218d98",
+        patch_args = ["-p0"],
+        patches = [
+            "@io_kythe//third_party:souffle_remove_config.patch",
+        ],
     )
 
     maybe(

--- a/kythe/cxx/verifier/BUILD
+++ b/kythe/cxx/verifier/BUILD
@@ -80,6 +80,27 @@ cc_test(
 )
 
 cc_library(
+    name = "souffle_entrystream_support",
+    srcs = [
+        "souffle_entrysteam_support.cc",
+    ],
+    deps = [
+        "//kythe/proto:common_cc_proto",
+        "//kythe/proto:storage_cc_proto",
+        "@com_google_protobuf//:protobuf",
+        "@souffle",
+    ],
+)
+
+cc_binary(
+    name = "souffle_with_kythe",
+    deps = [
+        ":souffle_entrystream_support",
+        "@souffle//:main",
+    ],
+)
+
+cc_library(
     name = "lib",
     srcs = [
         "assertions.cc",

--- a/kythe/cxx/verifier/BUILD
+++ b/kythe/cxx/verifier/BUILD
@@ -90,6 +90,7 @@ cc_library(
         "@com_google_protobuf//:protobuf",
         "@souffle",
     ],
+    alwayslink = True,
 )
 
 cc_binary(

--- a/kythe/cxx/verifier/souffle_entrysteam_support.cc
+++ b/kythe/cxx/verifier/souffle_entrysteam_support.cc
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2020 The Kythe Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "google/protobuf/io/coded_stream.h"
+#include "google/protobuf/io/zero_copy_stream.h"
+#include "google/protobuf/io/zero_copy_stream_impl.h"
+#include "kythe/proto/storage.pb.h"
+#include "souffle/io/IOSystem.h"
+
+#ifdef __APPLE__
+extern "C" {
+// TODO(zarko): fix these on darwin
+void ffi_call() { abort(); }
+void ffi_prep_cif_machdep() { abort(); }
+void ffi_prep_closure_loc() { abort(); }
+}
+#endif  // defined(__APPLE__)
+
+namespace kythe {
+namespace {
+
+/// Number of elements in the vname representation and their offsets.
+constexpr int kVNameElements = 5;
+constexpr int kSignatureEntry = 0;
+constexpr int kCorpusEntry = 1;
+constexpr int kPathEntry = 2;
+constexpr int kRootEntry = 3;
+constexpr int kLanguageEntry = 4;
+/// Number of elements in the entry representation and their offsets.
+constexpr int kEntryElements = 4;
+constexpr int kSourceEntry = 0;
+constexpr int kKindEntry = 1;
+constexpr int kTargetEntry = 2;
+constexpr int kValueEntry = 3;
+
+class KytheEntryStreamReadStream : public souffle::ReadStream {
+ public:
+  explicit KytheEntryStreamReadStream(
+      const std::map<std::string, std::string>& rw_operation,
+      souffle::SymbolTable& symbol_table, souffle::RecordTable& record_table)
+      : souffle::ReadStream(rw_operation, symbol_table, record_table),
+        raw_input_(STDIN_FILENO) {
+    // Check that the relation has the correct type.
+    if (typeAttributes.size() == kEntryElements &&
+        typeAttributes[0] == "r:vname" && typeAttributes[1] == "s:symbol" &&
+        typeAttributes[2] == "r:vname" && typeAttributes[3] == "s:symbol") {
+      const auto& record_info = types["records"]["r:vname"];
+      size_t arity = record_info["arity"].long_value();
+      const auto& types = record_info["types"];
+      if (arity == kVNameElements) {
+        relation_ok_ = true;
+        for (size_t i = 0; i < arity; ++i) {
+          if (types[i].string_value() != "s:symbol") {
+            relation_ok_ = false;
+            break;
+          }
+        }
+      }
+    }
+    if (!relation_ok_) {
+      fprintf(stderr, R"(error: bad relation for kythe_entrystream. Use:
+
+.type vname = [
+  signature:symbol,
+  corpus:symbol,
+  path:symbol,
+  root:symbol,
+  language:symbol
+]
+
+.decl entry(source:vname, kind:symbol, target:vname, value:symbol)
+
+Note that this is an experimental feature and this declaration may change.
+)");
+    }
+  }
+
+ protected:
+  souffle::Own<souffle::RamDomain[]> readNextTuple() override {
+    if (!relation_ok_) {
+      return nullptr;
+    }
+    google::protobuf::uint32 byte_size;
+    google::protobuf::io::CodedInputStream coded_input(&raw_input_);
+    coded_input.SetTotalBytesLimit(INT_MAX);
+    if (!coded_input.ReadVarint32(&byte_size)) {
+      return nullptr;
+    }
+    coded_input.PushLimit(byte_size);
+    if (!entry_.ParseFromCodedStream(&coded_input)) {
+      fprintf(stderr, "error reading input stream\n");
+      return nullptr;
+    }
+    auto tuple = std::make_unique<souffle::RamDomain[]>(kEntryElements);
+    souffle::RamDomain vname[kVNameElements];
+    CopyVName(entry_.source(), vname);
+    tuple[kSourceEntry] = recordTable.pack(vname, kVNameElements);
+    tuple[kKindEntry] = symbolTable.unsafeLookup(entry_.fact_name());
+    CopyVName(entry_.target(), vname);
+    tuple[kTargetEntry] = recordTable.pack(vname, kVNameElements);
+    tuple[kValueEntry] = symbolTable.unsafeLookup(entry_.fact_value());
+    return tuple;
+  }
+
+ private:
+  /// Copies the fields from `vname` to `target`.
+  void CopyVName(const kythe::proto::VName& vname, souffle::RamDomain* target) {
+    target[kSignatureEntry] = symbolTable.unsafeLookup(vname.signature());
+    target[kCorpusEntry] = symbolTable.unsafeLookup(vname.corpus());
+    target[kPathEntry] = symbolTable.unsafeLookup(vname.path());
+    target[kRootEntry] = symbolTable.unsafeLookup(vname.root());
+    target[kLanguageEntry] = symbolTable.unsafeLookup(vname.language());
+  }
+  /// This entry is reused for each tuple.
+  kythe::proto::Entry entry_;
+  /// This `FileInputStream` reads from stdin.
+  google::protobuf::io::FileInputStream raw_input_;
+  /// True when the relation we're reading has the expected type.
+  bool relation_ok_ = false;
+};
+
+class KytheEntryStreamReadFactory : public souffle::ReadStreamFactory {
+ public:
+  souffle::Own<souffle::ReadStream> getReader(
+      const std::map<std::string, std::string>& rw_operation,
+      souffle::SymbolTable& symbol_table,
+      souffle::RecordTable& record_table) override {
+    return souffle::mk<KytheEntryStreamReadStream>(rw_operation, symbol_table,
+                                                   record_table);
+  }
+
+  const std::string& getName() const override {
+    static const std::string name = "kythe_entrystream";
+    return name;
+  }
+};
+
+struct AutoRegisterReader {
+  AutoRegisterReader() {
+    souffle::IOSystem::getInstance().registerReadStreamFactory(
+        std::make_shared<KytheEntryStreamReadFactory>());
+  }
+} register_reader;
+
+}  // anonymous namespace
+}  // namespace kythe

--- a/kythe/cxx/verifier/souffle_entrysteam_support.cc
+++ b/kythe/cxx/verifier/souffle_entrysteam_support.cc
@@ -100,18 +100,19 @@ Note that this is an experimental feature and this declaration may change.
       return nullptr;
     }
     coded_input.PushLimit(byte_size);
-    if (!entry_.ParseFromCodedStream(&coded_input)) {
+    kythe::proto::Entry entry;
+    if (!entry.ParseFromCodedStream(&coded_input)) {
       fprintf(stderr, "error reading input stream\n");
       return nullptr;
     }
     auto tuple = std::make_unique<souffle::RamDomain[]>(kEntryElements);
     souffle::RamDomain vname[kVNameElements];
-    CopyVName(entry_.source(), vname);
+    CopyVName(entry.source(), vname);
     tuple[kSourceEntry] = recordTable.pack(vname, kVNameElements);
-    tuple[kKindEntry] = symbolTable.unsafeLookup(entry_.fact_name());
-    CopyVName(entry_.target(), vname);
+    tuple[kKindEntry] = symbolTable.unsafeLookup(entry.fact_name());
+    CopyVName(entry.target(), vname);
     tuple[kTargetEntry] = recordTable.pack(vname, kVNameElements);
-    tuple[kValueEntry] = symbolTable.unsafeLookup(entry_.fact_value());
+    tuple[kValueEntry] = symbolTable.unsafeLookup(entry.fact_value());
     return tuple;
   }
 
@@ -124,8 +125,6 @@ Note that this is an experimental feature and this declaration may change.
     target[kRootEntry] = symbolTable.unsafeLookup(vname.root());
     target[kLanguageEntry] = symbolTable.unsafeLookup(vname.language());
   }
-  /// This entry is reused for each tuple.
-  kythe::proto::Entry entry_;
   /// This `FileInputStream` reads from stdin.
   google::protobuf::io::FileInputStream raw_input_;
   /// True when the relation we're reading has the expected type.

--- a/third_party/souffle.BUILD
+++ b/third_party/souffle.BUILD
@@ -59,3 +59,9 @@ cc_library(
         "@org_sourceware_libffi//:libffi",
     ],
 )
+
+cc_library(
+    name = "main",
+    srcs = ["src/main.cpp"],
+    deps = [":souffle"],
+)

--- a/third_party/souffle_remove_config.patch
+++ b/third_party/souffle_remove_config.patch
@@ -1,0 +1,11 @@
+--- src/main.cpp
++++ src/main.cpp
+@@ -60,7 +60,7 @@
+ #include "ast/transform/SimplifyAggregateTargetExpression.h"
+ #include "ast/transform/UniqueAggregationVariables.h"
+ #include "ast2ram/AstToRamTranslator.h"
+-#include "config.h"
++#define PACKAGE_VERSION "2.0.2-352-gfbb4c4b96"
+ #include "interpreter/Engine.h"
+ #include "interpreter/ProgInterface.h"
+ #include "parser/ParserDriver.h"


### PR DESCRIPTION
This PR builds a version of the souffle frontend that can read an
entrystream directly. For example, the program

```
.type vname = [
  signature:symbol,
  corpus:symbol,
  path:symbol,
  root:symbol,
  language:symbol
]

.decl entry(source:vname, kind:symbol, target:vname, value:symbol)
.input entry(IO=kythe_entrystream)

.decl outentry(source:vname, kind:symbol, target:vname, value:symbol)
.output outentry(IO=json)

outentry(s,k,t,v) :- entry(s,k,t,v).
```

when invoked as
```
./bazel-bin/kythe/cxx/verifier/souffle_with_kythe example.dl \
    < in.entries
```

will print the entries as JSON.

libffi still doesn't work on Darwin and the fix isn't immediately
clear (I did look at a different BUILD file, but I think their
version of libffi was different; ours seems to be missing some
Darwin headers for x86_64?). I've stubbed the relevant symbols
out to make the linker happy.

I don't know if this is the most efficient representation of the
Kythe graph or if it has other problems, so please don't rely on
it (and suggestions for improvement are welcome).