### PR TITLE
fix: update debian version in go extractor

### DIFF
--- a/kythe/go/extractors/cmd/gotool/Dockerfile
+++ b/kythe/go/extractors/cmd/gotool/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/cloud-builders/go:debian
+FROM gcr.io/cloud-builders/go:debian-1.17
 
 RUN apt-get update && \
     apt-get install -y parallel && \


### PR DESCRIPTION
The current debian version gives an error when building the docker image. Update explicitly to 1.17

Error:

```
ERROR:
.../go/extractors/cmd/gotool/BUILD:20:13:
Executing genrule //kythe/go/extractors/cmd/gotool:docker failed: (Exit
100): bash failed: error executing command /bin/bash -c ... (remaining 1
argument(s) skipped)
The command '/bin/sh -c apt-get update &&     apt-get install -y
parallel &&     apt-get clean' returned a non-zero code: 100
Sending build context to Docker daemon  20.43MB
Step 1/8 : FROM gcr.io/cloud-builders/go:debian
 ---> 42247a86b532
 Step 2/8 : RUN apt-get update &&     apt-get install -y parallel &&
 apt-get clean
  ---> Running in 71129e1f967c
  Get:1 http://deb.debian.org/debian buster InRelease [122 kB]
  Get:2 http://security.debian.org/debian-security buster/updates
  InRelease [65.4 kB]
  Get:3 http://deb.debian.org/debian buster-updates InRelease [51.9 kB]
  Reading package lists...
  E: Repository 'http://security.debian.org/debian-security
  buster/updates InRelease' changed its 'Suite' value from 'stable' to
  'oldstable'
  E: Repository 'http://deb.debian.org/debian buster InRelease' changed
  its 'Suite' value from 'stable' to 'oldstable'
  E: Repository 'http://deb.debian.org/debian buster-updates InRelease'
  changed its 'Suite' value from 'stable-updates' to 'oldstable-updates'
  Removing intermediate container 71129e1f967c
  Target //kythe/go/extractors/cmd/gotool:docker failed to build
  Use --verbose_failures to see the command lines of failed build steps.
  INFO: Elapsed time: 6.242s, Critical Path: 5.87s
  INFO: 2 processes: 2 internal.
  FAILED: Build did NOT complete successfully
```