### PR TITLE
fix(cxx_common): change selector serialization to work better with protos

### DIFF
--- a/kythe/cxx/extractor/bazel_artifact_selector.h
+++ b/kythe/cxx/extractor/bazel_artifact_selector.h
@@ -60,7 +60,7 @@ class BazelArtifactSelector {
   /// \brief Updates any per-stream state from the provided proto.
   /// Stateless selectors should unconditionally return a kUnimplemented status.
   /// Stateful selectors should return OK if the provided state contains a
-  /// suitable proto, InvalidArgument is the proto is of the right type, but
+  /// suitable proto, InvalidArgument if the proto is of the right type but
   /// cannot be decoded or FailedPrecondition if the proto is of the wrong type.
   virtual absl::Status DeserializeFrom(const google::protobuf::Any& state) {
     return absl::UnimplementedError("stateless selector");


### PR DESCRIPTION
The resulting design is predicated on a couple of things:

1) protos may be arena allocated, which makes output parameters preferred
2) RepeatedPtrField is awkward to work with, suggesting an overload to better accommodate it.
3) Overloads and virtual member functions don't play well.
4) So update the deserialization protocol to operate on a single Any, with non-virtual members which make use of that.

I've also included tests of the serialization/deserialization both generically and for AspectArtifactSelector.  The remaining changes are due to updates in clang-format.
