### PR TITLE
docs: include specific note that anchors should include a language

### DIFF
--- a/kythe/docs/schema/schema.txt
+++ b/kythe/docs/schema/schema.txt
@@ -1761,7 +1761,7 @@ Naming convention::
   Corpus:::
     The *Corpus* of the <<file>> containing this anchor.
   Language::
-    The *Language* of the indexer emitting this anchor.
+    The *Language* of the compilation producing this anchor.
 Expected out-edges::
   <<defines>>, <<definesbinding,[defines/binding]>>, <<ref>>,
   <<refcall,[ref/call]>>

--- a/kythe/docs/schema/schema.txt
+++ b/kythe/docs/schema/schema.txt
@@ -1760,6 +1760,8 @@ Naming convention::
     The *Root* of the <<file>> containing this anchor.
   Corpus:::
     The *Corpus* of the <<file>> containing this anchor.
+  Language::
+    The *Language* of the indexer emitting this anchor.
 Expected out-edges::
   <<defines>>, <<definesbinding,[defines/binding]>>, <<ref>>,
   <<refcall,[ref/call]>>


### PR DESCRIPTION
While implied elsewhere, the lack of this field on file nodes causes some confusion.  Make it explicit in the documentation.

Note that the current use of anchors when constructing `imputes` edges strongly suggests that we should either fully specify the expected signature as well or use a distinct language for that case.