### PR TITLE
feat(go extractor): add flag to put deps in default corpus

### DIFF
--- a/kythe/go/extractors/cmd/gotool/gotool.go
+++ b/kythe/go/extractors/cmd/gotool/gotool.go
@@ -53,6 +53,7 @@ var (
 
 	canonicalizePackageCorpus = flag.Bool("canonicalize_package_corpus", false, "Whether to use a package's canonical repository root URL as their corpus")
 	useDefaultCorpusForStdLib = flag.Bool("use_default_corpus_for_stdlib", false, "By default, go stdlib files are given the 'golang.org' corpus. If this flag is enabled, they will instead be assigned the corpus from the --corpus flag.")
+	useDefaultCorpusForDeps   = flag.Bool("use_default_corpus_for_deps", false, "By default, imported modules are assigned a corpus based on their import path. If this flag is enabled, they will instead be assigned the corpus from the --corpus flag and a root corresponding the their import path.")
 
 	buildTags flagutil.StringList
 )
@@ -123,6 +124,7 @@ func main() {
 			CanonicalizePackageCorpus: *canonicalizePackageCorpus,
 			RootDirectory:             os.Getenv("KYTHE_ROOT_DIRECTORY"),
 			UseDefaultCorpusForStdLib: *useDefaultCorpusForStdLib,
+			UseDefaultCorpusForDeps:   *useDefaultCorpusForDeps,
 		},
 	}
 	if *extraFiles != "" {

--- a/kythe/go/extractors/govname/govname.go
+++ b/kythe/go/extractors/govname/govname.go
@@ -63,6 +63,11 @@ type PackageVNameOptions struct {
 	// UseDefaultCorpusForStdLib tells the extractor to assign the DefaultCorpus
 	// to go stdlib files rather than the default of 'golang.org'.
 	UseDefaultCorpusForStdLib bool
+
+	// UseDefaultCorpusForDeps tells the extractor to set the vname corpus for
+	// imported modules to DefaultCorpus and to use the module's import path as
+	// the vname's root.
+	UseDefaultCorpusForDeps bool
 }
 
 // ForPackage returns a VName for a Go package.
@@ -144,6 +149,12 @@ func ForPackage(pkg *build.Package, opts *PackageVNameOptions) *spb.VName {
 		} else {
 			v.Corpus = r.Root
 		}
+
+		if opts.UseDefaultCorpusForDeps && v.Corpus != opts.DefaultCorpus {
+			v.Root = v.Corpus
+			v.Corpus = opts.DefaultCorpus
+		}
+
 		return v
 	}
 

--- a/kythe/go/extractors/govname/govname_test.go
+++ b/kythe/go/extractors/govname/govname_test.go
@@ -39,13 +39,15 @@ func TestForPackage(t *testing.T) {
 		}}]`
 
 	tests := []struct {
-		path      string // import path
-		dir       string // on-disk directory that contains this package
-		root      string // GOPATH if set, otherwise working directory from which extractor was invoked
-		ticket    string
-		canonical string
-		isRoot    bool
-		rulesJSON string
+		path                    string // import path
+		dir                     string // on-disk directory that contains this package
+		root                    string // GOPATH if set, otherwise working directory from which extractor was invoked
+		ticket                  string
+		canonical               string
+		isRoot                  bool
+		rulesJSON               string
+		defaultCorpus           string
+		useDefaultCorpusForDeps bool
 	}{
 		{path: "bytes", ticket: "kythe://golang.org?lang=go?path=bytes#package", isRoot: true},
 		// Rules should have no effect on go stdlib packages.
@@ -63,6 +65,7 @@ func TestForPackage(t *testing.T) {
 		{path: "bitbucket.org/creachadair/stringset/makeset", ticket: "kythe://bitbucket.org/creachadair/stringset?lang=go?path=makeset#package"},
 		{path: "launchpad.net/~frood/blee/blor", ticket: "kythe://launchpad.net/~frood/blee/blor?lang=go#package"},
 		{path: "launchpad.net/~frood/blee/blor/baz", ticket: "kythe://launchpad.net/~frood/blee/blor?lang=go?path=baz#package"},
+		{path: "bitbucket.org/creachadair/stringset/makeset", defaultCorpus: "github.com/kythe/kythe", useDefaultCorpusForDeps: true, ticket: "kythe://github.com/kythe/kythe?lang=go?path=makeset?root=bitbucket.org/creachadair/stringset#package"},
 	}
 	for _, test := range tests {
 		var rules vnameutil.Rules
@@ -80,7 +83,11 @@ func TestForPackage(t *testing.T) {
 			Dir:        test.dir,
 			Root:       test.root,
 		}
-		got := ForPackage(pkg, &PackageVNameOptions{Rules: rules})
+		got := ForPackage(pkg, &PackageVNameOptions{
+			DefaultCorpus:           test.defaultCorpus,
+			UseDefaultCorpusForDeps: test.useDefaultCorpusForDeps,
+			Rules:                   rules,
+		})
 		gotTicket := kytheuri.ToString(got)
 		if gotTicket != test.ticket {
 			t.Errorf(`ForPackage([%s], nil): got %q, want %q`, test.path, gotTicket, test.ticket)

--- a/kythe/go/extractors/govname/govname_test.go
+++ b/kythe/go/extractors/govname/govname_test.go
@@ -97,7 +97,12 @@ func TestForPackage(t *testing.T) {
 		if test.canonical != "" {
 			canonical = test.canonical
 		}
-		canonicalOpts := &PackageVNameOptions{CanonicalizePackageCorpus: true, Rules: rules}
+		canonicalOpts := &PackageVNameOptions{
+			DefaultCorpus:             test.defaultCorpus,
+			UseDefaultCorpusForDeps:   test.useDefaultCorpusForDeps,
+			CanonicalizePackageCorpus: true,
+			Rules:                     rules,
+		}
 		if got := kytheuri.ToString(ForPackage(pkg, canonicalOpts)); got != canonical {
 			t.Errorf(`ForPackage([%s], %#v): got %q, want canonicalized %q`, test.path, canonicalOpts, got, canonical)
 		}


### PR DESCRIPTION
This will be used in our extraction of repos for the oss pipeline, where we want all extracted items to be assigned to the main/default corpus.