### PR TITLE
feat(cxx_common): add a regular wrapper for RE2

### DIFF
--- a/kythe/cxx/common/BUILD
+++ b/kythe/cxx/common/BUILD
@@ -537,3 +537,29 @@ cc_library(
         "@com_google_absl//absl/debugging:symbolize",
     ],
 )
+
+cc_library(
+    name = "regex",
+    srcs = ["regex.cc"],
+    hdrs = ["regex.h"],
+    deps = [
+        "@com_github_google_glog//:glog",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/types:span",
+        "@com_googlesource_code_re2//:re2",
+    ],
+)
+
+cc_test(
+    name = "regex_test",
+    srcs = ["regex_test.cc"],
+    deps = [
+        ":regex",
+        "//third_party:gtest",
+        "//third_party:gtest_main",
+        "@com_github_google_glog//:glog",
+        "@com_googlesource_code_re2//:re2",
+    ],
+)

--- a/kythe/cxx/common/regex.cc
+++ b/kythe/cxx/common/regex.cc
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2020 The Kythe Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "kythe/cxx/common/regex.h"
+
+#include <memory>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "glog/logging.h"
+#include "re2/re2.h"
+
+namespace kythe {
+namespace {
+
+template <typename T>
+union NoDestructor {
+  T value;
+  ~NoDestructor() {}
+};
+
+std::shared_ptr<const RE2> DefaultRegex() {
+  static const NoDestructor<std::shared_ptr<const RE2>> kEmpty = {
+      std::make_shared<RE2>("")};
+  return kEmpty.value;
+}
+
+std::shared_ptr<const RE2::Set> DefaultSet() {
+  static const NoDestructor<std::shared_ptr<const RE2::Set>> kEmpty = {[] {
+    auto set = std::make_shared<RE2::Set>(RE2::Options(), RE2::UNANCHORED);
+    set->Compile();
+    return set;
+  }()};
+  return kEmpty.value;
+}
+
+RE2::Set CheckCompiled(RE2::Set set) {
+  RE2::Set::ErrorInfo error;
+  if (!set.Match("", nullptr, &error)) {
+    if (error.kind == RE2::Set::kNotCompiled) {
+      LOG(DFATAL) << "Uncompiled RE2::Set passed to RegexSet";
+      CHECK(set.Compile()) << "Failed to compile RE2::Set";
+    }
+  }
+  return set;
+}
+}  // namespace
+
+absl::StatusOr<Regex> Regex::Compile(absl::string_view pattern,
+                                     const RE2::Options& options) {
+  std::shared_ptr<const RE2> re = std::make_shared<RE2>(pattern, options);
+  if (!re->ok()) {
+    return absl::InvalidArgumentError(re->error());
+  }
+  return Regex(std::move(re));
+}
+
+Regex::Regex() : re_(DefaultRegex()) {}
+
+Regex::Regex(const RE2& re)
+    : re_(std::make_shared<RE2>(re.pattern(), re.options())) {
+  CHECK(re_->ok()) << "Cannot initialize Regex from invalid RE2: "
+                   << re_->error();
+}
+
+Regex::Regex(Regex&& other) noexcept : re_(std::move(other.re_)) {
+  other.re_ = DefaultRegex();
+}
+
+Regex& Regex::operator=(Regex&& other) noexcept {
+  re_ = std::move(other.re_);
+  other.re_ = DefaultRegex();
+  return *this;
+}
+
+absl::StatusOr<RegexSet> RegexSet::Build(absl::Span<const std::string> patterns,
+                                         const RE2::Options& options,
+                                         RE2::Anchor anchor) {
+  RE2::Set set(options, anchor);
+  for (const auto& value : patterns) {
+    std::string error;
+    if (set.Add(value, &error) == -1) {
+      return absl::InvalidArgumentError(error);
+    }
+  }
+  if (!set.Compile()) {
+    return absl::ResourceExhaustedError(
+        "Out of memory attempting to compile RegexSet");
+  }
+  return RegexSet(std::move(set));
+}
+
+RegexSet::RegexSet() : set_(DefaultSet()) {}
+RegexSet::RegexSet(RE2::Set set)
+    : set_(std::make_shared<RE2::Set>(CheckCompiled(std::move(set)))) {}
+
+RegexSet::RegexSet(RegexSet&& other) noexcept : set_(std::move(other.set_)) {
+  other.set_ = DefaultSet();
+}
+
+RegexSet& RegexSet::operator=(RegexSet&& other) noexcept {
+  set_ = std::move(other.set_);
+  other.set_ = DefaultSet();
+  return *this;
+}
+
+absl::StatusOr<std::vector<int>> RegexSet::ExplainMatch(
+    absl::string_view value) const {
+  RE2::Set::ErrorInfo error;
+  std::vector<int> matches;
+  if (set_->Match(value, &matches, &error)) {
+    return matches;
+  }
+  matches.clear();
+  switch (error.kind) {
+    case RE2::Set::kNoError:
+      return matches;  // Empty match == no error, but no matches.
+    case RE2::Set::kNotCompiled:
+      // Shouldn't happen.
+      return absl::InternalError("Match() called on uncompiled Set");
+    case RE2::Set::kOutOfMemory:
+      return absl::ResourceExhaustedError("Match() ran out of memory");
+    case RE2::Set::kInconsistent:
+      return absl::InternalError("RE2::Match() had inconsistent result");
+  }
+  return absl::UnknownError("");
+}
+
+}  // namespace kythe

