### PR TITLE
chore: update LLVM

### DIFF
--- a/external.bzl
+++ b/external.bzl
@@ -67,17 +67,6 @@ def _proto_dependencies():
 
 def _cc_dependencies():
     maybe(
-        http_archive,
-        name = "llvm-project-raw",
-        build_file_content = "#empty",
-        sha256 = "e20dcfb060f7078124bf29d9c8dee8c5c56b4bebee33ab3b6fef2898262651f2",
-        strip_prefix = "llvm-project-82a3b606b01d2da23a40785222f3f7d15401dda0",
-        urls = [
-            "https://github.com/llvm/llvm-project/archive/82a3b606b01d2da23a40785222f3f7d15401dda0.zip",
-        ],
-    )
-
-    maybe(
         llvm_terminfo_disable,
         name = "llvm_terminfo",
     )

--- a/setup.bzl
+++ b/setup.bzl
@@ -1,12 +1,16 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
-def github_archive(name, repo_name, commit, kind = "zip", **kwargs):
+def github_archive(name, repo_name, commit, kind = "zip", strip_prefix = "", **kwargs):
     """Defines a GitHub commit-based repository rule."""
     project = repo_name[repo_name.index("/"):]
     http_archive(
         name = name,
-        strip_prefix = "{project}-{commit}".format(project = project, commit = commit),
+        strip_prefix = "{project}-{commit}/{prefix}".format(
+            project = project,
+            commit = commit,
+            prefix = strip_prefix,
+        ),
         urls = [u.format(commit = commit, repo_name = repo_name, kind = kind) for u in [
             "https://mirror.bazel.build/github.com/{repo_name}/archive/{commit}.{kind}",
             "https://github.com/{repo_name}/archive/{commit}.{kind}",
@@ -134,14 +138,28 @@ def kythe_rule_repositories():
         url = "https://github.com/bazelbuild/rules_foreign_cc/archive/0.2.0.zip",
     )
 
+    # LLVM sticks the bazel configuration under a subdirectory, which expects to
+    # be the project root, so currently needs to be two distinct repositories
+    # from the same upstream source.
+    llvm_commit = "487f74a6c4151d13d3a7b54ee4ab7beaf3e87487"
+    llvm_sha256 = "cb8d1acf60e71894a692f273ab8c2a1fb6bd9e547de77cb9ee76829b2e429e7d"
+
     maybe(
-        http_archive,
+        github_archive,
+        repo_name = "llvm/llvm-project",
+        commit = llvm_commit,
+        name = "llvm-project-raw",
+        build_file_content = "#empty",
+        sha256 = llvm_sha256,
+    )
+
+    maybe(
+        github_archive,
+        repo_name = "llvm/llvm-project",
+        commit = llvm_commit,
         name = "llvm-bazel",
+        strip_prefix = "utils/bazel",
+        sha256 = llvm_sha256,
         patch_args = ["-p2"],
         patches = ["@io_kythe//third_party:llvm-bazel-glob.patch"],
-        sha256 = "1c54ed1c322cb96a64daab8d2d99e0178de17812e2992bf07f53756b13805822",
-        strip_prefix = "llvm-bazel-e3593b2e6eeb96e3972278073bc35ac8f4ea8f4b/llvm-bazel",
-        urls = [
-            "https://github.com/google/llvm-bazel/archive/e3593b2e6eeb96e3972278073bc35ac8f4ea8f4b.zip",
-        ],
     )


### PR DESCRIPTION
The primary purpose here is to switch to using the in-tree Bazel targets rather than the external overlay.