### PR TITLE
go extractor: Fix package directory resolution.

### DIFF
--- a/kythe/go/extractors/cmd/gotool/analyze_packages.sh
+++ b/kythe/go/extractors/cmd/gotool/analyze_packages.sh
@@ -61,7 +61,7 @@ fi
 
 # cd into the top-level git directory of our package and query git for the
 # commit timestamp.
-pushd "/workspace/gopath/src/$(dirname ${PACKAGES[1]})"
+pushd "$(go env GOPATH)/src/$(dirname ${PACKAGES[0]})"
 TIMESTAMP="$(git log --pretty='%ad' -n 1 HEAD)"
 popd
 


### PR DESCRIPTION
This fixes 2 issues in the script:
- Use $GOPATH instead of the hard-coded /workspace directory.
This makes the script be more agnostic to how the script is being ran
(e.g. assuming where go get puts the underlying source).
- Use PACKAGES[0] instead of PACKAGES[1]. Since the script args are
shifted, package params specified by the user start at 0, not 1.