### PR TITLE
fix(go_vnames): properly map .x file vnames

### DIFF
--- a/kythe/data/vnames.go.json
+++ b/kythe/data/vnames.go.json
@@ -1,20 +1,20 @@
 [
   {
-    "pattern": "bazel-out/[^%]*%/(github\\.com(?:/[-.\\w]+){2})(?:/([^~]+))?\\.a(?:~partial.a)?$",
+    "pattern": "bazel-out/[^%]*%/(github\\.com(?:/[-.\\w]+){2})(?:/([^~]+))?\\.[xa](?:~partial.[xa])?$",
     "vname": {
       "corpus": "@1@",
       "path": "@2@"
     }
   },
   {
-    "pattern": "bazel-out/[^%]*%/(bitbucket\\.org(?:/[-.\\w]+){2})(?:/(.+))?\\.a$",
+    "pattern": "bazel-out/[^%]*%/(bitbucket\\.org(?:/[-.\\w]+){2})(?:/(.+))?\\.[xa]$",
     "vname": {
       "corpus": "@1@",
       "path": "@2@"
     }
   },
   {
-    "pattern": "bazel-out/[^%]*%/(golang\\.org(?:/x/\\w+))/(.+)\\.a$",
+    "pattern": "bazel-out/[^%]*%/(golang\\.org(?:/x/\\w+))/(.+)\\.[xa]$",
     "vname": {
       "corpus": "@1@",
       "path": "@2@"
@@ -36,21 +36,21 @@
     }
   },
   {
-    "pattern": ".*/go_sdk/pkg/\\w+/vendor/golang_org/x/(\\w+)/(.*)\\.a$",
+    "pattern": ".*/go_sdk/pkg/\\w+/vendor/golang_org/x/(\\w+)/(.*)\\.[xa]$",
     "vname": {
       "corpus": "golang.org/x/@1@",
       "path": "@2@"
     }
   },
   {
-    "pattern": ".*/go_sdk/pkg/\\w+/(.*)\\.a$",
+    "pattern": ".*/go_sdk/pkg/\\w+/(.*)\\.[xa]$",
     "vname": {
       "corpus": "golang.org",
       "path": "@1@"
     }
   },
   {
-    "pattern": "bazel-out/[^/]+/(\\w+)/[^%]*%/([-.\\w]+)/(.+)\\.a(?:~partial.a)?$",
+    "pattern": "bazel-out/[^/]+/(\\w+)/[^%]*%/([-.\\w]+)/(.+)\\.[xa](?:~partial.[xa])?$",
     "vname": {
       "root" : "bazel-out/@1@",
       "corpus": "@2@",

--- a/kythe/data/vnames_test.go.json
+++ b/kythe/data/vnames_test.go.json
@@ -13,7 +13,20 @@
     }
   },
   {
+    "input": "bazel-out/foo/bin/nonce%/github.com/kythe/kythe/blah.x",
+    "match": true,
+    "want": {
+      "corpus": "github.com/kythe/kythe",
+      "path": "blah"
+    }
+  },
+  {
     "input": "bazel-out/foo/bin/nonce%/bitbucket.org/creachadair/stringset.a",
+    "match": true,
+    "want": {"corpus": "bitbucket.org/creachadair/stringset"}
+  },
+  {
+    "input": "bazel-out/foo/bin/nonce%/bitbucket.org/creachadair/stringset.x",
     "match": true,
     "want": {"corpus": "bitbucket.org/creachadair/stringset"}
   },
@@ -38,6 +51,11 @@
     "want": {"corpus": "bitbucket.org/nobble/fleem", "path": "wharrgarbl"}
   },
   {
+    "input": "bazel-out/itty/bin/nonce%/bitbucket.org/nobble/fleem/wharrgarbl.x",
+    "match": true,
+    "want": {"corpus": "bitbucket.org/nobble/fleem", "path": "wharrgarbl"}
+  },
+  {
     "input": "bazel-out/foo/genfiles/kythe/proto/analysis.pb.go",
     "match": true,
     "want": {
@@ -47,6 +65,14 @@
   },
   {
     "input": "external/go_sdk/pkg/linux_amd64/io/ioutil.a",
+    "match": true,
+    "want": {
+      "corpus": "golang.org",
+      "path": "io/ioutil"
+    }
+  },
+  {
+    "input": "external/go_sdk/pkg/linux_amd64/io/ioutil.x",
     "match": true,
     "want": {
       "corpus": "golang.org",


### PR DESCRIPTION
Update the generic Go vnames.json to strip both .a and .x suffixes