### PR TITLE
feat(go_indexer): add option to put tapp nodes in the CU corpus

### DIFF
--- a/kythe/go/indexer/BUILD
+++ b/kythe/go/indexer/BUILD
@@ -220,6 +220,12 @@ go_indexer_test(
     deps = [":types_test"],
 )
 
+go_indexer_test(
+    name = "tappcorpus_test",
+    srcs = ["testdata/basic/tappcorpus.go"],
+    use_compilation_corpus_as_default = True,
+)
+
 # load(":testdata/go_indexer_test.bzl", "go_integration_test")
 # TODO(#2375): (closed?) requires MarkedSource resolution in pipeline
 # go_integration_test(

--- a/kythe/go/indexer/cmd/go_example/go_example.go
+++ b/kythe/go/indexer/cmd/go_example/go_example.go
@@ -64,8 +64,6 @@ Options:
 }
 
 func main() {
-	panic("testing that go_example is getting rebuilt")
-	log.Fatal("testing that go_example is getting rebuilt")
 	flag.Parse()
 
 	if flag.NArg() == 0 {

--- a/kythe/go/indexer/cmd/go_example/go_example.go
+++ b/kythe/go/indexer/cmd/go_example/go_example.go
@@ -64,6 +64,8 @@ Options:
 }
 
 func main() {
+	panic("testing that go_example is getting rebuilt")
+	log.Fatal("testing that go_example is getting rebuilt")
 	flag.Parse()
 
 	if flag.NArg() == 0 {

--- a/kythe/go/indexer/cmd/go_indexer/go_indexer.go
+++ b/kythe/go/indexer/cmd/go_indexer/go_indexer.go
@@ -51,6 +51,7 @@ var (
 	onlyEmitDocURIsForStandardLibs = flag.Bool("only_emit_doc_uris_for_standard_libs", false, "If true, the doc/uri fact is only emitted for go std library packages")
 	verbose                        = flag.Bool("verbose", false, "Emit verbose log information")
 	contOnErr                      = flag.Bool("continue", false, "Log errors encountered during analysis but do not exit unsuccessfully")
+	useCompilationCorpusAsDefault = flag.Bool("use_compilation_corpus_as_default", false, "Nodes that otherwise wouldn't have a corpus (such as tapps) are given the corpus of the compilation unit being indexed.")
 
 	writeEntry func(context.Context, *spb.Entry) error
 	docURL     *url.URL
@@ -158,6 +159,7 @@ func indexGo(ctx context.Context, unit *apb.CompilationUnit, f indexer.Fetcher) 
 		EmitLinkages:                   *metaSuffix != "",
 		DocBase:                        docURL,
 		OnlyEmitDocURIsForStandardLibs: *onlyEmitDocURIsForStandardLibs,
+		UseCompilationCorpusAsDefault: *useCompilationCorpusAsDefault,
 	})
 }
 

--- a/kythe/go/indexer/cmd/go_indexer/go_indexer.go
+++ b/kythe/go/indexer/cmd/go_indexer/go_indexer.go
@@ -51,7 +51,7 @@ var (
 	onlyEmitDocURIsForStandardLibs = flag.Bool("only_emit_doc_uris_for_standard_libs", false, "If true, the doc/uri fact is only emitted for go std library packages")
 	verbose                        = flag.Bool("verbose", false, "Emit verbose log information")
 	contOnErr                      = flag.Bool("continue", false, "Log errors encountered during analysis but do not exit unsuccessfully")
-	useCompilationCorpusAsDefault = flag.Bool("use_compilation_corpus_as_default", false, "Nodes that otherwise wouldn't have a corpus (such as tapps) are given the corpus of the compilation unit being indexed.")
+	useCompilationCorpusAsDefault  = flag.Bool("use_compilation_corpus_as_default", false, "Nodes that otherwise wouldn't have a corpus (such as tapps) are given the corpus of the compilation unit being indexed.")
 
 	writeEntry func(context.Context, *spb.Entry) error
 	docURL     *url.URL
@@ -159,7 +159,7 @@ func indexGo(ctx context.Context, unit *apb.CompilationUnit, f indexer.Fetcher) 
 		EmitLinkages:                   *metaSuffix != "",
 		DocBase:                        docURL,
 		OnlyEmitDocURIsForStandardLibs: *onlyEmitDocURIsForStandardLibs,
-		UseCompilationCorpusAsDefault: *useCompilationCorpusAsDefault,
+		UseCompilationCorpusAsDefault:  *useCompilationCorpusAsDefault,
 	})
 }
 