--- a/kythe/cxx/common/regex.h
+++ b/kythe/cxx/common/regex.h
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2020 The Kythe Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <memory>
+
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "absl/types/span.h"
+#include "re2/re2.h"
+#include "re2/set.h"
+
+#ifndef KYTHE_CXX_COMMON_REGEX_H_
+#define KYTHE_CXX_COMMON_REGEX_H_
+
+namespace kythe {
+
+/// \brief Regex is a Regular value type implemented on top of RE2.
+class Regex {
+ public:
+  /// \brief Compiles the pattern into a Regex with the provided options.
+  static absl::StatusOr<Regex> Compile(
+      absl::string_view pattern,
+      const RE2::Options& options = RE2::DefaultOptions);
+
+  /// \brief Constructs a Regex from an already-compiled RE2 object.
+  /// Requires: re.ok()
+  explicit Regex(const RE2& re);
+
+  /// \brief Constructs an empty Regex.
+  Regex();
+
+  /// \brief Regex is copyable.
+  Regex(const Regex&) = default;
+  Regex& operator=(const Regex&) = default;
+
+  /// \brief Regex is movable.
+  /// Moves leave the moved-from object in a default constructed state.
+  Regex(Regex&&) noexcept;
+  Regex& operator=(Regex&&) noexcept;
+
+  /// \brief Retrieves the underlying RE2 object to be compatible with the RE2
+  /// non-member functions.
+  operator const RE2&() const { return *re_; }
+
+ private:
+  explicit Regex(std::shared_ptr<const RE2> re) : re_(std::move(re)) {}
+
+  std::shared_ptr<const RE2> re_;  // non-null.
+};
+
+/// \brief RegexSet is a regular value-type wrapper around RE2::Set.
+class RegexSet {
+ public:
+  /// \brief Builds a RegexSet from the list of patterns and options.
+  static absl::StatusOr<RegexSet> Build(
+      absl::Span<const std::string> patterns,
+      const RE2::Options& = RE2::DefaultOptions, RE2::Anchor = RE2::UNANCHORED);
+
+  /// \brief Constructs a RegexSet from the extant RE2::Set.
+  /// Requires: set has been compiled
+  explicit RegexSet(RE2::Set set);
+
+  /// \brief Default constructs an empty RegexSet. Matches nothing.
+  RegexSet();
+
+  /// \brief Regex set is copyable.
+  RegexSet(const RegexSet& other) = default;
+  RegexSet& operator=(const RegexSet& other) = default;
+
+  /// \brief Regex set is movable.
+  /// Moves leave the moved-from object in a default ocnstructed state.
+  RegexSet(RegexSet&& other) noexcept;
+  RegexSet& operator=(RegexSet&& other) noexcept;
+
+  /// \brief Returns true if the provided value matches one of the contained
+  /// regular expressions.
+  bool Match(absl::string_view value) const {
+    return set_->Match(value, nullptr);
+  }
+
+  /// \brief Matches the input against the contained regular expressions,
+  /// returning the indices at which the value matched or an empty vector if it
+  /// did not.
+  absl::StatusOr<std::vector<int>> ExplainMatch(absl::string_view value) const;
+
+ private:
+  std::shared_ptr<const RE2::Set> set_;  // non-null.
+};
+
+}  // namespace kythe
+
+#endif  // KYTHE_CXX_COMMON_REGEX_H_

