### PR TITLE
fix: adjust regex in simple_vnames.json

### DIFF
--- a/kythe/data/simple_vnames.json
+++ b/kythe/data/simple_vnames.json
@@ -40,7 +40,7 @@
     }
   },
   {
-    "pattern": "/(.*)",
+    "pattern": "^/(.*)",
     "vname": {
       "corpus": "CORPUS",
       "root": "/",


### PR DESCRIPTION
This change adjusts one of the regex patterns so that it works properly with Rust