### PR TITLE
chore: update LLVM and fix tests

### DIFF
--- a/kythe/cxx/indexer/cxx/testdata/basic/decltype_auto.cc
+++ b/kythe/cxx/indexer/cxx/testdata/basic/decltype_auto.cc
@@ -6,7 +6,7 @@ const int x = 42;
 // NB: "auto" doesn't refer to anything here; it's just taking up space.
 //- @v defines/binding VarV
 //- VarV typed ConstIntType
-//- @decltype ref ConstIntType
+//- @"decltype(auto)" ref ConstIntType
 decltype(auto) v = x;
 //- @auto ref IntType
 auto w = x;

--- a/setup.bzl
+++ b/setup.bzl
@@ -138,7 +138,7 @@ def kythe_rule_repositories():
     maybe(
         github_archive,
         repo_name = "llvm/llvm-project",
-        commit = "ad1b8772cf6b16c1162bb8ff425679f5ff046ae9",
+        commit = "f77d115cc136585f39d30a78c741eb296f9e804d",
         name = "llvm-project-raw",
         build_file_content = "#empty",
         patch_args = ["-p1"],


### PR DESCRIPTION
Unlike the generic `decltype(expr)` `decltype(auto)` is a special-case of `AutoTypeLoc` and, importantly, can't contain arbitrary expressions.  We fixed the former by only decorating the `decltype` keyword to avoid potentially conflicting decorations within the expression body along with a general distaste for anchors which may span lines (not forbidden, but often not handled well by UIs).  `decltype(auto)` doesn't have those problems so just decorate the entire thing and update the test.

If desired, however, I can make the behavior consistent between `decltype(auto)` and `decltype(expr)`