### PR TITLE
feat(cxx_common): allow any range-of-string-like-types for RegexSet::Build

### DIFF
--- a/kythe/cxx/common/regex.cc
+++ b/kythe/cxx/common/regex.cc
@@ -87,23 +87,6 @@ Regex& Regex::operator=(Regex&& other) noexcept {
   return *this;
 }
 
-absl::StatusOr<RegexSet> RegexSet::Build(absl::Span<const std::string> patterns,
-                                         const RE2::Options& options,
-                                         RE2::Anchor anchor) {
-  RE2::Set set(options, anchor);
-  for (const auto& value : patterns) {
-    std::string error;
-    if (set.Add(value, &error) == -1) {
-      return absl::InvalidArgumentError(error);
-    }
-  }
-  if (!set.Compile()) {
-    return absl::ResourceExhaustedError(
-        "Out of memory attempting to compile RegexSet");
-  }
-  return RegexSet(std::move(set));
-}
-
 RegexSet::RegexSet() : set_(DefaultSet()) {}
 RegexSet::RegexSet(RE2::Set set)
     : set_(std::make_shared<RE2::Set>(CheckCompiled(std::move(set)))) {}

--- a/kythe/cxx/common/regex.h
+++ b/kythe/cxx/common/regex.h
@@ -67,7 +67,7 @@ class RegexSet {
   /// \brief Builds a RegexSet from the list of patterns and options.
   template <typename Range = absl::Span<const absl::string_view>>
   static absl::StatusOr<RegexSet> Build(
-      Range&& patterns, const RE2::Options& = RE2::DefaultOptions,
+      const Range& patterns, const RE2::Options& = RE2::DefaultOptions,
       RE2::Anchor = RE2::UNANCHORED);
 
   /// \brief Constructs a RegexSet from the extant RE2::Set.
@@ -102,11 +102,11 @@ class RegexSet {
 };
 
 template <typename Range>
-absl::StatusOr<RegexSet> RegexSet::Build(Range&& patterns,
+absl::StatusOr<RegexSet> RegexSet::Build(const Range& patterns,
                                          const RE2::Options& options,
                                          RE2::Anchor anchor) {
   RE2::Set set(options, anchor);
-  for (const auto& value : std::forward<Range>(patterns)) {
+  for (const auto& value : patterns) {
     std::string error;
     if (set.Add(value, &error) == -1) {
       return absl::InvalidArgumentError(error);


### PR DESCRIPTION
There are a wide variety of data structures from which we might want to Build a RegexSet and not all of them will fit into a `Span<const std::string>`.  So template Build on a range-of-string-like things to allow more flexible construction.