### PR TITLE
feat(java): emit visibility and other modifier facts

### DIFF
--- a/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
@@ -126,9 +126,6 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
   /** Name for special source file containing package annotations and documentation. */
   private static final String PACKAGE_INFO_NAME = "package-info";
 
-  /** Fact name for visibility. */
-  private static final String VISIBILITY_FACT_NAME = "/kythe/visibility";
-
   private final JavaIndexerConfig config;
 
   private final JavaEntrySets entrySets;
@@ -1280,7 +1277,16 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
 
     final String factValue;
 
-    static Visibility getDefault(TreeContext ctx) {
+    static Visibility get(JCModifiers modifiers, TreeContext ctx) {
+      if (modifiers.getFlags().contains(Modifier.PUBLIC)) {
+        return PUBLIC;
+      }
+      if (modifiers.getFlags().contains(Modifier.PRIVATE)) {
+        return PRIVATE;
+      }
+      if (modifiers.getFlags().contains(Modifier.PROTECTED)) {
+        return PROTECTED;
+      }
       JCClassDecl parent = ctx.getClassParentDecl();
       if (parent == null) {
         return PACKAGE;
@@ -1481,17 +1487,9 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
   }
 
   private void emitVisibility(VName node, JCModifiers modifiers, TreeContext ctx) {
-    if (modifiers.getFlags().contains(Modifier.PUBLIC)) {
-      entrySets.getEmitter().emitFact(node, VISIBILITY_FACT_NAME, Visibility.PUBLIC.factValue);
-    } else if (modifiers.getFlags().contains(Modifier.PRIVATE)) {
-      entrySets.getEmitter().emitFact(node, VISIBILITY_FACT_NAME, Visibility.PRIVATE.factValue);
-    } else if (modifiers.getFlags().contains(Modifier.PROTECTED)) {
-      entrySets.getEmitter().emitFact(node, VISIBILITY_FACT_NAME, Visibility.PROTECTED.factValue);
-    } else {
-      entrySets
-          .getEmitter()
-          .emitFact(node, VISIBILITY_FACT_NAME, Visibility.getDefault(ctx).factValue);
-    }
+    entrySets
+        .getEmitter()
+        .emitFact(node, "/kythe/visibility", Visibility.get(modifiers, ctx).factValue);
   }
 
   // Unwraps the target EntrySet and emits an edge to it from the sourceNode

--- a/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
@@ -126,6 +126,9 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
   /** Name for special source file containing package annotations and documentation. */
   private static final String PACKAGE_INFO_NAME = "package-info";
 
+  /** Fact name for visibility. */
+  private static final String VISIBILITY_FACT_NAME = "/kythe/visibility";
+
   private final JavaIndexerConfig config;
 
   private final JavaEntrySets entrySets;
@@ -1479,11 +1482,11 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
 
   private void emitVisibility(VName node, JCModifiers modifiers, TreeContext ctx) {
     if (modifiers.getFlags().contains(Modifier.PUBLIC)) {
-      entrySets.getEmitter().emitFact(node, "/kythe/visibility", Visibility.PUBLIC.factValue);
+      entrySets.getEmitter().emitFact(node, VISIBILITY_FACT_NAME, Visibility.PUBLIC.factValue);
     } else if (modifiers.getFlags().contains(Modifier.PRIVATE)) {
-      entrySets.getEmitter().emitFact(node, "/kythe/visibility", Visibility.PRIVATE.factValue);
+      entrySets.getEmitter().emitFact(node, VISIBILITY_FACT_NAME, Visibility.PRIVATE.factValue);
     } else if (modifiers.getFlags().contains(Modifier.PROTECTED)) {
-      entrySets.getEmitter().emitFact(node, "/kythe/visibility", Visibility.PROTECTED.factValue);
+      entrySets.getEmitter().emitFact(node, VISIBILITY_FACT_NAME, Visibility.PROTECTED.factValue);
     } else {
       entrySets
           .getEmitter()

--- a/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
@@ -386,20 +386,6 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
       emitComment(classDef, classNode);
     }
 
-    if (classDef.getModifiers().getFlags().contains(Modifier.ABSTRACT)) {
-      entrySets.getEmitter().emitFact(classNode, "/kythe/tag/abstract", "");
-    }
-
-    if (classDef.getModifiers().getFlags().contains(Modifier.PUBLIC)) {
-      entrySets.getEmitter().emitFact(classNode, "/kythe/visibility/public", "");
-    }
-    if (classDef.getModifiers().getFlags().contains(Modifier.PRIVATE)) {
-      entrySets.getEmitter().emitFact(classNode, "/kythe/visibility/private", "");
-    }
-    if (classDef.getModifiers().getFlags().contains(Modifier.PUBLIC)) {
-      entrySets.getEmitter().emitFact(classNode, "/kythe/visibility/protected", "");
-    }
-
     visitAnnotations(classNode, classDef.getModifiers().getAnnotations(), ctx);
 
     JavaNode superClassNode = scan(classDef.getExtendsClause(), ctx);
@@ -1445,6 +1431,10 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
   }
 
   private void emitModifiers(VName node, JCModifiers modifiers) {
+    if (modifiers.getFlags().contains(Modifier.ABSTRACT)) {
+      entrySets.getEmitter().emitFact(node, "/kythe/tag/abstract", "");
+    }
+
     if (modifiers.getFlags().contains(Modifier.STATIC)) {
       entrySets.getEmitter().emitFact(node, "/kythe/tag/static", "");
     }

--- a/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
@@ -1279,17 +1279,17 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
     }
 
     final String factValue;
-  }
 
-  private static Visibility getDefaultVisibility(TreeContext ctx) {
-    JCClassDecl parent = ctx.getClassParentDecl();
-    if (parent == null) {
-      return Visibility.PACKAGE;
+    static Visibility getDefault(TreeContext ctx) {
+      JCClassDecl parent = ctx.getClassParentDecl();
+      if (parent == null) {
+        return PACKAGE;
+      }
+      if (parent.getKind().equals(Kind.INTERFACE)) {
+        return PUBLIC;
+      }
+      return PACKAGE;
     }
-    if (parent.getKind().equals(Kind.INTERFACE)) {
-      return Visibility.PUBLIC;
-    }
-    return Visibility.PACKAGE;
   }
 
   private static ImmutableList<VName> getScope(TreeContext ctx) {
@@ -1490,7 +1490,7 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
     } else {
       entrySets
           .getEmitter()
-          .emitFact(node, "/kythe/visibility", getDefaultVisibility(ctx).factValue);
+          .emitFact(node, VISIBILITY_FACT_NAME, Visibility.getDefault(ctx).factValue);
     }
   }
 

--- a/kythe/java/com/google/devtools/kythe/analyzers/java/TreeContext.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/TreeContext.java
@@ -94,6 +94,17 @@ class TreeContext {
     return parent;
   }
 
+  public JCClassDecl getClassParentDecl() {
+    TreeContext parent = up();
+    while (parent != null && !(parent.getTree() instanceof JCClassDecl)) {
+      parent = parent.up();
+    }
+    if (parent == null) {
+      return null;
+    }
+    return (JCClassDecl) parent.getTree();
+  }
+
   public TreeContext getScope() {
     TreeContext parent = up();
     while (parent != null

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/BUILD
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/BUILD
@@ -356,6 +356,18 @@ java_verifier_test(
 )
 
 java_verifier_test(
+    name = "visibility_tests",
+    size = "small",
+    srcs = ["Visibility.java"],
+)
+
+java_verifier_test(
+    name = "modifier_tests",
+    size = "small",
+    srcs = ["Modifiers.java"],
+)
+
+java_verifier_test(
     name = "package_tests",
     size = "small",
     srcs = [

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Modifiers.java
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Modifiers.java
@@ -1,24 +1,37 @@
 package pkg;
 
 @SuppressWarnings("unused")
-public class Modifiers {
+public abstract class Modifiers {
 
   //- @privMember defines/binding PrivateMember
   private int privMember;
   //- @volMember defines/binding VolatileMember
   private volatile int volMember;
 
+  //- @method defines/binding Method
+  int method() {
+    return 0;
+  }
+
+  //- @absmethod defines/binding AbstractMethod
+  abstract int absmethod();
+
   interface Intf {
-    //- @func defines/binding Method
+    //- @func defines/binding IMethod
     int func();
 
     //- @defFunc defines/binding DefaultMethod
-    default int defFunc() { return 0; }
+    default int defFunc() {
+      return 0;
+    }
   }
 }
 
 //- !{ PrivateMember.tag/volatile _ }
 //- VolatileMember.tag/volatile _
 
-//- !{ Method.tag/default _ }
+//- !{ IMethod.tag/default _ }
 //- DefaultMethod.tag/default _
+
+//- !{ Method.tag/abstract _ }
+//- AbstractMethod.tag/abstract _

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Modifiers.java
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Modifiers.java
@@ -8,6 +8,8 @@ public abstract class Modifiers {
   private int privMember;
   //- @volMember defines/binding VolatileMember
   private volatile int volMember;
+  //- @volStatic defines/binding VolatileStatic
+  private static volatile int volStatic;
 
   //- @method defines/binding Method
   int method() {
@@ -34,6 +36,7 @@ public abstract class Modifiers {
 
 //- !{ PrivateMember.tag/volatile _ }
 //- VolatileMember.tag/volatile _
+//- VolatileStatic.tag/volatile _
 
 //- !{ IMethod.tag/default _ }
 //- DefaultMethod.tag/default _

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Modifiers.java
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Modifiers.java
@@ -1,6 +1,7 @@
 package pkg;
 
 @SuppressWarnings("unused")
+//- @Modifiers defines/binding AbstractClass
 public abstract class Modifiers {
 
   //- @privMember defines/binding PrivateMember
@@ -16,6 +17,10 @@ public abstract class Modifiers {
   //- @absmethod defines/binding AbstractMethod
   abstract int absmethod();
 
+  //- @Clazz defines/binding Class
+  class Clazz { }
+
+  //- @Intf defines/binding Interface
   interface Intf {
     //- @func defines/binding IMethod
     int func();
@@ -35,3 +40,7 @@ public abstract class Modifiers {
 
 //- !{ Method.tag/abstract _ }
 //- AbstractMethod.tag/abstract _
+
+//- !{ Class.tag/abstract _ }
+//- AbstractClass.tag/abstract _
+//- !{ Interface.tag/abstract _ }

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Modifiers.java
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Modifiers.java
@@ -1,0 +1,24 @@
+package pkg;
+
+@SuppressWarnings("unused")
+public class Modifiers {
+
+  //- @privMember defines/binding PrivateMember
+  private int privMember;
+  //- @volMember defines/binding VolatileMember
+  private volatile int volMember;
+
+  interface Intf {
+    //- @func defines/binding Method
+    int func();
+
+    //- @defFunc defines/binding DefaultMethod
+    default int defFunc() { return 0; }
+  }
+}
+
+//- !{ PrivateMember.tag/volatile _ }
+//- VolatileMember.tag/volatile _
+
+//- !{ Method.tag/default _ }
+//- DefaultMethod.tag/default _

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Visibility.java
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Visibility.java
@@ -32,7 +32,10 @@ public class Visibility {
 
   //- @pubMethod defines/binding PublicMethod
   public int pubMethod() {
-    return 0;
+
+    //- @local defines/binding LocalVar
+    int local = 0;
+    return local;
   }
 
   //- @PrivClass defines/binding PrivateClass
@@ -49,16 +52,18 @@ public class Visibility {
 }
 
 //- PrivateMember.visibility private
-//- !{ DefaultMember.visibility _ }
+//- DefaultMember.visibility package
 //- ProtectedMember.visibility protected
 //- PublicMember.visibility public
 
 //- PrivateMethod.visibility private
-//- !{ DefaultMethod.visibility _}
+//- DefaultMethod.visibility package
 //- ProtectedMethod.visibility protected
 //- PublicMethod.visibility public
 
 //- PrivateClass.visibility private
-//- !{ DefaultClass.visibility _ }
+//- DefaultClass.visibility package
 //- ProtectedClass.visibility protected
 //- PublicClass.visibility public
+
+//- !{ LocalVar.visibility _ }

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Visibility.java
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Visibility.java
@@ -36,13 +36,13 @@ public class Visibility {
   }
 
   //- @PrivClass defines/binding PrivateClass
-  private class PrivClass { }
+  private class PrivClass {}
 
   //- @DefClass defines/binding DefaultClass
-  class DefClass { }
+  class DefClass {}
 
   //- @ProtClass defines/binding ProtectedClass
-  protected class ProtClass { }
+  protected class ProtClass {}
 
   //- @PubClass defines/binding PublicClass
   public class PubClass {}

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Visibility.java
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Visibility.java
@@ -49,6 +49,19 @@ public class Visibility {
 
   //- @PubClass defines/binding PublicClass
   public class PubClass {}
+
+  //- @DefIntf defines/binding DefaultInterface
+  interface DefIntf {
+    //- @f defines/binding DefaultInterfaceMethod
+    int f();
+  }
+
+  //- @DefEnum defines/binding DefaultEnum
+  enum DefEnum {
+    //- @X defines/binding EnumValueX
+    X,
+    Y;
+  }
 }
 
 //- PrivateMember.visibility private
@@ -67,3 +80,10 @@ public class Visibility {
 //- PublicClass.visibility public
 
 //- !{ LocalVar.visibility _ }
+
+//- DefaultInterface.visibility package
+//- DefaultInterfaceMethod.visibility public
+
+//- DefaultEnum.visibility package
+// N.B. enum values are tagged as public, final and static by the Java compiler.
+//- EnumValueX.visibility public

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Visibility.java
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Visibility.java
@@ -1,0 +1,64 @@
+package pkg;
+
+@SuppressWarnings("unused")
+public class Visibility {
+
+  //- @privMember defines/binding PrivateMember
+  private int privMember;
+
+  //- @defMember defines/binding DefaultMember
+  int defMember;
+
+  //- @protMember defines/binding ProtectedMember
+  protected int protMember;
+
+  //- @pubMember defines/binding PublicMember
+  public int pubMember;
+
+  //- @privMethod defines/binding PrivateMethod
+  private int privMethod() {
+    return 0;
+  }
+
+  //- @defMethod defines/binding DefaultMethod
+  int defMethod() {
+    return 0;
+  }
+
+  //- @protMethod defines/binding ProtectedMethod
+  protected int protMethod() {
+    return 0;
+  }
+
+  //- @pubMethod defines/binding PublicMethod
+  public int pubMethod() {
+    return 0;
+  }
+
+  //- @PrivClass defines/binding PrivateClass
+  private class PrivClass { }
+
+  //- @DefClass defines/binding DefaultClass
+  class DefClass { }
+
+  //- @ProtClass defines/binding ProtectedClass
+  protected class ProtClass { }
+
+  //- @PubClass defines/binding PublicClass
+  public class PubClass {}
+}
+
+//- PrivateMember.visibility private
+//- !{ DefaultMember.visibility _ }
+//- ProtectedMember.visibility protected
+//- PublicMember.visibility public
+
+//- PrivateMethod.visibility private
+//- !{ DefaultMethod.visibility _}
+//- ProtectedMethod.visibility protected
+//- PublicMethod.visibility public
+
+//- PrivateClass.visibility private
+//- !{ DefaultClass.visibility _ }
+//- ProtectedClass.visibility protected
+//- PublicClass.visibility public


### PR DESCRIPTION
Adds support for 
 * visibility = {public, private, package, protected}

Also adds support for
 * tag/volatile
 * tag/abstract
 * tag/default
