### PR TITLE
fix(rust_indexer): allow extractor target to be set manually

### DIFF
--- a/tools/build_rules/verifier_test/rust_indexer_test.bzl
+++ b/tools/build_rules/verifier_test/rust_indexer_test.bzl
@@ -176,11 +176,13 @@ def _rust_indexer(
         has_marked_source = False,
         emit_anchor_scopes = False,
         allow_duplicates = False,
-        metadata_suffix = ""):
+        metadata_suffix = "",
+        extractor = None):
     kzip = name + "_units"
     rust_extract(
         name = kzip,
         srcs = srcs,
+        extractor = extractor,
     )
     entries = name + "_entries"
     rust_entries(
@@ -199,10 +201,12 @@ def rust_indexer_test(
         log_entries = False,
         has_marked_source = False,
         emit_anchor_scopes = False,
-        allow_duplicates = False):
+        allow_duplicates = False,
+        extractor = None):
     # Generate entries using the Rust indexer
     entries = _rust_indexer(
         name = name,
+        extractor = extractor,
         srcs = srcs,
         has_marked_source = has_marked_source,
         emit_anchor_scopes = emit_anchor_scopes,

--- a/tools/build_rules/verifier_test/rust_indexer_test.bzl
+++ b/tools/build_rules/verifier_test/rust_indexer_test.bzl
@@ -57,7 +57,7 @@ def _rust_extract_impl(ctx):
     output = ctx.outputs.kzip
     ctx.actions.run(
         mnemonic = "RustExtract",
-        executable = ctx.executable._extractor,
+        executable = ctx.executable.extractor,
         arguments = [
             "--extra_action=%s" % extra_action_file.path,
             "--output=%s" % output.path,
@@ -88,8 +88,9 @@ rust_extract = rule(
         "crate_name": attr.string(
             default = "test_crate",
         ),
-        "_extractor": attr.label(
+        "extractor": attr.label(
             default = Label("//kythe/rust/extractor:extractor_script"),
+            allow_files = True,
             executable = True,
             cfg = "exec",
         ),


### PR DESCRIPTION
This allows the extractor target in the rust_indexer_test macro to be set manually