--- a/kythe/go/indexer/emit.go
+++ b/kythe/go/indexer/emit.go
@@ -113,6 +113,9 @@ type impl struct{ A, B types.Object }
 // sink. In case of errors, processing continues as far as possible before the
 // first error encountered is reported.
 func (pi *PackageInfo) Emit(ctx context.Context, sink Sink, opts *EmitOptions) error {
+	if opts == nil {
+		opts = &EmitOptions{}
+	}
 	e := &emitter{
 		ctx:      ctx,
 		pi:       pi,

--- a/kythe/go/indexer/emit.go
+++ b/kythe/go/indexer/emit.go
@@ -64,6 +64,10 @@ type EmitOptions struct {
 
 	// If true, the doc/uri fact is only emitted for go std library packages.
 	OnlyEmitDocURIsForStandardLibs bool
+
+	// Nodes that otherwise wouldn't have a corpus (such as tapps) are given the
+	// corpus of the compilation unit being indexed.
+	UseCompilationCorpusAsDefault bool
 }
 
 func (e *EmitOptions) emitMarkedSource() bool {
@@ -280,6 +284,9 @@ func (e *emitter) emitTApp(ms *cpb.MarkedSource, ctorKind string, ctor *spb.VNam
 		components = append(components, p)
 	}
 	v := &spb.VName{Language: govname.Language, Signature: hashSignature(components)}
+	if e.opts.UseCompilationCorpusAsDefault {
+		v.Corpus = e.pi.VName.GetCorpus()
+	}
 	if e.pi.typeEmitted.Add(v.Signature) {
 		e.writeFact(v, facts.NodeKind, nodes.TApp)
 		e.writeEdge(v, ctor, edges.ParamIndex(0))

--- a/kythe/go/indexer/testdata/basic/tappcorpus.go
+++ b/kythe/go/indexer/testdata/basic/tappcorpus.go
@@ -1,0 +1,9 @@
+package tappcorpus
+
+// When --use_compilation_corpus_as_default is enabled in the go indexer, tapp
+// nodes should use the compilation unit's corpus rather than the empty corpus.
+
+//- @x defines/binding VarX=vname(_,"kythe",_,_,"go")
+//- VarX typed IntSlice=vname(_,"kythe",_,_,"go")
+//- IntSlice.node/kind tapp
+var x []int

--- a/kythe/go/indexer/testdata/go_indexer_test.bzl
+++ b/kythe/go/indexer/testdata/go_indexer_test.bzl
@@ -203,8 +203,7 @@ go_entries = rule(
 
         # The suffix used to recognize linkage metadata files, if non-empty.
         "metadata_suffix": attr.string(default = ""),
-
-        "use_compilation_corpus_as_default": attr.bool(default=False),
+        "use_compilation_corpus_as_default": attr.bool(default = False),
 
         # The location of the Go indexer binary.
         "_indexer": attr.label(
@@ -294,7 +293,7 @@ def go_indexer_test(
         has_marked_source = False,
         emit_anchor_scopes = False,
         allow_duplicates = False,
-        use_compilation_corpus_as_default=False,
+        use_compilation_corpus_as_default = False,
         metadata_suffix = ""):
     entries = _go_indexer(
         name = name,
@@ -302,7 +301,7 @@ def go_indexer_test(
         data = data,
         has_marked_source = has_marked_source,
         emit_anchor_scopes = emit_anchor_scopes,
-        use_compilation_corpus_as_default=use_compilation_corpus_as_default,
+        use_compilation_corpus_as_default = use_compilation_corpus_as_default,
         importpath = import_path,
         metadata_suffix = metadata_suffix,
         deps = deps,

--- a/kythe/go/indexer/testdata/go_indexer_test.bzl
+++ b/kythe/go/indexer/testdata/go_indexer_test.bzl
@@ -166,6 +166,9 @@ def _go_entries(ctx):
     if ctx.attr.emit_anchor_scopes:
         iargs.append("-anchor_scopes")
 
+    if ctx.attr.use_compilation_corpus_as_default:
+        iargs.append("-use_compilation_corpus_as_default")
+
     # If the test wants linkage metadata, enable support for it in the indexer.
     if ctx.attr.metadata_suffix:
         iargs += ["-meta", ctx.attr.metadata_suffix]
@@ -200,6 +203,8 @@ go_entries = rule(
 
         # The suffix used to recognize linkage metadata files, if non-empty.
         "metadata_suffix": attr.string(default = ""),
+
+        "use_compilation_corpus_as_default": attr.bool(default=False),
 
         # The location of the Go indexer binary.
         "_indexer": attr.label(
@@ -247,6 +252,7 @@ def _go_indexer(
         has_marked_source = False,
         emit_anchor_scopes = False,
         allow_duplicates = False,
+        use_compilation_corpus_as_default = False,
         metadata_suffix = ""):
     if importpath == None:
         importpath = native.package_name() + "/" + name
@@ -268,6 +274,7 @@ def _go_indexer(
         name = entries,
         has_marked_source = has_marked_source,
         emit_anchor_scopes = emit_anchor_scopes,
+        use_compilation_corpus_as_default = use_compilation_corpus_as_default,
         kzip = ":" + kzip,
         metadata_suffix = metadata_suffix,
     )
@@ -287,6 +294,7 @@ def go_indexer_test(
         has_marked_source = False,
         emit_anchor_scopes = False,
         allow_duplicates = False,
+        use_compilation_corpus_as_default=False,
         metadata_suffix = ""):
     entries = _go_indexer(
         name = name,
@@ -294,6 +302,7 @@ def go_indexer_test(
         data = data,
         has_marked_source = has_marked_source,
         emit_anchor_scopes = emit_anchor_scopes,
+        use_compilation_corpus_as_default=use_compilation_corpus_as_default,
         importpath = import_path,
         metadata_suffix = metadata_suffix,
         deps = deps,


### PR DESCRIPTION
this is essentially the same as the c++ indexer's
--use_compilation_corpus_as_default option, which assigns the
compilation unit's corpus to template instantiations, etc.