### PR TITLE
Add Rust extractor script to the Kythe release and docker build

### DIFF
--- a/kythe/release/BUILD
+++ b/kythe/release/BUILD
@@ -7,7 +7,6 @@ docker_build(
     data = [
         "kythe.sh",
         "maven_extractor.sh",
-        "rust_extractor.sh",
         "//kythe/cxx/indexer/cxx:indexer",
         "//kythe/go/indexer/cmd/go_indexer",
         "//kythe/go/platform/tools/dedup_stream",
@@ -38,6 +37,7 @@ genrule(
         ":bazel_jvm_extractor",
         ":bazel_proto_extractor",
         ":bazel_rust_extractor",
+        ":bazel_rust_extractor_script",
         ":javac_extractor",
         ":javac_wrapper",
         ":cc_proto_metadata_plugin",
@@ -88,6 +88,7 @@ genrule(
         "--cp $(location bazel_jvm_extractor) extractors/bazel_jvm_extractor.jar",
         "--cp $(location bazel_proto_extractor) extractors/bazel_proto_extractor",
         "--cp $(location bazel_rust_extractor) extractors/bazel_rust_extractor",
+        "--cp $(location bazel_rust_extractor_script) extractors/bazel_rust_extractor_script.sh",
         "--cp $(location javac_wrapper) extractors/javac-wrapper.sh",
         "--cp $(location fuchsia_rust_extractor) extractors/fuchsia_rust_extractor",
         "--cp $(location @maven//:org_apache_tomcat_tomcat_annotations_api) jsr250-api-1.0.jar",
@@ -257,6 +258,11 @@ filegroup(
 filegroup(
     name = "rust_indexer",
     srcs = ["//kythe/rust/indexer:bazel_indexer"],
+)
+
+filegroup(
+    name = "bazel_rust_extractor_script",
+    srcs = [":bazel_rust_extractor_script.sh"],
 )
 
 filegroup(

--- a/kythe/release/BUILD
+++ b/kythe/release/BUILD
@@ -7,6 +7,7 @@ docker_build(
     data = [
         "kythe.sh",
         "maven_extractor.sh",
+        "rust_extractor.sh",
         "//kythe/cxx/indexer/cxx:indexer",
         "//kythe/go/indexer/cmd/go_indexer",
         "//kythe/go/platform/tools/dedup_stream",

--- a/kythe/release/bazel_rust_extractor_script.sh
+++ b/kythe/release/bazel_rust_extractor_script.sh
@@ -13,12 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# The base bazel directory name is based of the workspace name
-DIRNAME="$(dirname)"
-WORKSPACE_NAME="$(basename "$DIRNAME")"
-
 # Add the Rust compiler shared library path
-LIBRARY_DIR="bazel-$WORKSPACE_NAME/rust_linux_x86_64/lib/rustlib/x86_64-unknown-linux-gnu/lib"
+LIBRARY_DIR="external/rust_linux_x86_64/lib/rustlib/x86_64-unknown-linux-gnu/lib"
 export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$LIBRARY_DIR"
 
-exec "extractors/bazel_rust_extractor" "$@"
+exec external/kythe_release/extractors/bazel_rust_extractor "$@"

--- a/kythe/release/release.BUILD
+++ b/kythe/release/release.BUILD
@@ -154,6 +154,11 @@ filegroup(
     srcs = ["extractors/bazel_rust_extractor"],
 )
 
+filegroup(
+    name = "bazel_rust_extractor_script",
+    srcs = ["rust_extractor.sh"],
+)
+
 extractor_action(
     name = "extract_kzip_cxx",
     args = [
@@ -249,7 +254,7 @@ extractor_action(
         "--vnames_config=$(location :vnames_config)",
     ],
     data = [":vnames_config"],
-    extractor = ":bazel_rust_extractor",
+    extractor = ":bazel_rust_extractor_script",
     mnemonics = [
         "Rustc",
     ],

--- a/kythe/release/release.BUILD
+++ b/kythe/release/release.BUILD
@@ -156,7 +156,7 @@ filegroup(
 
 filegroup(
     name = "bazel_rust_extractor_script",
-    srcs = ["rust_extractor.sh"],
+    srcs = ["extractors/bazel_rust_extractor_script.sh"],
 )
 
 extractor_action(
@@ -253,7 +253,11 @@ extractor_action(
         "--output=$(output $(ACTION_ID).rust.kzip)",
         "--vnames_config=$(location :vnames_config)",
     ],
-    data = [":vnames_config"],
+    data = [
+        ":bazel_rust_extractor",
+        ":vnames_config",
+        "@rust_linux_x86_64//:rustc_lib",
+    ],
     extractor = ":bazel_rust_extractor_script",
     mnemonics = [
         "Rustc",

--- a/kythe/release/rust_extractor.sh
+++ b/kythe/release/rust_extractor.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Copyright 2021 The Kythe Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The base bazel directory name is based of the workspace name
+DIRNAME="$(dirname)"
+WORKSPACE_NAME="$(basename "$DIRNAME")"
+
+# Add the Rust compiler shared library path
+LIBRARY_DIR="bazel-$WORKSPACE_NAME/rust_linux_x86_64/lib/rustlib/x86_64-unknown-linux-gnu/lib"
+export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$LIBRARY_DIR"
+
+exec "extractors/bazel_rust_extractor" "$@"


### PR DESCRIPTION
Currently, running the Rust extractor extra action in the Docker image does not work because the shared libraries are not found. This change adds a new script to set up the shared libraries and launch the extractor.