### PR TITLE
fix: the mac build

### DIFF
--- a/external.bzl
+++ b/external.bzl
@@ -160,8 +160,8 @@ def _cc_dependencies():
         github_archive,
         name = "com_google_absl",
         repo_name = "abseil/abseil-cpp",
-        commit = "e9b9e38f67a008d66133535a72ada843bd66013f",
-        sha256 = "49c93740b3b09f73cd2f10da778ea4129d59733085393f458a4acd17774503fb",
+        commit = "ec0d76f1d012cc1a4b3b08dfafcfc5237f5ba2c9",
+        sha256 = "32a00f5834195d6656097c800a773e2fc766741e434d1eff092ed5578a21dd3a",
     )
 
     maybe(

--- a/setup.bzl
+++ b/setup.bzl
@@ -46,11 +46,11 @@ def kythe_rule_repositories():
     maybe(
         http_archive,
         name = "rules_cc",
-        sha256 = "29daf0159f0cf552fcff60b49d8bcd4f08f08506d2da6e41b07058ec50cfeaec",
-        strip_prefix = "rules_cc-b7fe9697c0c76ab2fd431a891dbb9a6a32ed7c3e",
+        sha256 = "ff7876d80cd3f6b8c7a064bd9aa42a78e02096544cca2b22a9cf390a4397a53e",
+        strip_prefix = "rules_cc-081771d4a0e9d7d3aa0eed2ef389fa4700dfb23e",
         urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_cc/archive/b7fe9697c0c76ab2fd431a891dbb9a6a32ed7c3e.tar.gz",
-            "https://github.com/bazelbuild/rules_cc/archive/b7fe9697c0c76ab2fd431a891dbb9a6a32ed7c3e.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_cc/archive/081771d4a0e9d7d3aa0eed2ef389fa4700dfb23e.tar.gz",
+            "https://github.com/bazelbuild/rules_cc/archive/081771d4a0e9d7d3aa0eed2ef389fa4700dfb23e.tar.gz",
         ],
     )
 
@@ -141,10 +141,9 @@ def kythe_rule_repositories():
     maybe(
         github_archive,
         repo_name = "llvm/llvm-project",
-        commit = "40d85f16c45e09c1e280bcb8e63342392036f1eb",
+        commit = "661a232e34845a89789c4d617b9c764eded002a1",
         name = "llvm-project-raw",
         build_file_content = "#empty",
-        sha256 = "938127d27b04c2fcff4814075771e2e434eb5e20a8b6935e0141454effaf6be7",
         patch_args = ["-p1"],
         patches = ["@io_kythe//third_party:llvm-bazel-glob.patch"],
     )


### PR DESCRIPTION
Macs are (mostly) case-insensitive. A change to LLVM resulted in
a file called CXXABI.h being visible in the system search path
ahead of the actual cxxabi.h. This caused certain Abseil libraries
to fail to build as they depend on the content of that header.

This PR pushes Abseil to head (why not?), LLVM to head (as they
fixed this problem upstream), and rules_cc to head (because the
LLVM fix requires a more recent version).

Addresses #5133