### PR TITLE
chore: rustfmt pre-commit check should apply changes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -91,7 +91,7 @@ repos:
         description: Runs `rustfmt` on Rust files
         language: system
         entry: rustfmt
-        args: [--config-path, tools/rust/rustfmt.toml, --check]
+        args: [--config-path, tools/rust/rustfmt.toml]
         types: [rust]
         exclude: '^(kythe/proto/.*|third_party/.*)'
 exclude: '(.*/testdata/.*)|(third_party/.*)|(tools/platforms/configs/(versions.bzl|default_toolchain_config_spec_name/.*)$)'


### PR DESCRIPTION
In the GCB build we run pre-commit itself to print out any diffs from the applied checks and, similarly, pre-commit will fail if any of the checks change the local repository.  As such, we can just have it do the formatting directly and save a step.