### PR TITLE
chore: reorder GCB steps in presubmit

### DIFF
--- a/kythe/release/cloudbuild/presubmit.yaml
+++ b/kythe/release/cloudbuild/presubmit.yaml
@@ -1,16 +1,16 @@
 # Cloud Build configuration for mandatory presubmit tests.
 steps:
   - name: gcr.io/kythe-repo/bazelisk-builder-client
-    id: bazel
+    id: bazel-minversion
+    env:
+      - USE_BAZEL_VERSION=min
     args:
       - bazel
       - test
       - '--config=remote'
       - //...
   - name: gcr.io/kythe-repo/bazelisk-builder-client
-    id: bazel-minversion
-    env:
-      - USE_BAZEL_VERSION=min
+    id: bazel
     args:
       - bazel
       - test


### PR DESCRIPTION
Under the hypothesis that increasing versions is more likely to share cache as is keeping a consistent version in sequence, where possible.