### PR TITLE
refactor(kcd): use Revision instead of string params

### DIFF
--- a/kythe/go/platform/kcd/kcd.go
+++ b/kythe/go/platform/kcd/kcd.go
@@ -74,8 +74,9 @@ type Writer interface {
 	WriteRevision(_ context.Context, rev Revision, replace bool) error
 
 	// WriteUnit records unit in the store at the given revision, and returns
-	// the digest of the stored unit.  It is an error if revision == "".
-	WriteUnit(_ context.Context, revision, corpus, formatKey string, unit Unit) (string, error)
+	// the digest of the stored unit.  It is an error if rev is invalid per
+	// WriteRevision.
+	WriteUnit(_ context.Context, rev Revision, formatKey string, unit Unit) (string, error)
 
 	// WriteFile fully reads r and records its content as a file in the store.
 	// Returns the digest of the stored file.

--- a/kythe/go/platform/kcd/locked/locked.go
+++ b/kythe/go/platform/kcd/locked/locked.go
@@ -98,13 +98,13 @@ func (db *locker) WriteRevision(ctx context.Context, rev kcd.Revision, replace b
 }
 
 // WriteUnit implements a method of kcd.Writer.
-func (db *locker) WriteUnit(ctx context.Context, revision, corpus, formatKey string, unit kcd.Unit) (string, error) {
+func (db *locker) WriteUnit(ctx context.Context, rev kcd.Revision, formatKey string, unit kcd.Unit) (string, error) {
 	if db.wr == nil {
 		return "", ErrNotSupported
 	}
 	db.μ.Lock()
 	defer db.μ.Unlock()
-	return db.wr.WriteUnit(ctx, revision, corpus, formatKey, unit)
+	return db.wr.WriteUnit(ctx, rev, formatKey, unit)
 }
 
 // WriteFile implements a method of kcd.Writer.

--- a/kythe/go/platform/kcd/memdb/memdb.go
+++ b/kythe/go/platform/kcd/memdb/memdb.go
@@ -179,7 +179,8 @@ func (db *DB) WriteRevision(_ context.Context, rev kcd.Revision, replace bool) e
 
 // WriteUnit implements a method of kcd.Writer.  On success, the returned
 // digest is the kcd.HexDigest of whatever unit.MarshalBinary returned.
-func (db *DB) WriteUnit(_ context.Context, revision, corpus, formatKey string, unit kcd.Unit) (string, error) {
+func (db *DB) WriteUnit(_ context.Context, rev kcd.Revision, formatKey string, unit kcd.Unit) (string, error) {
+	revision, corpus := rev.Revision, rev.Corpus
 	if revision == "" {
 		return "", errors.New("empty revision marker")
 	}

--- a/kythe/go/platform/kcd/testutil/testutil.go
+++ b/kythe/go/platform/kcd/testutil/testutil.go
@@ -206,7 +206,10 @@ func Run(t *testing.T, ctx context.Context, db kcd.ReadWriter) []error {
 			}},
 			OutputKey: "quux.a",
 		}}
-		digest, err := db.WriteUnit(ctx, Revision, Corpus, FormatKey, dummy)
+		digest, err := db.WriteUnit(ctx, kcd.Revision{
+			Revision: Revision,
+			Corpus:   Corpus,
+		}, FormatKey, dummy)
 		if err != nil {
 			fail("WriteUnit", err)
 			return


### PR DESCRIPTION
Replace error-prone pair of string params with named struct fields