### PR TITLE
feat(schema): add completedby and its implementation in C++

### DIFF
--- a/kythe/cxx/common/indexing/KytheGraphRecorder.cc
+++ b/kythe/cxx/common/indexing/KytheGraphRecorder.cc
@@ -86,7 +86,8 @@ static const std::string* kEdgeKindSpellings[] = {
     new std::string("/kythe/edge/ref/writes/implicit"),
     new std::string("/kythe/edge/influences"),
     new std::string("/kythe/edge/ref/file"),
-    new std::string("/kythe/edge/tparam")};
+    new std::string("/kythe/edge/tparam"),
+    new std::string("/kythe/edge/completedby")};
 
 bool of_spelling(absl::string_view str, EdgeKindID* edge_id) {
   size_t edge_index = 0;

--- a/kythe/cxx/common/indexing/KytheGraphRecorder.h
+++ b/kythe/cxx/common/indexing/KytheGraphRecorder.h
@@ -128,7 +128,8 @@ enum class EdgeKindID {
   kRefWritesImplicit,
   kInfluences,
   kRefFile,
-  kTParam
+  kTParam,
+  kCompletedby
 };
 
 /// \brief Returns the Kythe spelling of `node_kind_id`

--- a/kythe/cxx/indexer/cxx/KytheGraphObserver.cc
+++ b/kythe/cxx/indexer/cxx/KytheGraphObserver.cc
@@ -804,6 +804,8 @@ void KytheGraphObserver::recordCompletionRange(
                           ? EdgeKindID::kUniquelyCompletes
                           : EdgeKindID::kCompletes,
                       completing_node);
+  recorder_->AddEdge(VNameRefFromNodeId(node), EdgeKindID::kCompletedby,
+                     VNameRefFromNodeId(completing_node));
 }
 
 GraphObserver::NodeId KytheGraphObserver::nodeIdForNominalTypeNode(

--- a/kythe/docs/schema/schema.txt
+++ b/kythe/docs/schema/schema.txt
@@ -304,6 +304,37 @@ template <typename T> struct C {
 template struct C<int>;
 --------------------------------------------------------------------------------
 
+[[completedby]]
+completedby
+~~~~~~~~~~~
+
+Brief description::
+  Declaration A *completedby* definition B if B fully specifies A.
+  There may exist other definitions that may also fully specify A.
+Commonly arises from::
+  definitions of forward declarations
+Points from::
+  semantic nodes with `complete` facts set to `incomplete` or `complete`
+Points toward::
+  semantic nodes with `complete` facts set to `complete`
+See also::
+  <<record>>, <<sum>>
+
+[kythe,C++,"Declarations are completed by definitions."]
+--------------------------------------------------------------------------------
+#include "test.h"
+//- Decl1 completedby Defn
+//- Decl2 completedby Defn
+//- @C defines/binding Defn
+class C { };
+
+#example test.h
+//- @C defines/binding Decl1
+class C;
+//- @C defines/binding Decl2
+class C;
+--------------------------------------------------------------------------------
+
 [[completes]]
 completes
 ~~~~~~~~~
@@ -319,6 +350,9 @@ Points toward::
   semantic nodes with `complete` facts set to `incomplete` or `complete`
 See also::
   <<record>>, <<sum>>, <<completesuniquely,[completes/uniquely]>>
+
+WARNING: *completes* edges are deprecated.  Their structure should be replaced
+with the one documented for <<completedby>>.
 
 [kythe,C++,"Definitions complete forward declarations in headers."]
 --------------------------------------------------------------------------------
@@ -350,6 +384,9 @@ Points toward::
   semantic nodes with `complete` facts set to `incomplete` or `complete`
 See also::
   <<completes>>, <<record>>, <<sum>>
+
+WARNING: *completes/uniquely* edges are deprecated.  Their structure should be
+replaced with the one documented for <<completedby>>.
 
 [kythe,C++,"Definitions uniquely complete same-file forward declarations."]
 --------------------------------------------------------------------------------


### PR DESCRIPTION
We're deprecating completes and completes/uniquely in favor of
a simpler, completely semantic edge. This new edge also has the
advantage of reducing fanout.