### PR TITLE
chore: update Flogger and use Maven version

### DIFF
--- a/external.bzl
+++ b/external.bzl
@@ -277,23 +277,6 @@ def _cc_dependencies():
 
 def _java_dependencies():
     maybe(
-        # For @com_google_common_flogger
-        http_archive,
-        name = "google_bazel_common",
-        strip_prefix = "bazel-common-b3778739a9c67eaefe0725389f03cf821392ac67",
-        sha256 = "4ae0fd0af627be9523a166b88d1298375335f418dcc13a82e9e77a0089a4d254",
-        urls = [
-            "https://mirror.bazel.build/github.com/google/bazel-common/archive/b3778739a9c67eaefe0725389f03cf821392ac67.zip",
-            "https://github.com/google/bazel-common/archive/b3778739a9c67eaefe0725389f03cf821392ac67.zip",
-        ],
-    )
-    maybe(
-        git_repository,
-        name = "com_google_common_flogger",
-        commit = "ca8ad22bc1479b5675118308f88ef3fff7d26c1f",
-        remote = "https://github.com/google/flogger",
-    )
-    maybe(
         git_repository,
         name = "io_bazel",
         commit = "20c4596365d6e198ce9e4559a372190ceedff3f5",
@@ -302,6 +285,8 @@ def _java_dependencies():
     maven_install(
         name = "maven",
         artifacts = [
+            "com.google.flogger:flogger:0.7.2",
+            "com.google.flogger:flogger-system-backend:0.7.2",
             "com.beust:jcommander:1.81",
             "com.google.auto.service:auto-service:1.0",
             "com.google.auto.service:auto-service-annotations:1.0",

--- a/kythe/java/com/google/devtools/kythe/analyzers/java/BUILD
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/BUILD
@@ -89,9 +89,9 @@ java_binary(
         "//kythe/proto:analysis_java_proto",
         "//kythe/proto:storage_java_proto",
         "//third_party/guava",
-        "@com_google_common_flogger//api",
         "@com_google_protobuf//:protobuf_java",
         "@maven//:com_beust_jcommander",
+        "@maven//:com_google_flogger_flogger",
     ],
 )
 

--- a/kythe/java/com/google/devtools/kythe/common/BUILD
+++ b/kythe/java/com/google/devtools/kythe/common/BUILD
@@ -4,8 +4,8 @@ package(default_visibility = ["//kythe:default_visibility"])
 
 java_library(
     name = "flogger",
-    exports = ["@com_google_common_flogger//api"],
-    runtime_deps = ["@com_google_common_flogger//api:system_backend"],
+    exports = ["@maven//:com_google_flogger_flogger"],
+    runtime_deps = ["@maven//:com_google_flogger_flogger_system_backend"],
 )
 
 java_plugin(

--- a/kythe/java/com/google/devtools/kythe/extractors/java/standalone/BUILD
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/standalone/BUILD
@@ -49,7 +49,7 @@ java_library(
         "//kythe/proto:analysis_java_proto",
         "//third_party/guava",
         "//third_party/javac",
-        "@com_google_common_flogger//api",
+        "@maven//:com_google_flogger_flogger",
     ],
 )
 

--- a/kythe/java/com/google/devtools/kythe/extractors/shared/BUILD
+++ b/kythe/java/com/google/devtools/kythe/extractors/shared/BUILD
@@ -28,7 +28,7 @@ java_library(
     ],
     deps = [
         "//third_party/guava",
-        "@com_google_common_flogger//api",
+        "@maven//:com_google_flogger_flogger",
     ],
 )
 

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -35,7 +35,6 @@ filegroup(
         "@com_github_google_leveldb//:license",
         "@com_github_google_snappy//:license",
         "@com_github_tencent_rapidjson//:license",
-        "@com_google_common_flogger//:LICENSE",
         "@com_google_protobuf//:LICENSE",
         "@org_brotli//:LICENSE",
     ],


### PR DESCRIPTION
While we don't use Flogger in such a vulnerable way (we only use the system backend, not log4j), update to a version of flogger which addresses the issue as well.

Also, use the maven version rather than building from source.