### PR TITLE
fix(rust_extractor): change argument processing due to rules_rust change

### DIFF
--- a/kythe/extractors/BUILD
+++ b/kythe/extractors/BUILD
@@ -198,6 +198,7 @@ extractor_action(
     data = ["//external:vnames_config"],
     env = {
         "LD_LIBRARY_PATH": "external/rust_linux_x86_64/lib:external/rust_darwin_x86_64/lib",
+        "KYTHE_CORPUS": "kythe.io",
     },
     extractor = "@io_kythe//kythe/rust/extractor",
     mnemonics = [

--- a/kythe/extractors/BUILD
+++ b/kythe/extractors/BUILD
@@ -198,6 +198,7 @@ extractor_action(
     data = ["//external:vnames_config"],
     env = {
         "LD_LIBRARY_PATH": "external/rust_linux_x86_64/lib:external/rust_darwin_x86_64/lib",
+        # TODO(wcalandro): Remove this once the extractor has support for VName configuration
         "KYTHE_CORPUS": "kythe.io",
     },
     extractor = "@io_kythe//kythe/rust/extractor",

--- a/kythe/rust/extractor/src/bin/save_analysis.rs
+++ b/kythe/rust/extractor/src/bin/save_analysis.rs
@@ -38,10 +38,12 @@ fn generate_arguments(arguments: Vec<String>, output_dir: &Path) -> Result<Vec<S
         .position(|arg| arg == "--")
         .ok_or_else(|| anyhow!("Could not find the start of the rustc arguments"))?;
 
-    // Keep the "--" argument and replace it with an empty string because
+    // The rust compiler executable path is the argument directly after "--"
+    // We keep the path argument and  replace it with an empty string because
     // `kythe_rust_extractor::generate_analysis` requires the first argument in
     // `arguments` to be an empty string
-    let mut rustc_arguments = arguments.split_at(argument_position).1.to_vec();
+    let mut rustc_arguments = arguments.split_at(argument_position + 1).1.to_vec();
+
     rustc_arguments[0] = String::from("");
 
     // Change the original compiler output to the temporary directory

--- a/kythe/rust/extractor/tests/integration_test.rs
+++ b/kythe/rust/extractor/tests/integration_test.rs
@@ -43,6 +43,7 @@ fn main() -> Result<()> {
     let sysroot = std::env::var("SYSROOT").expect("SYSROOT variable missing");
     let arguments: Vec<String> = vec![
         "--".to_string(),
+        "rustc".to_string(),
         rust_test_source.clone(),
         format!("-L{}", sysroot),
         "--crate-name=test_crate".to_string(),

--- a/tools/rust/extra_action/src/main.rs
+++ b/tools/rust/extra_action/src/main.rs
@@ -84,6 +84,7 @@ fn main() -> Result<()> {
     };
     let arguments: Vec<String> = vec![
         "--".to_string(),
+        "rustc".to_string(),
         // Only the main source file gets passed to the compiler
         main_source_file.to_string(),
         format!("-L{}", matches.value_of("sysroot").unwrap()),


### PR DESCRIPTION
Fixes a bug in the Rust extractor caused by changes in the arguments passed to the rules_rust `process_wrapper` binary