### PR TITLE
feat(java_extractor): allow specifying java sources batch size for extractor

### DIFF
--- a/kythe/java/com/google/devtools/kythe/extractors/java/UsageAsInputReportingFileManager.java
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/UsageAsInputReportingFileManager.java
@@ -174,9 +174,7 @@ class UsageAsInputReportingFileManager extends ForwardingStandardJavaFileManager
     } catch (UnsupportedOperationException err) {
       try {
         return Paths.get(fo.toUri());
-      } catch (
-          @SuppressWarnings("UnusedException")
-          Throwable unused) {
+      } catch (Throwable unused) {
         throw err; // Re-throw the original error.
       }
     }

--- a/kythe/java/com/google/devtools/kythe/extractors/java/UsageAsInputReportingFileManager.java
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/UsageAsInputReportingFileManager.java
@@ -174,7 +174,9 @@ class UsageAsInputReportingFileManager extends ForwardingStandardJavaFileManager
     } catch (UnsupportedOperationException err) {
       try {
         return Paths.get(fo.toUri());
-      } catch (@SuppressWarnings("UnusedException") Throwable unused) {
+      } catch (
+          @SuppressWarnings("UnusedException")
+          Throwable unused) {
         throw err; // Re-throw the original error.
       }
     }

--- a/kythe/java/com/google/devtools/kythe/extractors/java/UsageAsInputReportingFileManager.java
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/UsageAsInputReportingFileManager.java
@@ -174,7 +174,7 @@ class UsageAsInputReportingFileManager extends ForwardingStandardJavaFileManager
     } catch (UnsupportedOperationException err) {
       try {
         return Paths.get(fo.toUri());
-      } catch (Throwable unused) {
+      } catch (@SuppressWarnings("UnusedException") Throwable unused) {
         throw err; // Re-throw the original error.
       }
     }

