### PR TITLE
feat(common): allow named captures in vnames.json rules

### DIFF
--- a/external.bzl
+++ b/external.bzl
@@ -290,7 +290,7 @@ def _java_dependencies():
             "com.google.errorprone:error_prone_annotations:2.3.1",
             "com.google.guava:guava:26.0-jre",
             "com.google.jimfs:jimfs:1.1",
-            "com.google.re2j:re2j:1.2",
+            "com.google.re2j:re2j:1.6",
             "com.google.truth:truth:1.0",
             "com.googlecode.java-diff-utils:diffutils:1.3.0",
             "org.apache.tomcat:tomcat-annotations-api:9.0.34",

--- a/kythe/cxx/common/BUILD
+++ b/kythe/cxx/common/BUILD
@@ -124,12 +124,10 @@ cc_library(
 cc_library(
     name = "lib",
     srcs = [
-        "file_vname_generator.cc",
         "kythe_metadata_file.cc",
         "protobuf_metadata_file.cc",
     ],
     hdrs = [
-        "file_vname_generator.h",
         "kythe_metadata_file.h",
         "protobuf_metadata_file.h",
         "vname_ordering.h",
@@ -141,6 +139,7 @@ cc_library(
     ],
     visibility = [PUBLIC_VISIBILITY],
     deps = [
+        ":file_vname_generator",
         ":json_proto",
         "//external:zlib",
         "//kythe/cxx/common/schema:edges",
@@ -187,20 +186,17 @@ cc_library(
 )
 
 cc_library(
-    name = "file_vname_generator_testlib",
-    testonly = 1,
-    srcs = [
-        "file_vname_generator_test.cc",
-    ],
-    copts = [
-        "-Wno-non-virtual-dtor",
-        "-Wno-unused-variable",
-        "-Wno-implicit-fallthrough",
-    ],
+    name = "file_vname_generator",
+    srcs = ["file_vname_generator.cc"],
+    hdrs = ["file_vname_generator.h"],
     deps = [
-        ":lib",
-        "//third_party:gtest",
-        "@com_google_protobuf//:protobuf",
+        "//kythe/proto:storage_cc_proto",
+        "@com_github_google_glog//:glog",
+        "@com_github_tencent_rapidjson//:rapidjson",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/types:optional",
         "@com_googlesource_code_re2//:re2",
     ],
 )
@@ -208,8 +204,14 @@ cc_library(
 cc_test(
     name = "file_vname_generator_test",
     size = "small",
+    srcs = [
+        "file_vname_generator_test.cc",
+    ],
     deps = [
-        ":file_vname_generator_testlib",
+        ":file_vname_generator",
+        "//third_party:gtest",
+        "@com_google_protobuf//:protobuf",
+        "@com_googlesource_code_re2//:re2",
     ],
 )
 

--- a/kythe/cxx/common/file_vname_generator.cc
+++ b/kythe/cxx/common/file_vname_generator.cc
@@ -27,9 +27,6 @@
 namespace kythe {
 namespace {
 
-// FullMatchN supports "3..16 args"
-constexpr int kMaxRegexArgs = 16;
-
 const LazyRE2 kSubstitutionsPattern = {R"(@\w+@)"};
 
 std::string EscapeBackslashes(absl::string_view value) {
@@ -54,9 +51,8 @@ absl::StatusOr<std::string> ParseTemplate(const RE2& pattern,
 
     int index = 0;
     if (!absl::SimpleAtoi(group, &index)) {
-      auto iter = kSubstitutionsPattern->NamedCapturingGroups().find(
-          std::string(group));
-      if (iter == kSubstitutionsPattern->NamedCapturingGroups().end()) {
+      auto iter = pattern.NamedCapturingGroups().find(std::string(group));
+      if (iter == pattern.NamedCapturingGroups().end()) {
         return absl::InvalidArgumentError(
             absl::StrCat("Unknown named capture: ", group));
       }

--- a/kythe/cxx/common/file_vname_generator.h
+++ b/kythe/cxx/common/file_vname_generator.h
@@ -21,6 +21,9 @@
 #include <string>
 #include <vector>
 
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
 #include "kythe/proto/storage.pb.h"
 #include "re2/re2.h"
 
@@ -29,20 +32,21 @@ namespace kythe {
 /// \brief Generates file VNames based on user-configurable paths and templates.
 class FileVNameGenerator {
  public:
-  FileVNameGenerator();
+  explicit FileVNameGenerator() = default;
 
   /// \brief Adds configuration entries from the json-encoded `json_string`.
   /// \param json_string The string containing the configuration to add.
   /// \param error_text Non-null. Will be set to text describing any errors.
   /// \return false if the string could not be parsed.
-  bool LoadJsonString(const std::string& data, std::string* error_text);
+  bool LoadJsonString(absl::string_view data, std::string* error_text);
+  absl::Status LoadJsonString(absl::string_view data);
 
   /// \brief Returns a base VName for a given file path (or an empty VName if
   /// no configuration rule matches the path).
-  kythe::proto::VName LookupBaseVName(const std::string& path) const;
+  kythe::proto::VName LookupBaseVName(absl::string_view path) const;
 
   /// \brief Returns a VName for the given file path.
-  kythe::proto::VName LookupVName(const std::string& path) const;
+  kythe::proto::VName LookupVName(absl::string_view path) const;
 
   /// \brief Sets the default base VName to use when no rules match.
   void set_default_base_vname(const kythe::proto::VName& default_vname) {
@@ -50,47 +54,19 @@ class FileVNameGenerator {
   }
 
  private:
-  /// \brief A command to use when building a result string.
-  struct StringConsNode {
-    enum class Kind {
-      kEmitText,        ///< Emit text verbatim.
-      kUseSubstitution  ///< Copy from a regex capture.
-    } kind;
-    /// Text to emit if `kind` is `kEmitText`.
-    std::string raw_text;
-    /// Substitution to use if `kind` is `kUseSubstitution`.
-    int capture_index;
-  };
-  using StringConsRule = std::vector<StringConsNode>;
-  /// \brief Applies a `StringConsRule` using the result of a regex match.
-  /// \param rule The rule to apply.
-  /// \param argv The `RE2::Arg` results from the regex match.
-  /// \param argc The length of the array `argv`.
-  std::string ApplyRule(const StringConsRule& rule,
-                        const re2::StringPiece* argv, int argc) const;
-  /// \brief Parses `rule` into a `StringConsRule`.
-  /// \param rule The rule to parse.
-  /// \param max_capture_index The maximum utterable capture index.
-  /// \param result The StringConsRule to parse into.
-  /// \param error_text Set to a descriptive message if parsing fails.
-  /// \return false if we could not parse a rule.
-  bool ParseRule(const std::string& rule, int max_capture_index,
-                 StringConsRule* result, std::string* error_text);
   /// \brief A rule to apply to certain paths.
   struct VNameRule {
     /// The pattern used to match against a path.
     std::shared_ptr<re2::RE2> pattern;
     /// Substitution pattern used to construct the corpus.
-    StringConsRule corpus;
+    std::string corpus;
     /// Substitution pattern used to construct the root.
-    StringConsRule root;
+    std::string root;
     /// Substitution pattern used to construct the path.
-    StringConsRule path;
+    std::string path;
   };
   /// The rules to apply to incoming paths. The first one to match is used.
   std::vector<VNameRule> rules_;
-  /// Used internally to find substitution markers when compiling rules.
-  RE2 substitution_matcher_{"([^@]*)@([^@]+)@"};
   /// The default base VName to use when no rules match.
   kythe::proto::VName default_vname_;
 };

--- a/kythe/cxx/common/file_vname_generator_test.cc
+++ b/kythe/cxx/common/file_vname_generator_test.cc
@@ -86,7 +86,7 @@ TEST(FileVNameGenerator, LookupGroups) {
   EXPECT_EQ(corpus_vname.DebugString(),
             generator.LookupBaseVName("corpus/some/path/here").DebugString());
   kythe::proto::VName grp1_vname;
-  grp1_vname.set_corpus("grp1/endingGroup");
+  grp1_vname.set_corpus("grp1/grp1/endingGroup");
   grp1_vname.set_root("12345");
   EXPECT_EQ(grp1_vname.DebugString(),
             generator.LookupBaseVName("grp1/12345/endingGroup").DebugString());
@@ -249,10 +249,10 @@ const char kSharedTestFile[] = R"d([
     }
   },
   {
-    "pattern": "(grp1)/(\\d+)/(.*)",
+    "pattern": "(?P<CORPUS>grp1)/(\\d+)/(.*)",
     "vname": {
       "root": "@2@",
-      "corpus": "@1@/@3@"
+      "corpus": "@1@/@CORPUS@/@3@"
     }
   },
   {

--- a/kythe/cxx/extractor/proto/BUILD
+++ b/kythe/cxx/extractor/proto/BUILD
@@ -28,6 +28,7 @@ cc_library(
     visibility = ["//kythe/cxx/extractor/textproto:__subpackages__"],
     deps = [
         "//kythe/cxx/common:file_utils",
+        "//kythe/cxx/common:file_vname_generator",
         "//kythe/cxx/common:index_writer",
         "//kythe/cxx/common:lib",
         "//kythe/cxx/common:path_utils",

--- a/kythe/cxx/indexer/proto/BUILD
+++ b/kythe/cxx/indexer/proto/BUILD
@@ -42,6 +42,7 @@ cc_library(
         ":proto_graph_builder",
         ":search_path",
         ":source_tree",
+        "//kythe/cxx/common:file_vname_generator",
         "//kythe/cxx/common:kythe_uri",
         "//kythe/cxx/common:lib",
         "//kythe/cxx/common:path_utils",
@@ -115,6 +116,7 @@ cc_binary(
     visibility = ["//visibility:public"],
     deps = [
         ":proto_analyzer",
+        "//kythe/cxx/common:file_vname_generator",
         "//kythe/cxx/common:init",
         "//kythe/cxx/common:json_proto",
         "//kythe/cxx/common:kzip_reader",

--- a/kythe/java/com/google/devtools/kythe/extractors/shared/FileVNames.java
+++ b/kythe/java/com/google/devtools/kythe/extractors/shared/FileVNames.java
@@ -187,7 +187,7 @@ public class FileVNames {
     }
   }
 
-  /** Subset of a {@link VName} with built-in templating '@<num>@' markers. */
+  /** Subset of a {@link VName} with built-in templating '@<group>@' markers. */
   private static class VNameTemplate {
     private final String corpus;
     private final String root;
@@ -232,20 +232,19 @@ public class FileVNames {
       return fillInWith(m, () -> defaultCorpus);
     }
 
-    private static final Pattern replacerMatcher = Pattern.compile("@(\\d+)@");
+    private static final Pattern replacerPattern = Pattern.compile("@(\\w+)@");
 
     private static String fillIn(String tmpl, Matcher m) {
-      Matcher replacers = replacerMatcher.matcher(tmpl);
+      Matcher replacers = replacerPattern.matcher(tmpl);
       Deque<ReplacementMarker> matches = new ArrayDeque<>();
       while (replacers.find()) {
         matches.addFirst(
-            new ReplacementMarker(
-                replacers.start(), replacers.end(), Integer.parseInt(replacers.group(1))));
+            new ReplacementMarker(replacers.start(), replacers.end(), replacers.group(1)));
       }
       StringBuilder builder = new StringBuilder(tmpl);
       while (!matches.isEmpty()) {
         ReplacementMarker res = matches.removeFirst();
-        builder.replace(res.start, res.end, m.group(res.grp));
+        builder.replace(res.start, res.end, res.groupText(m));
       }
       return builder.toString();
     }
@@ -260,12 +259,21 @@ public class FileVNames {
   private static class ReplacementMarker {
     final int start;
     final int end;
-    final int grp;
+    final String grp;
 
-    ReplacementMarker(int start, int end, int grp) {
+    ReplacementMarker(int start, int end, String grp) {
       this.start = start;
       this.end = end;
       this.grp = grp;
+    }
+
+    String groupText(Matcher m) {
+      try {
+        int idx = Integer.parseInt(grp);
+        return m.group(idx);
+      } catch (NumberFormatException unused) {
+        return m.group(grp);
+      }
     }
   }
 

--- a/kythe/javatests/com/google/devtools/kythe/extractors/shared/FileVNamesTest.java
+++ b/kythe/javatests/com/google/devtools/kythe/extractors/shared/FileVNamesTest.java
@@ -53,10 +53,10 @@ public class FileVNamesTest extends TestCase {
                 "    }",
                 "  },",
                 "  {",
-                "    \"pattern\": \"(grp1)/(\\\\d+)/(.*)\",",
+                "    \"pattern\": \"(?P<corpus>grp1)/(\\\\d+)/(.*)\",",
                 "    \"vname\": {",
                 "      \"root\": \"@2@\",",
-                "      \"corpus\": \"@1@/@3@\"",
+                "      \"corpus\": \"@1@/@corpus@/@3@\"",
                 "    }",
                 "  },",
                 "  {",
@@ -95,7 +95,7 @@ public class FileVNamesTest extends TestCase {
           .addRule(rule("static/path", v("static", "root", "")))
           .addRule(rule("dup/path", v("first", "", "")))
           .addRule(rule("dup/path2", v("second", "", "")))
-          .addRule(rule("(grp1)/(\\d+)/(.*)", v("@1@/@3@", "@2@", "")))
+          .addRule(rule("(?P<corpus>grp1)/(\\d+)/(.*)", v("@1@/@corpus@/@3@", "@2@", "")))
           .addRule(rule("bazel-bin/([^/]+)/java/.*[.]jar!/.*", v("@1@", "java", "")))
           .addRule(rule("third_party/([^/]+)/.*[.]jar!/.*", v("third_party", "@1@", "")))
           .addRule(rule("([^/]+)/java/.*", v("@1@", "java", "")))
@@ -137,7 +137,7 @@ public class FileVNamesTest extends TestCase {
     assertThat(f.lookupBaseVName("corpus/some/path/here"))
         .isEqualTo(VName.newBuilder().setCorpus("corpus").build());
     assertThat(f.lookupBaseVName("grp1/12345/endingGroup"))
-        .isEqualTo(VName.newBuilder().setCorpus("grp1/endingGroup").setRoot("12345").build());
+        .isEqualTo(VName.newBuilder().setCorpus("grp1/grp1/endingGroup").setRoot("12345").build());
 
     assertThat(f.lookupBaseVName("bazel-bin/kythe/java/some/path/A.jar!/some/path/A.class"))
         .isEqualTo(VName.newBuilder().setCorpus("kythe").setRoot("java").build());


### PR DESCRIPTION
Allow the use of named captures and replacements in vnames.json.  Go already had this, but the 3 languages should be consistent.