### PR TITLE
chore(cxx_indexer): update LLVM

### DIFF
--- a/kythe/cxx/indexer/cxx/IndexerASTHooks.cc
+++ b/kythe/cxx/indexer/cxx/IndexerASTHooks.cc
@@ -1915,6 +1915,13 @@ bool IndexerASTVisitor::VisitTypedefTypeLoc(clang::TypedefTypeLoc TL) {
   return true;
 }
 
+bool IndexerASTVisitor::VisitUsingTypeLoc(clang::UsingTypeLoc TL) {
+  // Uses of using-declared types should match uses of other using-declared
+  // names and reference the underlying entity.
+  RecordTypeLocSpellingLocation(TL);
+  return true;
+}
+
 bool IndexerASTVisitor::VisitInjectedClassNameTypeLoc(
     clang::InjectedClassNameTypeLoc TL) {
   RecordTypeLocSpellingLocation(TL);
@@ -4566,6 +4573,10 @@ NodeSet IndexerASTVisitor::BuildNodeSetForElaborated(
   return BuildNodeSetForType(T.getNamedType());
 }
 
+NodeSet IndexerASTVisitor::BuildNodeSetForUsing(const clang::UsingType& T) {
+  return BuildNodeSetForType(T.getUnderlyingType());
+}
+
 NodeSet IndexerASTVisitor::BuildNodeSetForTypedef(const clang::TypedefType& T) {
   // TODO(zarko): Return canonicalized versions as well.
   GraphObserver::NameId AliasID = BuildNameIdForDecl(T.getDecl());
@@ -4853,6 +4864,7 @@ NodeSet IndexerASTVisitor::BuildNodeSetForTypeInternal(const clang::Type& T) {
     DELEGATE_TYPE(Typedef);
     DELEGATE_TYPE(Decltype);
     DELEGATE_TYPE(Elaborated);
+    DELEGATE_TYPE(Using);
     // "Within an instantiated template, all template type parameters have
     // been replaced with these. They are used solely to record that a type
     // was originally written as a template type parameter; therefore they are

--- a/kythe/cxx/indexer/cxx/IndexerASTHooks.h
+++ b/kythe/cxx/indexer/cxx/IndexerASTHooks.h
@@ -224,6 +224,7 @@ class IndexerASTVisitor : public RecursiveTypeVisitor<IndexerASTVisitor> {
   bool VisitDecltypeTypeLoc(clang::DecltypeTypeLoc TL);
   bool VisitElaboratedTypeLoc(clang::ElaboratedTypeLoc TL);
   bool VisitTypedefTypeLoc(clang::TypedefTypeLoc TL);
+  bool VisitUsingTypeLoc(clang::UsingTypeLoc TL);
   bool VisitInjectedClassNameTypeLoc(clang::InjectedClassNameTypeLoc TL);
   bool VisitDependentNameTypeLoc(clang::DependentNameTypeLoc TL);
   bool VisitPackExpansionTypeLoc(clang::PackExpansionTypeLoc TL);
@@ -380,6 +381,7 @@ class IndexerASTVisitor : public RecursiveTypeVisitor<IndexerASTVisitor> {
   NodeSet BuildNodeSetForDecltype(const clang::DecltypeType& T);
   NodeSet BuildNodeSetForElaborated(const clang::ElaboratedType& T);
   NodeSet BuildNodeSetForTypedef(const clang::TypedefType& T);
+  NodeSet BuildNodeSetForUsing(const clang::UsingType& T);
 
   NodeSet BuildNodeSetForSubstTemplateTypeParm(
       const clang::SubstTemplateTypeParmType& T);

--- a/kythe/cxx/indexer/cxx/recursive_type_visitor.h
+++ b/kythe/cxx/indexer/cxx/recursive_type_visitor.h
@@ -273,6 +273,7 @@ DEF_TRAVERSE_TYPEPAIR(FunctionProtoType, {
 });
 DEF_TRAVERSE_TYPEPAIR(UnresolvedUsingType, {});
 DEF_TRAVERSE_TYPEPAIR(TypedefType, {});
+DEF_TRAVERSE_TYPEPAIR(UsingType, {});
 DEF_TRAVERSE_TYPEPAIR(TypeOfExprType, {
   return getDerived().TraverseStmt(TL.getUnderlyingExpr());
 });

--- a/kythe/cxx/indexer/cxx/testdata/basic/using_declaration_ref.cc
+++ b/kythe/cxx/indexer/cxx/testdata/basic/using_declaration_ref.cc
@@ -13,4 +13,9 @@ using nasa::Shuttle;
 //- @Launch ref FnLaunch
 //- @Launch ref FnLaunchInt
 using nasa::Launch;
+
+void fn() {
+  // @Shuttle ref StructS
+  Shuttle s;
+}
 }

--- a/setup.bzl
+++ b/setup.bzl
@@ -138,7 +138,7 @@ def kythe_rule_repositories():
     maybe(
         github_archive,
         repo_name = "llvm/llvm-project",
-        commit = "ae53d02f557cdec5f05a19239f887b06d1a8518d",
+        commit = "6f1a501fddaef72fdc4c7bcccedce0307d111ffb",
         name = "llvm-project-raw",
         build_file_content = "#empty",
         patch_args = ["-p1"],


### PR DESCRIPTION
Good news: Upstream clang seems to have added better support for tracking types found via using declaration.
Bad news: That broke some tests ;-)