### PR TITLE
feat(extraction): accept "arguments" in addition to "command" in compdb

### DIFF
--- a/kythe/go/extractors/config/runextractor/compdb/BUILD
+++ b/kythe/go/extractors/config/runextractor/compdb/BUILD
@@ -17,6 +17,7 @@ go_test(
     srcs = ["compdb_test.go"],
     data = [
         "testdata/compilation_database.json",
+        "testdata/compilation_database_arguments.json",
         "testdata/test_file.cc",
         "//kythe/cxx/extractor:cxx_extractor",
     ],

--- a/kythe/go/extractors/config/runextractor/compdb/compdb_test.go
+++ b/kythe/go/extractors/config/runextractor/compdb/compdb_test.go
@@ -38,6 +38,9 @@ const (
 func setupEnvironment(t *testing.T) string {
 	t.Helper()
 	// TODO(shahms): ExtractCompilations should take an output path.
+	if _, ok := os.LookupEnv("TEST_TMPDIR"); !ok {
+		t.Skip("Skipping test due to incompatible environment (missing TEST_TMPDIR)")
+	}
 	output := t.TempDir()
 	if err := os.Setenv("KYTHE_OUTPUT_DIRECTORY", output); err != nil {
 		t.Fatalf("Error setting KYTHE_OUTPUT_DIRECTORY: %v", err)

--- a/kythe/go/extractors/config/runextractor/compdb/testdata/compilation_database_arguments.json
+++ b/kythe/go/extractors/config/runextractor/compdb/testdata/compilation_database_arguments.json
@@ -1,0 +1,7 @@
+[
+    {
+      "directory": "./../testdata/",
+      "arguments": ["/usr/bin/g++", "-c", "-o", "test_file.o", "test_file.cc"],
+      "file": "test_file.cc"
+    }
+  ]


### PR DESCRIPTION
[some](https://github.com/rizsotto/Bear) tools generate "arguments" instead of "command",
both are valid according to https://clang.llvm.org/docs/JSONCompilationDatabase.html