### PR TITLE
feat(rust_common): upgrade to Rust 2021 edition

### DIFF
--- a/kythe/rust/examples/hello_world/BUILD
+++ b/kythe/rust/examples/hello_world/BUILD
@@ -3,6 +3,6 @@ load("@rules_rust//rust:defs.bzl", "rust_binary")
 rust_binary(
     name = "hello_world",
     srcs = ["src/main.rs"],
-    edition = "2018",
+    edition = "2021",
     deps = ["//kythe/rust/cargo:colored"],
 )

--- a/kythe/rust/extractor/BUILD
+++ b/kythe/rust/extractor/BUILD
@@ -10,7 +10,7 @@ rust_library(
         include = ["src/**/*.rs"],
         exclude = ["src/bin/**"],
     ),
-    edition = "2018",
+    edition = "2021",
     deps = [
         "//kythe/proto:analysis_rust_proto",
         "//kythe/rust/cargo:anyhow",
@@ -23,7 +23,7 @@ rust_library(
 rust_binary(
     name = "extractor",
     srcs = glob(["src/bin/**/*.rs"]),
-    edition = "2018",
+    edition = "2021",
     deps = [
         ":kythe_rust_extractor",
         "//kythe/proto:analysis_rust_proto",
@@ -62,7 +62,7 @@ rust_clippy(
 rust_binary(
     name = "extractor_test_binary",
     srcs = ["tests/test.rs"],
-    edition = "2018",
+    edition = "2021",
     rustc_flags = [
         "--test",
     ],
@@ -83,7 +83,7 @@ rust_binary(
     name = "extractor_integration_test_binary",
     srcs = ["tests/integration_test.rs"],
     data = ["//external:vnames_config"],
-    edition = "2018",
+    edition = "2021",
     deps = [
         "//kythe/proto:analysis_rust_proto",
         "//kythe/rust/cargo:anyhow",

--- a/kythe/rust/fuchsia_extractor/BUILD
+++ b/kythe/rust/fuchsia_extractor/BUILD
@@ -8,7 +8,7 @@ rust_library(
         include = ["src/**/*.rs"],
         exclude = ["src/bin/**/*.rs"],
     ),
-    edition = "2018",
+    edition = "2021",
     deps = [
         "//kythe/cxx/common:kzip_writer_c_api",
         "//kythe/proto:analysis_rust_proto",
@@ -21,7 +21,7 @@ rust_library(
 rust_test(
     name = "fuchsia_extractor_lib_test",
     crate = ":fuchsia_extractor_lib",
-    edition = "2018",
+    edition = "2021",
     # See https://github.com/bazelbuild/rules_rust/issues/118.  Without this,
     # rust binaries require their deps to be compiled with -fPIC, which is not
     # always the case. fastbuild and dbg use -fPIC, but opt does not; and rust
@@ -41,7 +41,7 @@ rust_test(
 rust_binary(
     name = "fuchsia_extractor",
     srcs = glob(["src/bin/**/*.rs"]),
-    edition = "2018",
+    edition = "2021",
     rustc_flags = select({
         ":if_opt": ["-Crelocation-model=static"],
         "//conditions:default": [],
@@ -70,7 +70,7 @@ rust_test(
         "//kythe/go/platform/tools/kzip",
         "//kythe/rust/fuchsia_extractor/testdata",
     ],
-    edition = "2018",
+    edition = "2021",
     # See https://github.com/bazelbuild/rules_rust/issues/118.  Without this,
     # rust binaries require their deps to be compiled with -fPIC, which is not
     # always the case. fastbuild and dbg use -fPIC, but opt does not; and rust

--- a/kythe/rust/indexer/BUILD
+++ b/kythe/rust/indexer/BUILD
@@ -9,7 +9,7 @@ rust_library(
         include = ["src/**/*.rs"],
         exclude = ["src/bin/**"],
     ),
-    edition = "2018",
+    edition = "2021",
     deps = [
         "//kythe/proto:analysis_rust_proto",
         "//kythe/proto:storage_rust_proto",
@@ -32,7 +32,7 @@ rust_binary(
         include = ["src/bin/bazel/*.rs"],
     ),
     crate_root = ":src/bin/bazel/main.rs",
-    edition = "2018",
+    edition = "2021",
     deps = [
         ":kythe_rust_indexer",
         "//kythe/proto:analysis_rust_proto",
@@ -49,7 +49,7 @@ rust_binary(
         include = ["src/bin/proxy/*.rs"],
     ),
     crate_root = ":src/bin/proxy/main.rs",
-    edition = "2018",
+    edition = "2021",
     deps = [
         ":kythe_rust_indexer",
         "//kythe/proto:analysis_rust_proto",

--- a/tools/rust/extra_action/BUILD
+++ b/tools/rust/extra_action/BUILD
@@ -5,7 +5,7 @@ package(default_visibility = ["//visibility:public"])
 rust_binary(
     name = "extra_action",
     srcs = glob(["src/**/*.rs"]),
-    edition = "2018",
+    edition = "2021",
     deps = [
         "//kythe/rust/cargo:anyhow",
         "//kythe/rust/cargo:clap",

--- a/tools/rust/runfiles/BUILD
+++ b/tools/rust/runfiles/BUILD
@@ -5,7 +5,7 @@ package(default_visibility = ["//visibility:public"])
 rust_library(
     name = "runfiles",
     srcs = ["lib.rs"],
-    edition = "2018",
+    edition = "2021",
 )
 
 rust_clippy(


### PR DESCRIPTION
Changes the Kythe Rust targets to build with edition 2021. This does not require any code updates, but will allow us to use new Rust features in the future.