### PR TITLE
fix(cxx_indexer): add missing cases and remove default from clang enum switches

### DIFF
--- a/kythe/cxx/indexer/cxx/IndexerASTHooks.cc
+++ b/kythe/cxx/indexer/cxx/IndexerASTHooks.cc
@@ -3937,22 +3937,25 @@ IndexerASTVisitor::BuildNodeIdForTemplateName(const clang::TemplateName& Name) {
     }
     case TemplateName::OverloadedTemplate:
       CHECK(IgnoreUnimplemented) << "TN.OverloadedTemplate";
-      break;
+      return absl::nullopt;
+    case TemplateName::AssumedTemplate:
+      CHECK(IgnoreUnimplemented) << "TN.AssumedTemplate";
+      return absl::nullopt;
     case TemplateName::QualifiedTemplate:
       CHECK(IgnoreUnimplemented) << "TN.QualifiedTemplate";
-      break;
+      return absl::nullopt;
     case TemplateName::DependentTemplate:
       CHECK(IgnoreUnimplemented) << "TN.DependentTemplate";
-      break;
+      return absl::nullopt;
     case TemplateName::SubstTemplateTemplateParm:
       CHECK(IgnoreUnimplemented) << "TN.SubstTemplateTemplateParmParm";
-      break;
+      return absl::nullopt;
     case TemplateName::SubstTemplateTemplateParmPack:
       CHECK(IgnoreUnimplemented) << "TN.SubstTemplateTemplateParmPack";
-      break;
-    default:
-      LOG(FATAL) << "Unexpected TemplateName kind!";
+      return absl::nullopt;
   }
+  CHECK(IgnoreUnimplemented)
+      << "Unexpected TemplateName kind: " << Name.getKind();
   return absl::nullopt;
 }
 

--- a/kythe/cxx/indexer/cxx/IndexerPPCallbacks.cc
+++ b/kythe/cxx/indexer/cxx/IndexerPPCallbacks.cc
@@ -92,19 +92,18 @@ void IndexerPPCallbacks::FileChanged(clang::SourceLocation Loc,
   switch (Reason) {
     case clang::PPCallbacks::EnterFile:
       Observer.pushFile(LastInclusionHash, Loc);
-      break;
+      return;
     case clang::PPCallbacks::ExitFile:
       Observer.popFile();
-      break;
+      return;
     case clang::PPCallbacks::SystemHeaderPragma:
-      break;
+      return;
     // RenameFile occurs when a #line directive is encountered, for example:
     // #line 10 "foo.cc"
     case clang::PPCallbacks::RenameFile:
-      break;
-    default:
-      llvm::dbgs() << "Unknown FileChangeReason " << Reason << "\n";
+      return;
   }
+  llvm::dbgs() << "Unknown FileChangeReason " << Reason << "\n";
 }
 
 void IndexerPPCallbacks::FilterAndEmitDeferredRecords() {

--- a/kythe/cxx/indexer/cxx/KytheGraphObserver.cc
+++ b/kythe/cxx/indexer/cxx/KytheGraphObserver.cc
@@ -1047,24 +1047,25 @@ void KytheGraphObserver::recordExtendsEdge(const NodeId& from, const NodeId& to,
                          is_virtual ? EdgeKindID::kExtendsPublicVirtual
                                     : EdgeKindID::kExtendsPublic,
                          VNameRefFromNodeId(to));
-      break;
+      return;
     case clang::AccessSpecifier::AS_protected:
       recorder_->AddEdge(VNameRefFromNodeId(from),
                          is_virtual ? EdgeKindID::kExtendsProtectedVirtual
                                     : EdgeKindID::kExtendsProtected,
                          VNameRefFromNodeId(to));
-      break;
+      return;
     case clang::AccessSpecifier::AS_private:
       recorder_->AddEdge(VNameRefFromNodeId(from),
                          is_virtual ? EdgeKindID::kExtendsPrivateVirtual
                                     : EdgeKindID::kExtendsPrivate,
                          VNameRefFromNodeId(to));
-      break;
-    default:
+      return;
+    case clang::AccessSpecifier::AS_none:
       recorder_->AddEdge(
           VNameRefFromNodeId(from),
           is_virtual ? EdgeKindID::kExtendsVirtual : EdgeKindID::kExtends,
           VNameRefFromNodeId(to));
+      return;
   }
 }
 

--- a/kythe/cxx/indexer/cxx/semantic_hash.cc
+++ b/kythe/cxx/indexer/cxx/semantic_hash.cc
@@ -33,6 +33,9 @@ uint64_t SemanticHash::Hash(const clang::TemplateName& name) const {
     case TemplateName::OverloadedTemplate:
       CHECK(ignore_unimplemented_) << "SemanticHash(OverloadedTemplate)";
       return 0;
+    case TemplateName::AssumedTemplate:
+      CHECK(ignore_unimplemented_) << "SemanticHash(AssumedTemplate)";
+      return 0;
     case TemplateName::QualifiedTemplate:
       CHECK(ignore_unimplemented_) << "SemanticHash(QualifiedTemplate)";
       return 0;
@@ -46,9 +49,9 @@ uint64_t SemanticHash::Hash(const clang::TemplateName& name) const {
       CHECK(ignore_unimplemented_)
           << "SemanticHash(SubstTemplateTemplateParmPack)";
       return 0;
-    default:
-      LOG(FATAL) << "Unexpected TemplateName Kind";
   }
+  CHECK(ignore_unimplemented_)
+      << "Unexpected TemplateName Kind: " << name.getKind();
   return 0;
 }
 
@@ -88,9 +91,9 @@ uint64_t SemanticHash::Hash(const clang::TemplateArgument& arg) const {
       }
       return out;
     }
-    default:
-      LOG(FATAL) << "Unexpected TemplateArgument Kind";
   }
+  CHECK(ignore_unimplemented_)
+      << "Unexpected TemplateArgument Kind: " << arg.getKind();
   return 0;
 }
 


### PR DESCRIPTION
Omit the `default` case for some switches which should be exhaustive, add `case` statements for the missing enumerators.  Remove `LOG(FATAL)` in favor of `CHECK(IgnoreUnimplemented)` where appropriate.