### PR TITLE
proto: update generator script to support Python3

### DIFF
--- a/kythe/proto/generate_protobufs.py
+++ b/kythe/proto/generate_protobufs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 #
 # Copyright 2016 The Kythe Authors. All rights reserved.
 #
@@ -36,14 +36,17 @@ import shutil
 import stat
 import sys
 
+def string_output(args):
+    return check_output(args).decode('utf-8')
+
 # Find the locations of the workspace root and the generated files directory.
-workspace = check_output(['bazel', 'info', 'workspace']).strip()
-bazel_bin = check_output(['bazel', 'info', 'bazel-bin']).strip()
+workspace = string_output(['bazel', 'info', 'workspace']).strip()
+bazel_bin = string_output(['bazel', 'info', 'bazel-bin']).strip()
 targets = '//kythe/...'
 import_base = 'kythe.io'
 
 def do_lang(lang, ext):
-    protos = check_output([
+    protos = string_output([
         'bazel',
         'query',
         'kind("%s_proto_library", %s)' % (lang, targets),


### PR DESCRIPTION
Convert Bazel output to a string rather than bytes, so that string operations
in Python 3 will work correctly. This change assumes the output is UTF-8, which
should be safe in the Kythe repository.