--- a/kythe/cxx/common/regex_test.cc
+++ b/kythe/cxx/common/regex_test.cc
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2020 The Kythe Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "kythe/cxx/common/regex.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "re2/re2.h"
+
+namespace kythe {
+namespace {
+
+TEST(RegexTest, DefaultConstructorWorks) {
+  Regex regex;
+  EXPECT_TRUE(RE2::FullMatch("", regex));
+}
+
+TEST(RegexTest, MoveOperationsAreSane) {
+  Regex orig = Regex::Compile("^hello_world$").value();
+  EXPECT_TRUE(RE2::FullMatch("hello_world", orig));
+
+  Regex dest = std::move(orig);
+  EXPECT_TRUE(RE2::FullMatch("hello_world", dest));
+  EXPECT_FALSE(RE2::FullMatch("hello_world", orig));
+  EXPECT_TRUE(RE2::FullMatch("", orig));
+}
+
+TEST(RegexTest, CopyOperationsAreSane) {
+  Regex orig = Regex::Compile("^hello_world$").value();
+  EXPECT_TRUE(RE2::FullMatch("hello_world", orig));
+
+  Regex dest = orig;
+  EXPECT_TRUE(RE2::FullMatch("hello_world", dest));
+  EXPECT_TRUE(RE2::FullMatch("hello_world", orig));
+}
+
+TEST(RegexTest, CopiesFromRE2) {
+  RE2::Options options;
+  // Use non-default options to ensure they are copied as well.
+  options.set_literal(true);
+  RE2 re("^hello_world$", options);
+
+  Regex regex(re);
+
+  EXPECT_FALSE(RE2::FullMatch("hello_world", re));
+  EXPECT_FALSE(RE2::FullMatch("hello_world", regex));
+  EXPECT_TRUE(RE2::FullMatch("^hello_world$", re));
+  EXPECT_TRUE(RE2::FullMatch("^hello_world$", regex));
+}
+
+TEST(RegexSetTest, DefaultConstructorWorks) {
+  RegexSet set;
+  EXPECT_FALSE(set.Match(""));
+}
+
+TEST(RegexSetTest, MoveOperationsAreSane) {
+  RegexSet orig = RegexSet::Build({"^hello_world$"}).value();
+  EXPECT_TRUE(orig.Match("hello_world"));
+
+  RegexSet dest = std::move(orig);
+  EXPECT_TRUE(dest.Match("hello_world"));
+  EXPECT_FALSE(orig.Match("hello_world"));
+}
+
+TEST(RegexSetTest, CopyOperationsAreSane) {
+  RegexSet orig = RegexSet::Build({"^hello_world$"}).value();
+  EXPECT_TRUE(orig.Match("hello_world"));
+
+  RegexSet dest = orig;
+  EXPECT_TRUE(dest.Match("hello_world"));
+  EXPECT_TRUE(orig.Match("hello_world"));
+}
+
+TEST(RegexSetTest, ConstructsFromCompiledRE2Set) {
+  RE2::Set base(RE2::DefaultOptions, RE2::UNANCHORED);
+  ASSERT_EQ(base.Add("hello_world", nullptr), 0);
+  ASSERT_TRUE(base.Compile());
+
+  RegexSet set(std::move(base));
+  EXPECT_TRUE(set.Match("hello_world"));
+}
+
+TEST(RegexSetTest, ExplainsMatch) {
+  using ::testing::IsEmpty;
+  using ::testing::UnorderedElementsAre;
+
+  RE2::Options options;
+  options.set_never_capture(true);
+  RegexSet set = RegexSet::Build({"(hello_)?world", "(goodbye_)?world"},
+                                 options, RE2::ANCHOR_BOTH)
+                     .value();
+
+  auto result = set.ExplainMatch("world");
+  ASSERT_TRUE(result.ok());
+  EXPECT_THAT(*result, UnorderedElementsAre(0, 1));
+
+  result = set.ExplainMatch("unmatched");
+  ASSERT_TRUE(result.ok());
+  EXPECT_THAT(*result, IsEmpty());
+}
+
+}  // namespace
+}  // namespace kythe

