### PR TITLE
fix(bazel_go_extractor): include .x files in required input

### DIFF
--- a/kythe/go/extractors/cmd/bazel/bazel_go_extractor/bazel_go_extractor.go
+++ b/kythe/go/extractors/cmd/bazel/bazel_go_extractor/bazel_go_extractor.go
@@ -144,8 +144,8 @@ func (e *extractor) checkAction(_ context.Context, info *bazel.ActionInfo) error
 
 func (e *extractor) checkInput(path string) (string, bool) {
 	switch filepath.Ext(path) {
-	case ".go", ".a":
-		return path, true // keep source files, archives
+	case ".go", ".a", ".x":
+		return path, true // keep source files, archives, and export info
 	}
 	return path, false
 }


### PR DESCRIPTION
The Go compiler produces these as well as .a archive files and they contain the minimal interface information necessary for dependencies.  I'm not entirely sure of the details (and searching for information on ".x" is predictably unfruitful), but they cause issues with xrefs when omitted.