### PR TITLE
fix: force selection of `ar` to unbreak os x build of libffi

### DIFF
--- a/third_party/libffi.BUILD
+++ b/third_party/libffi.BUILD
@@ -25,6 +25,7 @@ configure_make(
         "--disable-multi-os-directory",
         "--disable-dependency-tracking",
         "--disable-docs",
+        "AR=ar",
     ],
     lib_source = ":all_srcs",
     visibility = ["//visibility:public"],


### PR DESCRIPTION
I'm not clear why a `configure` in a checkout of libffi finds `ar` properly but running `configure` inside bazel ends up choosing `libtool`, but a blunt hammer seems to work on linux as wel.