--- a/kythe/cxx/extractor/BUILD
+++ b/kythe/cxx/extractor/BUILD
@@ -312,6 +312,7 @@ cc_library(
     hdrs = ["bazel_artifact_selector.h"],
     deps = [
         ":bazel_artifact",
+        "//kythe/cxx/common:regex",
         "//kythe/proto:bazel_artifact_selector_cc_proto",
         "@build_event_stream_proto//:build_event_stream_cc_proto",
         "@com_github_google_glog//:glog",
@@ -331,6 +332,7 @@ cc_test(
     deps = [
         ":bazel_artifact",
         ":bazel_artifact_selector",
+        "//kythe/cxx/common:regex",
         "//third_party:gtest",
         "//third_party:gtest_main",
         "@build_event_stream_proto//:build_event_stream_cc_proto",

--- a/kythe/cxx/extractor/bazel_artifact_selector.cc
+++ b/kythe/cxx/extractor/bazel_artifact_selector.cc
@@ -61,7 +61,7 @@ struct FromRange {
 };
 
 template <typename T>
-FromRange(const T&) -> FromRange<T>;
+FromRange(const T&)->FromRange<T>;
 
 }  // namespace
 

--- a/kythe/cxx/extractor/bazel_artifact_selector.cc
+++ b/kythe/cxx/extractor/bazel_artifact_selector.cc
@@ -61,7 +61,7 @@ struct FromRange {
 };
 
 template <typename T>
-FromRange(const T&)->FromRange<T>;
+FromRange(const T&) -> FromRange<T>;
 
 }  // namespace
 
@@ -115,7 +115,7 @@ absl::optional<BazelArtifact> AspectArtifactSelector::SelectFileSet(
     absl::string_view id, const build_event_stream::NamedSetOfFiles& filesets) {
   bool kept = false;
   for (const auto& file : filesets.files()) {
-    if (options_->file_name_allowlist.Match(file.name(), nullptr)) {
+    if (options_.file_name_allowlist.Match(file.name())) {
       kept = true;
       *state_.filesets[id].add_files() = file;
     }
@@ -147,13 +147,12 @@ absl::optional<BazelArtifact> AspectArtifactSelector::SelectTargetCompleted(
     const build_event_stream::BuildEventId::TargetCompletedId& id,
     const build_event_stream::TargetComplete& payload) {
   if (payload.success() &&
-      options_->target_aspect_allowlist.Match(id.aspect(), nullptr)) {
+      options_.target_aspect_allowlist.Match(id.aspect())) {
     BazelArtifact result = {
         .label = id.label(),
     };
     for (const auto& output_group : payload.output_group()) {
-      if (options_->output_group_allowlist.Match(output_group.name(),
-                                                 nullptr)) {
+      if (options_.output_group_allowlist.Match(output_group.name())) {
         for (const auto& filesets : output_group.file_sets()) {
           ReadFilesInto(filesets.id(), id.label(), result.files);
         }

--- a/kythe/cxx/extractor/bazel_artifact_selector_test.cc
+++ b/kythe/cxx/extractor/bazel_artifact_selector_test.cc
@@ -67,14 +67,12 @@ TEST(AspectArtifactSelectorTest, SelectsOutOfOrderFileSets) {
         name: "kythe_compilation_unit"
         file_sets { id: "1" }
       }
-    })pb")),
-              Eq(absl::nullopt));
+    })pb")), Eq(absl::nullopt));
   EXPECT_THAT(selector.Select(ParseEventOrDie(R"pb(
     id { named_set { id: "1" } }
     named_set_of_files {
       files { name: "path/to/file.kzip" uri: "file:///path/to/file.kzip" }
-    })pb")),
-              Eq(BazelArtifact{
+    })pb")), Eq(BazelArtifact{
                   .label = "//path/to/target:name",
                   .files = {{
                       .local_path = "path/to/file.kzip",
@@ -90,8 +88,7 @@ TEST(AspectArtifactSelectorTest, SelectsMatchingTargetsOnce) {
     id { named_set { id: "1" } }
     named_set_of_files {
       files { name: "path/to/file.kzip" uri: "file:///path/to/file.kzip" }
-    })pb")),
-              Eq(absl::nullopt));
+    })pb")), Eq(absl::nullopt));
   EXPECT_THAT(selector.Select(ParseEventOrDie(R"pb(
     id {
       target_completed {
@@ -105,8 +102,7 @@ TEST(AspectArtifactSelectorTest, SelectsMatchingTargetsOnce) {
         name: "kythe_compilation_unit"
         file_sets { id: "1" }
       }
-    })pb")),
-              Eq(BazelArtifact{
+    })pb")), Eq(BazelArtifact{
                   .label = "//path/to/target:name",
                   .files = {{
                       .local_path = "path/to/file.kzip",
@@ -128,8 +124,7 @@ TEST(AspectArtifactSelectorTest, SelectsMatchingTargetsOnce) {
         name: "kythe_compilation_unit"
         file_sets { id: "1" }
       }
-    })pb")),
-              Eq(absl::nullopt));
+    })pb")), Eq(absl::nullopt));
 }
 
 TEST(AspectArtifactSelectorTest, CompatibleWithAny) {
@@ -182,14 +177,13 @@ TEST(ExtraActionSelector, SelectsAllByDefault) {
       configuration { id: "hash0" }
       type: "extract_kzip_cxx_extra_action"
     }
-  )pb")),
-              Eq(BazelArtifact{
-                  .label = "//kythe/cxx/extractor:bazel_artifact_selector",
-                  .files = {{
-                      .local_path = "path/to/file/dummy.kzip",
-                      .uri = "file:///home/path/to/file/dummy.kzip",
-                  }},
-              }));
+  )pb")), Eq(BazelArtifact{
+               .label = "//kythe/cxx/extractor:bazel_artifact_selector",
+               .files = {{
+                   .local_path = "path/to/file/dummy.kzip",
+                   .uri = "file:///home/path/to/file/dummy.kzip",
+               }},
+           }));
 }
 
 TEST(ExtraActionSelector, SelectsFromList) {
@@ -209,14 +203,13 @@ TEST(ExtraActionSelector, SelectsFromList) {
       configuration { id: "hash0" }
       type: "matching_action_type"
     }
-  )pb")),
-              Eq(BazelArtifact{
-                  .label = "//kythe/cxx/extractor:bazel_artifact_selector",
-                  .files = {{
-                      .local_path = "path/to/file/dummy.kzip",
-                      .uri = "file:///home/path/to/file/dummy.kzip",
-                  }},
-              }));
+  )pb")), Eq(BazelArtifact{
+               .label = "//kythe/cxx/extractor:bazel_artifact_selector",
+               .files = {{
+                   .local_path = "path/to/file/dummy.kzip",
+                   .uri = "file:///home/path/to/file/dummy.kzip",
+               }},
+           }));
   EXPECT_THAT(selector.Select(ParseEventOrDie(R"pb(
     id {
       action_completed {
@@ -232,8 +225,7 @@ TEST(ExtraActionSelector, SelectsFromList) {
       configuration { id: "hash0" }
       type: "another_action_type"
     }
-  )pb")),
-              Eq(absl::nullopt));
+  )pb")), Eq(absl::nullopt));
 }
 
 TEST(ExtraActionSelector, SelectsFromPattern) {
@@ -254,14 +246,13 @@ TEST(ExtraActionSelector, SelectsFromPattern) {
       configuration { id: "hash0" }
       type: "matching_action_type"
     }
-  )pb")),
-              Eq(BazelArtifact{
-                  .label = "//kythe/cxx/extractor:bazel_artifact_selector",
-                  .files = {{
-                      .local_path = "path/to/file/dummy.kzip",
-                      .uri = "file:///home/path/to/file/dummy.kzip",
-                  }},
-              }));
+  )pb")), Eq(BazelArtifact{
+               .label = "//kythe/cxx/extractor:bazel_artifact_selector",
+               .files = {{
+                   .local_path = "path/to/file/dummy.kzip",
+                   .uri = "file:///home/path/to/file/dummy.kzip",
+               }},
+           }));
   EXPECT_THAT(selector.Select(ParseEventOrDie(R"pb(
     id {
       action_completed {
@@ -277,8 +268,7 @@ TEST(ExtraActionSelector, SelectsFromPattern) {
       configuration { id: "hash0" }
       type: "another_action_type"
     }
-  )pb")),
-              Eq(absl::nullopt));
+  )pb")), Eq(absl::nullopt));
 }
 
 TEST(ExtraActionSelector, SelectsNoneWithEmptyPattern) {
@@ -299,8 +289,7 @@ TEST(ExtraActionSelector, SelectsNoneWithEmptyPattern) {
       configuration { id: "hash0" }
       type: "another_action_type"
     }
-  )pb")),
-              Eq(absl::nullopt));
+  )pb")), Eq(absl::nullopt));
 }
 
 TEST(ExtraActionSelector, SelectsNoneWithNullPattern) {
@@ -320,8 +309,7 @@ TEST(ExtraActionSelector, SelectsNoneWithNullPattern) {
       configuration { id: "hash0" }
       type: "another_action_type"
     }
-  )pb")),
-              Eq(absl::nullopt));
+  )pb")), Eq(absl::nullopt));
 }
 
 }  // namespace


### PR DESCRIPTION
RE2::Set is an awkward move-only quasi-value type that is harder to work with than necessary.  

While less of an issue for RE2 itself, the lack of copy/move for a conceptual value type and combined error-and-valid state model means RE2 frequently gets passed as a pointer, which clients then have to check both for nullness and then check the provided RE2 object for validity.  This is obnoxious.

These wrappers provide regular types, which are default constructible, movable and copyable.  They are always valid, provide factories to encapsulate failure and may be constructed from their respective wrapped types.