--- a/kythe/java/com/google/devtools/kythe/extractors/java/standalone/AbstractJavacWrapper.java
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/standalone/AbstractJavacWrapper.java
@@ -213,6 +213,18 @@ public abstract class AbstractJavacWrapper {
   }
 
   static String readEnvironmentVariable(String variableName, String defaultValue) {
+    return tryReadEnvironmentVariable(variableName)
+        .orElseGet(
+            () -> {
+              if (Strings.isNullOrEmpty(defaultValue)) {
+                System.err.printf("Missing environment variable: %s%n", variableName);
+                System.exit(1);
+              }
+              return defaultValue;
+            });
+  }
+
+  static Optional<String> tryReadEnvironmentVariable(String variableName) {
     // First see if we have a system property.
     String result = System.getProperty(variableName);
     if (Strings.isNullOrEmpty(result)) {
@@ -220,17 +232,13 @@ public abstract class AbstractJavacWrapper {
       result = System.getenv(variableName);
     }
     if (Strings.isNullOrEmpty(result)) {
-      if (Strings.isNullOrEmpty(defaultValue)) {
-        System.err.printf("Missing environment variable: %s%n", variableName);
-        System.exit(1);
-      }
-      result = defaultValue;
+      return Optional.empty();
     }
-    return result;
+    return Optional.of(result);
   }
 
   static Optional<Integer> readSourcesBatchSize() {
-    return Optional.ofNullable(readEnvironmentVariable("KYTHE_JAVA_SOURCE_BATCH_SIZE"))
+    return tryReadEnvironmentVariable("KYTHE_JAVA_SOURCE_BATCH_SIZE")
         .map(
             s -> {
               try {

--- a/kythe/java/com/google/devtools/kythe/extractors/java/standalone/BUILD
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/standalone/BUILD
@@ -46,6 +46,7 @@ java_library(
         "//kythe/proto:analysis_java_proto",
         "//third_party/guava",
         "//third_party/javac",
+        "@com_google_common_flogger//api",
     ],
 )
 

--- a/kythe/java/com/google/devtools/kythe/extractors/java/standalone/Javac8Wrapper.java
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/standalone/Javac8Wrapper.java
@@ -18,6 +18,7 @@ package com.google.devtools.kythe.extractors.java.standalone;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
+import com.google.common.collect.Lists;
 import com.google.devtools.kythe.extractors.java.JavaCompilationUnitExtractor;
 import com.google.devtools.kythe.extractors.shared.CompilationDescription;
 import com.sun.tools.javac.file.JavacFileManager;
@@ -27,6 +28,7 @@ import com.sun.tools.javac.util.Context;
 import com.sun.tools.javac.util.Options;
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.EnumSet;
 import java.util.List;
 import javax.tools.JavaFileObject;
@@ -35,7 +37,7 @@ import javax.tools.StandardLocation;
 /** A class that wraps javac to extract compilation information and write it to an index file. */
 public class Javac8Wrapper extends AbstractJavacWrapper {
   @Override
-  protected CompilationDescription processCompilation(
+  protected Collection<CompilationDescription> processCompilation(
       String[] arguments, JavaCompilationUnitExtractor javaCompilationUnitExtractor)
       throws Exception {
 
@@ -97,18 +99,25 @@ public class Javac8Wrapper extends AbstractJavacWrapper {
       outputDirectory = ".";
     }
 
-    String analysisTarget =
-        readEnvironmentVariable("KYTHE_ANALYSIS_TARGET", createTargetFromSourceFiles(sources));
-    return javaCompilationUnitExtractor.extract(
-        analysisTarget,
-        sources,
-        classPaths,
-        bootclasspath,
-        sourcePaths,
-        processorPaths,
-        processors,
-        completeOptions,
-        outputDirectory);
+    int batchSize = readSourcesBatchSize().orElse(sources.size());
+    List<CompilationDescription> results = new ArrayList<>();
+    for (List<String> sourceBatch : Lists.partition(sources, batchSize)) {
+      String analysisTarget =
+          readEnvironmentVariable(
+              "KYTHE_ANALYSIS_TARGET", createTargetFromSourceFiles(sourceBatch));
+      results.add(
+          javaCompilationUnitExtractor.extract(
+              analysisTarget,
+              sourceBatch,
+              classPaths,
+              bootclasspath,
+              sourcePaths,
+              processorPaths,
+              processors,
+              completeOptions,
+              outputDirectory));
+    }
+    return results;
   }
 
   @Override

--- a/kythe/java/com/google/devtools/kythe/extractors/java/standalone/Javac9Wrapper.java
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/standalone/Javac9Wrapper.java
@@ -18,6 +18,7 @@ package com.google.devtools.kythe.extractors.java.standalone;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
+import com.google.common.collect.Lists;
 import com.google.devtools.kythe.extractors.java.JavaCompilationUnitExtractor;
 import com.google.devtools.kythe.extractors.shared.CompilationDescription;
 import com.sun.tools.javac.file.JavacFileManager;
@@ -27,6 +28,7 @@ import com.sun.tools.javac.util.Context;
 import com.sun.tools.javac.util.Options;
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.EnumSet;
 import java.util.List;
 import javax.tools.JavaFileObject;
@@ -35,7 +37,7 @@ import javax.tools.StandardLocation;
 /** A class that wraps javac to extract compilation information and write it to an index file. */
 public class Javac9Wrapper extends AbstractJavacWrapper {
   @Override
-  protected CompilationDescription processCompilation(
+  protected Collection<CompilationDescription> processCompilation(
       String[] arguments, JavaCompilationUnitExtractor javaCompilationUnitExtractor)
       throws Exception {
 
@@ -112,19 +114,26 @@ public class Javac9Wrapper extends AbstractJavacWrapper {
       outputDirectory = ".";
     }
 
-    String analysisTarget =
-        readEnvironmentVariable("KYTHE_ANALYSIS_TARGET", createTargetFromSourceFiles(sources));
+    int batchSize = readSourcesBatchSize().orElse(sources.size());
+    List<CompilationDescription> results = new ArrayList<>();
+    for (List<String> sourceBatch : Lists.partition(sources, batchSize)) {
+      String analysisTarget =
+          readEnvironmentVariable(
+              "KYTHE_ANALYSIS_TARGET", createTargetFromSourceFiles(sourceBatch));
 
-    return javaCompilationUnitExtractor.extract(
-        analysisTarget,
-        sources,
-        classPaths,
-        bootclasspath,
-        sourcePaths,
-        processorPaths,
-        processors,
-        completeOptions,
-        outputDirectory);
+      results.add(
+          javaCompilationUnitExtractor.extract(
+              analysisTarget,
+              sourceBatch,
+              classPaths,
+              bootclasspath,
+              sourcePaths,
+              processorPaths,
+              processors,
+              completeOptions,
+              outputDirectory));
+    }
+    return results;
   }
 
   @Override

--- a/kythe/java/com/google/devtools/kythe/extractors/shared/IndexInfoUtils.java
+++ b/kythe/java/com/google/devtools/kythe/extractors/shared/IndexInfoUtils.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 import com.google.devtools.kythe.platform.kzip.KZip;
 import com.google.devtools.kythe.platform.kzip.KZipException;
 import com.google.devtools.kythe.platform.kzip.KZipReader;
@@ -130,15 +131,22 @@ public class IndexInfoUtils {
 
   public static void writeKzipToFile(CompilationDescription description, String path)
       throws IOException {
+    writeKzipToFile(ImmutableList.of(description), path);
+  }
+
+  public static void writeKzipToFile(Collection<CompilationDescription> descriptions, String path)
+      throws IOException {
     Paths.get(path).getParent().toFile().mkdirs();
     try (KZip.Writer writer = new KZipWriter(new File(path))) {
-      Analysis.IndexedCompilation indexedCompilation =
-          Analysis.IndexedCompilation.newBuilder()
-              .setUnit(description.getCompilationUnit())
-              .build();
-      writer.writeUnit(indexedCompilation);
-      for (FileData fileData : description.getFileContents()) {
-        writer.writeFile(fileData.getContent().toByteArray());
+      for (CompilationDescription description : descriptions) {
+        Analysis.IndexedCompilation indexedCompilation =
+            Analysis.IndexedCompilation.newBuilder()
+                .setUnit(description.getCompilationUnit())
+                .build();
+        writer.writeUnit(indexedCompilation);
+        for (FileData fileData : description.getFileContents()) {
+          writer.writeFile(fileData.getContent().toByteArray());
+        }
       }
     }
   }

--- a/kythe/java/com/google/devtools/kythe/platform/kzip/KZipWriter.java
+++ b/kythe/java/com/google/devtools/kythe/platform/kzip/KZipWriter.java
@@ -129,7 +129,7 @@ public final class KZipWriter implements KZip.Writer {
       output.write(data);
       output.closeEntry();
     } else {
-      logger.atWarning().log("Warning: Already wrote %s to kzip.", path);
+      logger.atInfo().log("Already wrote %s to kzip.", path);
     }
   }
 


### PR DESCRIPTION
via the KYTHE_JAVA_SOURCE_BATCH_SIZE environment variable.

From my limited testing, this appears to work and yields indexable compilation units.