### PR TITLE
feat(verifier): don't spend time sorting input for the fast solver

### DIFF
--- a/kythe/cxx/verifier/verifier.cc
+++ b/kythe/cxx/verifier/verifier.cc
@@ -1060,11 +1060,11 @@ static bool EncodedFactHasValidForm(Verifier* cxt, AstNode* a) {
 
 Verifier::InternedVName Verifier::InternVName(AstNode* node) {
   auto* tuple = node->AsTuple();
-  return std::make_tuple(tuple->element(0)->AsIdentifier()->symbol(),
-                         tuple->element(1)->AsIdentifier()->symbol(),
-                         tuple->element(2)->AsIdentifier()->symbol(),
-                         tuple->element(3)->AsIdentifier()->symbol(),
-                         tuple->element(4)->AsIdentifier()->symbol());
+  return {tuple->element(0)->AsIdentifier()->symbol(),
+          tuple->element(1)->AsIdentifier()->symbol(),
+          tuple->element(2)->AsIdentifier()->symbol(),
+          tuple->element(3)->AsIdentifier()->symbol(),
+          tuple->element(4)->AsIdentifier()->symbol()};
 }
 
 bool Verifier::ProcessFactTupleForFastSolver(Tuple* tuple) {

--- a/kythe/cxx/verifier/verifier.h
+++ b/kythe/cxx/verifier/verifier.h
@@ -190,7 +190,16 @@ class Verifier {
   /// \brief Don't search for file vnames.
   void IgnoreFileVnames() { file_vnames_ = false; }
 
+  /// \brief Use the fast solver.
+  void UseFastSolver(bool value) { use_fast_solver_ = value; }
+
  private:
+  using InternedVName = std::tuple<Symbol, Symbol, Symbol, Symbol, Symbol>;
+
+  /// \brief Interns an AST node known to be a VName.
+  /// \param node the node to intern.
+  InternedVName InternVName(AstNode* node);
+
   /// \brief Generate a VName that will not conflict with any other VName.
   AstNode* NewUniqueVName(const yy::location& loc);
 
@@ -219,6 +228,11 @@ class Verifier {
   void AddAnchor(AstNode* vname, size_t begin, size_t end) {
     anchors_.emplace(std::make_pair(begin, end), vname);
   }
+
+  /// \brief Processes a fact tuple for the fast solver.
+  /// \param tuple the five-tuple representation of a fact
+  /// \return true if successful.
+  bool ProcessFactTupleForFastSolver(Tuple* tuple);
 
   /// \sa parser()
   AssertionParser parser_;
@@ -394,6 +408,18 @@ class Verifier {
 
   /// Find file vnames by examining file content.
   bool file_vnames_ = true;
+
+  /// Use the fast solver.
+  bool use_fast_solver_ = false;
+
+  /// Sentinel value for a known file.
+  Symbol known_file_sym_;
+
+  /// Sentinel value for a known nonfile.
+  Symbol known_not_file_sym_;
+
+  /// Maps VNames to known_file_sym_, known_not_file_sym_, or file text.
+  absl::flat_hash_map<InternedVName, Symbol> fast_solver_files_;
 };
 
 }  // namespace verifier

--- a/kythe/cxx/verifier/verifier_main.cc
+++ b/kythe/cxx/verifier/verifier_main.cc
@@ -53,6 +53,9 @@ ABSL_FLAG(bool, convert_marked_source, false,
 ABSL_FLAG(bool, show_anchors, false, "Show anchor locations instead of @s");
 ABSL_FLAG(bool, file_vnames, true,
           "Find file vnames by matching file content.");
+ABSL_FLAG(bool, use_fast_solver, false,
+          "Use the fast solver. EXPERIMENTAL; NOT ALL FEATURES ARE CURRENTLY "
+          "SUPPORTED.");
 
 int main(int argc, char** argv) {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
@@ -104,6 +107,8 @@ Example:
     v.IgnoreFileVnames();
   }
 
+  v.UseFastSolver(absl::GetFlag(FLAGS_use_fast_solver));
+
   std::string dbname = "database";
   size_t facts = 0;
   kythe::proto::Entry entry;
@@ -131,7 +136,7 @@ Example:
     ++facts;
   }
 
-  if (!v.PrepareDatabase()) {
+  if (!absl::GetFlag(FLAGS_use_fast_solver) && !v.PrepareDatabase()) {
     return 1;
   }
 


### PR DESCRIPTION
The existing solver depends on sorting input facts for various
reasons. As it turns out, these sorting phases take a significant
amount of the runtime of a single verification test. This PR adds
a flag (meant to eventually invoke the fast solver) that removes
the sorting phases while preserving some invariants.

In greater detail, there are two phases. In the first, the verifier
identifies anchor nodes (for an optimization that turns anchors into
a different internal data type) and file nodes (as we support reading
goals from file nodes). Sorting is necessary to group entries
according to VName (and to provide other guarantees, like the ordering
of well-known facts) that makes this process easy to encode as a
state machine. While we no longer need the optimization, we still
need to discover goals in file nodes. Unfortunately, the "text" fact
can appear on doc nodes as well as file nodes, so we need to determine
which "text" facts are actually relevant. This PR uses a simple map
from (interned) VName to file/not-file/possibly file content symbols
to that end.

There is another mapping that needs to be preserved that's used
when goals are *not* read from file nodes. This associates file content,
provided as explicit files on the command line, with file node VNames
that are discovered from entries. This method was commonly used before
we had better Bazel support for tests and is something we could consider
dropping as reading goals from file nodes makes it redundant.

The ordering is also used after the first phase to check for duplicate
entries and for conflicting facts. It may be possible to perform the
conflicting fact check efficiently with the new solver. It is less
clear whether the duplicate entry check will need to be done before
solving (e.g., by using an interned entry set).

The second sorting phase is purely to optimize common search patterns
for the old solver and can be dropped.

Unfortunately, because we can't provide entries to the fast solver
without first giving it a full program to solve, it looks like we'll
have to (in the general case, because we need to read file nodes from
entries to get goals) (1) store all entries ourselves before giving
them to the fast solver; and (2) iterate over them at least twice.