### PR TITLE
Do not include "new " in java constructor refs

### DIFF
--- a/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
@@ -901,7 +901,7 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
         new Span(
             filePositions.getStart(newClass.getIdentifier()),
             filePositions.getEnd(newClass.getIdentifier()));
-    // Span over "new Class"
+    // Span over "new Class(...)"
     Span callSpan = new Span(filePositions.getStart(newClass), filePositions.getEnd(newClass));
 
     if (owner.getTree().getTag() == JCTree.Tag.VARDEF) {

--- a/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
@@ -897,11 +897,11 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
       return emitDiagnostic(ctx, "error analyzing class", null, null);
     }
 
-    // Span over "new Class"
     Span refSpan =
-        new Span(filePositions.getStart(newClass), filePositions.getEnd(newClass.getIdentifier()));
-    // Span over "new Class(...)"
-    Span callSpan = new Span(refSpan.getStart(), filePositions.getEnd(newClass));
+        new Span(filePositions.getStart(newClass.getIdentifier()), filePositions.getEnd(newClass.getIdentifier()));
+    // Span over "new Class"
+    Span callSpan =
+        new Span(filePositions.getStart(newClass), filePositions.getEnd(newClass));
 
     if (owner.getTree().getTag() == JCTree.Tag.VARDEF) {
       JCVariableDecl varDef = (JCVariableDecl) owner.getTree();

--- a/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
@@ -898,10 +898,11 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
     }
 
     Span refSpan =
-        new Span(filePositions.getStart(newClass.getIdentifier()), filePositions.getEnd(newClass.getIdentifier()));
+        new Span(
+            filePositions.getStart(newClass.getIdentifier()),
+            filePositions.getEnd(newClass.getIdentifier()));
     // Span over "new Class"
-    Span callSpan =
-        new Span(filePositions.getStart(newClass), filePositions.getEnd(newClass));
+    Span callSpan = new Span(filePositions.getStart(newClass), filePositions.getEnd(newClass));
 
     if (owner.getTree().getTag() == JCTree.Tag.VARDEF) {
       JCVariableDecl varDef = (JCVariableDecl) owner.getTree();

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Callgraph.java
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Callgraph.java
@@ -60,9 +60,12 @@ public class Callgraph {
   //- CtorCall.loc/start @^"new Callgraph()"
   //- CtorCall.loc/end @$"new Callgraph()"
   //- CtorCall ref/call ECtor
+  //- CtorRef.loc/start @^"Callgraph"
+  //- CtorRef.loc/end @$"Callgraph"
+  //- CtorRef ref ECtor
   //- CtorCall childof ECtor
   //- CtorCall childof SCtor
-  final Callgraph instance = new Callgraph();
+  final Object instance = new Callgraph();
 
   //- @Callgraph defines/binding ECtor
   //- ECtor.node/kind function
@@ -78,12 +81,12 @@ public class Callgraph {
   //- F.node/kind function
   //- F typed _FType
   static void f(int n) {
-    //- @"new Callgraph" ref ECtor
+    //- @"Callgraph" ref ECtor
     //- ECtorCall.loc/start @^"new Callgraph()"
     //- ECtorCall.loc/end @$"new Callgraph()"
-    Callgraph cg = new Callgraph();
+    Object cg = new Callgraph();
     //
-    //- @"new Callgraph" ref SCtor
+    //- @"Callgraph" ref SCtor
     //- SCtorCall.loc/start @^"new Callgraph(null)"
     //- SCtorCall.loc/end @$"new Callgraph(null)"
     cg = new Callgraph(null);

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/GenericMethodRef.java
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/GenericMethodRef.java
@@ -1,8 +1,13 @@
 package pkg;
 
 @SuppressWarnings("unused")
+//- @GenericMethodRef defines/binding GClass
 public final class GenericMethodRef {
-  public static final class Optional<T> {}
+  //- @Optional defines/binding OClass
+  public static final class Optional<T> {
+    //- @Optional defines/binding OptionalConstructor
+    Optional() {}
+  }
 
   //- @Optional ref OptionalClass
   //- @wildcard defines/binding WildcardFnAbs
@@ -28,5 +33,13 @@ public final class GenericMethodRef {
     //- @verboseWildcard ref VerboseWildcardFnAbs
     //- @"verboseWildcard(null)" ref/call VerboseWildcardFnAbs
     verboseWildcard(null);
+  }
+
+  private static void constructor() {
+    //- @Optional ref/call OptionalConstructor
+    //- @Optional ref OptionalConstructor
+    //- @Optional ref OClass
+    //- @GenericMethodRef ref GClass
+    Object o = new Optional<GenericMethodRef>();
   }
 }

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Methods.java
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Methods.java
@@ -31,7 +31,7 @@ public class Methods {
   //- CreateType param.2 VoidBuiltin
   public static Methods create() {
     //- @Methods ref Class
-    //- @"new Methods" ref Ctor
+    //- @"Methods" ref Ctor
     return new Methods();
   }
 


### PR DESCRIPTION
### The practical justification

Users expect that the primary linkages in the statement

`new Foo<Bar>(z)`

will be to the constructor of `Foo`, the definition of class `Bar`, and the definition/declaration of variable `z`. Existing behavior is to set the span for the constructor reference to be `new Foo`. This turns out to require a lot of special casing in resolving all the overlapping references in such a way that users expect. If we remove `new ` from that span, a relatively simple straightforward approach of choosing "smallest" spans, accompanied with a prioritization of `ref/call` edges, yields satisfactory results.

### Theoretical

It can be (has been?) argued that `new ` is *part* of the constructor name, on the basis that Java method references use the word "new", e.g. in `String::new`. However, the constructor is declared with the name the same as the class, not "new", and the method reference can be construed as approximately syntactic sugar (approximate because there is no other valid form, e.g.`String::String` is not a valid method reference for the `String` constructor).

