### PR TITLE
fix(go extractor image): updates for extracting to a single corpus

### DIFF
--- a/kythe/go/extractors/cmd/gotool/readme.md
+++ b/kythe/go/extractors/cmd/gotool/readme.md
@@ -1,0 +1,20 @@
+# golang-extractor image
+
+## Example usage
+
+```.sh
+mkdir -p /tmp/workspace/gopath/src/golang.org/x
+
+git clone https://go.googlesource.com/tools /tmp/workspace/gopath/src/golang.org/x/tools
+
+docker run \
+  -v /tmp/workspace:/workspace:z \
+  -e KYTHE_CORPUS=golang.org/x/tools \
+  -e GOPATH=/workspace/gopath \
+  -e OUTPUT=/workspace/out \
+  gcr.io/kythe-public/golang-extractor:latest \
+  golang.org/x/tools
+
+# inspect output kzip
+kzip info --input /tmp/workspace/out/compilations.kzip | jq
+```


### PR DESCRIPTION
* additional checks for required environment variables
* only handles one top-level go package
* automatically gather deps using `go mod vendor` (requires the
  extracted go package to use modules)

This change is currently running in the :latest version of the golang-extractor image, which we're using for our go builds on GCB