### PR TITLE
fix(fuschia-extractor): Fix panic format string for Rust 2021

### DIFF
--- a/kythe/rust/fuchsia_extractor/src/bin/main.rs
+++ b/kythe/rust/fuchsia_extractor/src/bin/main.rs
@@ -959,10 +959,10 @@ mod testing {
             let result: analysis::IndexedCompilation = protobuf::parse_from_bytes(&buf).unwrap();
             return result;
         }
-        panic!(format!(
+        panic!(
             "pbunits file not found in existing zip file: zip_path: {:?}",
             &zip_path.as_ref(),
-        ));
+        );
     }
 
     #[test]


### PR DESCRIPTION
Small change to fix a warning about `panic!` supporting format strings natively in Rust 2021
```
INFO: From Compiling Rust bin fuchsia_extractor_test (1 files):
warning: panic message is not a string literal
   --> kythe/rust/fuchsia_extractor/src/bin/main.rs:962:16
    |
962 |           panic!(format!(
    |  ________________^
963 | |             "pbunits file not found in existing zip file: zip_path: {:?}",
964 | |             &zip_path.as_ref(),
965 | |         ));
    | |_________^
    |
    = note: `#[warn(non_fmt_panic)]` on by default
    = note: this is no longer accepted in Rust 2021
    = note: the panic!() macro supports formatting, so there's no need for the format!() macro here
```