### PR TITLE
fix(go_vnames): add go vname archives to simple_vnames.json

### DIFF
--- a/kythe/data/simple_vnames.json
+++ b/kythe/data/simple_vnames.json
@@ -1,6 +1,22 @@
 [
   {
+    "pattern": "bazel-out/[^/]+/([^/]+/external/[^/]+)/(.*)\\.[xa]$",
+    "vname": {
+      "corpus": "CORPUS",
+      "root": "bazel-out/@1@",
+      "path": "@3@"
+    }
+  },
+  {
     "pattern": "bazel-out/[^/]+/([^/]+/external/[^/]+)/(.+)",
+    "vname": {
+      "corpus": "CORPUS",
+      "root": "bazel-out/@1@",
+      "path": "@2@"
+    }
+  },
+  {
+    "pattern": "bazel-out/[^/]+/([^/]+)/(.*)\\.[xa]$",
     "vname": {
       "corpus": "CORPUS",
       "root": "bazel-out/@1@",

--- a/kythe/data/simple_vnames.json
+++ b/kythe/data/simple_vnames.json
@@ -4,7 +4,7 @@
     "vname": {
       "corpus": "CORPUS",
       "root": "bazel-out/@1@",
-      "path": "@3@"
+      "path": "@2@"
     }
   },
   {

--- a/kythe/data/vnames.go.json
+++ b/kythe/data/vnames.go.json
@@ -1,64 +1,50 @@
 [
   {
-    "pattern": "bazel-out/[^%]*%/(github\\.com(?:/[-.\\w]+){2})(?:/([^~]+))?\\.[xa](?:~partial.[xa])?$",
+    "pattern": "external/go_sdk/pkg/[^/]+/vendor/golang.org/x/(\\w+)/(.*)\\.[xa]$",
     "vname": {
-      "corpus": "@1@",
+      "corpus": "org_golang_x_@1@",
       "path": "@2@"
     }
   },
   {
-    "pattern": "bazel-out/[^%]*%/(bitbucket\\.org(?:/[-.\\w]+){2})(?:/(.+))?\\.[xa]$",
-    "vname": {
-      "corpus": "@1@",
-      "path": "@2@"
-    }
-  },
-  {
-    "pattern": "bazel-out/[^%]*%/(golang\\.org(?:/x/\\w+))/(.+)\\.[xa]$",
-    "vname": {
-      "corpus": "@1@",
-      "path": "@2@"
-    }
-  },
-  {
-    "pattern": "bazel-out/[^/]+/(\\w+)/[^%]*%/([-.\\w]+)/(.+\\.go)$",
-    "vname": {
-      "corpus": "@2@",
-      "root": "bazel-out/@1@",
-      "path": "@3@"
-    }
-  },
-  {
-    "pattern": "bazel-out/[^/]+/(\\w+)/([^%]+)/\\w+/(\\w+)+%/testmain.go$",
-    "vname": {
-      "root": "bazel-out/@1@",
-      "path": "@2@/@3@/testmain.go"
-    }
-  },
-  {
-    "pattern": ".*/go_sdk/pkg/\\w+/vendor/golang_org/x/(\\w+)/(.*)\\.[xa]$",
-    "vname": {
-      "corpus": "golang.org/x/@1@",
-      "path": "@2@"
-    }
-  },
-  {
-    "pattern": ".*/go_sdk/pkg/\\w+/(.*)\\.[xa]$",
+    "pattern": "external/go_sdk/pkg/[^/]+/(.*)\\.[xa]$",
     "vname": {
       "corpus": "golang.org",
       "path": "@1@"
     }
   },
   {
-    "pattern": "bazel-out/[^/]+/(\\w+)/[^%]*%/([-.\\w]+)/(.+)\\.[xa](?:~partial.[xa])?$",
+    "pattern": "external/([^/]+)/(.*\\.go)$",
     "vname": {
-      "root" : "bazel-out/@1@",
+      "corpus": "@1@",
+      "path": "@2@"
+    }
+  },
+  {
+    "pattern": "bazel-out/[^/]+/([^/]+)/external/([^/]+)/(.*\\.go)$",
+    "vname": {
       "corpus": "@2@",
+      "root": "bazel-out/@1@",
       "path": "@3@"
     }
   },
   {
-    "pattern": "bazel-out/[^/]+/(\\w+)/(kythe/.+\\.go)$",
+    "pattern": "bazel-out/[^/]+/([^/]+)/external/([^/]+)/(.*)\\.[xa]$",
+    "vname": {
+      "corpus": "@2@",
+      "root": "bazel-out/@1@",
+      "path": "@3@"
+    }
+  },
+  {
+    "pattern": "bazel-out/[^/]+/([^/]+)/(.*\\.go)$",
+    "vname": {
+      "root": "bazel-out/@1@",
+      "path": "@2@"
+    }
+  },
+  {
+    "pattern": "bazel-out/[^/]+/([^/]+)/(.*)\\.[xa]$",
     "vname": {
       "root": "bazel-out/@1@",
       "path": "@2@"

--- a/kythe/data/vnames_test.go.json
+++ b/kythe/data/vnames_test.go.json
@@ -5,57 +5,6 @@
     "want": null
   },
   {
-    "input": "bazel-out/foo/bin/nonce%/github.com/kythe/kythe/blah.a",
-    "match": true,
-    "want": {
-      "corpus": "github.com/kythe/kythe",
-      "path": "blah"
-    }
-  },
-  {
-    "input": "bazel-out/foo/bin/nonce%/github.com/kythe/kythe/blah.x",
-    "match": true,
-    "want": {
-      "corpus": "github.com/kythe/kythe",
-      "path": "blah"
-    }
-  },
-  {
-    "input": "bazel-out/foo/bin/nonce%/bitbucket.org/creachadair/stringset.a",
-    "match": true,
-    "want": {"corpus": "bitbucket.org/creachadair/stringset"}
-  },
-  {
-    "input": "bazel-out/foo/bin/nonce%/bitbucket.org/creachadair/stringset.x",
-    "match": true,
-    "want": {"corpus": "bitbucket.org/creachadair/stringset"}
-  },
-  {
-    "_note": "cgo output has this pattern.",
-    "input": "bazel-out/foo/bin/nonce%/github.com/google/brotli/go/cbrotli.a~partial.a",
-    "match": true,
-    "want": {
-      "corpus": "github.com/google/brotli",
-      "path": "go/cbrotli"
-    }
-  },
-  {
-    "_note": "cgo output has this pattern as well.",
-    "input": "bazel-out/foo/bin/nonce%/github.com/bar/baz.a~partial.a",
-    "match": true,
-    "want": {"corpus": "github.com/bar/baz"}
-  },
-  {
-    "input": "bazel-out/itty/bin/nonce%/bitbucket.org/nobble/fleem/wharrgarbl.a",
-    "match": true,
-    "want": {"corpus": "bitbucket.org/nobble/fleem", "path": "wharrgarbl"}
-  },
-  {
-    "input": "bazel-out/itty/bin/nonce%/bitbucket.org/nobble/fleem/wharrgarbl.x",
-    "match": true,
-    "want": {"corpus": "bitbucket.org/nobble/fleem", "path": "wharrgarbl"}
-  },
-  {
     "input": "bazel-out/foo/genfiles/kythe/proto/analysis.pb.go",
     "match": true,
     "want": {
@@ -77,15 +26,6 @@
     "want": {
       "corpus": "golang.org",
       "path": "io/ioutil"
-    }
-  },
-  {
-    "_note": "Go generated test binary wrappers have this pattern.",
-    "input": "bazel-out/foo/bin/bar/baz/nonce/quux%/testmain.go",
-    "match": true,
-    "want": {
-      "root": "bazel-out/bin",
-      "path": "bar/baz/quux/testmain.go"
     }
   }
 ]


### PR DESCRIPTION
The bazel Go rules no longer create the same symlink forest they used to and instead stick to the standard Bazel file structure.  Update the vnames.go.json and corresponding tests to account for this.  Also add a special case for .x and .a files to the "simplified" vnames.json so that Go archives map to the same node.