### PR TITLE
chore(rust_common): format all Rust files

### DIFF
--- a/kythe/rust/extractor/src/bin/cli.rs
+++ b/kythe/rust/extractor/src/bin/cli.rs
@@ -26,10 +26,7 @@ pub struct ExtractorConfig {
 impl ExtractorConfig {
     /// Create a new ExtractorConfig using the supplied parameters
     pub fn new(extra_action_path: PathBuf, output_path: PathBuf) -> Self {
-        Self {
-            extra_action_path,
-            output_path,
-        }
+        Self { extra_action_path, output_path }
     }
 }
 

--- a/kythe/rust/extractor/src/bin/extractor.rs
+++ b/kythe/rust/extractor/src/bin/extractor.rs
@@ -44,12 +44,8 @@ fn main() -> Result<()> {
     )?;
 
     // Create the output kzip
-    let kzip_file = File::create(&config.output_path).with_context(|| {
-        format!(
-            "Failed to create kzip file at path {:?}",
-            config.output_path
-        )
-    })?;
+    let kzip_file = File::create(&config.output_path)
+        .with_context(|| format!("Failed to create kzip file at path {:?}", config.output_path))?;
     let mut kzip = ZipWriter::new(kzip_file);
     kzip.add_directory("root/", FileOptions::default())?;
 
@@ -120,15 +116,12 @@ fn get_spawn_info(file_path: impl AsRef<Path>) -> Result<SpawnInfo> {
     let mut file = File::open(file_path).context("Failed to open extra action file")?;
 
     let mut file_contents_bytes = Vec::new();
-    file.read_to_end(&mut file_contents_bytes)
-        .context("Failed to read extra action file")?;
+    file.read_to_end(&mut file_contents_bytes).context("Failed to read extra action file")?;
 
     let extra_action = protobuf::parse_from_bytes::<ExtraActionInfo>(&file_contents_bytes)
         .context("Failed to parse extra action protobuf")?;
 
-    SPAWN_INFO
-        .get(&extra_action)
-        .ok_or_else(|| anyhow!("SpawnInfo extension missing"))
+    SPAWN_INFO.get(&extra_action).ok_or_else(|| anyhow!("SpawnInfo extension missing"))
 }
 
 /// Create an IndexedCompilation protobuf from the supplied arguments
@@ -191,11 +184,7 @@ fn kzip_add_required_input(
         .read_to_end(&mut source_file_contents)
         .with_context(|| format!("Failed read file {:?}", file_path_string))?;
     let digest = sha256digest(&source_file_contents);
-    kzip_add_file(
-        format!("root/files/{}", digest),
-        &source_file_contents,
-        zip_writer,
-    )?;
+    kzip_add_file(format!("root/files/{}", digest), &source_file_contents, zip_writer)?;
 
     // Generate FileInput and add it to the list of required inputs
     let mut file_input = CompilationUnit_FileInput::new();

--- a/kythe/rust/extractor/src/bin/save_analysis.rs
+++ b/kythe/rust/extractor/src/bin/save_analysis.rs
@@ -48,15 +48,9 @@ fn generate_arguments(arguments: Vec<String>, output_dir: &Path) -> Result<Vec<S
     let outdir_position = rustc_arguments
         .iter()
         .position(|arg| arg.contains("--out-dir"))
-        .ok_or_else(|| {
-            anyhow!(
-                "Could not find the output directory argument: {:?}",
-                arguments
-            )
-        })?;
-    let outdir_str = output_dir
-        .to_str()
-        .ok_or_else(|| anyhow!("Couldn't convert temporary path to string"))?;
+        .ok_or_else(|| anyhow!("Could not find the output directory argument: {:?}", arguments))?;
+    let outdir_str =
+        output_dir.to_str().ok_or_else(|| anyhow!("Couldn't convert temporary path to string"))?;
     rustc_arguments[outdir_position] = format!("--out-dir={}", outdir_str);
 
     Ok(rustc_arguments)

--- a/kythe/rust/extractor/src/lib.rs
+++ b/kythe/rust/extractor/src/lib.rs
@@ -30,9 +30,8 @@ use std::path::PathBuf;
 /// The save_analysis JSON output file will be located at
 /// {output_dir}/save-analysis/{crate_name}.json
 pub fn generate_analysis(rustc_arguments: Vec<String>, output_dir: PathBuf) -> Result<(), String> {
-    let first_arg = rustc_arguments
-        .get(0)
-        .ok_or_else(|| "Arguments vector should not be empty".to_string())?;
+    let first_arg =
+        rustc_arguments.get(0).ok_or_else(|| "Arguments vector should not be empty".to_string())?;
     if first_arg != &"".to_string() {
         return Err("The first argument must be an empty string".into());
     }

--- a/kythe/rust/extractor/tests/integration_test.rs
+++ b/kythe/rust/extractor/tests/integration_test.rs
@@ -20,8 +20,8 @@ use extra_actions_base_rust_proto::*;
 use protobuf::Message;
 use std::fs::File;
 use std::io::{BufReader, Write};
-use std::process::Command;
 use std::path::Path;
+use std::process::Command;
 use tempdir::TempDir;
 
 fn main() -> Result<()> {
@@ -85,12 +85,7 @@ fn main() -> Result<()> {
 
     missing_arguments_fail();
     bad_extra_action_path_fails();
-    correct_arguments_succeed(
-        &extra_action_path_str,
-        &temp_dir_str,
-        &output_key,
-        arguments,
-    );
+    correct_arguments_succeed(&extra_action_path_str, &temp_dir_str, &output_key, arguments);
 
     Ok(())
 }
@@ -99,15 +94,18 @@ fn missing_arguments_fail() {
     let extractor_path = std::env::var("EXTRACTOR_PATH").expect("Couldn't find extractor path");
     let mut output = Command::new(&extractor_path).arg("--output=/tmp/wherever").output().unwrap();
     assert_eq!(output.status.code().unwrap(), 1);
-    assert!(String::from_utf8_lossy(&output.stderr).starts_with("error: The following required arguments were not provided:"));
+    assert!(String::from_utf8_lossy(&output.stderr)
+        .starts_with("error: The following required arguments were not provided:"));
 
     output = Command::new(&extractor_path).arg("--extra_action=/tmp/wherever").output().unwrap();
     assert_eq!(output.status.code().unwrap(), 1);
-    assert!(String::from_utf8_lossy(&output.stderr).starts_with("error: The following required arguments were not provided:"));
+    assert!(String::from_utf8_lossy(&output.stderr)
+        .starts_with("error: The following required arguments were not provided:"));
 
     output = Command::new(&extractor_path).output().unwrap();
     assert_eq!(output.status.code().unwrap(), 1);
-    assert!(String::from_utf8_lossy(&output.stderr).starts_with("error: The following required arguments were not provided:"));
+    assert!(String::from_utf8_lossy(&output.stderr)
+        .starts_with("error: The following required arguments were not provided:"));
 }
 
 fn bad_extra_action_path_fails() {
@@ -154,10 +152,7 @@ fn correct_arguments_succeed(
             cu_path_str = file.name().to_string();
         }
     }
-    assert_ne!(
-        cu_path_str, "",
-        "IndexedCompilation protobuf missing from kzip"
-    );
+    assert_ne!(cu_path_str, "", "IndexedCompilation protobuf missing from kzip");
 
     // Read it into an IndexedCompilation
     let cu_file = kzip.by_name(&cu_path_str).unwrap();
@@ -176,41 +171,24 @@ fn correct_arguments_succeed(
     );
 
     let output_key = compilation_unit.get_output_key();
-    assert_eq!(
-        output_key, expected_output_key,
-        "output_key field doesn't match"
-    );
+    assert_eq!(output_key, expected_output_key, "output_key field doesn't match");
 
     let unit_vname = compilation_unit.get_v_name();
-    assert_eq!(
-        unit_vname.get_language(),
-        "rust",
-        "VName language field doesn't match"
-    );
+    assert_eq!(unit_vname.get_language(), "rust", "VName language field doesn't match");
 
     let arguments = compilation_unit.get_argument();
-    assert_eq!(
-        arguments, expected_arguments,
-        "Argument field doesn't match"
-    );
+    assert_eq!(arguments, expected_arguments, "Argument field doesn't match");
 
     let required_inputs = compilation_unit.get_required_input().to_vec();
-    let source_input = required_inputs
-        .get(0)
-        .expect("Failed to get first required input");
+    let source_input = required_inputs.get(0).expect("Failed to get first required input");
     assert_eq!(source_input.get_v_name().get_corpus(), "test_corpus");
-    assert_eq!(
-        source_input.get_info().get_path(),
-        "kythe/rust/extractor/main.rs"
-    );
+    assert_eq!(source_input.get_info().get_path(), "kythe/rust/extractor/main.rs");
     assert_eq!(
         source_input.get_info().get_digest(),
         "7cb3b3c74ecdf86f434548ba15c1651c92bf03b6690fd0dfc053ab09d094cf03"
     );
 
-    let analysis_input = required_inputs
-        .get(1)
-        .expect("Failed to get second required input");
+    let analysis_input = required_inputs.get(1).expect("Failed to get second required input");
     assert_eq!(analysis_input.get_v_name().get_corpus(), "test_corpus");
     let analysis_path = analysis_input.get_info().get_path();
     assert!(

--- a/kythe/rust/extractor/tests/test.rs
+++ b/kythe/rust/extractor/tests/test.rs
@@ -25,10 +25,7 @@ fn empty_args_fails() {
     let temp_dir = TempDir::new("extractor_test").expect("Could not create temporary directory");
     let analysis_directory = PathBuf::new().join(temp_dir.path());
     let result = generate_analysis(args, analysis_directory);
-    assert_eq!(
-        result.unwrap_err(),
-        "Arguments vector should not be empty".to_string()
-    );
+    assert_eq!(result.unwrap_err(), "Arguments vector should not be empty".to_string());
 }
 
 #[test]
@@ -37,10 +34,7 @@ fn nonempty_string_first_fails() {
     let temp_dir = TempDir::new("extractor_test").expect("Could not create temporary directory");
     let analysis_directory = PathBuf::new().join(temp_dir.path());
     let result = generate_analysis(args, analysis_directory);
-    assert_eq!(
-        result.unwrap_err(),
-        "The first argument must be an empty string".to_string()
-    );
+    assert_eq!(result.unwrap_err(), "The first argument must be an empty string".to_string());
 }
 
 #[test]

--- a/kythe/rust/fuchsia_extractor/src/kzip.rs
+++ b/kythe/rust/fuchsia_extractor/src/kzip.rs
@@ -65,15 +65,9 @@ impl Writer {
             )
         };
         if status != 0 {
-            return Err(anyhow::anyhow!(
-                "could not create KzipWriter: code: {}",
-                status
-            ));
+            return Err(anyhow::anyhow!("could not create KzipWriter: code: {}", status));
         }
-        Ok(Writer {
-            rep: std::ptr::NonNull::new(raw).expect("non-null in try_new"),
-            closed: false,
-        })
+        Ok(Writer { rep: std::ptr::NonNull::new(raw).expect("non-null in try_new"), closed: false })
     }
 
     /// Closes the writer and flushes its buffers.i
@@ -126,9 +120,8 @@ impl Writer {
         const CAPACITY: usize = 200;
         let mut buf: Vec<u8> = vec![0; CAPACITY];
         let mut resulting_buffer_size: sys::size_t = 0;
-        let content = unit
-            .write_to_bytes()
-            .with_context(|| "kzip::write_unit: while writing protobuf")?;
+        let content =
+            unit.write_to_bytes().with_context(|| "kzip::write_unit: while writing protobuf")?;
         let status = unsafe {
             sys::KzipWriter_WriteUnit(
                 self.rep.as_ptr(),
@@ -162,25 +155,13 @@ mod tests {
         let output_file = temp_dir.path().join("out.kzip");
         let content = "content";
         let unit = analysis::IndexedCompilation::new();
-        assert!(
-            !Path::exists(&output_file),
-            "file exists but should not: {:?}",
-            &output_file
-        );
+        assert!(!Path::exists(&output_file), "file exists but should not: {:?}", &output_file);
         {
             let mut writer =
                 Writer::try_new(&output_file, Encoding::Proto).expect("created writer");
-            writer
-                .write_file(content.as_bytes())
-                .expect("wrote file with success");
-            writer
-                .write_unit(&unit)
-                .expect("wrote compilation unit with success");
+            writer.write_file(content.as_bytes()).expect("wrote file with success");
+            writer.write_unit(&unit).expect("wrote compilation unit with success");
         }
-        assert!(
-            Path::exists(&output_file),
-            "file does not exist but should: {:?}",
-            &output_file
-        );
+        assert!(Path::exists(&output_file), "file does not exist but should: {:?}", &output_file);
     }
 }

--- a/kythe/rust/indexer/src/bin/bazel/main.rs
+++ b/kythe/rust/indexer/src/bin/bazel/main.rs
@@ -88,7 +88,8 @@ pub fn extract_analysis_from_kzip(
                 })?;
 
                 let output_path = temp_path.join(input_path_buf.file_name().unwrap());
-                let mut output_file = File::create(&output_path).context("Failed to create file")?;
+                let mut output_file =
+                    File::create(&output_path).context("Failed to create file")?;
                 output_file.write_all(&file_contents).with_context(|| {
                     format!(
                         "Failed to copy contents of \"{}\" with digest \"{}\" to \"{}\"",

--- a/kythe/rust/indexer/src/bin/proxy/main.rs
+++ b/kythe/rust/indexer/src/bin/proxy/main.rs
@@ -13,10 +13,7 @@
 // limitations under the License.
 extern crate kythe_rust_indexer;
 use kythe_rust_indexer::{
-    error::KytheError,
-    indexer::KytheIndexer,
-    providers::*,
-    writer::ProxyWriter
+    error::KytheError, indexer::KytheIndexer, providers::*, writer::ProxyWriter,
 };
 
 use analysis_rust_proto::*;
@@ -38,7 +35,8 @@ fn main() -> Result<()> {
     loop {
         let unit = request_compilation_unit()?;
         // Retrieve the save_analysis file
-        let temp_dir = TempDir::new("rust_indexer").context("Couldn't create temporary directory")?;
+        let temp_dir =
+            TempDir::new("rust_indexer").context("Couldn't create temporary directory")?;
         let temp_path = PathBuf::new().join(temp_dir.path());
         let write_res = write_analysis_to_directory(&unit, &temp_path, &mut file_provider);
         if write_res.is_err() {
@@ -72,27 +70,24 @@ pub fn write_analysis_to_directory(
             if let Some("json") = os_str.to_str() {
                 let digest = required_input.get_info().get_digest();
                 let file_contents = provider.contents(&input_path, digest).map_err(|err| {
-                    KytheError::IndexerError(
-                        format!(
-                            "Failed to get contents of file \"{}\" with digest \"{}\": {:?}",
-                            input_path, digest, err
-                        )
-                    )
+                    KytheError::IndexerError(format!(
+                        "Failed to get contents of file \"{}\" with digest \"{}\": {:?}",
+                        input_path, digest, err
+                    ))
                 })?;
 
                 let output_path = temp_path.join(input_path_buf.file_name().unwrap());
-                let mut output_file = File::create(&output_path)
-                    .map_err(|err| KytheError::IndexerError(format!("Failed to create file: {:?}", err)))?;
+                let mut output_file = File::create(&output_path).map_err(|err| {
+                    KytheError::IndexerError(format!("Failed to create file: {:?}", err))
+                })?;
                 output_file.write_all(&file_contents).map_err(|err| {
-                    KytheError::IndexerError(
-                        format!(
-                            "Failed to copy contents of \"{}\" with digest \"{}\" to \"{}\": {:?}",
-                            input_path,
-                            digest,
-                            output_path.display(),
-                            err
-                        )
-                    )
+                    KytheError::IndexerError(format!(
+                        "Failed to copy contents of \"{}\" with digest \"{}\" to \"{}\": {:?}",
+                        input_path,
+                        digest,
+                        output_path.display(),
+                        err
+                    ))
                 })?;
             }
         }
@@ -106,17 +101,16 @@ fn request_compilation_unit() -> Result<CompilationUnit> {
 
     // Read the response from the proxy
     let mut response_string = String::new();
-    io::stdin()
-        .read_line(&mut response_string)
-        .context("Failed to read response from proxy")?;
+    io::stdin().read_line(&mut response_string).context("Failed to read response from proxy")?;
 
     // Convert to json and extract information
-    let response: Value = serde_json::from_str(&response_string)
-        .context("Failed to parse response as JSON")?;
+    let response: Value =
+        serde_json::from_str(&response_string).context("Failed to parse response as JSON")?;
     if response["rsp"].as_str().unwrap() == "ok" {
         let args = response["args"].clone();
         let unit_base64 = args["unit"].as_str().unwrap();
-        let unit_bytes = hex::decode(unit_base64).context("Failed to decode CompilationUnit sent by proxy")?;
+        let unit_bytes =
+            hex::decode(unit_base64).context("Failed to decode CompilationUnit sent by proxy")?;
         let unit = protobuf::parse_from_bytes::<CompilationUnit>(&unit_bytes)
             .context("Failed to parse protobuf")?;
         Ok(unit)
@@ -125,7 +119,8 @@ fn request_compilation_unit() -> Result<CompilationUnit> {
     }
 }
 
-/// Sends the "done" request to the proxy. The first argument sets the "ok" value, and the second sets the error message if the first argument is false.
+/// Sends the "done" request to the proxy. The first argument sets the "ok"
+/// value, and the second sets the error message if the first argument is false.
 fn send_done(ok: bool, msg: String) -> Result<()> {
     if ok {
         println!(r#"{{"req":"done", "args"{{"ok":"true","msg":""}}}}"#);
@@ -136,8 +131,6 @@ fn send_done(ok: bool, msg: String) -> Result<()> {
 
     // Grab the response, but we don't care what it is so just throw it away
     let mut response_string = String::new();
-    io::stdin()
-        .read_line(&mut response_string)
-        .context("Failed to read response from proxy")?;
+    io::stdin().read_line(&mut response_string).context("Failed to read response from proxy")?;
     Ok(())
 }

--- a/kythe/rust/indexer/src/indexer/analyzers.rs
+++ b/kythe/rust/indexer/src/indexer/analyzers.rs
@@ -110,7 +110,7 @@ impl<'a> UnitAnalyzer<'a> {
             file_vnames,
             file_digests,
             offset_index: OffsetIndex::default(),
-            provider
+            provider,
         }
     }
 
@@ -122,22 +122,22 @@ impl<'a> UnitAnalyzer<'a> {
             let vname = self.get_file_vname(source_file)?;
 
             // Create the file node fact
-            self.emitter
-                .emit_node(&vname, "/kythe/node/kind", b"file".to_vec())?;
+            self.emitter.emit_node(&vname, "/kythe/node/kind", b"file".to_vec())?;
 
             // Create language fact
-            self.emitter
-                .emit_node(&vname, "/kythe/language", b"rust".to_vec())?;
+            self.emitter.emit_node(&vname, "/kythe/language", b"rust".to_vec())?;
 
             // Read the file contents and set it on the fact
             // Returns a FileReadError if we can't read the file
             let file_contents: String;
             if let Some(file_digest) = self.file_digests.get(&source_file.to_string()) {
                 let file_bytes = self.provider.contents(&source_file, file_digest)?;
-                file_contents = String::from_utf8(file_bytes)
-                    .map_err(|_| KytheError::IndexerError(
-                        format!("Failed to read file {} as UTF8 string", source_file.to_string())
-                    ))?;
+                file_contents = String::from_utf8(file_bytes).map_err(|_| {
+                    KytheError::IndexerError(format!(
+                        "Failed to read file {} as UTF8 string",
+                        source_file.to_string()
+                    ))
+                })?;
             } else {
                 return Err(KytheError::FileNotFoundError(source_file.to_string()));
             }
@@ -146,8 +146,7 @@ impl<'a> UnitAnalyzer<'a> {
             self.offset_index.add_file(&source_file, &file_contents);
 
             // Create text fact
-            self.emitter
-                .emit_node(&vname, "/kythe/text", file_contents.into_bytes())?;
+            self.emitter.emit_node(&vname, "/kythe/text", file_contents.into_bytes())?;
         }
         Ok(())
     }
@@ -179,10 +178,7 @@ impl<'a> UnitAnalyzer<'a> {
             "Failed to find VName for file \"{}\" located in the save analysis. Is it included in the required inputs of the Compilation Unit?",
             file_name
         );
-        let vname = self
-            .file_vnames
-            .get(file_name)
-            .ok_or(KytheError::IndexerError(err_msg))?;
+        let vname = self.file_vnames.get(file_name).ok_or(KytheError::IndexerError(err_msg))?;
         Ok(vname.clone())
     }
 }
@@ -275,14 +271,11 @@ impl<'a, 'b> CrateAnalyzer<'a, 'b> {
 
         // First emit the node for our own crate and add it to the hashmap
         let krate_id = &krate_prelude.crate_id;
-        let krate_signature = format!(
-            "{}_{}_{}",
-            krate_id.disambiguator.0, krate_id.disambiguator.1, krate_id.name
-        );
+        let krate_signature =
+            format!("{}_{}_{}", krate_id.disambiguator.0, krate_id.disambiguator.1, krate_id.name);
         let krate_vname = self.generate_crate_vname(&krate_signature);
         self.krate_vname = krate_vname.clone();
-        self.emitter
-            .emit_node(&krate_vname, "/kythe/node/kind", b"package".to_vec())?;
+        self.emitter.emit_node(&krate_vname, "/kythe/node/kind", b"package".to_vec())?;
         self.krate_ids.insert(0u32, krate_id.clone());
 
         // Then, do the same for all of the external crates
@@ -293,10 +286,8 @@ impl<'a, 'b> CrateAnalyzer<'a, 'b> {
                 krate_id.disambiguator.0, krate_id.disambiguator.1, krate_id.name
             );
             let krate_vname = self.generate_crate_vname(&krate_signature);
-            self.emitter
-                .emit_node(&krate_vname, "/kythe/node/kind", b"package".to_vec())?;
-            self.krate_ids
-                .insert((krate_num + 1) as u32, krate_id.clone());
+            self.emitter.emit_node(&krate_vname, "/kythe/node/kind", b"package".to_vec())?;
+            self.krate_ids.insert((krate_num + 1) as u32, krate_id.clone());
         }
 
         Ok(())
@@ -305,8 +296,7 @@ impl<'a, 'b> CrateAnalyzer<'a, 'b> {
     /// Emits tbuiltin nodes for all of the Rust built-in types
     pub fn emit_tbuiltin_nodes(&mut self) -> Result<(), KytheError> {
         for vname in self.type_vnames.values() {
-            self.emitter
-                .emit_node(vname, "/kythe/node/kind", b"tbuiltin".to_vec())?;
+            self.emitter.emit_node(vname, "/kythe/node/kind", b"tbuiltin".to_vec())?;
         }
 
         Ok(())
@@ -349,18 +339,9 @@ impl<'a, 'b> CrateAnalyzer<'a, 'b> {
                     // The save_analysis file will have the krate and index be maxint if the
                     // implementation is not on a trait.
                     let max_int = 4294967295;
-                    let trait_target = if relation.to.krate != max_int {
-                        Some(relation.to)
-                    } else {
-                        None
-                    };
-                    method_index.insert(
-                        *child,
-                        MethodImpl {
-                            struct_target,
-                            trait_target,
-                        },
-                    );
+                    let trait_target =
+                        if relation.to.krate != max_int { Some(relation.to) } else { None };
+                    method_index.insert(*child, MethodImpl { struct_target, trait_target });
                 }
             }
         }
@@ -395,12 +376,7 @@ impl<'a, 'b> CrateAnalyzer<'a, 'b> {
         // If the file name is mod.rs, then the expected name is the directory name
         if Some(OsStr::new("mod.rs")) == file_path.file_name() {
             if let Some(parent_directory) = file_path.parent() {
-                expected_name = parent_directory
-                    .file_name()
-                    .unwrap()
-                    .to_str()
-                    .unwrap()
-                    .to_string();
+                expected_name = parent_directory.file_name().unwrap().to_str().unwrap().to_string();
             } else {
                 // This should only happen if there is something wrong with the file path we
                 // were provided in the CompilationUnit
@@ -464,8 +440,7 @@ impl<'a, 'b> CrateAnalyzer<'a, 'b> {
                     child_id
                 ))
             })?;
-            self.emitter
-                .emit_edge(&child_vname, parent_vname, "/kythe/edge/childof")?;
+            self.emitter.emit_edge(&child_vname, parent_vname, "/kythe/edge/childof")?;
         }
 
         Ok(())
@@ -489,8 +464,7 @@ impl<'a, 'b> CrateAnalyzer<'a, 'b> {
                 if let Some(child_vname) = self.definition_vnames.get(child) {
                     // The child definition has already been visited and we can emit the childof
                     // edge now
-                    self.emitter
-                        .emit_edge(child_vname, def_vname, "/kythe/edge/childof")?;
+                    self.emitter.emit_edge(child_vname, def_vname, "/kythe/edge/childof")?;
                 } else {
                     self.children_ids.insert(*child, def_vname.clone());
                 }
@@ -500,8 +474,7 @@ impl<'a, 'b> CrateAnalyzer<'a, 'b> {
         // Check if the current definition is a child of another node and remove the
         // entry if it existed
         if let Some(parent_vname) = self.children_ids.remove(&def.id) {
-            self.emitter
-                .emit_edge(def_vname, &parent_vname, "/kythe/edge/childof")?;
+            self.emitter.emit_edge(def_vname, &parent_vname, "/kythe/edge/childof")?;
         }
 
         // Store the definition's VName so it can be referenced by its id later
@@ -537,8 +510,7 @@ impl<'a, 'b> CrateAnalyzer<'a, 'b> {
                         ))
                     })?;
                     // Emit the childof edge between this node and the parent
-                    self.emitter
-                        .emit_edge(def_vname, parent_vname, "/kythe/edge/childof")?;
+                    self.emitter.emit_edge(def_vname, parent_vname, "/kythe/edge/childof")?;
                 }
             }
             DefKind::Function => {
@@ -608,8 +580,7 @@ impl<'a, 'b> CrateAnalyzer<'a, 'b> {
                         vname
                     };
                     // Emit a childof edge to the parent struct
-                    self.emitter
-                        .emit_edge(def_vname, &parent_vname, "/kythe/edge/childof")?;
+                    self.emitter.emit_edge(def_vname, &parent_vname, "/kythe/edge/childof")?;
                 }
             }
             DefKind::Mod => {
@@ -618,8 +589,7 @@ impl<'a, 'b> CrateAnalyzer<'a, 'b> {
                 facts.push(("/kythe/complete", b"definition"));
                 // Emit the childof edge on the crate if this is the main module
                 if def.qualname == "::" {
-                    self.emitter
-                        .emit_edge(def_vname, &self.krate_vname, "/kythe/edge/childof")?;
+                    self.emitter.emit_edge(def_vname, &self.krate_vname, "/kythe/edge/childof")?;
                 }
             }
             DefKind::Struct => {
@@ -656,8 +626,7 @@ impl<'a, 'b> CrateAnalyzer<'a, 'b> {
                 // If it aliases a builtin type, emit an aliases edge
                 // TODO: Make this work with custom types
                 if let Some(type_vname) = self.type_vnames.get(&def.value) {
-                    self.emitter
-                        .emit_edge(def_vname, type_vname, "/kythe/edge/aliases")?;
+                    self.emitter.emit_edge(def_vname, type_vname, "/kythe/edge/aliases")?;
                 }
             }
             DefKind::Union => {
@@ -671,18 +640,13 @@ impl<'a, 'b> CrateAnalyzer<'a, 'b> {
 
         // Emit nodes for all fact/value pairs
         for (fact_name, fact_value) in facts.iter() {
-            self.emitter
-                .emit_node(def_vname, fact_name, fact_value.to_vec())?;
+            self.emitter.emit_node(def_vname, fact_name, fact_value.to_vec())?;
         }
 
         // Calculate the byte_start and byte_end using the OffsetIndex
         let byte_start = self
             .offset_index
-            .get_byte_offset(
-                file_vname.get_path(),
-                def.span.line_start.0,
-                def.span.column_start.0,
-            )
+            .get_byte_offset(file_vname.get_path(), def.span.line_start.0, def.span.column_start.0)
             .ok_or_else(|| {
                 KytheError::IndexerError(format!(
                     "Failed to get starting offset for definition {:?}",
@@ -691,11 +655,7 @@ impl<'a, 'b> CrateAnalyzer<'a, 'b> {
             })?;
         let byte_end = self
             .offset_index
-            .get_byte_offset(
-                file_vname.get_path(),
-                def.span.line_end.0,
-                def.span.column_end.0,
-            )
+            .get_byte_offset(file_vname.get_path(), def.span.line_end.0, def.span.column_end.0)
             .ok_or_else(|| {
                 KytheError::IndexerError(format!(
                     "Failed to get ending offset for definition {:?}",
@@ -710,17 +670,12 @@ impl<'a, 'b> CrateAnalyzer<'a, 'b> {
         // Module definitions need special logic if they are implicit
         if def.kind == DefKind::Mod && self.is_module_implicit(def) {
             // Emit a 0-length anchor and defines edge at the top of the file
-            self.emitter
-                .emit_node(&anchor_vname, "/kythe/node/kind", b"anchor".to_vec())?;
-            self.emitter
-                .emit_node(&anchor_vname, "/kythe/loc/start", b"0".to_vec())?;
-            self.emitter
-                .emit_node(&anchor_vname, "/kythe/loc/end", b"0".to_vec())?;
-            self.emitter
-                .emit_edge(&anchor_vname, def_vname, "/kythe/edge/defines/implicit")?;
+            self.emitter.emit_node(&anchor_vname, "/kythe/node/kind", b"anchor".to_vec())?;
+            self.emitter.emit_node(&anchor_vname, "/kythe/loc/start", b"0".to_vec())?;
+            self.emitter.emit_node(&anchor_vname, "/kythe/loc/end", b"0".to_vec())?;
+            self.emitter.emit_edge(&anchor_vname, def_vname, "/kythe/edge/defines/implicit")?;
         } else {
-            self.emitter
-                .emit_anchor(&anchor_vname, def_vname, byte_start, byte_end)?;
+            self.emitter.emit_anchor(&anchor_vname, def_vname, byte_start, byte_end)?;
         }
 
         // If documentation isn't "" also generate a documents node
@@ -730,15 +685,13 @@ impl<'a, 'b> CrateAnalyzer<'a, 'b> {
             let mut doc_vname = def_vname.clone();
             let doc_signature = format!("{}_doc", def_vname.get_signature());
             doc_vname.set_signature(doc_signature);
-            self.emitter
-                .emit_node(&doc_vname, "/kythe/node/kind", b"doc".to_vec())?;
+            self.emitter.emit_node(&doc_vname, "/kythe/node/kind", b"doc".to_vec())?;
             self.emitter.emit_node(
                 &doc_vname,
                 "/kythe/text",
                 def.docs.trim().as_bytes().to_vec(),
             )?;
-            self.emitter
-                .emit_edge(&doc_vname, def_vname, "/kythe/edge/documents")?;
+            self.emitter.emit_edge(&doc_vname, def_vname, "/kythe/edge/documents")?;
         }
 
         Ok(())
@@ -787,10 +740,8 @@ impl<'a, 'b> CrateAnalyzer<'a, 'b> {
                 })?;
 
             // Create signature based on span
-            reference_vname.set_signature(format!(
-                "{}_ref_{}_{}",
-                krate_signature, start_byte, end_byte
-            ));
+            reference_vname
+                .set_signature(format!("{}_ref_{}_{}", krate_signature, start_byte, end_byte));
 
             // Create VName being referenced
             let krate_id = self.krate_ids.get(&reference.ref_id.krate).ok_or_else(|| {
@@ -804,14 +755,11 @@ impl<'a, 'b> CrateAnalyzer<'a, 'b> {
                 krate_id.disambiguator.0, krate_id.disambiguator.1, krate_id.name
             );
             let mut target_vname = template_vname.clone();
-            target_vname.set_signature(format!(
-                "{}_def_{}",
-                krate_signature, reference.ref_id.index
-            ));
+            target_vname
+                .set_signature(format!("{}_def_{}", krate_signature, reference.ref_id.index));
             target_vname.set_language("rust".to_string());
 
-            self.emitter
-                .emit_reference(&reference_vname, &target_vname, start_byte, end_byte)?;
+            self.emitter.emit_reference(&reference_vname, &target_vname, start_byte, end_byte)?;
         }
         Ok(())
     }

--- a/kythe/rust/indexer/src/indexer/entries.rs
+++ b/kythe/rust/indexer/src/indexer/entries.rs
@@ -83,11 +83,7 @@ impl<'a> EntryEmitter<'a> {
             "/kythe/loc/start",
             byte_start.to_string().into_bytes().to_vec(),
         )?;
-        self.emit_node(
-            anchor_vname,
-            "/kythe/loc/end",
-            byte_end.to_string().into_bytes().to_vec(),
-        )?;
+        self.emit_node(anchor_vname, "/kythe/loc/end", byte_end.to_string().into_bytes().to_vec())?;
         self.emit_edge(anchor_vname, target_vname, "/kythe/edge/defines/binding")
     }
 
@@ -109,11 +105,7 @@ impl<'a> EntryEmitter<'a> {
             "/kythe/loc/start",
             byte_start.to_string().into_bytes().to_vec(),
         )?;
-        self.emit_node(
-            anchor_vname,
-            "/kythe/loc/end",
-            byte_end.to_string().into_bytes().to_vec(),
-        )?;
+        self.emit_node(anchor_vname, "/kythe/loc/end", byte_end.to_string().into_bytes().to_vec())?;
         self.emit_edge(anchor_vname, target_vname, "/kythe/edge/ref")
     }
 }

--- a/kythe/rust/indexer/src/indexer/mod.rs
+++ b/kythe/rust/indexer/src/indexer/mod.rs
@@ -38,7 +38,12 @@ impl<'a> KytheIndexer<'a> {
 
     /// Accepts a CompilationUnit and the directory for analysis files and
     /// indexes the CompilationUnit
-    pub fn index_cu(&mut self, unit: &CompilationUnit, analysis_dir: &Path, provider: &mut dyn FileProvider) -> Result<(), KytheError> {
+    pub fn index_cu(
+        &mut self,
+        unit: &CompilationUnit,
+        analysis_dir: &Path,
+        provider: &mut dyn FileProvider,
+    ) -> Result<(), KytheError> {
         let mut generator = UnitAnalyzer::new(unit, self.writer, provider);
 
         // First, create file nodes for all of the source files in the CompilationUnit

--- a/kythe/rust/indexer/src/indexer/offset.rs
+++ b/kythe/rust/indexer/src/indexer/offset.rs
@@ -22,9 +22,7 @@ pub struct OffsetIndex {
 impl OffsetIndex {
     /// Initialize an empty OffsetIndex
     pub fn new() -> Self {
-        Self {
-            files: HashMap::new(),
-        }
+        Self { files: HashMap::new() }
     }
 
     /// Adds a new file using the provided string content
@@ -111,12 +109,7 @@ impl LineIndex {
         num_columns: u32,
         column_indices: Vec<u32>,
     ) -> Self {
-        Self {
-            all_single_byte,
-            offset,
-            num_columns,
-            column_indices,
-        }
+        Self { all_single_byte, offset, num_columns, column_indices }
     }
 
     /// Get the byte offset of the character on this line at the provided

--- a/kythe/rust/indexer/src/indexer/save_analysis.rs
+++ b/kythe/rust/indexer/src/indexer/save_analysis.rs
@@ -46,10 +46,7 @@ impl AnalysisLoader for Loader {
         None
     }
     fn search_directories(&self) -> Vec<SearchDirectory> {
-        vec![SearchDirectory {
-            path: self.deps_dir.clone(),
-            prefix_rewrite: None,
-        }]
+        vec![SearchDirectory { path: self.deps_dir.clone(), prefix_rewrite: None }]
     }
 }
 

--- a/kythe/rust/indexer/src/providers.rs
+++ b/kythe/rust/indexer/src/providers.rs
@@ -35,8 +35,8 @@ pub trait FileProvider {
 
     /// Retrieves the byte contents of a file.
     ///
-    /// This function takes a file path and digest, and returns the bytes contents of the
-    /// file in a vector.
+    /// This function takes a file path and digest, and returns the bytes
+    /// contents of the file in a vector.
     ///
     /// # Errors
     ///
@@ -84,10 +84,7 @@ impl KzipFileProvider {
             path.to_str().unwrap().to_owned().replace("/", "")
         };
 
-        Ok(Self {
-            zip_archive,
-            root_name,
-        })
+        Ok(Self { zip_archive, root_name })
     }
 
     /// Retrieve the Compilation Units from the kzip.
@@ -115,14 +112,15 @@ impl KzipFileProvider {
 }
 
 impl FileProvider for KzipFileProvider {
-    /// Given a file path and digest, returns whether the file exists in the kzip.
+    /// Given a file path and digest, returns whether the file exists in the
+    /// kzip.
     fn exists(&mut self, _path: &str, digest: &str) -> Result<bool, KytheError> {
         let name = format!("{}/files/{}", self.root_name, digest);
         Ok(self.zip_archive.by_name(&name).is_ok())
     }
 
-    /// Given a file path and digest, returns the vector of bytes of the file from the
-    /// kzip.
+    /// Given a file path and digest, returns the vector of bytes of the file
+    /// from the kzip.
     ///
     /// # Errors
     ///
@@ -130,10 +128,8 @@ impl FileProvider for KzipFileProvider {
     fn contents(&mut self, _path: &str, digest: &str) -> Result<Vec<u8>, KytheError> {
         // Ensure the file exists in the kzip
         let name = format!("{}/files/{}", self.root_name, digest);
-        let file = self
-            .zip_archive
-            .by_name(&name)
-            .map_err(|_| KytheError::FileNotFoundError(name))?;
+        let file =
+            self.zip_archive.by_name(&name).map_err(|_| KytheError::FileNotFoundError(name))?;
         let mut reader = BufReader::new(file);
         let mut file_contents: Vec<u8> = Vec::new();
         reader.read_to_end(&mut file_contents)?;
@@ -157,22 +153,31 @@ impl Default for ProxyFileProvider {
 }
 
 impl FileProvider for ProxyFileProvider {
-    /// Given a file path and digest, returns whether the proxy can find the file.
+    /// Given a file path and digest, returns whether the proxy can find the
+    /// file.
     fn exists(&mut self, path: &str, digest: &str) -> Result<bool, KytheError> {
         // Submit the file request to the proxy
         println!(r#"{{"req": "file","args":{{"path": "{}","digest": "{}"}}}}"#, path, digest);
-        io::stdout().flush()
-            .map_err(|err| KytheError::IndexerError(format!("Failed to flush stdout: {:?}", err)))?;
+        io::stdout().flush().map_err(|err| {
+            KytheError::IndexerError(format!("Failed to flush stdout: {:?}", err))
+        })?;
 
         // Read the response from the proxy
         let mut response_string = String::new();
-        io::stdin()
-            .read_line(&mut response_string)
-            .map_err(|err| KytheError::IndexerError(format!("Failed to read proxy file response from stdin: {:?}", err)))?;
+        io::stdin().read_line(&mut response_string).map_err(|err| {
+            KytheError::IndexerError(format!(
+                "Failed to read proxy file response from stdin: {:?}",
+                err
+            ))
+        })?;
 
         // Convert to json and extract information
-        let response: Value = serde_json::from_str(&response_string)
-            .map_err(|err| KytheError::IndexerError(format!("Failed to read proxy file response from stdin: {:?}", err)))?;
+        let response: Value = serde_json::from_str(&response_string).map_err(|err| {
+            KytheError::IndexerError(format!(
+                "Failed to read proxy file response from stdin: {:?}",
+                err
+            ))
+        })?;
         if response["rsp"].as_str().unwrap() == "error" {
             // The file couldn't be found
             Ok(false)
@@ -184,18 +189,26 @@ impl FileProvider for ProxyFileProvider {
     fn contents(&mut self, path: &str, digest: &str) -> Result<Vec<u8>, KytheError> {
         // Submit the file request to the proxy
         println!(r#"{{"req": "file","args":{{"path": "{}","digest": "{}"}}}}"#, path, digest);
-        io::stdout().flush()
-            .map_err(|err| KytheError::IndexerError(format!("Failed to flush stdout: {:?}", err)))?;
+        io::stdout().flush().map_err(|err| {
+            KytheError::IndexerError(format!("Failed to flush stdout: {:?}", err))
+        })?;
 
         // Read the response from the proxy
         let mut response_string = String::new();
-        io::stdin()
-            .read_line(&mut response_string)
-            .map_err(|err| KytheError::IndexerError(format!("Failed to read proxy file response from stdin: {:?}", err)))?;
+        io::stdin().read_line(&mut response_string).map_err(|err| {
+            KytheError::IndexerError(format!(
+                "Failed to read proxy file response from stdin: {:?}",
+                err
+            ))
+        })?;
 
         // Convert to json and extract information
-        let response: Value = serde_json::from_str(&response_string)
-            .map_err(|err| KytheError::IndexerError(format!("Failed to read proxy file response from stdin: {:?}", err)))?;
+        let response: Value = serde_json::from_str(&response_string).map_err(|err| {
+            KytheError::IndexerError(format!(
+                "Failed to read proxy file response from stdin: {:?}",
+                err
+            ))
+        })?;
         if response["rsp"].as_str().unwrap() == "error" {
             // The file couldn't be found
             Err(KytheError::FileNotFoundError(path.to_string()))
@@ -203,8 +216,12 @@ impl FileProvider for ProxyFileProvider {
             let args: Value = response["args"].clone();
             // Retrieve base64 content and convert to a Vec<u8>
             let content_base64: &str = args["content"].as_str().unwrap();
-            let content: Vec<u8> = hex::decode(&content_base64)
-                .map_err(|err| KytheError::IndexerError(format!("Failed to convert base64 file contents response to bytes: {:?}", err)))?;
+            let content: Vec<u8> = hex::decode(&content_base64).map_err(|err| {
+                KytheError::IndexerError(format!(
+                    "Failed to convert base64 file contents response to bytes: {:?}",
+                    err
+                ))
+            })?;
             Ok(content)
         }
     }

--- a/kythe/rust/indexer/src/writer.rs
+++ b/kythe/rust/indexer/src/writer.rs
@@ -51,9 +51,7 @@ impl<'a> CodedOutputStreamWriter<'a> {
     ///
     /// Takes a writer that implements the `Write` trait as the only argument.
     pub fn new(writer: &'a mut dyn Write) -> CodedOutputStreamWriter<'a> {
-        Self {
-            output_stream: CodedOutputStream::new(writer),
-        }
+        Self { output_stream: CodedOutputStream::new(writer) }
     }
 }
 
@@ -67,12 +65,8 @@ impl<'a> KytheWriter for CodedOutputStreamWriter<'a> {
     /// An error is returned if the write fails.
     fn write_entry(&mut self, entry: Entry) -> Result<(), KytheError> {
         let entry_size_bytes = entry.compute_size();
-        self.output_stream
-            .write_raw_varint32(entry_size_bytes)
-            .map_err(KytheError::WriterError)?;
-        entry
-            .write_to_with_cached_sizes(&mut self.output_stream)
-            .map_err(KytheError::WriterError)
+        self.output_stream.write_raw_varint32(entry_size_bytes).map_err(KytheError::WriterError)?;
+        entry.write_to_with_cached_sizes(&mut self.output_stream).map_err(KytheError::WriterError)
     }
 
     fn flush(&mut self) -> Result<(), KytheError> {
@@ -90,9 +84,7 @@ impl ProxyWriter {
     ///
     /// Takes a writer that implements the `Write` trait as the only argument.
     pub fn new() -> ProxyWriter {
-        Self {
-            buffer: Vec::new(),
-        }
+        Self { buffer: Vec::new() }
     }
 }
 
@@ -111,8 +103,8 @@ impl KytheWriter for ProxyWriter {
     /// An error is returned if the write fails.
     fn write_entry(&mut self, entry: Entry) -> Result<(), KytheError> {
         let bytes = entry.write_to_bytes().map_err(KytheError::WriterError)?;
-        // Convert the entry bytes to base64 and surround with quotes to prepare for inserting into a JSON
-        // array
+        // Convert the entry bytes to base64 and surround with quotes to prepare for
+        // inserting into a JSON array
         let b64 = format!(r#""{}""#, hex::encode(&bytes));
         self.buffer.push(b64);
         if self.buffer.len() >= 1000 {
@@ -128,22 +120,31 @@ impl KytheWriter for ProxyWriter {
 
         // Write the proxy command to output
         println!(r#"{{"req":"output_wire","args":[{}]}}"#, buffer_json_array);
-        io::stdout().flush()
-            .map_err(|err| KytheError::IndexerError(format!("Failed to flush stdout: {:?}", err)))?;
+        io::stdout().flush().map_err(|err| {
+            KytheError::IndexerError(format!("Failed to flush stdout: {:?}", err))
+        })?;
 
         // Read the response from the proxy
         let mut response_string = String::new();
-        io::stdin()
-            .read_line(&mut response_string)
-            .map_err(|err| KytheError::IndexerError(format!("Failed to read proxy file response from stdin: {:?}", err)))?;
+        io::stdin().read_line(&mut response_string).map_err(|err| {
+            KytheError::IndexerError(format!(
+                "Failed to read proxy file response from stdin: {:?}",
+                err
+            ))
+        })?;
 
         // Convert to json and extract information
-        let response: Value = serde_json::from_str(&response_string)
-            .map_err(|err| KytheError::IndexerError(format!("Failed to read proxy file response from stdin: {:?}", err)))?;
-        if response["rsp"].as_str().unwrap() == "error" {
-            Err(KytheError::IndexerError(
-                format!("Got error back from proxy after sending entries: {}", response["args"].as_str().unwrap())
+        let response: Value = serde_json::from_str(&response_string).map_err(|err| {
+            KytheError::IndexerError(format!(
+                "Failed to read proxy file response from stdin: {:?}",
+                err
             ))
+        })?;
+        if response["rsp"].as_str().unwrap() == "error" {
+            Err(KytheError::IndexerError(format!(
+                "Got error back from proxy after sending entries: {}",
+                response["args"].as_str().unwrap()
+            )))
         } else {
             Ok(())
         }

--- a/kythe/rust/indexer/tests/array_writer.rs
+++ b/kythe/rust/indexer/tests/array_writer.rs
@@ -26,9 +26,7 @@ pub struct ArrayWriter {
 impl ArrayWriter {
     /// Returns a new ArrayWriter
     pub fn new() -> Self {
-        Self {
-            entries: Vec::new(),
-        }
+        Self { entries: Vec::new() }
     }
 }
 

--- a/kythe/rust/indexer/tests/providers.rs
+++ b/kythe/rust/indexer/tests/providers.rs
@@ -44,20 +44,14 @@ fn test_kzip_provider() {
         kzip_provider.exists("/tmp/main.rs", file_hash).unwrap(),
         "File should exist in kzip but doesn't"
     );
-    assert!(
-        !kzip_provider.exists("invalid", "invalid").unwrap(),
-        "File shouldn't exist but does"
-    );
+    assert!(!kzip_provider.exists("invalid", "invalid").unwrap(), "File shouldn't exist but does");
 
     // Check the `contents` function
     let contents_result = kzip_provider.contents("/tmp/main.rs", file_hash);
     assert!(!contents_result.is_err());
     let contents_string =
         String::from_utf8(contents_result.unwrap()).expect("File contents was not valid UTF-8");
-    assert_eq!(
-        contents_string, "Test\n",
-        "File contents did not match expected contents"
-    );
+    assert_eq!(contents_string, "Test\n", "File contents did not match expected contents");
 
     let invalid_contents = kzip_provider.contents("invalid", "invalid");
     assert!(invalid_contents.is_err(), "Expected Err while reading contents for non-existent file, but received file contents: {:?}", invalid_contents.unwrap());

--- a/tools/rust/rustfmt.sh
+++ b/tools/rust/rustfmt.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-find kythe/rust/ tools/rust/ -name '*.rs' -not -wholename "*target/*" -not -wholename "*indexer/testdata/*" -print0 | while read -r -d $'\0' f
+find kythe/rust/ tools/rust/ -name '*.rs' -not -wholename "*target/*" -not -wholename "*rust/*/testdata/*" -print0 | while read -r -d $'\0' f
 do
     echo "Formatting $f";
     rustfmt --config-path "$(dirname "${BASH_SOURCE[0]}")" "$f";


### PR DESCRIPTION
Runs `tools/rust/rustfmt.sh` to format all the Rust files. A future PR will add formatting checks to the pre-submit.