### PR TITLE
chore(cxx_indexer): remove obsolete clang nested namespace

### DIFF
--- a/kythe/cxx/indexer/cxx/IndexerASTHooks.cc
+++ b/kythe/cxx/indexer/cxx/IndexerASTHooks.cc
@@ -477,7 +477,7 @@ const IndexedParentMap* IndexerASTVisitor::getAllParents() {
 }
 
 const IndexedParent* IndexerASTVisitor::getIndexedParent(
-    const ast_type_traits::DynTypedNode& Node) {
+    const DynTypedNode& Node) {
   return getAllParents()->GetIndexedParent(Node);
 }
 

--- a/kythe/cxx/indexer/cxx/IndexerASTHooks.h
+++ b/kythe/cxx/indexer/cxx/IndexerASTHooks.h
@@ -818,7 +818,7 @@ class IndexerASTVisitor : public RecursiveTypeVisitor<IndexerASTVisitor> {
   /// NestedNameSpecifier or NestedNameSpecifierLoc.
   template <typename NodeT>
   const IndexedParent* getIndexedParent(const NodeT& Node) {
-    return getIndexedParent(clang::ast_type_traits::DynTypedNode::create(Node));
+    return getIndexedParent(clang::DynTypedNode::create(Node));
   }
 
   /// \return true if `Decl` and all of the nodes underneath it are prunable.
@@ -827,8 +827,7 @@ class IndexerASTVisitor : public RecursiveTypeVisitor<IndexerASTVisitor> {
   /// This excludes, for example, certain template instantiations.
   bool declDominatesPrunableSubtree(const clang::Decl* Decl);
 
-  const IndexedParent* getIndexedParent(
-      const clang::ast_type_traits::DynTypedNode& Node);
+  const IndexedParent* getIndexedParent(const clang::DynTypedNode& Node);
 
   /// Initializes AllParents, if necessary, and then returns a pointer to it.
   const IndexedParentMap* getAllParents();

--- a/kythe/cxx/indexer/cxx/indexed_parent_iterator.h
+++ b/kythe/cxx/indexer/cxx/indexed_parent_iterator.h
@@ -32,7 +32,7 @@ class RootTraversal {
   // Type containing the values used during root traversal iterator.
   struct value_type {
     // The current node in the traversal.
-    clang::ast_type_traits::DynTypedNode node;
+    clang::DynTypedNode node;
     // A pointer to the `clang::Decl` of the node, if any.
     const clang::Decl* decl;
     // A pointer to the IndexedParent of the current node, if any.
@@ -60,8 +60,8 @@ class RootTraversal {
     friend class RootTraversal;
 
     explicit iterator(const IndexedParentMap* parent_map,
-                      clang::ast_type_traits::DynTypedNode node,
-                      const clang::Decl* decl, const IndexedParent* parent)
+                      clang::DynTypedNode node, const clang::Decl* decl,
+                      const IndexedParent* parent)
         : parent_map_(parent_map), current_(value_type{node, decl, parent}) {
       // If we would be constructed from a TranslationUnitDecl, stop.
       if (decl && clang::isa<clang::TranslationUnitDecl>(decl)) {
@@ -71,19 +71,17 @@ class RootTraversal {
     }
 
     explicit iterator(const IndexedParentMap* parent_map,
-                      clang::ast_type_traits::DynTypedNode node,
-                      const clang::Decl* decl)
+                      clang::DynTypedNode node, const clang::Decl* decl)
         : iterator(parent_map, node, decl, parent_map->GetIndexedParent(node)) {
     }
 
     explicit iterator(const IndexedParentMap* parent_map,
-                      clang::ast_type_traits::DynTypedNode node)
+                      clang::DynTypedNode node)
         : iterator(parent_map, node, node.get<clang::Decl>()) {}
 
     explicit iterator(const IndexedParentMap* parent_map,
                       const clang::Decl* decl)
-        : iterator(parent_map,
-                   clang::ast_type_traits::DynTypedNode::create(*decl), decl) {}
+        : iterator(parent_map, clang::DynTypedNode::create(*decl), decl) {}
 
     iterator next() const;
     void advance();
@@ -114,8 +112,7 @@ class RootTraversal {
   }
   static iterator Start(const IndexedParentMap* parent_map,
                         const clang::Stmt* stmt) {
-    return stmt ? iterator(parent_map,
-                           clang::ast_type_traits::DynTypedNode::create(*stmt))
+    return stmt ? iterator(parent_map, clang::DynTypedNode::create(*stmt))
                 : iterator();
   }
   iterator start_;

--- a/kythe/cxx/indexer/cxx/indexed_parent_map.cc
+++ b/kythe/cxx/indexer/cxx/indexed_parent_map.cc
@@ -83,7 +83,7 @@ class IndexedParentASTVisitor
   // on values of type `T*` and returns a boolean traversal result.
   template <typename T, typename BaseTraverseFn>
   bool TraverseNode(T* node, BaseTraverseFn traverse) {
-    using ::clang::ast_type_traits::DynTypedNode;
+    using ::clang::DynTypedNode;
     if (node == nullptr) return true;
     if (!parent_stack_.empty()) {
       auto& parent = parents_[node];
@@ -137,7 +137,7 @@ IndexedParentMap IndexedParentMap::Build(clang::TranslationUnitDecl* unit) {
 }
 
 const IndexedParent* IndexedParentMap::GetIndexedParent(
-    const clang::ast_type_traits::DynTypedNode& node) const {
+    const clang::DynTypedNode& node) const {
   CHECK(node.getMemoizationData() != nullptr)
       << "Invariant broken: only nodes that support memoization may be "
          "used in the parent map.";
@@ -150,7 +150,7 @@ const IndexedParent* IndexedParentMap::GetIndexedParent(
 
 bool IndexedParentMap::DeclDominatesPrunableSubtree(
     const clang::Decl* decl) const {
-  const auto node = clang::ast_type_traits::DynTypedNode::create(*decl);
+  const auto node = clang::DynTypedNode::create(*decl);
   const auto iter = parents_.find(node.getMemoizationData());
   if (iter == parents_.end()) {
     return false;  // Safe default.

--- a/kythe/cxx/indexer/cxx/indexed_parent_map.h
+++ b/kythe/cxx/indexer/cxx/indexed_parent_map.h
@@ -28,7 +28,7 @@ namespace kythe {
 /// node in some arbitrary but consistent order defined by the parent.
 struct IndexedParent {
   /// \brief The parent DynTypedNode associated with some key.
-  clang::ast_type_traits::DynTypedNode parent;
+  clang::DynTypedNode parent;
   /// \brief The index at which some associated key appears in `Parent`.
   size_t index;
 
@@ -59,8 +59,7 @@ class IndexedParentMap {
 
   /// \brief Returns the parent of the given node, along with the index
   /// at which the node appears underneath each parent.
-  const IndexedParent* GetIndexedParent(
-      const clang::ast_type_traits::DynTypedNode& node) const;
+  const IndexedParent* GetIndexedParent(const clang::DynTypedNode& node) const;
 
   /// \brief Returns the parent of the given node, along with the index
   /// at which the node appears underneath each parent.
@@ -69,7 +68,7 @@ class IndexedParentMap {
   /// NestedNameSpecifier or NestedNameSpecifierLoc.
   template <typename T>
   const IndexedParent* GetIndexedParent(const T& node) const {
-    return GetIndexedParent(clang::ast_type_traits::DynTypedNode::create(node));
+    return GetIndexedParent(clang::DynTypedNode::create(node));
   }
 
   /// \return true if `Decl` and all of the nodes underneath it are prunable.


### PR DESCRIPTION
This mirrors and automated internal cleanup.