### PR TITLE
fix(cxx_indexer): add required parameter

### DIFF
--- a/kythe/cxx/indexer/cxx/marked_source.cc
+++ b/kythe/cxx/indexer/cxx/marked_source.cc
@@ -695,7 +695,7 @@ void MarkedSourceGenerator::ReplaceMarkedSourceWithTemplateArgumentList(
     std::string pre_text;
     {
       llvm::raw_string_ostream stream(pre_text);
-      print_arg.print(policy, stream);
+      print_arg.print(policy, stream, true);
     }
     *next_arg->mutable_pre_text() = pre_text;
   }


### PR DESCRIPTION
this seems to have been set in google3 and was undone on import, breaking the build