### PR TITLE
feat(java_indexer): add option to put tapps in the CU corpus

### DIFF
--- a/kythe/java/com/google/devtools/kythe/analyzers/base/KytheEntrySets.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/base/KytheEntrySets.java
@@ -53,6 +53,7 @@ public class KytheEntrySets {
 
   private final VName compilationVName;
   private final Map<String, VName> inputVNames;
+  protected boolean useCompilationCorpusAsDefault;
 
   public KytheEntrySets(
       StatisticsCollector statistics,
@@ -76,6 +77,10 @@ public class KytheEntrySets {
       }
       inputVNames.put(digest, name.build());
     }
+  }
+
+  public final void setUseCompilationCorpusAsDefault(boolean d) {
+    this.useCompilationCorpusAsDefault = d;
   }
 
   /** Returns the {@link FactEmitter} used to emit generated {@link EntrySet}s. */
@@ -338,6 +343,7 @@ public class KytheEntrySets {
     if (ms != null) {
       builder.setProperty("code", ms);
     }
+    builder.setCorpusPath(defaultCorpusPath());
     EntrySet node = emitAndReturn(builder);
     emitEdge(node.getVName(), EdgeKind.PARAM, head, 0);
     emitOrdinalEdges(node.getVName(), EdgeKind.PARAM, arguments, 1);
@@ -359,6 +365,16 @@ public class KytheEntrySets {
   protected VName lookupVName(String digest) {
     VName inputVName = inputVNames.get(digest);
     return inputVName == null ? null : EntrySet.extendVName(compilationVName, inputVName);
+  }
+
+  /**
+   * Returns a CorpusPath containing the default corpus. This will either be
+   * empty string or the compilation unit's corpus depending on the
+   * --use_compilation_corpus_as_default option.
+   */
+  public CorpusPath defaultCorpusPath() {
+    return new CorpusPath(
+        useCompilationCorpusAsDefault ? compilationVName.getCorpus() : "", "", "");
   }
 
   protected EntrySet emitAndReturn(EntrySet.Builder b) {

--- a/kythe/java/com/google/devtools/kythe/analyzers/base/KytheEntrySets.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/base/KytheEntrySets.java
@@ -368,9 +368,8 @@ public class KytheEntrySets {
   }
 
   /**
-   * Returns a CorpusPath containing the default corpus. This will either be
-   * empty string or the compilation unit's corpus depending on the
-   * --use_compilation_corpus_as_default option.
+   * Returns a CorpusPath containing the default corpus. This will either be empty string or the
+   * compilation unit's corpus depending on the --use_compilation_corpus_as_default option.
    */
   public CorpusPath defaultCorpusPath() {
     return new CorpusPath(

--- a/kythe/java/com/google/devtools/kythe/analyzers/java/JavaEntrySets.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/JavaEntrySets.java
@@ -73,6 +73,7 @@ public class JavaEntrySets extends KytheEntrySets {
       JavaIndexerConfig config) {
     super(statistics, emitter, compilationVName, requiredInputs);
     this.config = config;
+    setUseCompilationCorpusAsDefault(config.getUseCompilationCorpusAsDefault());
   }
 
   Map<Symbol, VName> getSymbolNodes() {

--- a/kythe/java/com/google/devtools/kythe/analyzers/java/JavaIndexerConfig.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/JavaIndexerConfig.java
@@ -20,7 +20,6 @@ import com.beust.jcommander.Parameter;
 import com.google.devtools.kythe.analyzers.base.IndexerConfig;
 
 public class JavaIndexerConfig extends IndexerConfig {
-
   @Parameter(names = "--emit_jvm_signatures", description = "Generate vnames with jvm signatures.")
   private boolean emitJvmSignatures;
 
@@ -69,6 +68,11 @@ public class JavaIndexerConfig extends IndexerConfig {
               + " compiler insists on being read from the local file system.")
   private String temporaryDirectory;
 
+  @Parameter(
+      names = "--use_compilation_corpus_as_default",
+      description = "Use the CompilationUnit VName corpus as the default.")
+  private boolean useCompilationCorpusAsDefault;
+
   public JavaIndexerConfig(String programName) {
     super(programName);
   }
@@ -99,6 +103,10 @@ public class JavaIndexerConfig extends IndexerConfig {
 
   public String getTemporaryDirectory() {
     return temporaryDirectory;
+  }
+
+  public boolean getUseCompilationCorpusAsDefault() {
+    return useCompilationCorpusAsDefault;
   }
 
   public JavaIndexerConfig setIgnoreVNamePaths(boolean ignoreVNamePaths) {
@@ -134,6 +142,11 @@ public class JavaIndexerConfig extends IndexerConfig {
 
   public JavaIndexerConfig setTemporaryDirectory(String temporaryDirectory) {
     this.temporaryDirectory = temporaryDirectory;
+    return this;
+  }
+
+  public JavaIndexerConfig setUseCompilationCorpusAsDefault(boolean useCompilationCorpusAsDefault) {
+    this.useCompilationCorpusAsDefault = useCompilationCorpusAsDefault;
     return this;
   }
 }

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/BUILD
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/BUILD
@@ -511,3 +511,17 @@ java_verifier_test(
     name = "abstract_class_test",
     compilation = ":abstract_class",
 )
+
+java_library(
+    name = "default_corpus",
+    srcs = ["DefaultCorpus.java"],
+)
+
+java_verifier_test(
+    name = "default_corpus_test",
+    compilation = ":default_corpus",
+    indexer_opts = [
+        "--verbose",
+        "--use_compilation_corpus_as_default",
+    ],
+)

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/DefaultCorpus.java
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/DefaultCorpus.java
@@ -1,0 +1,14 @@
+package pkg;
+
+import java.util.List;
+
+// Test that when the --use_compilation_corpus_as_default option is enabled,
+// tapps are placed in the CU's corpus. In this example, the "List<String>" tapp
+// should be given the "kythe" corpus.
+
+class DefaultCorpus {
+  //- @myvar defines/binding MyVar?
+  //- MyVar typed ListStringType=vname(_,"kythe",_,_,"java")
+  //- ListStringType.node/kind "tapp"
+  private List<String> myvar;
+}


### PR DESCRIPTION
this is intended to match the behavior of the `--use_compilation_corpus_as_default` option in the c++ and go indexers

followup changes will apply this same logic to other types of corpus-less nodes

