### PR TITLE
Replace ij.bazel.io reference with ij.bazel.build.

### DIFF
--- a/kythe/java/com/google/devtools/kythe/analyzers/indexer.bazelproject
+++ b/kythe/java/com/google/devtools/kythe/analyzers/indexer.bazelproject
@@ -14,8 +14,8 @@
 
 # Project file to work on the java indexer in IntelliJ.
 #
-# See http://ij.bazel.io/docs/bazel-plugin.html for documentation and instructions on how to use the IntelliJ with Bazel
-# plugin.
+# See https://ij.bazel.build/docs/bazel-plugin.html for documentation and
+# instructions on how to use the IntelliJ with Bazel plugin.
 directories:
   kythe/java/com/google/devtools/kythe/analyzers/
   kythe/java/com/google/devtools/kythe/platform/java/helpers


### PR DESCRIPTION
Bazel's `*.bazel.io` domains are deprecated and redirect to their `*.bazel.build` equivalents.

I'm cleaning up references that I come across so that we can eventually retire the *.io subdomains completely.