### PR TITLE
feat(cxx_indexer): add fields to the influence graph

### DIFF
--- a/kythe/cxx/indexer/cxx/IndexerASTHooks.h
+++ b/kythe/cxx/indexer/cxx/IndexerASTHooks.h
@@ -122,6 +122,7 @@ class IndexerASTVisitor : public RecursiveTypeVisitor<IndexerASTVisitor> {
         TemplateInstanceExcludePathPattern(TIEPP) {}
 
   bool VisitDecl(const clang::Decl* Decl);
+  bool TraverseFieldDecl(clang::FieldDecl* Decl);
   bool VisitFieldDecl(const clang::FieldDecl* Decl);
   bool TraverseVarDecl(clang::VarDecl* Decl);
   bool VisitVarDecl(const clang::VarDecl* Decl);

--- a/kythe/cxx/indexer/cxx/testdata/BUILD
+++ b/kythe/cxx/indexer/cxx/testdata/BUILD
@@ -3255,6 +3255,12 @@ cc_indexer_test(
 )
 
 cc_indexer_test(
+    name = "df_field_influence",
+    srcs = ["df/df_field_influence.cc"],
+    tags = ["df"],
+)
+
+cc_indexer_test(
     name = "df_fncall_influence",
     srcs = ["df/df_fncall_influence.cc"],
     experimental_record_dataflow_edges = True,

--- a/kythe/cxx/indexer/cxx/testdata/BUILD
+++ b/kythe/cxx/indexer/cxx/testdata/BUILD
@@ -3257,6 +3257,7 @@ cc_indexer_test(
 cc_indexer_test(
     name = "df_field_influence",
     srcs = ["df/df_field_influence.cc"],
+    experimental_record_dataflow_edges = True,
     tags = ["df"],
 )
 

--- a/kythe/cxx/indexer/cxx/testdata/df/df_field_influence.cc
+++ b/kythe/cxx/indexer/cxx/testdata/df/df_field_influence.cc
@@ -1,0 +1,14 @@
+// Fields are included in the influence graph.
+struct S {
+  //- @x defines/binding VarX
+  int x = 0;
+  //- @y defines/binding VarY
+  //- VarX influences VarY
+  int y = x;  // desugars to this->x
+};
+//- @z defines/binding VarZ
+void f(S s, int z) {
+  //- @x ref/writes VarX
+  //- VarZ influences VarX
+  s.x = z;
+}


### PR DESCRIPTION
Fields appear under MemberExprs, which take care of both
direct (.) and indirect (->) access.