### PR TITLE
fix(rust_common): clippy fixes for new Rust version

### DIFF
--- a/external.bzl
+++ b/external.bzl
@@ -40,7 +40,7 @@ def _rule_dependencies():
     rules_proto_dependencies()
     py_repositories()
     bazel_toolchains_repositories()
-    rust_repositories(version = "nightly", iso_date = "2021-10-16", dev_components = True)
+    rust_repositories(version = "nightly", iso_date = "2021-12-20", dev_components = True)
     rust_proto_repositories()
     rules_ruby_dependencies()
     rules_ruby_select_sdk(version = "host")

--- a/kythe/rust/extractor/src/bin/extractor.rs
+++ b/kythe/rust/extractor/src/bin/extractor.rs
@@ -260,7 +260,7 @@ fn analysis_path_string(build_output_path: &str, temp_dir_path: &Path) -> Result
     // always replace the hyphens with underscores because the save_analysis
     // files for libraries have hyphens in them.
     if !path.exists() {
-        path = temp_dir_path.join("save-analysis").join(analysis_file_str.replace("-", "_"));
+        path = temp_dir_path.join("save-analysis").join(analysis_file_str.replace('-', "_"));
     }
 
     path.to_str()

--- a/kythe/rust/indexer/src/indexer/analyzers.rs
+++ b/kythe/rust/indexer/src/indexer/analyzers.rs
@@ -152,18 +152,18 @@ impl<'a> UnitAnalyzer<'a> {
 
             // Read the file contents and set it on the fact
             // Returns a FileReadError if we can't read the file
-            let file_contents: String;
-            if let Some(file_digest) = self.file_digests.get(&source_file.to_string()) {
-                let file_bytes = self.provider.contents(source_file, file_digest)?;
-                file_contents = String::from_utf8(file_bytes).map_err(|_| {
-                    KytheError::IndexerError(format!(
-                        "Failed to read file {} as UTF8 string",
-                        source_file
-                    ))
-                })?;
-            } else {
-                return Err(KytheError::FileNotFoundError(source_file.to_string()));
-            }
+            let file_contents: String =
+                if let Some(file_digest) = self.file_digests.get(source_file) {
+                    let file_bytes = self.provider.contents(source_file, file_digest)?;
+                    String::from_utf8(file_bytes).map_err(|_| {
+                        KytheError::IndexerError(format!(
+                            "Failed to read file {} as UTF8 string",
+                            source_file
+                        ))
+                    })?
+                } else {
+                    return Err(KytheError::FileNotFoundError(source_file.to_string()));
+                };
 
             // Add the file to the OffsetIndex
             self.offset_index.add_file(source_file, &file_contents);

--- a/kythe/rust/indexer/src/providers.rs
+++ b/kythe/rust/indexer/src/providers.rs
@@ -82,7 +82,7 @@ impl KzipFileProvider {
             }
             // Safe to unwrap because kzip read would have failed if the internal paths
             // weren't UTF-8
-            path.to_str().unwrap().to_owned().replace("/", "")
+            path.to_str().unwrap().to_owned().replace('/', "")
         };
 
         Ok(Self { zip_archive, root_name })


### PR DESCRIPTION
This PR upgrades the Rust toolchain to 2021-12-20 and applies clippy fixes for the new version. Unfortunately, this currently breaks the use of clippy on macOS Monterey due to issues with malloc.

See #5162 for tracking this issue