### PR TITLE
fix(rust_indexer): fix path confusion in vname and offset lookups

### DIFF
--- a/kythe/rust/indexer/src/indexer/offset.rs
+++ b/kythe/rust/indexer/src/indexer/offset.rs
@@ -74,6 +74,7 @@ impl OffsetIndex {
                 None
             }
         } else {
+            eprintln!("File not found");
             None
         }
     }


### PR DESCRIPTION
Currently, the Rust indexer can run into errors if a file's VName path and FileInfo path are different. This is because some functions of the indexer, such as cached vname lookups, are done based on file name. This change uses the FileInfo path in all locations to do the lookup, because this path is relative to the build directory and will be unique for each file.