### PR TITLE
fix(rust_indexer): serialize proxy communication with serde_json

### DIFF
--- a/kythe/rust/indexer/BUILD
+++ b/kythe/rust/indexer/BUILD
@@ -18,6 +18,7 @@ rust_library(
         "//kythe/rust/cargo:quick_error",
         "//kythe/rust/cargo:rls_analysis",
         "//kythe/rust/cargo:rls_data",
+        "//kythe/rust/cargo:serde",
         "//kythe/rust/cargo:serde_json",
         "//kythe/rust/cargo:sha2",
         "//kythe/rust/cargo:zip",

--- a/kythe/rust/indexer/src/bin/proxy/main.rs
+++ b/kythe/rust/indexer/src/bin/proxy/main.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 extern crate kythe_rust_indexer;
 use kythe_rust_indexer::{
-    error::KytheError, indexer::KytheIndexer, providers::*, writer::ProxyWriter,
+    error::KytheError, indexer::KytheIndexer, providers::*, proxyrequests, writer::ProxyWriter,
 };
 
 use analysis_rust_proto::*;
@@ -152,11 +152,8 @@ fn request_compilation_unit() -> Result<CompilationUnit> {
 /// Sends the "done" request to the proxy. The first argument sets the "ok"
 /// value, and the second sets the error message if the first argument is false.
 fn send_done(ok: bool, msg: String) -> Result<()> {
-    if ok {
-        println!(r#"{{"req":"done", "args":{{"ok":true,"msg":""}}}}"#);
-    } else {
-        println!(r#"{{"req":"done", "args":{{"ok":false,"msg":"{}"}}}}"#, msg);
-    }
+    let request = proxyrequests::done(ok, msg)?;
+    println!("{}", request);
     io::stdout().flush().context("Failed to flush stdout")?;
 
     // Grab the response, but we don't care what it is so just throw it away

--- a/kythe/rust/indexer/src/error.rs
+++ b/kythe/rust/indexer/src/error.rs
@@ -41,6 +41,11 @@ quick_error! {
             from()
             display("Failed to parse Protobuf: {}", err)
         }
+        /// There was an issue serializing a type to JSON
+        JsonSerializationError(err: serde_json::Error) {
+            from()
+            display("JSON Serialization Error: {}", err)
+        }
         /// The KytheWriter encounters an error
         WriterError(err: ProtobufError) {
             display("Writer encountered an error: {}", err)

--- a/kythe/rust/indexer/src/lib.rs
+++ b/kythe/rust/indexer/src/lib.rs
@@ -18,4 +18,5 @@ extern crate quick_error;
 pub mod error;
 pub mod indexer;
 pub mod providers;
+pub mod proxyrequests;
 pub mod writer;

--- a/kythe/rust/indexer/src/providers.rs
+++ b/kythe/rust/indexer/src/providers.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::error::KytheError;
+use crate::proxyrequests;
 use analysis_rust_proto::*;
 use serde_json::Value;
 use std::fs::File;
@@ -157,7 +158,8 @@ impl FileProvider for ProxyFileProvider {
     /// file.
     fn exists(&mut self, path: &str, digest: &str) -> Result<bool, KytheError> {
         // Submit the file request to the proxy
-        println!(r#"{{"req": "file","args":{{"path": "{}","digest": "{}"}}}}"#, path, digest);
+        let request = proxyrequests::file(path.to_string(), digest.to_string())?;
+        println!("{}", request);
         io::stdout().flush().map_err(|err| {
             KytheError::IndexerError(format!("Failed to flush stdout: {:?}", err))
         })?;
@@ -188,7 +190,8 @@ impl FileProvider for ProxyFileProvider {
 
     fn contents(&mut self, path: &str, digest: &str) -> Result<Vec<u8>, KytheError> {
         // Submit the file request to the proxy
-        println!(r#"{{"req": "file","args":{{"path": "{}","digest": "{}"}}}}"#, path, digest);
+        let request = proxyrequests::file(path.to_string(), digest.to_string())?;
+        println!("{}", request);
         io::stdout().flush().map_err(|err| {
             KytheError::IndexerError(format!("Failed to flush stdout: {:?}", err))
         })?;

--- a/kythe/rust/indexer/src/proxyrequests.rs
+++ b/kythe/rust/indexer/src/proxyrequests.rs
@@ -1,0 +1,63 @@
+// Copyright 2021 The Kythe Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use serde::Serialize;
+use serde_json::Result;
+
+#[derive(Serialize, Debug)]
+struct ProxyFileRequestArgs {
+    path: String,
+    digest: String,
+}
+
+#[derive(Serialize, Debug)]
+struct ProxyFileRequest {
+    req: String,
+    args: ProxyFileRequestArgs,
+}
+
+#[derive(Serialize, Debug)]
+struct ProxyDoneRequestArgs {
+    ok: bool,
+    msg: String,
+}
+
+#[derive(Serialize, Debug)]
+struct ProxyDoneRequest {
+    req: String,
+    args: ProxyDoneRequestArgs,
+}
+
+#[derive(Serialize, Debug)]
+struct ProxyOutputRequest {
+    req: String,
+    args: Vec<String>,
+}
+
+pub fn file(path: String, digest: String) -> Result<String> {
+    let request =
+        ProxyFileRequest { req: String::from("file"), args: ProxyFileRequestArgs { path, digest } };
+    serde_json::to_string(&request)
+}
+
+pub fn done(ok: bool, msg: String) -> Result<String> {
+    let request =
+        ProxyDoneRequest { req: String::from("done"), args: ProxyDoneRequestArgs { ok, msg } };
+    serde_json::to_string(&request)
+}
+
+pub fn output(args: Vec<String>) -> Result<String> {
+    let request = ProxyOutputRequest { req: String::from("output_wire"), args };
+    serde_json::to_string(&request)
+}

--- a/kythe/rust/indexer/src/proxyrequests.rs
+++ b/kythe/rust/indexer/src/proxyrequests.rs
@@ -45,18 +45,22 @@ struct ProxyOutputRequest {
     args: Vec<String>,
 }
 
+/// Create a proxystub command for requesting file information
 pub fn file(path: String, digest: String) -> Result<String> {
     let request =
         ProxyFileRequest { req: String::from("file"), args: ProxyFileRequestArgs { path, digest } };
     serde_json::to_string(&request)
 }
 
+/// Create a proxystub command indicating we are done indexing a compilation
+/// unit
 pub fn done(ok: bool, msg: String) -> Result<String> {
     let request =
         ProxyDoneRequest { req: String::from("done"), args: ProxyDoneRequestArgs { ok, msg } };
     serde_json::to_string(&request)
 }
 
+/// Create a proxystub command outputting entries
 pub fn output(args: Vec<String>) -> Result<String> {
     let request = ProxyOutputRequest { req: String::from("output_wire"), args };
     serde_json::to_string(&request)

--- a/kythe/rust/indexer/src/writer.rs
+++ b/kythe/rust/indexer/src/writer.rs
@@ -104,7 +104,6 @@ impl KytheWriter for ProxyWriter {
     /// An error is returned if the write fails.
     fn write_entry(&mut self, entry: Entry) -> Result<(), KytheError> {
         let bytes = entry.write_to_bytes().map_err(KytheError::WriterError)?;
-        // Convert the entry bytes to base64
         self.buffer.push(base64::encode(&bytes));
         if self.buffer.len() >= 1000 {
             self.flush()?;

--- a/kythe/rust/indexer/src/writer.rs
+++ b/kythe/rust/indexer/src/writer.rs
@@ -104,8 +104,7 @@ impl KytheWriter for ProxyWriter {
     /// An error is returned if the write fails.
     fn write_entry(&mut self, entry: Entry) -> Result<(), KytheError> {
         let bytes = entry.write_to_bytes().map_err(KytheError::WriterError)?;
-        // Convert the entry bytes to base64 and surround with quotes to prepare for
-        // inserting into a JSON array
+        // Convert the entry bytes to base64
         self.buffer.push(base64::encode(&bytes));
         if self.buffer.len() >= 1000 {
             self.flush()?;

--- a/kythe/rust/indexer/src/writer.rs
+++ b/kythe/rust/indexer/src/writer.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::error::KytheError;
+use crate::proxyrequests;
 use protobuf::{self, CodedOutputStream, Message};
 use serde_json::Value;
 use std::io::{self, Write};
@@ -105,8 +106,7 @@ impl KytheWriter for ProxyWriter {
         let bytes = entry.write_to_bytes().map_err(KytheError::WriterError)?;
         // Convert the entry bytes to base64 and surround with quotes to prepare for
         // inserting into a JSON array
-        let b64 = format!(r#""{}""#, base64::encode(&bytes));
-        self.buffer.push(b64);
+        self.buffer.push(base64::encode(&bytes));
         if self.buffer.len() >= 1000 {
             self.flush()?;
         }
@@ -114,12 +114,10 @@ impl KytheWriter for ProxyWriter {
     }
 
     fn flush(&mut self) -> Result<(), KytheError> {
-        // Combine all of the entries
-        let buffer_json_array = self.buffer.join(", ");
-        self.buffer.clear();
-
         // Write the proxy command to output
-        println!(r#"{{"req":"output_wire","args":[{}]}}"#, buffer_json_array);
+        let request = proxyrequests::output(self.buffer.clone())?;
+        self.buffer.clear();
+        println!("{}", request);
         io::stdout().flush().map_err(|err| {
             KytheError::IndexerError(format!("Failed to flush stdout: {:?}", err))
         })?;


### PR DESCRIPTION
Previously we constructed the proxystub commands with format strings, which could lead to issues if there were stray quotation marks. With this PR we let serde_json handle the JSON serialization for us.