### PR TITLE
chore(cxx_indexer): fork (most) template/generic tests into abs/tvar

### DIFF
--- a/kythe/cxx/indexer/cxx/testdata/BUILD
+++ b/kythe/cxx/indexer/cxx/testdata/BUILD
@@ -2563,6 +2563,810 @@ test_suite(
 )
 
 cc_indexer_test(
+    name = "tvar_template_alias",
+    srcs = ["tvar_template/template_alias.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_decl_arg",
+    srcs = ["tvar_template/template_decl_arg.cc"],
+    experimental_use_abs_nodes = False,
+    ignore_dups = True,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_alias_naming",
+    srcs = ["tvar_template/template_alias_naming.cc"],
+    check_for_singletons = True,
+    experimental_alias_template_instantiations = True,
+    experimental_use_abs_nodes = False,
+    ignore_dups = True,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_type_alias_param",
+    srcs = ["tvar_template/template_type_alias_param.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_alias_implicit_instantiation",
+    srcs = ["tvar_template/template_alias_implicit_instantiation.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_alias_implicit_instantiation_decls",
+    srcs = ["tvar_template/template_alias_implicit_instantiation_decls.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_alias_multilevel_abs",
+    srcs = ["tvar_template/template_alias_multilevel_abs.cc"],
+    check_for_singletons = True,
+    experimental_alias_template_instantiations = True,
+    experimental_use_abs_nodes = False,
+    ignore_dups = True,
+    ignore_unimplemented = True,  # hash of SubstTemplateTemplateParm
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_arg_multiple_typename",
+    srcs = ["tvar_template/template_arg_multiple_typename.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_arg_typename",
+    srcs = ["tvar_template/template_arg_typename.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_blame_member",
+    srcs = ["tvar_template/template_blame_member.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_blame_spec",
+    srcs = ["tvar_template/template_blame_spec.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_blame_pspec_member",
+    srcs = ["tvar_template/template_blame_pspec_member.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_blame_spec_member",
+    srcs = ["tvar_template/template_blame_spec_member.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_class_template_ctor",
+    srcs = ["tvar_template/template_class_template_ctor.cc"],
+    experimental_use_abs_nodes = False,
+    ignore_dups = True,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_class_ctor_default_and_init",
+    srcs = ["tvar_template/template_class_ctor_default_and_init.cc"],
+    experimental_use_abs_nodes = False,
+    ignore_dups = True,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_class_defn",
+    srcs = ["tvar_template/template_class_defn.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_class_fn_spec",
+    srcs = ["tvar_template/template_class_fn_spec.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_class_inner",
+    srcs = ["tvar_template/template_class_inner.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_class_inst_explicit",
+    srcs = ["tvar_template/template_class_inst_explicit.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_class_inst_implicit",
+    srcs = ["tvar_template/template_class_inst_implicit.cc"],
+    experimental_use_abs_nodes = False,
+    # Type alias alias inside a class template gets the same documentation text.
+    # TODO(zarkoexperimental_use_abs_nodes = False, ): Should the two aliases be distinctly named?
+    ignore_dups = True,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_class_inst_implicit_dependent",
+    srcs = ["tvar_template/template_class_inst_implicit_dependent.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_class_inst_vs_spec",
+    srcs = ["tvar_template/template_class_inst_vs_spec.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_class_ref",
+    srcs = ["tvar_template/template_class_ref.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_class_ref_ps",
+    srcs = ["tvar_template/template_class_ref_ps.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_class_skip_implicit_on",
+    srcs = ["tvar_template/template_class_skip_implicit_on.cc"],
+    experimental_use_abs_nodes = False,
+    index_template_instantiations = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_depbase_field_ref",
+    srcs = ["tvar_template/template_depbase_field_ref.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_dependent_ctor",
+    srcs = ["tvar_template/template_dependent_ctor.cc"],
+    experimental_use_abs_nodes = False,
+    ignore_dups = True,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_dependent_ctor_small",
+    srcs = ["tvar_template/template_dependent_ctor_small.cc"],
+    experimental_use_abs_nodes = False,
+    ignore_dups = True,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_dependent_dtor",
+    srcs = ["tvar_template/template_dependent_dtor.cc"],
+    experimental_use_abs_nodes = False,
+    ignore_dups = True,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_dependent_dtor_qualified",
+    srcs = ["tvar_template/template_dependent_dtor_qualified.cc"],
+    experimental_use_abs_nodes = False,
+    ignore_dups = True,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template/template_dependent_name_ref",
+    srcs = ["tvar_template/template_dependent_name_ref.cc"],
+    experimental_use_abs_nodes = False,
+    ignore_dups = True,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_dependent_sized_array",
+    srcs = ["tvar_template/template_dependent_sized_array.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_depexpr_field_ref",
+    srcs = ["tvar_template/template_depexpr_field_ref.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_depname_field_ref",
+    srcs = ["tvar_template/template_depname_field_ref.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_depname_template_field_ref",
+    srcs = ["tvar_template/template_depname_template_field_ref.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_depname_class",
+    srcs = ["tvar_template/template_depname_class.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_depname_implicit",
+    srcs = ["tvar_template/template_depname_implicit.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_depname_inst_class",
+    srcs = ["tvar_template/template_depname_inst_class.cc"],
+    experimental_use_abs_nodes = False,
+    ignore_unimplemented = True,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_depname_path_graph",
+    srcs = ["tvar_template/template_depname_path_graph.cc"],
+    experimental_use_abs_nodes = False,
+    ignore_dups = True,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_drop_redundant_wraiths_off",
+    srcs = ["tvar_template/template_drop_redundant_wraiths.cc"],
+    experimental_drop_instantiation_independent_data = False,
+    experimental_use_abs_nodes = False,
+    ignore_dups = True,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_drop_redundant_wraiths_on",
+    srcs = ["tvar_template/template_drop_redundant_wraiths.cc"],
+    experimental_drop_instantiation_independent_data = True,
+    experimental_use_abs_nodes = False,
+    ignore_dups = True,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_drop_redundant_wraiths_off_expect_fail",
+    srcs = ["tvar_template/template_drop_redundant_wraiths_expect_fail.cc"],
+    experimental_drop_instantiation_independent_data = False,
+    experimental_use_abs_nodes = False,
+    ignore_dups = True,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_drop_redundant_wraiths_on_expect_fail",
+    srcs = ["tvar_template/template_drop_redundant_wraiths_expect_fail.cc"],
+    expect_fail_verify = True,
+    experimental_drop_instantiation_independent_data = True,
+    experimental_use_abs_nodes = False,
+    ignore_dups = True,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_exclude",
+    srcs = ["tvar_template/template_exclude.cc"],
+    check_for_singletons = True,
+    experimental_use_abs_nodes = False,
+    ignore_dups = True,
+    tags = ["tvar_template"],
+    template_instance_exclude_path_pattern = ".*exclude.*",
+    deps = [
+        "tvar_template/exclude_this_file.h",
+        "tvar_template/include_this_file.h",
+    ],
+)
+
+cc_indexer_test(
+    name = "tvar_template_field",
+    srcs = ["tvar_template/template_field.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_file_call",
+    srcs = ["tvar_template/template_file_call.cc"],
+    check_for_singletons = True,
+    convert_marked_source = True,
+    experimental_use_abs_nodes = False,
+    std = "c++17",
+    tags = [
+        "c++17",
+        "tvar_template",
+    ],
+)
+
+cc_indexer_test(
+    name = "tvar_template_fn_call",
+    srcs = ["tvar_template/template_fn_call.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_fn_decl",
+    srcs = ["tvar_template/template_fn_decl.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_fn_decl_defn",
+    srcs = ["tvar_template/template_fn_decl_defn.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_fn_defines",
+    srcs = ["tvar_template/template_fn_defines.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_fn_defn",
+    srcs = ["tvar_template/template_fn_defn.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_fn_dependent_spec_defn",
+    srcs = ["tvar_template/template_fn_dependent_spec_defn.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_fn_explicit_spec_completes",
+    srcs = ["tvar_template/template_fn_explicit_spec_completes.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_fn_explicit_spec_with_default_completes",
+    srcs = ["tvar_template/template_fn_explicit_spec_with_default_completes.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_fn_implicit_spec",
+    srcs = ["tvar_template/template_fn_implicit_spec.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_fn_inst_vs_spec",
+    srcs = ["tvar_template/template_fn_inst_vs_spec.cc"],
+    experimental_use_abs_nodes = False,
+    ignore_dups = True,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_fn_member_spec_defn",
+    srcs = ["tvar_template/template_fn_member_spec_defn.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_fn_multi_decl_def",
+    srcs = ["tvar_template/template_fn_multi_decl_def.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_fn_multiple_implicit_spec",
+    srcs = ["tvar_template/template_fn_multiple_implicit_spec.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_fn_overload",
+    srcs = ["tvar_template/template_fn_overload.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_fn_spec",
+    srcs = ["tvar_template/template_fn_spec.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_fn_spec_decl",
+    srcs = ["tvar_template/template_fn_spec_decl.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_fn_spec_defn_decl",
+    srcs = ["tvar_template/template_fn_spec_defn_decl.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_fn_spec_defn_defn_decl_decl",
+    srcs = ["tvar_template/template_fn_spec_defn_defn_decl_decl.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_fn_spec_overload",
+    srcs = ["tvar_template/template_fn_spec_overload.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_incomplete_array",
+    srcs = ["tvar_template/template_incomplete_array.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_instance_type_from_class",
+    srcs = ["tvar_template/template_instance_type_from_class.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_nested_name",
+    srcs = ["tvar_template/template_nested_name.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_multilevel_argument",
+    srcs = ["tvar_template/template_multilevel_argument.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_pack_fn_decl",
+    srcs = ["tvar_template/template_pack_fn_decl.cc"],
+    experimental_use_abs_nodes = False,
+    ignore_dups = True,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_pack_fn_mono_call",
+    srcs = ["tvar_template/template_pack_fn_mono_call.cc"],
+    experimental_use_abs_nodes = False,
+    ignore_dups = True,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_pack_fn_pack_call",
+    srcs = ["tvar_template/template_pack_fn_pack_call.cc"],
+    experimental_use_abs_nodes = False,
+    ignore_dups = True,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_pack_rec_pack_call",
+    srcs = ["tvar_template/template_pack_rec_pack_call.cc"],
+    experimental_use_abs_nodes = False,
+    ignore_dups = True,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_ps_completes",
+    srcs = ["tvar_template/template_ps_completes.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_ps_decl",
+    srcs = ["tvar_template/template_ps_decl.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_ps_defn",
+    srcs = ["tvar_template/template_ps_defn.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_ps_multiple_decl",
+    srcs = ["tvar_template/template_ps_multiple_decl.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_ps_twovar_decl",
+    srcs = ["tvar_template/template_ps_twovar_decl.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_rec_member_abs",
+    srcs = ["tvar_template/template_rec_member_abs.cc"],
+    experimental_alias_template_instantiations = True,
+    experimental_use_abs_nodes = False,
+    ignore_dups = True,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_rec_override",
+    srcs = ["tvar_template/template_rec_override.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_rec_override_root",
+    srcs = ["tvar_template/template_rec_override_root.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_rec_override_root_aliasing",
+    srcs = ["tvar_template/template_rec_override_root_aliasing.cc"],
+    check_for_singletons = True,
+    experimental_alias_template_instantiations = True,
+    experimental_use_abs_nodes = False,
+    ignore_dups = True,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_redundant_constituents_anchored",
+    srcs = ["tvar_template/template_redundant_constituents_anchored.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_static_member",
+    srcs = ["tvar_template/template_static_member.cc"],
+    experimental_use_abs_nodes = False,
+    ignore_dups = True,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_two_arg_spec",
+    srcs = ["tvar_template/template_two_arg_spec.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_ty_typename",
+    srcs = ["tvar_template/template_ty_typename.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_unresolved_ctor_expr",
+    srcs = ["tvar_template/template_unresolved_ctor_expr.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_var_decl",
+    srcs = ["tvar_template/template_var_decl.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_var_defn",
+    srcs = ["tvar_template/template_var_defn.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_var_defn_completes",
+    srcs = ["tvar_template/template_var_defn_completes.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_var_explicit_spec",
+    srcs = ["tvar_template/template_var_explicit_spec.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_var_implicit_spec",
+    srcs = ["tvar_template/template_var_implicit_spec.cc"],
+    experimental_use_abs_nodes = False,
+    ignore_dups = True,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_var_inst_total_spec",
+    srcs = ["tvar_template/template_var_inst_total_spec.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_var_ps",
+    srcs = ["tvar_template/template_var_ps.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_var_ps_completes",
+    srcs = ["tvar_template/template_var_ps_completes.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_var_ps_implicit_spec",
+    srcs = ["tvar_template/template_var_ps_implicit_spec.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_var_ref_ps",
+    srcs = ["tvar_template/template_var_ref_ps.cc"],
+    experimental_use_abs_nodes = False,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_var_constexpr",
+    srcs = ["tvar_template/template_var_constexpr.cc"],
+    experimental_use_abs_nodes = False,
+    ignore_dups = True,
+    std = "c++14",
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
+    name = "tvar_generic_lambda",
+    srcs = ["tvar_template/generic_lambda.cc"],
+    experimental_use_abs_nodes = False,
+    ignore_dups = True,
+    std = "c++14",
+    tags = ["tvar_template, c++14"],
+)
+
+cc_indexer_test(
+    name = "tvar_template_using_pack_expansion",
+    srcs = ["tvar_template/template_using_pack_expansion.cc"],
+    experimental_use_abs_nodes = False,
+    std = "c++17",
+    tags = [
+        "c++17",
+        "tvar_template",
+    ],
+)
+
+cc_indexer_test(
+    name = "tvar_template_auto_parameter",
+    srcs = ["tvar_template/template_auto_parameter.cc"],
+    experimental_use_abs_nodes = False,
+    std = "c++17",
+    tags = [
+        "c++17",
+        "tvar_template",
+    ],
+)
+
+cc_indexer_test(
+    name = "tvar_template_fold_expressions",
+    srcs = ["tvar_template/template_fold_expressions.cc"],
+    experimental_use_abs_nodes = False,
+    ignore_dups = True,
+    std = "c++17",
+    tags = [
+        "c++17",
+        "tvar_template",
+    ],
+)
+
+cc_indexer_test(
+    name = "tvar_template_class_ctor_deduction",
+    srcs = ["tvar_template/template_class_ctor_deduction.cc"],
+    experimental_use_abs_nodes = False,
+    ignore_dups = True,
+    ignore_unimplemented = True,
+    std = "c++17",
+    tags = [
+        "c++17",
+        "tvar_template",
+    ],
+)
+
+test_suite(
+    name = "indexer_tvar_template",
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
     name = "ms_absvar",
     srcs = ["marked_source/ms_absvar.cc"],
     convert_marked_source = True,
@@ -2994,6 +3798,116 @@ objc_indexer_test(
 objc_indexer_test(
     name = "generic_unbound",
     srcs = ["objc/generics/generic_unbound.m"],
+    ignore_dups = True,
+    tags = ["objc"],
+)
+
+objc_indexer_test(
+    name = "tvar_generic_bound",
+    srcs = ["objc/tvar_generics/generic_bound.m"],
+    experimental_use_abs_nodes = False,
+    ignore_dups = True,
+    tags = ["objc"],
+)
+
+objc_indexer_test(
+    name = "tvar_generic_contravariant_decl",
+    srcs = ["objc/tvar_generics/generic_contravariant_decl.m"],
+    experimental_use_abs_nodes = False,
+    tags = ["objc"],
+)
+
+objc_indexer_test(
+    name = "tvar_generic_contravariant_restricted_super_class",
+    srcs = ["objc/tvar_generics/generic_contravariant_restricted_super_class.m"],
+    experimental_use_abs_nodes = False,
+    ignore_dups = True,
+    tags = ["objc"],
+)
+
+objc_indexer_test(
+    name = "tvar_generic_covariant_decl",
+    srcs = ["objc/tvar_generics/generic_covariant_decl.m"],
+    experimental_use_abs_nodes = False,
+    tags = ["objc"],
+)
+
+objc_indexer_test(
+    name = "tvar_generic_covariant_restricted_super_class",
+    srcs = ["objc/tvar_generics/generic_covariant_restricted_super_class.m"],
+    experimental_use_abs_nodes = False,
+    ignore_dups = True,
+    tags = ["objc"],
+)
+
+objc_indexer_test(
+    name = "tvar_generic_inherited",
+    srcs = ["objc/tvar_generics/generic_inherited.m"],
+    experimental_use_abs_nodes = False,
+    ignore_dups = True,
+    tags = ["objc"],
+)
+
+objc_indexer_test(
+    name = "tvar_generic_invariant",
+    srcs = ["objc/tvar_generics/generic_invariant.m"],
+    experimental_use_abs_nodes = False,
+    ignore_dups = True,
+    tags = ["objc"],
+)
+
+objc_indexer_test(
+    name = "tvar_generic_instantiation",
+    srcs = ["objc/tvar_generics/generic_instantiation.m"],
+    experimental_use_abs_nodes = False,
+    ignore_dups = True,
+    tags = ["objc"],
+)
+
+objc_indexer_test(
+    name = "tvar_generic_method_call",
+    srcs = ["objc/tvar_generics/generic_method_call.m"],
+    experimental_use_abs_nodes = False,
+    ignore_dups = True,
+    tags = ["objc"],
+)
+
+objc_indexer_test(
+    name = "tvar_generic_method_type",
+    srcs = ["objc/tvar_generics/generic_method_type.m"],
+    experimental_use_abs_nodes = False,
+    ignore_dups = True,
+    tags = ["objc"],
+)
+
+objc_indexer_test(
+    name = "tvar_generic_nested",
+    srcs = ["objc/tvar_generics/generic_nested.m"],
+    experimental_use_abs_nodes = False,
+    ignore_dups = True,
+    tags = ["objc"],
+)
+
+objc_indexer_test(
+    name = "tvar_generic_restricted_protocol",
+    srcs = ["objc/tvar_generics/generic_restricted_protocol.m"],
+    experimental_use_abs_nodes = False,
+    ignore_dups = True,
+    tags = ["objc"],
+)
+
+objc_indexer_test(
+    name = "tvar_generic_two_args",
+    srcs = ["objc/tvar_generics/generic_two_args.m"],
+    experimental_use_abs_nodes = False,
+    ignore_dups = True,
+    tags = ["objc"],
+)
+
+objc_indexer_test(
+    name = "tvar_generic_unbound",
+    srcs = ["objc/tvar_generics/generic_unbound.m"],
+    experimental_use_abs_nodes = False,
     ignore_dups = True,
     tags = ["objc"],
 )

--- a/kythe/cxx/indexer/cxx/testdata/objc/tvar_generics/README
+++ b/kythe/cxx/indexer/cxx/testdata/objc/tvar_generics/README
@@ -1,0 +1,5 @@
+For a good write-up on generics in Objective C, read
+https://lists.gnu.org/archive/html/gnustep-dev/2015-07/msg00006.html.
+
+A possibly useful commit message about type arguments is here:
+http://lists.llvm.org/pipermail/cfe-commits/Week-of-Mon-20150706/132422.html

--- a/kythe/cxx/indexer/cxx/testdata/objc/tvar_generics/generic_bound.m
+++ b/kythe/cxx/indexer/cxx/testdata/objc/tvar_generics/generic_bound.m
@@ -1,0 +1,46 @@
+// Test lightweight bound generics used to define a class.
+
+//- @O1 defines/binding O1Decl
+@interface O1
+@end
+
+//- @O1 defines/binding O1Impl
+@implementation O1
+@end
+
+//- @O2 defines/binding O2Decl
+@interface O2
+@end
+
+//- @O2 defines/binding O2Impl
+@implementation O2
+@end
+
+// No source range defines BoxDecl since this is a generic type.
+//- @Type defines/binding TypeVar
+//- @Box defines/binding BoxAbs
+//- TypeVar.node/kind absvar
+//- BoxDecl childof BoxAbs
+//- BoxAbs.node/kind abs
+//- BoxAbs param.0 TypeVar
+//- TypeVar bounded/upper O2Ptr
+//- O2Ptr.node/kind tapp
+//- O2Ptr param.0 vname("ptr#builtin", _, _, _, _)
+//- O2Ptr param.1 O2Impl
+//- @O2 ref O2Impl
+@interface Box<Type:O2*> : O1
+-(int) doSomething:(Type)t;
+@end
+
+//- @Box completes/uniquely BoxAbs
+//- @Box defines/binding BoxImpl
+//- File.node/kind file
+@implementation Box
+-(int) doSomething:(id)t {
+  return 0;
+}
+@end
+
+int main(int argc, char **argv) {
+  return 0;
+}

--- a/kythe/cxx/indexer/cxx/testdata/objc/tvar_generics/generic_contravariant_decl.m
+++ b/kythe/cxx/indexer/cxx/testdata/objc/tvar_generics/generic_contravariant_decl.m
@@ -1,0 +1,24 @@
+// Test lightweight generics (contravariant) used to define a class. The
+// contravariant modifier is ignored and should have no impact on the indexer.
+
+// No source range defines BoxDecl since this is a generic type.
+//- @Type defines/binding TypeVar
+//- @Box defines/binding BoxAbs
+//- TypeVar.node/kind absvar
+//- TypeVar.variance contravariant
+//- BoxDecl childof BoxAbs
+//- BoxAbs.node/kind abs
+//- BoxAbs param.0 TypeVar
+@interface Box<__contravariant Type>
+-(int) doSomething:(Type)t;
+@end
+
+@implementation Box
+-(int) doSomething:(id)t {
+  return 0;
+}
+@end
+
+int main(int argc, char **argv) {
+  return 0;
+}

--- a/kythe/cxx/indexer/cxx/testdata/objc/tvar_generics/generic_contravariant_restricted_super_class.m
+++ b/kythe/cxx/indexer/cxx/testdata/objc/tvar_generics/generic_contravariant_restricted_super_class.m
@@ -1,0 +1,67 @@
+// Test that we handle restricted type arguments correctly when that
+// restriction is based on a class.
+//
+// Also test that the contravariant type argument has the correct bounds.
+
+@interface O
+@end
+@implementation O
+@end
+
+//- @ObjParent defines/binding ObjParentDecl
+@interface ObjParent
+@end
+
+//- @ObjParent defines/binding ObjParentImpl
+@implementation ObjParent
+@end
+
+//- @ObjChild defines/binding ObjChildDecl
+@interface ObjChild : ObjParent
+@end
+
+//- @ObjChild defines/binding ObjChildImpl
+@implementation ObjChild
+@end
+
+//- @ObjGrandChild defines/binding ObjGrandChildDecl
+@interface ObjGrandChild : ObjChild
+@end
+
+//- @ObjGrandChild defines/binding ObjGrandChildImpl
+@implementation ObjGrandChild
+@end
+
+// No source range defines BoxDecl since this is a generic type.
+//- @Type defines/binding TypeVar
+//- @Box defines/binding BoxAbs
+//- TypeVar.node/kind absvar
+//- BoxDecl childof BoxAbs
+//- BoxAbs.node/kind abs
+//- BoxAbs param.0 TypeVar
+//- TypeVar bounded/upper ObjParentDeclPtrType
+//- ObjParentDeclPtrType.node/kind tapp
+//- ObjParentDeclPtrType param.0 vname("ptr#builtin", _, _, _, _)
+//- ObjParentDeclPtrType param.1 ObjParentImpl
+//- @ObjParent ref ObjParentImpl
+@interface Box<__contravariant Type: ObjParent*> : O
+-(Type) compute;
+@end
+
+@implementation Box
+-(id) compute {
+  ObjChild *child = [[ObjChild alloc] init];
+  return child;
+}
+@end
+
+int main(int argc, char **argv) {
+  // ObjChild* is a subtype of ObjParent*.
+  Box<ObjChild *> *b1 = [[Box alloc] init];
+
+  // Box<ObjChild *> is a subtype of Box<ObjGrandChild *> because we declared
+  // the type argument to be contravariant.
+  Box<ObjGrandChild *> *b2 = b1;
+
+  return 0;
+}

--- a/kythe/cxx/indexer/cxx/testdata/objc/tvar_generics/generic_covariant_decl.m
+++ b/kythe/cxx/indexer/cxx/testdata/objc/tvar_generics/generic_covariant_decl.m
@@ -1,0 +1,24 @@
+// Test lightweight generics (covariant) used to define a class. The covariant
+// modifier is ignored and should have no impact on the indexer.
+
+// No source range defines BoxDecl since this is a generic type.
+//- @Type defines/binding TypeVar
+//- @Box defines/binding BoxAbs
+//- TypeVar.node/kind absvar
+//- TypeVar.variance covariant
+//- BoxDecl childof BoxAbs
+//- BoxAbs.node/kind abs
+//- BoxAbs param.0 TypeVar
+@interface Box<__covariant Type>
+-(int) addToList:(Type)item;
+@end
+
+@implementation Box
+-(int) addToList:(id)item {
+  return 1;
+}
+@end
+
+int main(int argc, char **argv) {
+  return 0;
+}

--- a/kythe/cxx/indexer/cxx/testdata/objc/tvar_generics/generic_covariant_restricted_super_class.m
+++ b/kythe/cxx/indexer/cxx/testdata/objc/tvar_generics/generic_covariant_restricted_super_class.m
@@ -1,0 +1,57 @@
+// Test that we handle restricted type arguments correctly when that
+// restriction is based on a class.
+//
+// Also test that the covariant type argument has the correct bounds.
+
+@interface O
+@end
+@implementation O
+@end
+
+@interface Test<TTT> : O
+@end
+@implementation Test
+@end
+
+//- @ObjParent defines/binding ObjParentDecl
+@interface ObjParent
+@end
+
+//- @ObjParent defines/binding ObjParentImpl
+@implementation ObjParent
+@end
+
+@interface ObjChild : ObjParent
+@end
+
+@implementation ObjChild
+@end
+
+// No source range defines BoxDecl since this is a generic type.
+//- @Type defines/binding TypeVar
+//- @Box defines/binding BoxAbs
+//- TypeVar.node/kind absvar
+//- BoxDecl childof BoxAbs
+//- BoxAbs.node/kind abs
+//- BoxAbs param.0 TypeVar
+//- TypeVar bounded/upper ObjParentDeclPtrType
+//- ObjParentDeclPtrType.node/kind tapp
+//- ObjParentDeclPtrType param.0 vname("ptr#builtin", _, _, _, _)
+//- ObjParentDeclPtrType param.1 ObjParentImpl
+//- @ObjParent ref ObjParentImpl
+@interface Box<__covariant Type: ObjParent*> : O
+-(int) addToList:(Type)item;
+@end
+
+@implementation Box
+-(int) addToList:(id)item {
+  return 1;
+}
+@end
+
+int main(int argc, char **argv) {
+  Box<ObjChild *> *b1 = [[Box alloc] init];
+  Box<ObjParent *> *b2 = b1;
+
+  return 0;
+}

--- a/kythe/cxx/indexer/cxx/testdata/objc/tvar_generics/generic_inherited.m
+++ b/kythe/cxx/indexer/cxx/testdata/objc/tvar_generics/generic_inherited.m
@@ -1,0 +1,67 @@
+// Test subclasses of generic types.
+
+//- @O1 defines/binding O1Decl
+@interface O1
+@end
+
+//- @O1 defines/binding O1Impl
+@implementation O1
+@end
+
+//- O1Ptr.node/kind tapp
+//- O1Ptr param.0 vname("ptr#builtin", _, _, _, _)
+//- O1Ptr param.1 O1Impl
+
+//- @O2 defines/binding O2Decl
+@interface O2
+@end
+
+//- @O2 defines/binding O2Impl
+@implementation O2
+@end
+
+// No source range defines BoxDecl since this is a generic type.
+//- @Type defines/binding TypeVar
+//- @Box defines/binding BoxAbs
+//- @O1 ref O1Impl
+//- TypeVar.node/kind absvar
+//- TypeVar bounded/upper O1Ptr
+//- BoxDecl childof BoxAbs
+//- BoxAbs.node/kind abs
+//- BoxAbs param.0 TypeVar
+//- BoxDecl extends O2Impl
+//- @O2 ref O2Impl
+//- @O2 ref O2Decl
+@interface Box<Type : O1*> : O2
+@end
+
+//- @Box defines/binding BoxImpl
+@implementation Box
+@end
+
+
+// No source range defines PackageDecl since this is a generic type.
+//- @Type defines/binding PTypeVar
+//- @Package defines/binding PackageAbs
+//- @O1 ref O1Impl
+//- PTypeVar.node/kind absvar
+//- PTypeVar bounded/upper O1Ptr
+//- PackageDecl childof PackageAbs
+//- PackageAbs.node/kind abs
+//- PackageAbs param.0 PTypeVar
+@interface Package<Type : O1*>
+//- @Type ref PTypeVar
+//- PackageDecl extends BoxType
+//- @Box ref BoxImpl
+//- BoxType.node/kind tapp
+//- BoxType param.0 BoxImpl
+//- BoxType param.1 PTypeVar
+: Box<Type>
+@end
+
+@implementation Package
+@end
+
+int main(int argc, char **argv) {
+  return 0;
+}

--- a/kythe/cxx/indexer/cxx/testdata/objc/tvar_generics/generic_instantiation.m
+++ b/kythe/cxx/indexer/cxx/testdata/objc/tvar_generics/generic_instantiation.m
@@ -1,0 +1,53 @@
+// Test instantiation of a lightweight generic class. The class decl should
+// reference the Abs node, but the class instantiation should just treat this
+// like a standard type application.
+
+@interface Obj
+@end
+
+@implementation Obj
+@end
+
+//- @O defines/binding ODecl
+@interface O
+@end
+
+//- @O defines/binding OImpl
+@implementation O
+@end
+
+// No source range defines BoxDecl since this is a generic type.
+//- @Type defines/binding TypeVar
+//- @Box defines/binding BoxAbs
+//- TypeVar.node/kind absvar
+//- BoxDecl childof BoxAbs
+//- BoxAbs.node/kind abs
+//- BoxAbs param.0 TypeVar
+@interface Box<Type> : Obj
+-(int) addToList:(Type)item;
+@end
+
+//- @Box defines/binding BoxImpl
+@implementation Box
+-(int) addToList:(id)item {
+  return 1;
+}
+@end
+
+int main(int argc, char **argv) {
+  //- @O ref OImpl
+  //- @box defines/binding BoxVar
+  //- BoxVar typed PtrBoxVarType
+  //- PtrBoxVarType.node/kind tapp
+  //- PtrBoxVarType param.0 vname("ptr#builtin", _, _, _, _)
+  //- PtrBoxVarType param.1 BoxVarType
+  //- BoxVarType.node/kind tapp
+  //- BoxVarType param.0 BoxImpl
+  //- BoxVarType param.1 PtrOType
+  //- PtrOType.node/kind tapp
+  //- PtrOType param.0 vname("ptr#builtin", _, _, _, _)
+  //- PtrOType param.1 OImpl
+  Box<O *> *box = [[Box alloc] init];
+
+  return 0;
+}

--- a/kythe/cxx/indexer/cxx/testdata/objc/tvar_generics/generic_invariant.m
+++ b/kythe/cxx/indexer/cxx/testdata/objc/tvar_generics/generic_invariant.m
@@ -1,0 +1,44 @@
+// Test lightweight generics (invariant) used to define a class.
+//
+// This file also tests the implementation for a lightweight generic. Since the
+// implementation knows nothing of the type arguments, it is treated like a
+// regular implementation block. It is a child of the file, it completes the
+// decl, etc.
+//
+// There is no actual test of the implied invariant attribute in this file. We
+// don't record any information for invariance, so there is nothing to test
+// beyond making sure the indexer doesn't crash.
+
+@interface O
+@end
+@implementation O
+@end
+
+// Type parameter bounds cannot refer to other type parameters
+// @interface Disallowed<T, X : T> : O
+// @end
+
+// No source range defines BoxDecl since this is a generic type.
+//- @Type defines/binding TypeVar
+//- @Box defines/binding BoxAbs
+//- TypeVar.node/kind absvar
+//- TypeVar.variance invariant
+//- BoxDecl childof BoxAbs
+//- BoxAbs.node/kind abs
+//- BoxAbs param.0 TypeVar
+@interface Box<Type> : O
+-(int) doSomething:(Type)t;
+@end
+
+//- @Box defines/binding BoxImpl
+//- File.node/kind file
+//- @Box completes/uniquely BoxAbs
+@implementation Box
+-(int) doSomething:(id)t {
+  return 0;
+}
+@end
+
+int main(int argc, char **argv) {
+  return 0;
+}

--- a/kythe/cxx/indexer/cxx/testdata/objc/tvar_generics/generic_method_call.m
+++ b/kythe/cxx/indexer/cxx/testdata/objc/tvar_generics/generic_method_call.m
@@ -1,0 +1,55 @@
+// Test a method call of a method that uses type arguments. This tests that
+// the method refs are correct.
+
+@interface Obj
+@end
+
+@implementation Obj
+@end
+
+//- @O defines/binding ODecl
+@interface O
+@end
+
+//- @O defines/binding OImpl
+@implementation O
+@end
+
+//- @Child defines/binding ChildDecl
+@interface Child : O
+@end
+
+//- @Child defines/binding ChildImpl
+@implementation Child
+@end
+
+// No source range defines BoxDecl since this is a generic type.
+//- @Type defines/binding TypeVar
+//- @Box defines/binding BoxAbs
+//- TypeVar.node/kind absvar
+//- BoxDecl childof BoxAbs
+//- BoxAbs.node/kind abs
+//- BoxAbs param.0 TypeVar
+@interface Box<Type> : Obj
+//- @addToList defines/binding FuncDecl
+-(int) addToList:(Type)item;
+@end
+
+//- @Box defines/binding BoxImpl
+@implementation Box
+//- @addToList defines/binding FuncImpl
+-(int) addToList:(id)item {
+  return 1;
+}
+@end
+
+int main(int argc, char **argv) {
+  Box<O *> *b = [[Box alloc] init];
+  Child *child = [[Child alloc] init];
+
+  //- @"[b addToList:child]" ref/call FuncImpl
+  //- @addToList ref FuncImpl
+  [b addToList:child];
+
+  return 0;
+}

--- a/kythe/cxx/indexer/cxx/testdata/objc/tvar_generics/generic_method_type.m
+++ b/kythe/cxx/indexer/cxx/testdata/objc/tvar_generics/generic_method_type.m
@@ -1,0 +1,60 @@
+// Test the type of a method that uses type arguments.
+
+// Let's get a handle on the id type
+//- IdTy aliases IdPtrTy
+//- IdPtrTy.node/kind tapp
+//- IdPtrTy param.0 vname("ptr#builtin", _, _, _, _)
+//- IdPtrTy param.1 vname("id#builtin", _, _, _, _)
+
+@interface Obj
+@end
+
+@implementation Obj
+@end
+
+//- @O defines/binding ODecl
+@interface O
+@end
+
+//- @O defines/binding OImpl
+@implementation O
+@end
+
+// No source range defines BoxDecl since this is a generic type.
+//- @Type defines/binding TypeVar
+//- @Box defines/binding BoxAbs
+//- TypeVar.node/kind absvar
+//- BoxDecl childof BoxAbs
+//- BoxAbs.node/kind abs
+//- BoxAbs param.0 TypeVar
+@interface Box<Type> : Obj
+
+//- @addToList defines/binding FuncDecl
+//- FuncDecl typed FuncTy
+//- FuncTy.node/kind TApp
+//- FuncTy param.0 vname("fn#builtin", _, _, _, _)
+//- FuncTy param.1 vname("int#builtin", _, _, _, _)
+//- FuncTy param.2 TypeVar
+-(int) addToList:(Type)item;
+
+@end
+
+//- @Box defines/binding BoxImpl
+@implementation Box
+
+//- @addToList defines/binding FuncImpl
+//- FuncImpl typed FuncIdTy
+//- FuncIdTy.node/kind TApp
+//- FuncIdTy param.0 vname("fn#builtin", _, _, _, _)
+//- FuncIdTy param.1 vname("int#builtin", _, _, _, _)
+//- FuncIdTy param.2 IdTy
+-(int) addToList:(id)item {
+  return 1;
+}
+
+@end
+
+int main(int argc, char **argv) {
+
+  return 0;
+}

--- a/kythe/cxx/indexer/cxx/testdata/objc/tvar_generics/generic_nested.m
+++ b/kythe/cxx/indexer/cxx/testdata/objc/tvar_generics/generic_nested.m
@@ -1,0 +1,86 @@
+// Test the source locations for nested type arguments and that the types
+// are correct.
+
+//- @O1 defines/binding O1Decl
+@interface O1
+@end
+
+//- @O1 defines/binding O1Impl
+@implementation O1
+@end
+
+//- @Fizzy defines/binding FizzyDecl
+@interface Fizzy
+@end
+
+//- @Fizzy defines/binding FizzyImpl
+@implementation Fizzy
+@end
+
+// No source range for CupDecl since this is a generic type.
+@interface Cup<T> : O1
+@end
+
+//- @Cup defines/binding CupImpl
+@implementation Cup
+@end
+
+// No source range for DrinkDecl sicne this is a generic type.
+@interface Drink<T> : O1
+@end
+
+//- @Drink defines/binding DrinkImpl
+@implementation Drink
+@end
+
+// No source range defines BoxDecl since this is a generic type.
+//- @Type defines/binding TypeVar
+//- @Box defines/binding BoxAbs
+//- TypeVar.node/kind absvar
+//- BoxDecl childof BoxAbs
+//- BoxAbs.node/kind abs
+//- BoxAbs param.0 TypeVar
+//- @Cup ref CupImpl
+//- @Drink ref DrinkImpl
+//- @Fizzy ref FizzyImpl
+//- BoxDecl extends O1Impl
+//- @O1 ref O1Decl
+//- @O1 ref O1Impl
+@interface Box<Type : Cup<Drink<Fizzy *>*>*> : O1
+@end
+
+//- TypeVar bounded/upper CupTypePtr
+//- CupTypePtr.node/kind tapp
+//- CupTypePtr param.0 vname("ptr#builtin", _, _, _, _)
+//- CupTypePtr param.1 CupType
+//- CupType.node/kind tapp
+//- CupType param.0 CupImpl
+//- CupType param.1 DrinkTypePtr
+//- DrinkTypePtr.node/kind tapp
+//- DrinkTypePtr param.0 vname("ptr#builtin", _, _, _, _)
+//- DrinkTypePtr param.1 DrinkType
+//- DrinkType.node/kind tapp
+//- DrinkType param.0 DrinkImpl
+//- DrinkType param.1 FizzyTypePtr
+//- FizzyTypePtr.node/kind tapp
+//- FizzyTypePtr param.0 vname("ptr#builtin", _, _, _, _)
+//- FizzyTypePtr param.1 FizzyImpl
+
+@implementation Box
+@end
+
+int main(int argc, char **argv) {
+  // This is a trivial example since there are no other possible types to give
+  // to Box.
+  //- @box defines/binding BoxVar
+  //- BoxVar typed BoxVarPtrType
+  //- BoxVarPtrType.node/kind tapp
+  //- BoxVarPtrType param.0 vname("ptr#builtin", _, _, _, _)
+  //- BoxVarPtrType param.1 BoxType
+  //- BoxType.node/kind tapp
+  //- BoxType param.0 BoxImpl
+  //- BoxType param.1 CupTypePtr
+  Box<Cup<Drink<Fizzy *>*>*> *box = [[Box alloc] init];
+
+  return 0;
+}

--- a/kythe/cxx/indexer/cxx/testdata/objc/tvar_generics/generic_restricted_protocol.m
+++ b/kythe/cxx/indexer/cxx/testdata/objc/tvar_generics/generic_restricted_protocol.m
@@ -1,0 +1,51 @@
+// Test that we handle restricted type arguments correctly when that
+// restriction is based on a protocol.
+
+@interface O
+@end
+
+@implementation O
+@end
+
+//- @Proto defines/binding ProtoDecl
+@protocol Proto
+@end
+
+@implementation ObjParent
+@end
+
+@interface ObjChild : ObjParent<Proto>
+@end
+
+@implementation ObjChild
+@end
+
+
+// No source range defines BoxDecl since this is a generic type.
+//- @Type defines/binding TypeVar
+//- @Box defines/binding BoxAbs
+//- TypeVar.node/kind absvar
+//- BoxDecl childof BoxAbs
+//- BoxAbs.node/kind abs
+//- BoxAbs param.0 TypeVar
+//- TypeVar bounded/upper ProtoDeclType
+//- ProtoDeclType.node/kind tapp
+//- ProtoDeclType param.0 vname("ptr#builtin", _, _, _, _)
+//- ProtoDeclType param.1 ProtoDecl
+//- @Proto ref ProtoDecl
+@interface Box<Type:id<Proto> > : O
+-(int) addToList:(Type)item;
+@end
+
+@implementation Box
+-(int) addToList:(id)item {
+  return 1;
+}
+@end
+
+int main(int argc, char **argv) {
+  Box<ObjChild *> *b = [[Box alloc] init];
+  ObjChild *o = [[ObjChild alloc] init];
+  [b addToList:o];
+  return 0;
+}

--- a/kythe/cxx/indexer/cxx/testdata/objc/tvar_generics/generic_two_args.m
+++ b/kythe/cxx/indexer/cxx/testdata/objc/tvar_generics/generic_two_args.m
@@ -1,0 +1,34 @@
+// Test multiple type arguments are referenced correctly.
+
+@interface O
+@end
+@implementation O
+@end
+
+// No source range defines BoxDecl since this is a generic type.
+//- @Box defines/binding BoxAbs
+//- BoxDecl childof BoxAbs
+//- @FooType defines/binding FooTypeVar
+//- @BarType defines/binding BarTypeVar
+//- FooTypeVar.node/kind absvar
+//- BarTypeVar.node/kind absvar
+//- BoxAbs.node/kind abs
+//- BoxAbs param.0 FooTypeVar
+//- BoxAbs param.1 BarTypeVar
+@interface Box<FooType, BarType> : O
+
+//- @BarType ref BarTypeVar
+//- @FooType ref FooTypeVar
+-(BarType) doSomething:(FooType)t;
+
+@end
+
+@implementation Box
+-(id) doSomething:(id)t {
+  return 0;
+}
+@end
+
+int main(int argc, char **argv) {
+  return 0;
+}

--- a/kythe/cxx/indexer/cxx/testdata/objc/tvar_generics/generic_unbound.m
+++ b/kythe/cxx/indexer/cxx/testdata/objc/tvar_generics/generic_unbound.m
@@ -1,0 +1,34 @@
+// Test lightweight unbound generics used to define a class.
+
+@interface O
+@end
+@implementation O
+@end
+
+// The generic type is unbound.
+//- !{ TypeVar bounded/upper Anything0
+//-    TypeVar bounded/lower Anything1 }
+
+// No source range defines BoxDecl since this is a generic type.
+//- @Type defines/binding TypeVar
+//- @Box defines/binding BoxAbs
+//- TypeVar.node/kind absvar
+//- BoxDecl childof BoxAbs
+//- BoxAbs.node/kind abs
+//- BoxAbs param.0 TypeVar
+@interface Box<Type> : O
+-(int) doSomething:(Type)t;
+@end
+
+//- @Box defines/binding BoxImpl
+//- File.node/kind file
+//- @Box completes/uniquely BoxAbs
+@implementation Box
+-(int) doSomething:(id)t {
+  return 0;
+}
+@end
+
+int main(int argc, char **argv) {
+  return 0;
+}

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/exclude_this_file.h
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/exclude_this_file.h
@@ -1,0 +1,4 @@
+template <typename T> class Excluded { };
+template <typename T> void EF(T t) { }
+template <typename T> T exc_var = 0;
+#define EXC_MACRO template <typename T> class ExcludedMacro { };

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/generic_lambda.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/generic_lambda.cc
@@ -1,0 +1,13 @@
+
+void fn() {
+  //- @outer defines/binding OuterVar
+  int outer = 0;
+  //- @var defines/binding VarArg
+  //- @capture defines/binding CaptureBinding
+  //- @outer ref OuterVar
+  auto lambda = [capture=&outer] (const auto& var) {
+    //- @capture ref CaptureBinding
+    //- @var ref VarArg
+    return capture + var;
+  };
+};

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/include_this_file.h
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/include_this_file.h
@@ -1,0 +1,4 @@
+template <typename T> class Included { };
+template <typename T> void IF(T t) { }
+template <typename T> T inc_var = 0;
+#define INC_MACRO template <typename T> class IncludedMacro { };

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_alias.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_alias.cc
@@ -1,0 +1,13 @@
+// We index type alias templates.
+
+//- @U defines/binding TyvarU
+template<typename U>
+//- @T defines/binding AliasTemplate
+//- @U ref TyvarU
+using T = U;
+
+//- AliasTemplate.node/kind abs
+//- TyvarU.node/kind absvar
+//- AliasTemplate param.0 TyvarU
+//- Alias childof AliasTemplate
+//- Alias.node/kind talias

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_alias_implicit_instantiation.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_alias_implicit_instantiation.cc
@@ -1,0 +1,11 @@
+// Checks that specialization decls (not defns) generate specializes edges.
+template <typename T> struct S { };
+//- @T defines/binding TAlias
+using T = S<float>;
+//- TAlias aliases SFloatTy
+//- SFloatSpec specializes SFloatTy
+//- SFloatTy.node/kind tapp
+//- SFloatSpec.node/kind record
+// NB: T aliases the type application of S to float, _not_ the record that
+// results from the implicit instantiation of S<float>. Is this the behavior
+// we want?

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_alias_implicit_instantiation_decls.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_alias_implicit_instantiation_decls.cc
@@ -1,0 +1,8 @@
+// Checks that specialization decls are given the right names.
+//- @S defines/binding TemplateS
+template <typename T> struct S;
+//- @T defines/binding NominalAlias
+using T = S<float>;
+//- NominalAlias aliases TApp
+//- TApp param.0 TNominal
+//- TNominal.node/kind tnominal

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_alias_multilevel_abs.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_alias_multilevel_abs.cc
@@ -1,0 +1,35 @@
+// With aliasing on, we don't record childof edges to abs nodes, even under
+// multiple layers of implicit template expansion.
+template <template <typename T> class Tmpl>
+struct TemplateSel { };
+
+template <template <typename T> class Tv1>
+struct Templates1 {
+  typedef TemplateSel<Tv1> Box;
+};
+
+template <class TestSel>
+//- @T1 defines/binding AbsT1
+//- RecT1 childof AbsT1
+//- RecT1.node/kind record
+class T1 {
+ public:
+//- @f defines/binding FnF
+//- FnF childof RecT1
+//- !{FnF childof AbsT1}
+  static bool f() {
+    return true;
+  }
+};
+
+template <typename T2V>
+class T2 {
+ public:
+  static bool g() {
+    T1<typename T2V::Box>::f();
+    return true;
+  }
+};
+
+template <typename T> struct Content { };
+bool b = T2<Templates1<Content>>::g();

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_alias_naming.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_alias_naming.cc
@@ -1,0 +1,9 @@
+// Other flavors of template arguments don't confuse aliasing.
+
+//- @C defines/binding AbsC
+//- ClassC childof AbsC
+//- ClassC.node/kind record
+//- @f defines/binding FnF
+//- FnF childof ClassC
+template <void*> class C { public: void f() { } };
+void g() { typedef C<nullptr> I; I i; i.f(); }

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_arg_multiple_typename.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_arg_multiple_typename.cc
@@ -1,0 +1,31 @@
+// Checks that templates can accept multiple typename arguments.
+
+template
+//- @T defines/binding AbsT
+//- @S defines/binding AbsS
+<typename T, typename S>
+//- @C defines/binding CDecl1
+class C;
+
+template
+//- @N defines/binding AbsN
+//- @V defines/binding AbsV
+<typename N, typename V>
+//- @C defines/binding CDecl2
+class C;
+
+template
+//- @W defines/binding AbsW
+//- @X defines/binding AbsX
+<typename W, typename X>
+//- @C defines/binding CDefn
+//- @C completes/uniquely CDecl2
+//- @C completes/uniquely CDecl1
+class C { };
+
+//- CDecl1 param.0 AbsT
+//- CDecl1 param.1 AbsS
+//- CDecl2 param.0 AbsN
+//- CDecl2 param.1 AbsV
+//- CDefn param.0 AbsW
+//- CDefn param.1 AbsX

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_arg_typename.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_arg_typename.cc
@@ -1,0 +1,28 @@
+// Checks that templates can accept typename arguments.
+
+template
+//- @T defines/binding AbsT
+<typename T>
+//- @C defines/binding CDecl1
+class C;
+
+template
+//- @S defines/binding AbsS
+<typename S>
+//- @C defines/binding CDecl2
+class C;
+
+template
+//- @V defines/binding AbsV
+<typename V>
+//- @C defines/binding CDefn
+//- @C completes/uniquely CDecl1
+//- @C completes/uniquely CDecl2
+class C { };
+
+//- AbsT.node/kind absvar
+//- AbsS.node/kind absvar
+//- AbsV.node/kind absvar
+//- CDefn param.0 AbsV
+//- CDecl2 param.0 AbsS
+//- CDecl1 param.0 AbsT

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_auto_parameter.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_auto_parameter.cc
@@ -1,0 +1,16 @@
+// Verifies that Kythe references auto template type parameters
+// as it would any other non-type template parameter.
+
+//- @N defines/binding TemplateParamN
+template <auto N>
+struct S {
+  //- @#0N ref TemplateParamN
+  //- @#1N ref TemplateParamN
+  //- @values defines/binding FieldArr
+  decltype(N) values[N];
+};
+
+void f() {
+ S<10> ints;
+ S<'a'> chars;
+}

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_blame_member.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_blame_member.cc
@@ -1,0 +1,18 @@
+// We blame member functions of class templates.
+//- @g defines/binding FnG
+bool g() { return false; }
+//- @f defines/binding AbsF
+//- PtCall=@"g()" ref/call FnG
+//- PtCall childof FnF  // We should collapse K in abs(K) into cluster abs(K)
+//- FnF childof CBody
+//- CBody childof AbsC
+//- @C defines/binding AbsC
+//- FImp instantiates TUnaryAppAbsF
+//- FImpCall=@"g()" ref/call/implicit FnG
+//- FImpCall childof FImp
+template <typename T> struct C { bool f(T* t) { return g(); } };
+//- TheCall=@"j->f(nullptr)" ref/call TUnaryAppAbsF
+//- @h defines/binding FnH
+//- TheCall childof FnH
+//- TUnaryAppAbsF param.0 AbsF  // Until we record the whole type context: #1879
+bool h(C<int>* j) { return j->f(nullptr); }

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_blame_pspec_member.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_blame_pspec_member.cc
@@ -1,0 +1,25 @@
+// We blame member functions of partial specializations.
+//- @g defines/binding FnG
+bool g() { return false; }
+//- PtCall=@"g()" ref/call FnG
+//- PtCall childof FnF  // We should collapse K in abs(K) into cluster abs(K)
+//- FnF childof CBody
+//- CBody childof AbsC
+//- @C defines/binding AbsC
+template <typename T, typename S> struct C { bool f(T* t) { return g(); } };
+
+//- TsCall childof SpecF
+//- TsCall=@"g()" ref/call FnG
+//- SpecF.code _
+//- @f defines/binding SpecF
+//- TsImp instantiates TAppUnarySpecF
+//- TsImpCall=@"g()" ref/call/implicit FnG
+//- TsImpCall childof TsImp  // Aliasing is off by default
+template <typename T> struct C<T, int> { bool f(T* t) { return g(); } };
+
+// Until type contexts: #1879
+//- TheCall=@"j->f(nullptr)" ref/call TAppUnarySpecF
+//- @h defines/binding FnH
+//- TheCall childof FnH
+//- TAppUnarySpecF param.0 SpecF
+bool h(C<int, int>* j) { return j->f(nullptr); }

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_blame_spec.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_blame_spec.cc
@@ -1,0 +1,18 @@
+// We blame function specializations.
+//- @g defines/binding FnG
+bool g() { return false; }
+//- @f defines/binding AbsF
+//- PtCall=@"g()" ref/call FnG
+//- PtCall childof FnF  // We should collapse K in abs(K) into cluster abs(K)
+//- FnF childof AbsF
+//- FIntImp instantiates TAppAbsFInt
+//- FIntImpCall=@"g()" ref/call/implicit FnG  // Aliasing is off by default.
+//- FIntImpCall childof FIntImp
+template <typename T> bool f(T* t) { return g(); }
+//- TheCall=@"f(&i)" ref/call TAppAbsFInt
+//- @h defines/binding FnH
+//- TheCall childof FnH
+//- TAppAbsFInt param.0 AbsF
+//- TAppAbsFInt param.1 Int
+//- @int ref Int
+bool h(int i) { return f(&i); }

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_blame_spec_member.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_blame_spec_member.cc
@@ -1,0 +1,20 @@
+// We blame member functions of total specializations.
+//- @g defines/binding FnG
+bool g() { return false; }
+//- PtCall=@"g()" ref/call FnG
+//- PtCall childof FnF  // We should collapse K in abs(K) into cluster abs(K)
+//- FnF childof CBody
+//- CBody childof AbsC
+//- @C defines/binding AbsC
+template <typename T> struct C { bool f(T* t) { return g(); } };
+
+//- @f defines/binding SpecF
+//- TsCall=@"g()" ref/call FnG
+//- TsCall childof SpecF
+//- SpecF.code _
+template <> struct C<int> { bool f(int* t) { return g(); } };
+
+//- TheCall=@"j->f(nullptr)" ref/call SpecF
+//- @h defines/binding FnH
+//- TheCall childof FnH
+bool h(C<int>* j) { return j->f(nullptr); }

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_class_ctor_deduction.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_class_ctor_deduction.cc
@@ -1,0 +1,43 @@
+// Checks that we correctly attribute class template instantiation
+// via C++17 constructor argument deduction and guides.
+
+//- @S defines/binding StructS
+struct S {};
+
+template <typename T>
+//- @C defines/binding TemplC
+struct C {
+
+  //- @C defines/binding Ctor0
+  C() { }
+
+  //- @C defines/binding CtorT
+  C(T) { }
+
+  template <typename U>
+  //- @C defines/binding CtorU
+  C(U, U) { }
+};
+
+//- @#1C ref TemplC
+//- @S ref StructS
+C() -> C<S>;
+
+// TODO(shahms): This should not be considered an implicit ref.
+//- @#1C ref/implicit TemplC
+template <typename U> C(U, U) -> C<U>;
+
+void f() {
+  //- @C ref TemplC
+  //- @cz ref/call Ctor0App
+  //- Ctor0App param.0 Ctor0
+  C cz;
+  //- @C ref TemplC
+  //- @"ct(S{})" ref/call CtorTApp
+  //- CtorTApp param.0 CtorT
+  C ct(S{});
+  //- @C ref TemplC
+  //- @"cu(S{}, S{})" ref/call CtorUApp
+  //- CtorUApp param.0 CtorU
+  C cu(S{}, S{});
+}

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_class_ctor_default_and_init.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_class_ctor_default_and_init.cc
@@ -1,0 +1,63 @@
+// Checks that we correctly attribute initialization calls to templates.
+// (This is the same as function_ctor_default_and_init, except we check that
+// we do the right thing inside template bodies.)
+//- @foo defines/binding FnFoo
+int foo() { return 0; }
+//- @bar defines/binding FnBar
+int bar() { return 0; }
+template <typename T>
+class C {
+  //- @C defines/binding CtorC0
+  //- FooCall=@"foo()" ref/call FnFoo
+  //- FooCall childof CtorC0
+  //- !{ BarCall childof CtorC0 }
+  C() : i(foo()) { }
+  //- @C defines/binding CtorC1
+  //- !{ FooCall childof CtorC1 }
+  //- BarCall childof CtorC1
+  C(int) { }
+  //- @C defines/binding CtorC2
+  //- !{ FooCall childof CtorC2 }
+  //- BarCall childof CtorC2
+  C(float) { }
+  //- BarCall=@"bar()" ref/call FnBar
+  int i = bar();
+};
+
+template <typename T>
+class C<T*> {
+  //- @C defines/binding CtorCP0
+  //- FooCallP=@"foo()" ref/call FnFoo
+  //- FooCallP childof CtorCP0
+  //- !{ BarCallP childof CtorCP0 }
+  C() : i(foo()) { }
+  //- @C defines/binding CtorCP1
+  //- !{ FooCallP childof CtorCP1 }
+  //- BarCallP childof CtorCP1
+  C(int) { }
+  //- @C defines/binding CtorCP2
+  //- !{ FooCallP childof CtorCP2 }
+  //- BarCallP childof CtorCP2
+  C(float) { }
+  //- BarCallP=@"bar()" ref/call FnBar
+  int i = bar();
+};
+
+template <>
+class C<int> {
+  //- @C defines/binding CtorCT0
+  //- FooCallT=@"foo()" ref/call FnFoo
+  //- FooCallT childof CtorCT0
+  //- !{ BarCallT childof CtorCT0 }
+  C() : i(foo()) { }
+  //- @C defines/binding CtorCT1
+  //- !{ FooCallT childof CtorCT1 }
+  //- BarCallT childof CtorCT1
+  C(int) { }
+  //- @C defines/binding CtorCT2
+  //- !{ FooCallT childof CtorCT2 }
+  //- BarCallT childof CtorCT2
+  C(float) { }
+  //- BarCallT=@"bar()" ref/call FnBar
+  int i = bar();
+};

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_class_defn.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_class_defn.cc
@@ -1,0 +1,15 @@
+// Checks that references to a complete template class point to the right node.
+template
+<typename X>
+//- @C defines/binding Abs
+class C {};
+
+//- @U defines/binding AliasNode
+using U =
+C<int>;
+
+//- AliasNode aliases TApp
+//- TApp param.0 Abs
+//- Abs.node/kind abs
+//- ClassC childof Abs
+//- ClassC.node/kind record

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_class_fn_spec.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_class_fn_spec.cc
@@ -1,0 +1,18 @@
+// Checks that we get edges for member function specialization and calls
+// thereto.
+//- @F defines/binding _MemDecl
+//- @C defines/binding TmplDefn
+template <typename T> struct C { static void F(); };
+
+//- @F defines/binding IntMemDefn
+//- @F completes/uniquely IntMemDecl
+template <> void C<int>::F() {}
+//- IntMemDecl.complete incomplete
+//- IntMemDefn.complete definition
+//- IntMemDefn.code _
+//- IntMemDecl childof _IntTmplSpec
+//- _IntTmpl specializes TApp
+//- TApp param.0 TmplDefn
+
+//- @"C<int>::F()" ref/call IntMemDefn
+void dummy() { C<int>::F(); }

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_class_inner.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_class_inner.cc
@@ -1,0 +1,17 @@
+// Checks that inner defns are children of outer classes.
+template <typename T>
+//- @C defines/binding AbsC
+//- ClassC childof AbsC
+class C {
+  //- @R defines/binding EnumR
+  //- EnumR childof ClassC
+  enum R : T {
+  };
+};
+//- @cshort defines/binding CShort
+//- CShort typed CShortAbs
+//- CShortAbsInst specializes CShortAbs
+//- CShortAbsEnum childof CShortAbsInst
+//- CShortAbsEnum.node/kind sum
+//- !{ CShortAbsEnum childof ClassC }
+C<short> cshort;

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_class_inst_explicit.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_class_inst_explicit.cc
@@ -1,0 +1,12 @@
+// Checks the behavior of explicit class template instantiations.
+using ExternalDef = int;
+//- @C defines/binding TemplateC
+template <typename T> struct C {
+  using X = ExternalDef;
+};
+template struct C<int>;
+//- ExplicitC.node/kind record
+//- XAnchor childof/context ExplicitC
+//- XAnchor.node/kind anchor
+//- XAnchor defines/binding ExternalDefAlias
+//- ExternalDefAlias.node/kind talias

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_class_inst_implicit.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_class_inst_implicit.cc
@@ -1,0 +1,29 @@
+// Checks the behavior of implicit class template instantiations.
+using ExternalDef = int;
+//- @C defines/binding TemplateC
+//- @T defines/binding AbsvarT
+template <typename T> struct C {
+//- @X defines/binding ExternalDefAlias
+//- @X.loc/start XStart
+//- @X.loc/end XEnd
+  using X = ExternalDef;
+//- @Y defines/binding AbsvarAlias
+//- @Y.loc/start YStart
+//- @Y.loc/end YEnd
+  using Y = T;
+};
+C<int> x;
+//- ImpX specializes TAppCInt
+//- TAppCInt.node/kind tapp
+//- TAppCInt param.0 TemplateC
+//- WraithXAnchor childof/context ImpX
+//- WraithXAnchor.node/kind anchor
+//- WraithXAnchor.loc/start XStart
+//- WraithXAnchor.loc/end XEnd
+//- WraithXAnchor defines/binding ExternalDefAlias
+//- AbsvarAlias aliases AbsvarT
+//- WraithYAnchor childof/context ImpX
+//- WraithYAnchor.loc/start YStart
+//- WraithYAnchor.loc/end YEnd
+//- WraithYAnchor defines/binding WraithAlias
+//- WraithAlias aliases vname("int#builtin",_,_,_,"c++")

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_class_inst_implicit_dependent.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_class_inst_implicit_dependent.cc
@@ -1,0 +1,12 @@
+// Checks the behavior of implicit class template instantiations.
+//- @T defines/binding TemplateT
+template <typename C> struct T {
+//- @X defines/binding XAlias
+//- XAlias aliases Lookup
+//- Lookup.node/kind lookup
+  using X = typename C::Y;
+};
+struct S { using Y = int; }; T<S>::X x;
+//- ImpX specializes TAppCS
+//- TAppCS.node/kind tapp
+//- TAppCS param.0 TemplateT

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_class_inst_vs_spec.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_class_inst_vs_spec.cc
@@ -1,0 +1,34 @@
+// Checks that instantiates/specializes are applied to class templates.
+//- @C defines/binding PrimaryT
+template<typename T, typename S> class C {};
+//- @C defines/binding PartialT
+template<typename S> class C<int, S> {};
+//- @C defines/binding TotalT
+template<> class C<float, double> {};
+
+// Specializes and instantiates primary
+//- @Primary defines/binding APrimary
+//- APrimary typed PrimaryLongShort
+//- PrimaryLongShort param.0 PrimaryT
+//- PrimaryImp specializes PrimaryLongShort
+//- PrimaryImp instantiates PrimaryLongShort
+C<long, short> Primary;
+
+// Specializes primary and instantiates partial
+// NB: the type is still PrimaryT<int, short>.
+//- @PartialSpec defines/binding APartialSpec
+//- APartialSpec typed PrimaryIntShort
+//- ImpPartialSpec specializes PrimaryIntShort
+//- PrimaryIntShort param.0 PrimaryT
+//- ImpPartialSpec instantiates PartialIntShort
+//- PartialIntShort param.0 PartialT
+//- PartialIntShort param.1 TShort
+//- @short ref TShort
+C<int, short> PartialSpec;
+
+// Specializes primary and instantiates primary
+//- @TotalSpec defines/binding ATotalSpec
+//- ATotalSpec typed PrimaryFloatDouble
+//- TotalT instantiates PrimaryFloatDouble
+//- TotalT specializes PrimaryFloatDouble
+C<float, double> TotalSpec;

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_class_ref.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_class_ref.cc
@@ -1,0 +1,31 @@
+//- @S defines/binding SPrim
+//- @S defines/binding S1
+template <typename T, typename U> struct S {};
+//- @S defines/binding S2
+template <typename T> struct S<T, int> {};
+//- @S defines/binding S3
+template <typename T> struct S<T, float> {};
+//- @S defines/binding S4
+template <typename U> struct S<int, U> {};
+//- @S defines/binding S5
+template <typename U> struct S<float, U> {};
+//- @S defines/binding S6
+template <> struct S<char, char> {};
+
+//- @S ref S1
+S<void *, void *> s1;
+//- @S ref S2
+S<void *, int> s2;
+//- @S ref S3
+S<void *, float> s3;
+//- @S ref S4
+S<int, void *> s4;
+//- @S ref S5
+S<float, void *> s5;
+//- @S ref S6
+S<char, char> s6;
+
+template <typename T, typename U> void f() {
+  //- @S ref SPrim
+  S<T, U> s;
+}

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_class_ref_ps.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_class_ref_ps.cc
@@ -1,0 +1,9 @@
+// Tests that references to ps class templates go to the ps via `specializes`.
+//- @V defines/binding VPrim
+template <typename T, typename S> struct V { S m; };
+//- @V defines/binding VInt
+//- VInt specializes TAppVIntInt
+template <typename S> struct V<int, S> { S mm; };
+//- @x defines/binding VarX
+//- VarX typed TAppVIntInt
+V<int, int> x;

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_class_skip_implicit_on.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_class_skip_implicit_on.cc
@@ -1,0 +1,10 @@
+// Checks that we still perform reasonably when skipping template instantations.
+// Run with --index_template_instantiations=false
+//- @vector defines/binding VectorAbs
+template <typename T> class vector { };
+//- @ty defines/binding TyAlias
+//- TyAlias aliases Tau
+//- Tau.node/kind tapp
+//- Tau param.0 VectorAbs
+using ty = vector<int>;
+ty var;

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_class_template_ctor.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_class_template_ctor.cc
@@ -1,0 +1,29 @@
+// Checks that we properly handle classes with constructor templates.
+//- @foo defines/binding FnFoo
+int foo() { return 0; }
+//- @bar defines/binding FnBar
+int bar() { return 0; }
+class C {
+ public:
+  template <typename T>
+  //- FooCall=@"foo()" ref/call FnFoo
+  //- FooCall childof CtorC
+  //- @C defines/binding AbsCtorC
+  //- CtorC childof AbsCtorC
+  //- !{ BarCall childof CtorC }
+  //- BarCallJ childof CtorC
+  C(T) : i(foo()) { }
+
+  //- BarCall=@"bar()" ref/call FnBar
+  int i = bar();
+  //- BarCallJ=@"bar()" ref/call FnBar
+  int j = bar();
+};
+
+template <> C::
+//- FooCall2=@"foo()" ref/call FnFoo
+//- FooCall2 childof CtorC2
+//- @C defines/binding CtorC2
+//- !{ BarCall childof CtorC2 }
+//- BarCallJ childof CtorC2
+C(float) : i(foo()) { }

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_decl_arg.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_decl_arg.cc
@@ -1,0 +1,38 @@
+// Verify that we support using pointers, references and pointer-to-members in
+// non-type template parameters.
+
+template <typename Type, Type Value>
+struct Pair {
+  using type = Type;
+  static constexpr type value() { return Value; }
+};
+
+//- @Value defines/binding ValueType
+struct Value {
+  //- @member defines/binding ValueMember
+  int member;
+};
+
+//- @fn defines/binding FnDecl
+void fn();
+
+//- @Alias defines/binding AliasDecl
+//- @Value ref ValueType
+//- @member ref ValueMember
+using Alias = Pair<decltype(&Value::member),
+  //- @Value ref ValueType
+  //- @member ref ValueMember
+  &Value::member>;
+
+
+//- @FnPtrAlias defines/binding FnPtrAliasType
+//- @fn ref FnDecl
+using FnPtrAlias = Pair<decltype(&fn),
+//- @fn ref FnDecl
+      &fn>;
+
+//- @FnRefAlias defines/binding FnRefAliasType
+//- @fn ref FnDecl
+using FnRefAlias = Pair<decltype(*fn),
+//- @fn ref FnDecl
+      fn>;

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_depbase_field_ref.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_depbase_field_ref.cc
@@ -1,0 +1,13 @@
+// Checks that we can refer to dependent fields.
+//- @T defines/binding TyvarT
+template <typename T> struct S {
+  T t;
+  //- @f ref DepF
+  //- DepF.node/kind lookup
+  //- DepF.text f
+  //- DepF param.0 DepBase
+  //- DepBase.node/kind lookup
+  //- DepBase.text "Base"
+  //- DepBase param.0 TyvarT
+  int i = t.Base::f;
+};

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_dependent_ctor.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_dependent_ctor.cc
@@ -1,0 +1,29 @@
+// Checks indexing dependent constructors.
+template <typename T>
+struct M {
+  M() { }
+  M(int) { }
+};
+
+template <typename T>
+struct S {
+  S(M<T>) { }
+};
+
+template <typename T>
+//- @L defines/binding AbsL
+struct L : S<T> {
+  //- StCall=@"S<T>(M<T>())" ref/call/implicit St
+  //- MtCall=@"M<T>()" ref/call/implicit Mt
+  //- @L defines/binding CtorL
+  //- StCall childof CtorL
+  //- MtCall childof CtorL
+  L() : S<T>(M<T>()) {}
+};
+
+//- @l defines/binding VarL
+//- VarL typed TAppLInt
+//- TAppLInt param.0 AbsL
+//- LInt specializes TAppLInt
+//- CtorL childof LInt
+L<int> l;

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_dependent_ctor_small.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_dependent_ctor_small.cc
@@ -1,0 +1,12 @@
+// Checks indexing dependent constructors.
+//- @T defines/binding TyvarT
+template <typename T>
+struct S : T::Q {
+  //- @"T::Q()" ref/call LookupTQCtor
+  //- LookupTQCtor.node/kind lookup
+  //- LookupTQCtor.text "#ctor"
+  //- LookupTQCtor param.0 LookupTQ
+  //- LookupTQ.text "Q"
+  //- LookupTQ param.0 TyvarT
+  S() : T::Q() { }
+};

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_dependent_dtor.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_dependent_dtor.cc
@@ -1,0 +1,19 @@
+// Checks that we index explicit calls to a dependent dtor.
+//- @T defines/binding TyvarT
+template <typename T>
+class C {
+  T *t;
+  void f() {
+    //- @"t->~T" ref/call LookupTDtor2
+    //- LookupTDtor2.node/kind lookup
+    //- LookupTDtor2 param.0 TyvarT
+    //- LookupTDtor2.text "#dtor"
+    //- @"~" ref LookupTDtor2
+    t->~T();
+    //- @"delete t" ref/call LookupTDtor
+    //- LookupTDtor.node/kind lookup
+    //- LookupTDtor param.0 TyvarT
+    //- LookupTDtor.text "#dtor"
+    delete t;
+  }
+};

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_dependent_dtor_qualified.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_dependent_dtor_qualified.cc
@@ -1,0 +1,21 @@
+// Checks that we index explicit calls to a dependent dtor with a qualifier.
+//- @T defines/binding TyvarT
+template <typename T>
+class C {
+  T *t;
+  void f() {
+    //- @"t->SomeId::Base::~Base" ref/call Dtor
+    //- Dtor.node/kind lookup
+    //- Dtor.text "#dtor"
+    //- Dtor param.0 BaseInT
+    //- BaseInT.node/kind lookup
+    //- BaseInT.text Base
+    //- BaseInT param.0 SomeId
+    //- SomeId.node/kind lookup
+    //- SomeId.text "SomeId"
+    //- @"~" ref Dtor
+    t->SomeId::Base::~Base();
+    // TODO(zarko): Does it make sense for SomeId param.0 TyvarT?
+    // What if instead of 'SomeId' we wrote 'T' above?
+  }
+};

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_dependent_name_ref.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_dependent_name_ref.cc
@@ -1,0 +1,8 @@
+
+template<typename T>
+void fn() {
+  //- @value_type ref DependentName
+  typename T::value_type a;
+  //- @value_type ref DependentName
+  typename T::value_type b;
+}

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_dependent_sized_array.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_dependent_sized_array.cc
@@ -1,0 +1,31 @@
+// We don't fall over on dependent-sized arrays.
+//- @S defines/binding TyvarS
+//- @T defines/binding TyvarT
+template<unsigned S, class... T> struct A {
+//- @S ref TyvarS
+//- @R defines/binding FieldR
+  int R[S];
+
+  void fn() {
+    //- @Q defines/binding VarQ
+    //- @T ref TyvarT
+    int Q[] = {sizeof(T)...};
+  }
+
+  //- @Z defines/binding FieldZ
+  //- @T ref TyvarT
+  int Z[sizeof...(T)];
+};
+//- FieldR typed TAppDArrIntExpr
+//- TAppDArrIntExpr.node/kind tapp
+//- TAppDArrIntExpr param.0 vname("darr#builtin",_,_,_,_)
+//- TAppDArrIntExpr param.1 vname("int#builtin",_,_,_,_)
+//- TAppDArrIntExpr param.2 SomeExpr
+//- VarQ typed QType
+//- QType.node/kind tapp
+//- QType param.0 vname("darr#builtin",_,_,_,_)
+//- QType param.1 vname("int#builtin",_,_,_,_)
+//- FieldZ typed ZType
+//- ZType.node/kind tapp
+//- ZType param.0 vname("darr#builtin",_,_,_,_)
+//- ZType param.1 vname("int#builtin",_,_,_,_)

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_depexpr_field_ref.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_depexpr_field_ref.cc
@@ -1,0 +1,13 @@
+// Checks that we don't fall over on fields that depend on expressions.
+//- @T defines/binding TyvarT
+template <typename T> struct S {
+  T t;
+  //- @f ref DepF
+  //- DepF.node/kind lookup
+  //- DepF.text f
+  //- !{DepF param.0 Anything}
+  //- @thing ref DepThing
+  //- DepThing.node/kind lookup
+  //- DepThing param.0 TyvarT
+  int i = (t.thing(3) + 4).f;
+};

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_depname_class.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_depname_class.cc
@@ -1,0 +1,14 @@
+// Checks the representation of dependent names.
+template
+//- @T defines/binding DepT
+<template <typename> class T>
+struct C {
+//- @D ref DepTIntD
+using S = typename T<int>::D;
+};
+//- DepTIntD.text D
+//- DepTIntD.node/kind lookup
+//- DepTIntD param.0 DepTInt
+//- DepTInt.node/kind tapp
+//- DepTInt param.0 DepT
+//- DepTInt param.1 Int

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_depname_field_ref.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_depname_field_ref.cc
@@ -1,0 +1,10 @@
+// Checks that we can refer to dependent fields.
+//- @T defines/binding TyvarT
+template <typename T> struct Sz {
+  T t;
+  //- @f ref DepF
+  //- DepF.node/kind lookup
+  //- DepF.text f
+  //- DepF param.0 TyvarT
+  int i = t.f;
+};

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_depname_implicit.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_depname_implicit.cc
@@ -1,0 +1,13 @@
+// Checks that we can refer to implicit dependent fields.
+//- @A defines/binding AbsA
+template <typename T> class A { };
+//- @T defines/binding TyvarT
+template <typename T> class C {
+//- @Dep ref Dep
+//- Dep param.0 At
+//- At.node/kind tapp
+//- At param.0 AbsA
+//- At param.1 TyvarT
+//- @T ref TyvarT
+  void f() { A<T>::Dep(); }
+};

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_depname_inst_class.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_depname_inst_class.cc
@@ -1,0 +1,18 @@
+// Checks the representation of resolved dependent names.
+template
+<template <typename> class T>
+//- @C defines/binding AbsC
+struct C {
+using S = typename T<int>::D;
+};
+template
+<typename Q>
+//- @Z defines/binding AbsZ
+struct Z {
+using D = Q;
+};
+// Somewhere we need to close the loop wrt the substitutions here.
+using U = C<Z>::S;
+//- AbsC.node/kind abs
+//- AbsZ.node/kind abs
+

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_depname_path_graph.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_depname_path_graph.cc
@@ -1,0 +1,38 @@
+// Checks that we index dependent name path graphs and that they reference
+// the same nodes within a template, but not between them.
+template
+//- @T defines/binding CParamT
+<template <typename> class T>
+struct C {
+//- @F ref CDepTIntDEF
+//- CDepTIntDEF.text F
+//- @E ref CDepTIntDE
+//- CDepTIntDE.text E
+//- @D ref CDepTIntD
+//- CDepTIntD.text D
+//- @T ref CParamT
+using X = typename T<int>::D::E::F;
+
+//- @F ref CDeptTIntDEF
+//- @E ref CDeptTIntDE
+//- @D ref CDeptTIntD
+//- @T ref CParamT
+using Y = typename T<int>::D::E::F;
+};
+//- CDeptTIntDEF param.0 CDeptTIntDE
+//- CDeptTIntDE param.0 CDeptTIntD
+
+template
+//- @T defines/binding DParamT
+<template <typename> class T>
+struct D {
+//- @F ref DDepTIntDEF
+//- @E ref DDepTIntDE
+//- @D ref DDepTIntD
+//- @T ref DParamT
+//- !{ @F ref CDepTIntDEF }
+//- !{ @E ref CDepTIntDE }
+//- !{ @D ref CDepTIntD }
+//- !{ @T ref CParamT }
+using Z = typename T<int>::D::E::F;
+};

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_depname_template_field_ref.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_depname_template_field_ref.cc
@@ -1,0 +1,18 @@
+// Checks that we can refer to dependent fields under other templates.
+//- @C defines/binding ClassC
+class C { };
+//- @T defines/binding TyvarT
+template <typename T> struct S {
+  T t;
+  //- @f ref DepF
+  //- DepF.node/kind lookup
+  //- DepF.text f
+  //- DepF param.0 TyvarT
+  //- @C ref ClassC
+  //- @"f<C>" ref TAppDepFC
+  //- TAppDepFC.node/kind tapp
+  //- TAppDepFC param.0 DepF
+  //- TAppDepFC param.1 ClassC
+  int i = t.template f<C>;
+  // (f<C> should refer to a lookup of (typeof t)::f applied to C)
+};

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_drop_redundant_wraiths.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_drop_redundant_wraiths.cc
@@ -1,0 +1,9 @@
+// Checks --experimental_drop_instantiation_independent_data.
+template <typename T> class C {
+//- @int ref TInt
+//- WInt=@int ref TInt
+//- WIField=@ifield defines/binding PTField
+//- WIField childof/context CInst
+  int ifield;
+};
+template class C<short>;

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_drop_redundant_wraiths_expect_fail.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_drop_redundant_wraiths_expect_fail.cc
@@ -1,0 +1,21 @@
+// Checks --experimental_drop_instantiation_independent_data.
+template <typename T> class C {
+//- @int ref TInt
+//- WInt=@int ref/implicit TInt
+//- WIField=@ifield defines/binding PTField
+//- WInt childof/context CInst
+//- WIField childof/context CInst
+//- ZInt=@int ref/implicit TInt
+//- ZIField=@ifield defines/binding OPTField
+//- ZInt childof/context DInst
+//- ZIField childof/context DInst
+//- CInst specializes TAppCShort
+//- DInst specializes TAppCInt
+//- TAppCShort param.1 TShort
+//- TAppCInt param.1 TInt
+  int ifield;
+};
+//- @short ref TShort
+short s;
+template class C<short>;
+template class C<int>;

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_exclude.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_exclude.cc
@@ -1,0 +1,50 @@
+#include "exclude_this_file.h"
+#include "include_this_file.h"
+
+//- @inc defines/binding VarInc
+Included<int> inc;
+//- @exc defines/binding VarExc
+Excluded<int> exc;
+
+//- VarInc typed TAppIncInt
+//- TAppIncInt.node/kind tapp
+//- TAppIncInt param.0 _TemplateIncluded
+//- _ImpInc instantiates TAppIncInt
+
+//- VarExc typed TAppExcInt
+//- TAppExcInt.node/kind tapp
+//- TAppExcInt param.0 _TemplateExcluded
+//- !{_ImpExc instantiates TAppExcInt}
+
+INC_MACRO
+EXC_MACRO
+
+//- @inc_macro defines/binding VarIncMacro
+IncludedMacro<int> inc_macro;
+//- @exc_macro defines/binding VarExcMacro
+ExcludedMacro<int> exc_macro;
+
+//- VarIncMacro typed TAppIncMacroInt
+//- TAppIncMacroInt.node/kind tapp
+//- TAppIncMacroInt param.0 _TemplateIncludedMacro
+//- _ImpMacroInc instantiates TAppIncMacroInt
+
+//- VarExcMacro typed TAppExcMacroInt
+//- TAppExcMacroInt.node/kind tapp
+//- TAppExcMacroInt param.0 _TemplateExcludedMacro
+//- !{_ExcMacroInc instantiates TAppExcMacroInt}
+
+void f() {
+  //- @IF ref IncFun
+  IF(1);
+  //- @EF ref ExcFun
+  EF(1);
+}
+
+//- _ImpIncFun instantiates IncFun
+//- !{_ImpExcFun instantiates ExcFun}
+
+//- @inc_var ref _IncVar
+int x = inc_var<int>;
+//- @exc_var ref _ExcVar
+int y = exc_var<int>;

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_field.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_field.cc
@@ -1,0 +1,14 @@
+// Checks that we index references to member variables of templates.
+//- @f defines/binding PField
+//- @S defines/binding SAbs
+//- SBody childof SAbs
+//- SBody.node/kind record
+//- PField childof SBody
+template <typename T> struct S { int f; };
+//- @t_int defines/binding TInt
+//- TInt typed SInt
+S<int> t_int;
+//- @f ref Field
+//- Field childof SIntImp
+//- SIntImp specializes SInt
+int i = t_int.f;

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_file_call.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_file_call.cc
@@ -1,0 +1,21 @@
+// Top-level function calls are blamed on files.
+template<class T, T v>
+struct constant {
+  static constexpr T value = v;
+};
+
+//- @foo defines/binding FooFn
+constexpr int foo() { return 1; }
+
+//- @foo ref FooFn
+//- Anchor=@"foo()" ref/call FooFn
+//- Anchor childof FooInit
+constant<int, foo()> n;
+
+//- FooInit code FooCode
+//- FooCode.kind "IDENTIFIER"
+//- FooCode.pre_text
+//-     Path="kythe/cxx/indexer/cxx/testdata/tvar_template/template_file_call.cc"
+//- FooInit.node/kind function
+//- FooInit.subkind initializer
+//- vname(_,_,_,Path,_) defines/binding FooInit

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_fn_call.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_fn_call.cc
@@ -1,0 +1,9 @@
+template <typename T> void f() {}
+
+//- @"A" defines/binding ClsA
+struct A {};
+
+void g() {
+  //- @"A" ref ClsA
+  f<A>();
+}

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_fn_decl.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_fn_decl.cc
@@ -1,0 +1,9 @@
+// Tests basic support for function template declarations.
+template <typename T>
+T
+//- @id defines/binding Abs
+id(T x);
+//- Abs.node/kind abs
+//- IdDecl childof Abs
+//- IdDecl.node/kind function
+//- IdDecl.complete incomplete

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_fn_decl_defn.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_fn_decl_defn.cc
@@ -1,0 +1,20 @@
+// Tests basic support for function template declarations and definitions.
+template <typename T>
+T
+//- @id defines/binding AbsDecl
+id(T x);
+
+template <typename T>
+T
+//- @id defines/binding AbsDefn
+//- @id completes/uniquely AbsDecl
+id(T x)
+{ return x; }
+//- AbsDecl.node/kind abs
+//- AbsDefn.node/kind abs
+//- Decl childof AbsDecl
+//- Defn childof AbsDefn
+//- Decl.node/kind function
+//- Defn.node/kind function
+//- Decl.complete incomplete
+//- Defn.complete definition

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_fn_defines.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_fn_defines.cc
@@ -1,0 +1,25 @@
+// Full definition ranges for function templates are recorded.
+
+//- @"template <typename T> void f(T t) { }" defines TFnF
+//- @f defines/binding TFnF
+template <typename T> void f(T t) { }
+
+//- @f defines/binding TFnFTS
+//- @"template <> void f(int t) { }" defines TFnFTS
+template <> void f(int t) { }
+
+//- @f defines/binding TFnFPS
+//- @"template <typename S> void f(S* s) { }" defines TFnFPS
+template <typename S> void f(S* s) { }
+
+class C {
+  //- @f defines/binding TMFn
+  //- @"template <typename T> void f(T t) { }" defines TMFn
+  template <typename T> void f(T t) { }
+
+  template <typename T> void g();
+};
+
+//- @g defines/binding TMFnExt
+//- @"template <typename T> void C::g() { }" defines TMFnExt
+template <typename T> void C::g() { }

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_fn_defn.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_fn_defn.cc
@@ -1,0 +1,17 @@
+// Tests basic support for function templates.
+//- @T defines/binding TyvarT
+//- TyvarT.node/kind absvar
+template <typename T>
+T
+//- @id defines/binding Abs
+id(T x)
+{ return x; }
+//- Abs.node/kind abs
+//- IdFun childof Abs
+//- IdFun.node/kind function
+//- IdFun.complete definition
+//- Abs param.0 TyvarT
+//- IdFun typed IdFunT
+//- IdFunT.node/kind tapp
+//- IdFunT param.1 TyvarT
+//- IdFunT param.2 TyvarT

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_fn_dependent_spec_defn.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_fn_dependent_spec_defn.cc
@@ -1,0 +1,14 @@
+// Checks indexing refs and defs of dependent function specializations.
+//- @f defines/binding AbsF
+template <typename S> long f(S s) { return 0; }
+template <typename T> struct S {
+  friend
+  //- @f defines/binding DepSpecFT
+  //- DepSpecFT specializes/speculative TAppAbsFT
+  //- TAppAbsFT param.0 AbsF
+  //- TAppAbsFT param.1 BuiltinInt
+  //- TAppAbsFT param.2 BuiltinShort
+  //- @int ref BuiltinInt
+  //- @short ref BuiltinShort
+  long f<int, short>(T t) { return 1; }
+};

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_fn_explicit_spec_completes.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_fn_explicit_spec_completes.cc
@@ -1,0 +1,10 @@
+// Checks that we get completion edges for explicit function template specs.
+template <typename T> T id(T x);
+//- @id defines/binding Decl1
+template <> int id(int x);
+//- @id defines/binding Defn
+//- @id completes/uniquely Decl2
+//- @id completes/uniquely Decl1
+template <> int id(int x) { return x; }
+//- @id defines/binding Decl2
+template <> int id(int x);

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_fn_explicit_spec_with_default_completes.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_fn_explicit_spec_with_default_completes.cc
@@ -1,0 +1,18 @@
+// Checks that we get completion edges for explicit function template specs.
+//- @id defines/binding PrimDecl
+template <typename T> T id(T x);
+//- @id defines/binding Decl1
+template <> int id(int x);
+//- @id defines/binding PrimDefn
+//- @id completes/uniquely PrimDecl
+template <typename T> T id (T x) { }
+//- @id defines/binding Defn
+//- @id completes/uniquely Decl2
+//- @id completes/uniquely Decl1
+template <> int id(int x) { return x; }
+//- @id defines/binding Decl2
+template <> int id(int x);
+//- Decl2 specializes TAppPrimDecl
+//- Decl1 specializes TAppPrimDecl
+//- Defn specializes TAppPrimDecl
+//- TAppPrimDecl param.0 PrimDecl

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_fn_implicit_spec.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_fn_implicit_spec.cc
@@ -1,0 +1,11 @@
+// Tests support for implicit specializations of function templates.
+//- @id defines/binding AbsId
+template <typename T> T id(T x) { return x; }
+//- @id ref TAppAbsInt
+int y = id(42);
+//- SpecId.node/kind function
+//- SpecId specializes TAppAbsInt
+//- TAppAbsInt.node/kind tapp
+//- TAppAbsInt param.0 AbsId
+//- AbsId.node/kind abs
+//- TAppAbsInt param.1 vname("int#builtin",_,_,_,_)

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_fn_inst_vs_spec.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_fn_inst_vs_spec.cc
@@ -1,0 +1,22 @@
+// Checks that instantiates/specializes are applied to function templates.
+// Note that function template partial specialization is not allowed. We will
+// still see instantiates edges, but they will point to either the primary
+// template or to the total specialization used.
+
+//- @f defines/binding PrimaryF
+template <typename T> bool f(T* arg);
+//- @f defines/binding TotalF
+template <> bool f(int* arg);
+
+//- @f ref TotalF
+//- TotalF specializes PrimaryFInt
+//- TotalF instantiates PrimaryFInt
+//- PrimaryFInt param.0 PrimaryF
+bool t = f((int*)nullptr);
+
+//- @f ref PrimaryFDouble
+//- ImpPrimaryFDouble.node/kind function
+//- ImpPrimaryFDouble specializes PrimaryFDouble
+//- ImpPrimaryFDouble instantiates PrimaryFDouble
+//- PrimaryFDouble param.0 PrimaryF
+bool s = f((double*)nullptr);

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_fn_member_spec_defn.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_fn_member_spec_defn.cc
@@ -1,0 +1,19 @@
+// Checks indexing refs and defs of member function specializations.
+//- @S defines/binding AbsS
+//- @f defines/binding FnF
+template <typename T> struct S { int f() { return 0; } };
+
+int q() {
+  //- @s defines/binding VarS
+  //- VarS typed TAppAbsSInt
+  //- TAppAbsSInt param.0 AbsS
+  S<int> s;
+  //- @f ref UnaryTAppF  // Until we index the full type context: #1879
+  //- UnaryTAppF.node/kind tapp
+  //- UnaryTAppF param.0 FnF
+  //- FnFImp instantiates UnaryTAppF
+  //- SInstInt specializes TAppAbsSInt
+  //- FnFImp childof SInstInt
+  //- @"s.f()" ref/call UnaryTAppF
+  return s.f();
+}

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_fn_multi_decl_def.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_fn_multi_decl_def.cc
@@ -1,0 +1,9 @@
+// Checks that we index function templates with mutliple forward declarations.
+//- @f defines/binding Decl1
+template <typename T> void f();
+//- @f defines/binding Decl2
+template <typename T> void f();
+//- @f defines/binding Defn
+//- @f completes/uniquely Decl1
+//- @f completes/uniquely Decl2
+template <typename T> void f() { }

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_fn_multiple_implicit_spec.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_fn_multiple_implicit_spec.cc
@@ -1,0 +1,15 @@
+// Tests support for implicit specializations of function templates.
+//- @id defines/binding AbsId
+template <typename T> T id(T x) { return x; }
+//- @id ref TAppAbsIdInt
+int y = id(42);
+//- @id ref TAppAbsIdFloat
+float z = id(42.0f);
+//- IntSpecId specializes TAppAbsIdInt
+//- IntSpecId.node/kind function
+//- FloatSpecId specializes TAppAbsIdFloat
+//- FloatSpecId.node/kind function
+//- TAppAbsIdInt param.0 AbsId
+//- TAppAbsIdInt param.1 vname("int#builtin",_,_,_,_)
+//- TAppAbsIdFloat param.0 AbsId
+//- TAppAbsIdFloat param.1 vname("float#builtin",_,_,_,_)

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_fn_overload.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_fn_overload.cc
@@ -1,0 +1,16 @@
+// Tests overloads of template functions.
+//- @T defines/binding FNoPtrT
+template <typename T>
+//- @f defines/binding FNoPtr
+void f(T t) { }
+//- @T defines/binding FPtrT
+template <typename T>
+//- @f defines/binding FPtr
+void f(T* t) { }
+//- FNoPtrFn childof FNoPtr
+//- FPtrFn childof FPtr
+//- FNoPtrFn typed TAppFnT
+//- TAppFnT param.2 FNoPtrT
+//- FPtrFn typed TAppFnTPtr
+//- TAppFnTPtr param.2 FPtrTTy
+//- FPtrTTy param.1 FPtrT

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_fn_spec.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_fn_spec.cc
@@ -1,0 +1,10 @@
+// Tests explicit specialization of function templates.
+// Note that function templates do not support partial specialization.
+//- @id defines/binding PrimaryTemplate
+template <typename T> T id(T x) { return T(); }
+//- @id defines/binding SpecTemplate
+template <> int id(int x) { return x; }
+//- SpecTemplate specializes TAppPTInt
+//- TAppPTInt.node/kind tapp
+//- TAppPTInt param.0 PrimaryTemplate
+//- TAppPTInt param.1 vname("int#builtin",_,_,_,_)

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_fn_spec_decl.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_fn_spec_decl.cc
@@ -1,0 +1,13 @@
+// Tests that declarations of template specializations are recorded.
+//- @id defines/binding IdDecl
+template <typename T> T id(T x);
+//- @id defines/binding IdSpecDecl
+//- IdSpecDecl specializes TApp
+//- TApp param.0 IdDecl
+template <> int id(int x);
+//- @id defines/binding IdDecl2
+template <typename T> T id(T x);
+//- @id defines/binding IdSpecDecl2
+//- IdSpecDecl2 specializes TApp2
+//- TApp2 param.0 IdDecl
+template <> int id(int x);

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_fn_spec_defn_decl.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_fn_spec_defn_decl.cc
@@ -1,0 +1,10 @@
+// Tests explicit specialization of function templates with defns and decls.
+//- @id defines/binding IdDecl
+template <typename T> T id(T x);
+//- @id defines/binding IdSpecDefn
+template <> int id(int x) { return x; }
+//- @id defines/binding IdDefn
+template <typename T> T id(T x) { return T(); }
+//- IdSpecDefn specializes TAppDefn
+//- TAppDefn.node/kind tapp
+//- TAppDefn param.0 IdDecl

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_fn_spec_defn_defn_decl_decl.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_fn_spec_defn_defn_decl_decl.cc
@@ -1,0 +1,15 @@
+// The choice of which defn/decl to associate with is arbitrary. In reality,
+// it is defined by the implementation, but it's useful to check if this
+// changes.
+//- @id defines/binding IdDecl
+template <typename T> T id(T x);
+//- @id defines/binding IdSpecDefn
+//- IdSpecDefn specializes TAppIdSpecDefnInt
+template <> int id(int x) { return x; }
+//- @id defines/binding IdDecl2
+template <typename T> T id(T x);
+//- @id defines/binding IdSpecDefn2
+//- IdSpecDefn2 specializes TAppIdSpecDefnFloat
+template <> float id(float x) { return x; }
+//- TAppIdSpecDefnInt param.0 IdDecl
+//- TAppIdSpecDefnFloat param.0 IdDecl

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_fn_spec_overload.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_fn_spec_overload.cc
@@ -1,0 +1,10 @@
+// Tests the combination of overloading and specialization on function
+// templates.
+//- @f defines/binding FnF
+template <typename T> void f(T t) { }
+//- @f defines/binding FnFInt
+template <> void f(int) { }
+//- @f defines/binding FnFPtr
+template <typename T> void f(T* t) { }
+//- FnFInt specializes TAppFnF
+//- TAppFnF param.0 FnF

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_fold_expressions.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_fold_expressions.cc
@@ -1,0 +1,10 @@
+// Verify that we parse and reference templates with C++17 fold expressions.
+
+//- @Args defines/binding ArgsParam
+template <typename... Args>
+//- @Args ref ArgsParam
+//- @args defines/binding ArgsVar
+auto Sum(Args... args){
+  //- @args ref ArgsVar
+  return (args + ...);
+}

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_incomplete_array.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_incomplete_array.cc
@@ -1,0 +1,10 @@
+// We don't fall over on incomplete arrays.
+//- @T defines/binding TyvarT
+template<typename T> struct A {
+//- @R defines/binding FieldR
+  T R[];
+};
+//- FieldR typed TAppIArrT
+//- TAppDArrIntExpr.node/kind tapp
+//- TAppDArrIntExpr param.0 vname("iarr#builtin",_,_,_,_)
+//- TAppDArrIntExpr param.1 TyvarT

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_instance_type_from_class.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_instance_type_from_class.cc
@@ -1,0 +1,8 @@
+// Checks the representation of types from template instantiations.
+template
+<typename X>
+struct C {
+using T = typename X::Y;
+};
+struct D { using Y = int; };
+using S = C<D>::T;

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_multilevel_argument.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_multilevel_argument.cc
@@ -1,0 +1,12 @@
+// Tests the behavior of multiple levels of template arguments.
+//- @T defines/binding AbsT
+template <typename T>
+struct X {
+//- @S defines/binding AbsS
+  template<typename S>
+  struct Y {
+//- @U defines/binding AliasU
+    using U = T;
+  };
+};
+//- AliasU aliases AbsT

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_nested_name.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_nested_name.cc
@@ -1,0 +1,24 @@
+// We emit references to nodes in nested names.
+template <typename T>
+//- @S defines/binding AbsS
+struct S {
+  static T x;
+  template <typename U>
+//- @V defines/binding AbsV
+  struct V {
+    static U y;
+  };
+};
+
+//- @S ref SInt
+//- @V ref VFloat
+//- @int ref Int
+//- @float ref Float
+double z = S<int>::V<float>::y;
+
+// Interestingly, we don't get the definition of V here:
+//- SInt instantiates AppSInt
+//- VFloat instantiates AppVFloat
+//- AppSInt param.0 AbsS
+//- AppVFloat param.0 NominalV
+//- NominalV.node/kind tnominal

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_pack_fn_decl.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_pack_fn_decl.cc
@@ -1,0 +1,7 @@
+// We index function template declarations with parameter pack arguments.
+//- @Ts defines/binding PackAbsvar
+template <typename... Ts>
+//- @Ts ref PackAbsvar
+//- @ts defines/binding PackParam
+//- PackParam typed PackAbsvar
+void f(Ts... ts) { }

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_pack_fn_mono_call.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_pack_fn_mono_call.cc
@@ -1,0 +1,22 @@
+// We index calls to function templates with parameter pack arguments.
+template <typename... Ts>
+//- @f defines/binding FnTF
+void f(Ts... ts) { }
+
+void g() {
+//- @f ref AppFnTFSigma
+  f(1, "one");
+}
+
+//- @cc defines/binding CC CC typed String
+const char *cc;
+//- @tn defines/binding TN TN typed Int
+int tn;
+
+//- FnF instantiates AppFnTFSigma
+//- FnF.node/kind function
+//- AppFnTFSigma param.0 FnTF
+//- AppFnTFSigma param.1 Sigma
+//- Sigma.node/kind tsigma
+//- Sigma param.0 Int
+//- Sigma param.1 String

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_pack_fn_pack_call.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_pack_fn_pack_call.cc
@@ -1,0 +1,18 @@
+// We index calls to function templates with parameter pack arguments.
+
+//- @Ts defines/binding FTs
+template <typename... Ts>
+//- @S defines/binding AbsS
+void S(Ts... ts);
+
+//- @Ts defines/binding GTs
+template <typename... Ts>
+//- @g defines/binding AbsG
+//- FnTG childof AbsG
+void g(Ts... ts) {
+  //- SCall childof FnTG
+  //- SCall ref/call LookupS
+  auto s = S<Ts...>(ts...);
+}
+
+//- LookupS.text "S<Ts...>"

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_pack_rec_pack_call.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_pack_rec_pack_call.cc
@@ -1,0 +1,24 @@
+// We index calls to ctors of class templates with parameter pack arguments.
+
+//- @Ts defines/binding FTs
+template <typename... Ts>
+//- @S defines/binding AbsS
+struct S {
+  S(Ts... ts);
+};
+
+//- @Ts defines/binding GTs
+template <typename... Ts>
+//- @g defines/binding AbsG
+//- FnTG childof AbsG
+void g(Ts... ts) {
+  //- CtorCall ref/call CtorLookup
+  //- CtorCall childof FnTG
+  auto s = S<Ts...>(ts...);
+}
+
+//- CtorLookup.node/kind lookup
+//- CtorLookup.text "#ctor"
+//- CtorLookup param.0 TAppAbsSTs
+//- TAppAbsSTs param.0 AbsS
+//- TAppAbsSTs param.1 GTs

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_ps_completes.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_ps_completes.cc
@@ -1,0 +1,17 @@
+// Checks that completion edges are properly recorded for specializations.
+
+//- @C defines/binding TemplateTS
+template <typename T, typename S> class C;
+//- @C defines/binding TemplateT
+template <typename T> class C<int, T>;
+//- @C defines/binding Template
+template <> class C<int, float>;
+
+//- @C completes/uniquely TemplateTS
+template <typename T, typename S> class C { };
+
+//- @C completes/uniquely TemplateT
+template <typename T> class C<int, T> { };
+
+//- @C completes/uniquely Template
+template <> class C<int, float> { };

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_ps_decl.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_ps_decl.cc
@@ -1,0 +1,20 @@
+// Checks that single-variable specialization decls are recorded.
+template
+<typename T>
+//- @C defines/binding CDecl
+class C;
+
+template
+<>
+//- @C defines/binding PCDecl
+class C
+<int>;
+
+//- PCDecl specializes TAppNomCInt
+//- TAppNomCInt.node/kind tapp
+//- TAppNomCInt param.0 NominalC
+//- IncompleteC childof CDecl
+//- IncompleteC.node/kind record
+//- IncompleteC.complete incomplete
+//- PCDecl.node/kind record
+//- PCDecl.complete incomplete

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_ps_defn.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_ps_defn.cc
@@ -1,0 +1,24 @@
+// Checks that declarations and definitions of templates are distinguished.
+
+//- @C defines/binding FwdTemplate
+template <typename T> class C;
+
+//- @C defines/binding FwdSpec
+template <> class C <int>;
+
+//- @C defines/binding Template
+//- @C completes/uniquely FwdTemplate
+template <typename T> class C { };
+
+//- @C defines/binding Spec
+//- @C completes/uniquely FwdSpec
+template <> class C <int> { };
+
+//- FwdTemplate.node/kind abs
+//- FwdSpec.node/kind record
+//- FwdSpec.complete incomplete
+//- Fwd.node/kind abs
+//- Spec.node/kind record
+//- Spec.complete definition
+//- Spec specializes TAppCInt
+//- FwdSpec specializes TAppCInt

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_ps_multiple_decl.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_ps_multiple_decl.cc
@@ -1,0 +1,26 @@
+// Checks that multiple declarations of a partial specialization are recorded.
+template
+<typename T, typename S>
+//- @C defines/binding CDecl
+class C;
+
+template
+//- 
+<typename V>
+//- @C defines/binding CVDecl
+class C
+<int, V>;
+
+template
+<typename W>
+//- @C defines/binding CWDecl
+class C
+<int, W>;
+
+//- CWDecl specializes TAppCNameW
+//- CVDecl specializes TAppCNameV
+//- TAppCNameW.node/kind tapp
+//- TAppCNameV.node/kind tapp
+//- TAppCNameW param.0 NominalC
+//- TAppCNameV param.0 NominalC
+//- NominalC.node/kind tnominal

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_ps_twovar_decl.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_ps_twovar_decl.cc
@@ -1,0 +1,18 @@
+// Checks that multi-variable partial specialization decls are recorded.
+template
+<typename T, typename S>
+//- @C defines/binding CDecl
+class C;
+
+template
+//- @U defines/binding AbsU
+<typename U>
+//- @C defines/binding PCDecl
+class C
+<int, U>;
+
+//- PCDecl specializes TAppCDeclIntAbsU
+//- TAppCDeclIntAbsU.node/kind tapp
+//- TAppCDeclIntAbsU param.2 AbsU
+//- PCDecl param.0 AbsU
+//- TAppCDeclIntAbsU param.0 CNominal

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_rec_member_abs.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_rec_member_abs.cc
@@ -1,0 +1,13 @@
+// Checks that we don't draw spurious childof edges when aliasing is on.
+template <typename T>
+//- @C defines/binding AbsC
+//- ClassC childof AbsC
+//- @F defines/binding CiF  // aliased.
+//- CiF childof ClassC
+struct C { void F() { } };
+
+//- CiF instantiates TAppCiFNil
+//- TAppCiFNil param.0 CiF
+void g() { C<int> ci; ci.F(); }
+
+//- !{ CiF childof AbsC }  // The bug in question.

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_rec_override.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_rec_override.cc
@@ -1,0 +1,11 @@
+// We index overrides that come from templates.
+// Note that we override C<int>::f, not \T.C<T>::f.
+//- @f defines/binding CF
+//- @C defines/binding TemplateC
+//- CF childof CInstInt
+//- CInstInt instantiates TAppCInt
+//- TAppCInt param.0 TemplateC
+template <typename T> class C { virtual void f() { } };
+//- @f defines/binding DF
+//- DF overrides CF
+class D : public C<int> { void f() override { } };

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_rec_override_root.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_rec_override_root.cc
@@ -1,0 +1,17 @@
+// We index overrides that come from templates.
+// Note that we override C<int>::f, not \T.C<T>::f.
+//- @f defines/binding CF
+//- @C defines/binding TemplateC
+//- CF childof CInstInt
+//- CInstInt instantiates TAppCInt
+//- TAppCInt param.0 TemplateC
+//- !{CF overrides/root _}
+template <typename T> class C { virtual void f() { } };
+//- @f defines/binding DF
+//- DF overrides CF
+//- DF overrides/root CF
+class D : public C<int> { void f() override { } };
+//- @f defines/binding EF
+//- EF overrides DF
+//- EF overrides/root CF
+class E : public D { void f() override { } };

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_rec_override_root_aliasing.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_rec_override_root_aliasing.cc
@@ -1,0 +1,17 @@
+// We point at the correct abs nodes in overrides when aliasing is on.
+//- @f defines/binding CF
+//- @C defines/binding TemplateC
+//- ClassC childof TemplateC
+//- CF childof ClassC
+//- !{CF overrides/root _}
+template <typename T> class C { virtual void f() { } };
+//- @f defines/binding DF
+//- DF overrides TAppCF
+//- DF overrides/root TAppCF
+//- TAppCF.node/kind tapp
+//- TAppCF param.0 CF
+class D : public C<int> { void f() override { } };
+//- @f defines/binding EF
+//- EF overrides DF
+//- EF overrides/root TAppCF
+class E : public D { void f() override { } };

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_redundant_constituents_anchored.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_redundant_constituents_anchored.cc
@@ -1,0 +1,8 @@
+// Checks that repeated structured types have their constituents marked.
+template <typename T> class C { };
+//- @D defines/binding ClassD
+class D { };
+//- @D ref ClassD
+C<D> x;
+//- @D ref ClassD
+C<D> y;

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_static_member.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_static_member.cc
@@ -1,0 +1,15 @@
+// We handle refs to static member function template specs in member expressions
+// Needs -ignore_dups (function pointer type ref is doubly emitted)
+//- @C defines/binding StructC
+struct C { };
+//- @f defines/binding MemberF
+struct S { template <typename T> static int f(void) { return 0; } };
+S s;
+//- @C ref StructC
+//- @f ref TAppFC
+//- @"s.f<C>()" ref/call TAppFC
+//- TAppFC param.0 MemberF
+//- TAppFC param.1 StructC
+//- Imp instantiates TAppFC
+//- Imp.node/kind function
+void qqq() { s.f<C>(); }

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_two_arg_spec.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_two_arg_spec.cc
@@ -1,0 +1,16 @@
+// Checks that record nodes underneath abstractions are given distinct names.
+// (This test's verifier load is mainly in the well-formedness checks.)
+
+//- @C defines/binding TemplateC
+//- TemplateC.node/kind abs
+//- TemplaceCBody childof TemplateC
+//- TemplaceCBody.node/kind record
+template <typename T, typename S> class C { };
+
+//- @C defines/binding PartialSpecializationC
+//- PartialSpecializationC.node/kind abs
+template <typename U> class C<int, U> { };
+
+//- @C defines/binding TotalSpecializationC
+//- TotalSpecializationC.node/kind record
+template <> class C<int, float> { };

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_ty_typename.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_ty_typename.cc
@@ -1,0 +1,8 @@
+// Checks that typename template parameters are properly recorded.
+template
+//- @X defines/binding AbsvX
+<typename X>
+//- @C defines/binding Abs
+class C {};
+//- Abs param.0 AbsvX
+//- AbsvX.node/kind absvar

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_type_alias_param.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_type_alias_param.cc
@@ -1,0 +1,7 @@
+// Checks that we don't fall over on type alias type parameters.
+
+template <typename T>
+struct tstruct {};
+
+template <typename T>
+using alias = typename tstruct<T>::type;

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_unresolved_ctor_expr.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_unresolved_ctor_expr.cc
@@ -1,0 +1,15 @@
+// Checks that we handle type-dependent maybe-ctor callish sites.
+//   see also CXXUnresolvedConstructExpr.
+//- @T defines/binding TyvarT
+template<typename T, typename A1>
+//- @make_a defines/binding AbsMakeA
+//- MakeA childof AbsMakeA
+//- MakeA.node/kind function
+inline T make_a(const A1& a1) {
+  //- CallAnchor=@"T(a1)" ref/call LookupCtorT
+  //- CallAnchor childof MakeA
+  //- LookupCtorT.node/kind lookup
+  //- LookupCtorT.text "#ctor"
+  //- LookupCtorT param.0 TyvarT
+  return T(a1);
+}

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_using_pack_expansion.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_using_pack_expansion.cc
@@ -1,0 +1,28 @@
+// Verify that we emit references for C++17 pack expansion using declarations.
+
+struct A {
+  //- @Call defines/binding ACallFn
+  void Call(const A&);
+};
+
+struct B {
+  //- @Call defines/binding BCallFn
+  void Call(const B&);
+};
+
+template <typename... Ts>
+struct S : Ts... {
+  //- @Call ref/implicit ACallFn
+  //- @Call ref/implicit BCallFn
+  using Ts::Call...;
+};
+
+void f() {
+  S<A, B> c;
+  //- @Call ref ACallFn
+  //- @"c.Call(A{})" ref/call ACallFn
+  c.Call(A{});
+  //- @Call ref BCallFn
+  //- @"c.Call(B{})" ref/call BCallFn
+  c.Call(B{});
+}

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_var_constexpr.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_var_constexpr.cc
@@ -1,0 +1,13 @@
+// We index constexpr variable templates.
+//- VariableTemplate defines/binding VTAbs
+//- VTAbs.node/kind abs
+template <typename T> constexpr T VariableTemplate{};
+//- @VariableTemplate ref VTVar
+//- @auto ref IntBuiltin
+auto TemplateValue = VariableTemplate<int>;
+//- TApp.node/kind tapp
+//- TApp param.0 VTAbs
+//- TApp param.1 IntBuiltin
+//- VTVar.node/kind variable
+//- VTVar instantiates TApp
+//- VTVar specializes TApp

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_var_decl.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_var_decl.cc
@@ -1,0 +1,11 @@
+// Checks that we index decls of variable templates.
+//- @T defines/binding TyvarT
+template <typename T>
+//- @T ref TyvarT
+//- @y defines/binding VarY
+extern T y;
+//- VarY.node/kind abs
+//- VarYBody childof VarY
+//- VarYBody.node/kind variable
+//- VarYBody typed TyvarT
+//- VarYBody.complete incomplete

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_var_defn.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_var_defn.cc
@@ -1,0 +1,11 @@
+// Checks that we index defns of variable templates.
+//- @T defines/binding TyvarT
+template <typename T>
+//- @T ref TyvarT
+//- @y defines/binding VarY
+T y;
+//- VarY.node/kind abs
+//- VarYBody childof VarY
+//- VarYBody.node/kind variable
+//- VarYBody typed TyvarT
+//- VarYBody.complete definition

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_var_defn_completes.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_var_defn_completes.cc
@@ -1,0 +1,5 @@
+// Checks that variable template defns complete variable template decls.
+//- @z defines/binding VarZAbsDecl
+template <typename T> extern T z;
+//- @z completes/uniquely VarZAbsDecl
+template <typename T> T z;

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_var_explicit_spec.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_var_explicit_spec.cc
@@ -1,0 +1,10 @@
+// Tests that we index explicit specializations of template variables.
+//- @v defines/binding PrimaryTemplateV
+template <typename T> T v;
+//- @v defines/binding SpecIntV
+//- SpecIntV specializes AppPTInt
+//- AppPTInt.node/kind tapp
+//- AppPTInt param.0 PrimaryTemplateV
+//- AppPTInt param.1 vname("int#builtin",_,_,_,_)
+template <> int v<int>;
+template <> float v<float>;

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_var_implicit_spec.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_var_implicit_spec.cc
@@ -1,0 +1,10 @@
+// Tests that we index implicit specializations of template variables.
+//- @v defines/binding PrimaryTemplateV
+template <typename T> T v;
+//- @v ref SpecIntV
+//- SpecIntV instantiates AppPTInt
+//- SpecIntV specializes AppPTInt
+//- AppPTInt.node/kind tapp
+//- AppPTInt param.0 PrimaryTemplateV
+//- AppPTInt param.1 vname("int#builtin",_,_,_,_)
+int w = v<int>;

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_var_inst_total_spec.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_var_inst_total_spec.cc
@@ -1,0 +1,10 @@
+// Checks that we correctly record instantiates edges for total specs.
+//- @s_equals_float defines/binding PrimaryT
+template <typename S> bool s_equals_float = false;
+//- @s_equals_float defines/binding TotalT
+template <> bool s_equals_float<float> = true;
+//- @s_equals_float ref TotalT
+//- TotalT instantiates PrimaryTFloat
+//- TotalT specializes PrimaryTFloat
+//- PrimaryTFloat param.0 PrimaryT
+bool is_true = s_equals_float<float>;

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_var_ps.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_var_ps.cc
@@ -1,0 +1,13 @@
+// Tests that we index partial specializations of template variables.
+//- @v defines/binding VarV
+template <typename T, typename S> T v;
+//- @U defines/binding TyvarU
+template <typename U>
+//- @v defines/binding VarPSU
+U v<U, int>;
+//- VarPSU.node/kind abs
+//- VarPSU specializes TAppVarV
+//- TAppVarV.node/kind tapp
+//- TAppVarV param.0 VarV
+//- TAppVarV param.1 TyvarU
+//- TAppVarV param.2 vname("int#builtin",_,_,_,_)

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_var_ps_completes.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_var_ps_completes.cc
@@ -1,0 +1,6 @@
+// Checks completion edges for variable template partial specializations.
+template <typename T, typename S> extern T z;
+//- @z defines/binding VarZPsAbsDecl
+template <typename U> extern int z<int, U>;
+//- @z completes/uniquely VarZPsAbsDecl
+template <typename U> int z<int, U>;

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_var_ps_implicit_spec.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_var_ps_implicit_spec.cc
@@ -1,0 +1,17 @@
+// Tests that we index instances of partial specializations of template vars.
+//- @v defines/binding Prim
+template <typename T, typename S, typename V> T v;
+template <typename U>
+//- @v defines/binding Ps
+U v<int, U, long>;
+//- Ps.node/kind abs
+//- @v ref Spec
+float w = v<int, float, long>;
+//- Spec specializes TAppPrim
+//- Spec instantiates TAppPs
+//- TAppPrim param.0 Prim
+//- TAppPrim param.1 vname("int#builtin",_,_,_,_)
+//- TAppPrim param.2 vname("float#builtin",_,_,_,_)
+//- TAppPrim param.3 vname("long#builtin",_,_,_,_)
+//- TAppPs param.0 Ps
+//- TAppPs param.1 vname("float#builtin",_,_,_,_)

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_var_ref_ps.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_var_ref_ps.cc
@@ -1,0 +1,13 @@
+/// Tests that references to ps var templates go to the ps and not the primary.
+//- @v defines/binding Primary
+template <typename T, typename S> T v = S();
+//- @v defines/binding Partial
+//- Partial.node/kind abs
+//- @v defines/binding PartialVar
+//- PartialVar.node/kind variable
+template <typename U> U v<U, int> = 3;
+//- @v ref Spec
+int w = v<int,int>;
+//- Spec.node/kind variable
+//- Spec instantiates TAppPartial
+//- TAppPartial param.0 Partial


### PR DESCRIPTION
cp -R'd the relevant directories.
tvar_template/template_file_call.cc had to be updated
because it matches on a vname path.