### PR TITLE
feat(cxx_indexer): emit ref edges along with ref/writes edges

### DIFF
--- a/kythe/cxx/indexer/cxx/KytheGraphObserver.cc
+++ b/kythe/cxx/indexer/cxx/KytheGraphObserver.cc
@@ -1086,7 +1086,9 @@ void KytheGraphObserver::recordSemanticDeclUseLocation(
     const GraphObserver::Range& source_range, const NodeId& node, UseKind kind,
     Claimability claimability, Implicit i) {
   if (kind == GraphObserver::UseKind::kUnknown ||
-      kind == GraphObserver::UseKind::kReadWrite) {
+      kind == GraphObserver::UseKind::kReadWrite ||
+      kind == GraphObserver::UseKind::kWrite) {
+    // TODO(zarko): remove kWrite.
     auto out_kind =
         (i == GraphObserver::Implicit::Yes ? EdgeKindID::kRefImplicit
                                            : EdgeKindID::kRef);

--- a/kythe/cxx/indexer/cxx/testdata/df/df_unary.cc
+++ b/kythe/cxx/indexer/cxx/testdata/df/df_unary.cc
@@ -16,7 +16,7 @@ void f() {
     //- VarX influences VarX
     //- !{ @x ref/writes VarX }
     //- !{ @z ref/writes VarZ }
-    //- !{ @y ref VarY }
+    //- // !{ @y ref VarY } todo(zarko): transitional change.
     //- @z ref VarZ
     //- @x ref VarX
     //- @y ref/writes VarY


### PR DESCRIPTION
This is a transitional change that will be reverted once
downstream users have had sufficient notice to expect
ref/writes edges.