### PR TITLE
feat(cxx_indexer): don't emit abs nodes

### DIFF
--- a/kythe/cxx/indexer/cxx/testdata/BUILD
+++ b/kythe/cxx/indexer/cxx/testdata/BUILD
@@ -2562,10 +2562,14 @@ test_suite(
     tags = ["template"],
 )
 
+# A note on all the ignore_dups = True lines: experimental_use_abs_nodes = False
+# implies the effects of experimental_alias_template_instantiations = True,
+# leading to more duplicate ("aliased") output.
 cc_indexer_test(
     name = "tvar_template_alias",
     srcs = ["tvar_template/template_alias.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -2591,6 +2595,7 @@ cc_indexer_test(
     name = "tvar_template_type_alias_param",
     srcs = ["tvar_template/template_type_alias_param.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -2598,6 +2603,7 @@ cc_indexer_test(
     name = "tvar_template_alias_implicit_instantiation",
     srcs = ["tvar_template/template_alias_implicit_instantiation.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -2605,6 +2611,7 @@ cc_indexer_test(
     name = "tvar_template_alias_implicit_instantiation_decls",
     srcs = ["tvar_template/template_alias_implicit_instantiation_decls.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -2623,6 +2630,7 @@ cc_indexer_test(
     name = "tvar_template_arg_multiple_typename",
     srcs = ["tvar_template/template_arg_multiple_typename.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -2630,6 +2638,7 @@ cc_indexer_test(
     name = "tvar_template_arg_typename",
     srcs = ["tvar_template/template_arg_typename.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -2637,6 +2646,7 @@ cc_indexer_test(
     name = "tvar_template_blame_member",
     srcs = ["tvar_template/template_blame_member.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -2644,6 +2654,7 @@ cc_indexer_test(
     name = "tvar_template_blame_spec",
     srcs = ["tvar_template/template_blame_spec.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -2651,6 +2662,7 @@ cc_indexer_test(
     name = "tvar_template_blame_pspec_member",
     srcs = ["tvar_template/template_blame_pspec_member.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -2658,6 +2670,7 @@ cc_indexer_test(
     name = "tvar_template_blame_spec_member",
     srcs = ["tvar_template/template_blame_spec_member.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -2681,6 +2694,7 @@ cc_indexer_test(
     name = "tvar_template_class_defn",
     srcs = ["tvar_template/template_class_defn.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -2688,6 +2702,7 @@ cc_indexer_test(
     name = "tvar_template_class_fn_spec",
     srcs = ["tvar_template/template_class_fn_spec.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -2695,6 +2710,7 @@ cc_indexer_test(
     name = "tvar_template_class_inner",
     srcs = ["tvar_template/template_class_inner.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -2702,6 +2718,7 @@ cc_indexer_test(
     name = "tvar_template_class_inst_explicit",
     srcs = ["tvar_template/template_class_inst_explicit.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -2710,7 +2727,7 @@ cc_indexer_test(
     srcs = ["tvar_template/template_class_inst_implicit.cc"],
     experimental_use_abs_nodes = False,
     # Type alias alias inside a class template gets the same documentation text.
-    # TODO(zarkoexperimental_use_abs_nodes = False, ): Should the two aliases be distinctly named?
+    # TODO(zarko): Should the two aliases be distinctly named?
     ignore_dups = True,
     tags = ["tvar_template"],
 )
@@ -2719,6 +2736,7 @@ cc_indexer_test(
     name = "tvar_template_class_inst_implicit_dependent",
     srcs = ["tvar_template/template_class_inst_implicit_dependent.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -2726,6 +2744,7 @@ cc_indexer_test(
     name = "tvar_template_class_inst_vs_spec",
     srcs = ["tvar_template/template_class_inst_vs_spec.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -2733,6 +2752,7 @@ cc_indexer_test(
     name = "tvar_template_class_ref",
     srcs = ["tvar_template/template_class_ref.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -2740,6 +2760,7 @@ cc_indexer_test(
     name = "tvar_template_class_ref_ps",
     srcs = ["tvar_template/template_class_ref_ps.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -2747,6 +2768,7 @@ cc_indexer_test(
     name = "tvar_template_class_skip_implicit_on",
     srcs = ["tvar_template/template_class_skip_implicit_on.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     index_template_instantiations = False,
     tags = ["tvar_template"],
 )
@@ -2755,6 +2777,7 @@ cc_indexer_test(
     name = "tvar_template_depbase_field_ref",
     srcs = ["tvar_template/template_depbase_field_ref.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -2802,6 +2825,7 @@ cc_indexer_test(
     name = "tvar_template_dependent_sized_array",
     srcs = ["tvar_template/template_dependent_sized_array.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -2809,6 +2833,7 @@ cc_indexer_test(
     name = "tvar_template_depexpr_field_ref",
     srcs = ["tvar_template/template_depexpr_field_ref.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -2816,6 +2841,7 @@ cc_indexer_test(
     name = "tvar_template_depname_field_ref",
     srcs = ["tvar_template/template_depname_field_ref.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -2823,6 +2849,7 @@ cc_indexer_test(
     name = "tvar_template_depname_template_field_ref",
     srcs = ["tvar_template/template_depname_template_field_ref.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -2830,6 +2857,7 @@ cc_indexer_test(
     name = "tvar_template_depname_class",
     srcs = ["tvar_template/template_depname_class.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -2837,6 +2865,7 @@ cc_indexer_test(
     name = "tvar_template_depname_implicit",
     srcs = ["tvar_template/template_depname_implicit.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -2844,6 +2873,7 @@ cc_indexer_test(
     name = "tvar_template_depname_inst_class",
     srcs = ["tvar_template/template_depname_inst_class.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     ignore_unimplemented = True,
     tags = ["tvar_template"],
 )
@@ -2911,6 +2941,7 @@ cc_indexer_test(
     name = "tvar_template_field",
     srcs = ["tvar_template/template_field.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -2920,6 +2951,7 @@ cc_indexer_test(
     check_for_singletons = True,
     convert_marked_source = True,
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     std = "c++17",
     tags = [
         "c++17",
@@ -2931,6 +2963,7 @@ cc_indexer_test(
     name = "tvar_template_fn_call",
     srcs = ["tvar_template/template_fn_call.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -2938,6 +2971,7 @@ cc_indexer_test(
     name = "tvar_template_fn_decl",
     srcs = ["tvar_template/template_fn_decl.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -2945,6 +2979,7 @@ cc_indexer_test(
     name = "tvar_template_fn_decl_defn",
     srcs = ["tvar_template/template_fn_decl_defn.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -2952,6 +2987,7 @@ cc_indexer_test(
     name = "tvar_template_fn_defines",
     srcs = ["tvar_template/template_fn_defines.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -2959,6 +2995,7 @@ cc_indexer_test(
     name = "tvar_template_fn_defn",
     srcs = ["tvar_template/template_fn_defn.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -2966,6 +3003,7 @@ cc_indexer_test(
     name = "tvar_template_fn_dependent_spec_defn",
     srcs = ["tvar_template/template_fn_dependent_spec_defn.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -2973,6 +3011,7 @@ cc_indexer_test(
     name = "tvar_template_fn_explicit_spec_completes",
     srcs = ["tvar_template/template_fn_explicit_spec_completes.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -2980,6 +3019,7 @@ cc_indexer_test(
     name = "tvar_template_fn_explicit_spec_with_default_completes",
     srcs = ["tvar_template/template_fn_explicit_spec_with_default_completes.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -2987,6 +3027,7 @@ cc_indexer_test(
     name = "tvar_template_fn_implicit_spec",
     srcs = ["tvar_template/template_fn_implicit_spec.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -3002,6 +3043,7 @@ cc_indexer_test(
     name = "tvar_template_fn_member_spec_defn",
     srcs = ["tvar_template/template_fn_member_spec_defn.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -3009,6 +3051,7 @@ cc_indexer_test(
     name = "tvar_template_fn_multi_decl_def",
     srcs = ["tvar_template/template_fn_multi_decl_def.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -3016,6 +3059,7 @@ cc_indexer_test(
     name = "tvar_template_fn_multiple_implicit_spec",
     srcs = ["tvar_template/template_fn_multiple_implicit_spec.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -3023,6 +3067,7 @@ cc_indexer_test(
     name = "tvar_template_fn_overload",
     srcs = ["tvar_template/template_fn_overload.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -3030,6 +3075,7 @@ cc_indexer_test(
     name = "tvar_template_fn_spec",
     srcs = ["tvar_template/template_fn_spec.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -3037,6 +3083,7 @@ cc_indexer_test(
     name = "tvar_template_fn_spec_decl",
     srcs = ["tvar_template/template_fn_spec_decl.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -3044,6 +3091,7 @@ cc_indexer_test(
     name = "tvar_template_fn_spec_defn_decl",
     srcs = ["tvar_template/template_fn_spec_defn_decl.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -3051,6 +3099,7 @@ cc_indexer_test(
     name = "tvar_template_fn_spec_defn_defn_decl_decl",
     srcs = ["tvar_template/template_fn_spec_defn_defn_decl_decl.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -3058,6 +3107,7 @@ cc_indexer_test(
     name = "tvar_template_fn_spec_overload",
     srcs = ["tvar_template/template_fn_spec_overload.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -3065,6 +3115,7 @@ cc_indexer_test(
     name = "tvar_template_incomplete_array",
     srcs = ["tvar_template/template_incomplete_array.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -3072,6 +3123,7 @@ cc_indexer_test(
     name = "tvar_template_instance_type_from_class",
     srcs = ["tvar_template/template_instance_type_from_class.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -3079,6 +3131,7 @@ cc_indexer_test(
     name = "tvar_template_nested_name",
     srcs = ["tvar_template/template_nested_name.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -3086,6 +3139,7 @@ cc_indexer_test(
     name = "tvar_template_multilevel_argument",
     srcs = ["tvar_template/template_multilevel_argument.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -3125,6 +3179,7 @@ cc_indexer_test(
     name = "tvar_template_ps_completes",
     srcs = ["tvar_template/template_ps_completes.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -3132,6 +3187,7 @@ cc_indexer_test(
     name = "tvar_template_ps_decl",
     srcs = ["tvar_template/template_ps_decl.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -3139,6 +3195,7 @@ cc_indexer_test(
     name = "tvar_template_ps_defn",
     srcs = ["tvar_template/template_ps_defn.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -3146,6 +3203,7 @@ cc_indexer_test(
     name = "tvar_template_ps_multiple_decl",
     srcs = ["tvar_template/template_ps_multiple_decl.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -3153,6 +3211,7 @@ cc_indexer_test(
     name = "tvar_template_ps_twovar_decl",
     srcs = ["tvar_template/template_ps_twovar_decl.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -3169,6 +3228,7 @@ cc_indexer_test(
     name = "tvar_template_rec_override",
     srcs = ["tvar_template/template_rec_override.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -3176,6 +3236,7 @@ cc_indexer_test(
     name = "tvar_template_rec_override_root",
     srcs = ["tvar_template/template_rec_override_root.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -3193,6 +3254,7 @@ cc_indexer_test(
     name = "tvar_template_redundant_constituents_anchored",
     srcs = ["tvar_template/template_redundant_constituents_anchored.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -3208,6 +3270,7 @@ cc_indexer_test(
     name = "tvar_template_two_arg_spec",
     srcs = ["tvar_template/template_two_arg_spec.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -3215,6 +3278,7 @@ cc_indexer_test(
     name = "tvar_template_ty_typename",
     srcs = ["tvar_template/template_ty_typename.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -3222,6 +3286,7 @@ cc_indexer_test(
     name = "tvar_template_unresolved_ctor_expr",
     srcs = ["tvar_template/template_unresolved_ctor_expr.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -3229,6 +3294,7 @@ cc_indexer_test(
     name = "tvar_template_var_decl",
     srcs = ["tvar_template/template_var_decl.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -3236,6 +3302,7 @@ cc_indexer_test(
     name = "tvar_template_var_defn",
     srcs = ["tvar_template/template_var_defn.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -3243,6 +3310,7 @@ cc_indexer_test(
     name = "tvar_template_var_defn_completes",
     srcs = ["tvar_template/template_var_defn_completes.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -3250,6 +3318,7 @@ cc_indexer_test(
     name = "tvar_template_var_explicit_spec",
     srcs = ["tvar_template/template_var_explicit_spec.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -3265,6 +3334,7 @@ cc_indexer_test(
     name = "tvar_template_var_inst_total_spec",
     srcs = ["tvar_template/template_var_inst_total_spec.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -3272,6 +3342,7 @@ cc_indexer_test(
     name = "tvar_template_var_ps",
     srcs = ["tvar_template/template_var_ps.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -3279,6 +3350,7 @@ cc_indexer_test(
     name = "tvar_template_var_ps_completes",
     srcs = ["tvar_template/template_var_ps_completes.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -3286,6 +3358,7 @@ cc_indexer_test(
     name = "tvar_template_var_ps_implicit_spec",
     srcs = ["tvar_template/template_var_ps_implicit_spec.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -3293,6 +3366,7 @@ cc_indexer_test(
     name = "tvar_template_var_ref_ps",
     srcs = ["tvar_template/template_var_ref_ps.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     tags = ["tvar_template"],
 )
 
@@ -3318,6 +3392,7 @@ cc_indexer_test(
     name = "tvar_template_using_pack_expansion",
     srcs = ["tvar_template/template_using_pack_expansion.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     std = "c++17",
     tags = [
         "c++17",
@@ -3329,6 +3404,7 @@ cc_indexer_test(
     name = "tvar_template_auto_parameter",
     srcs = ["tvar_template/template_auto_parameter.cc"],
     experimental_use_abs_nodes = False,
+    ignore_dups = True,
     std = "c++17",
     tags = [
         "c++17",

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_alias.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_alias.cc
@@ -2,13 +2,10 @@
 
 //- @U defines/binding TyvarU
 template<typename U>
-//- @T defines/binding AliasTemplate
+//- @T defines/binding T
 //- @U ref TyvarU
 using T = U;
 
-//- AliasTemplate.node/kind abs
 //- TyvarU.node/kind tvar
-//- T childof AliasTemplate
 //- T tparam.0 TyvarU
-//- Alias childof AliasTemplate
 //- Alias.node/kind talias

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_alias_implicit_instantiation_decls.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_alias_implicit_instantiation_decls.cc
@@ -1,8 +1,9 @@
 // Checks that specialization decls are given the right names.
-//- @S defines/binding TemplateS
+//- @S defines/binding StructS
 template <typename T> struct S;
 //- @T defines/binding NominalAlias
+//- NominalAlias.node/kind talias
 using T = S<float>;
 //- NominalAlias aliases TApp
-//- TApp param.0 TNominal
-//- TNominal.node/kind tnominal
+//- TApp param.0 StructS
+//- StructS.node/kind record

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_alias_multilevel_abs.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_alias_multilevel_abs.cc
@@ -1,4 +1,4 @@
-// With aliasing on, we don't record childof edges to abs nodes, even under
+// With aliasing on, we don't record childof edges, even under
 // multiple layers of implicit template expansion.
 template <template <typename T> class Tmpl>
 struct TemplateSel { };
@@ -9,14 +9,12 @@ struct Templates1 {
 };
 
 template <class TestSel>
-//- @T1 defines/binding AbsT1
-//- RecT1 childof AbsT1
+//- @T1 defines/binding RecT1
 //- RecT1.node/kind record
 class T1 {
  public:
 //- @f defines/binding FnF
 //- FnF childof RecT1
-//- !{FnF childof AbsT1}
   static bool f() {
     return true;
   }

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_alias_naming.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_alias_naming.cc
@@ -1,7 +1,6 @@
 // Other flavors of template arguments don't confuse aliasing.
 
-//- @C defines/binding AbsC
-//- ClassC childof AbsC
+//- @C defines/binding ClassC
 //- ClassC.node/kind record
 //- @f defines/binding FnF
 //- FnF childof ClassC

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_arg_multiple_typename.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_arg_multiple_typename.cc
@@ -4,28 +4,25 @@ template
 //- @T defines/binding TT
 //- @S defines/binding TS
 <typename T, typename S>
-//- @C defines/binding ACDecl1
+//- @C defines/binding CDecl1
 class C;
 
 template
 //- @N defines/binding TN
 //- @V defines/binding TV
 <typename N, typename V>
-//- @C defines/binding ACDecl2
+//- @C defines/binding CDecl2
 class C;
 
 template
 //- @W defines/binding TW
 //- @X defines/binding TX
 <typename W, typename X>
-//- @C defines/binding ACDefn
-//- @C completes/uniquely ACDecl2
-//- @C completes/uniquely ACDecl1
+//- @C defines/binding CDefn
+//- @C completes/uniquely CDecl2
+//- @C completes/uniquely CDecl1
 class C { };
 
-//- CDecl1 childof ACDecl1
-//- CDecl2 childof ACDecl2
-//- CDefn childof ACDefn
 //- CDecl1 tparam.0 TT
 //- CDecl1 tparam.1 TS
 //- CDecl2 tparam.0 TN

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_arg_typename.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_arg_typename.cc
@@ -3,26 +3,23 @@
 template
 //- @T defines/binding TT
 <typename T>
-//- @C defines/binding ACDecl1
+//- @C defines/binding CDecl1
 class C;
 
 template
 //- @S defines/binding TS
 <typename S>
-//- @C defines/binding ACDecl2
+//- @C defines/binding CDecl2
 class C;
 
 template
 //- @V defines/binding TV
 <typename V>
-//- @C defines/binding ACDefn
-//- @C completes/uniquely ACDecl1
-//- @C completes/uniquely ACDecl2
+//- @C defines/binding CDefn
+//- @C completes/uniquely CDecl1
+//- @C completes/uniquely CDecl2
 class C { };
 
-//- CDefn childof ACDefn
-//- CDecl1 childof ACDecl1
-//- CDecl2 childof ACDecl2
 //- TT.node/kind tvar
 //- TS.node/kind tvar
 //- TV.node/kind tvar

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_blame_member.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_blame_member.cc
@@ -1,18 +1,17 @@
 // We blame member functions of class templates.
 //- @g defines/binding FnG
 bool g() { return false; }
-//- @f defines/binding AbsF
+//- @f defines/binding FnF
 //- PtCall=@"g()" ref/call FnG
-//- PtCall childof FnF  // We should collapse K in abs(K) into cluster abs(K)
+//- PtCall childof FnF
 //- FnF childof CBody
-//- CBody childof AbsC
-//- @C defines/binding AbsC
-//- FImp instantiates TUnaryAppAbsF
+//- @C defines/binding CBody
+//- FImp instantiates TUnaryAppF
 //- FImpCall=@"g()" ref/call/implicit FnG
 //- FImpCall childof FImp
 template <typename T> struct C { bool f(T* t) { return g(); } };
-//- TheCall=@"j->f(nullptr)" ref/call TUnaryAppAbsF
+//- TheCall=@"j->f(nullptr)" ref/call TUnaryAppF
 //- @h defines/binding FnH
 //- TheCall childof FnH
-//- TUnaryAppAbsF param.0 AbsF  // Until we record the whole type context: #1879
+//- TUnaryAppF param.0 FnF  // Until we record the whole type context: #1879
 bool h(C<int>* j) { return j->f(nullptr); }

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_blame_pspec_member.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_blame_pspec_member.cc
@@ -2,10 +2,9 @@
 //- @g defines/binding FnG
 bool g() { return false; }
 //- PtCall=@"g()" ref/call FnG
-//- PtCall childof FnF  // We should collapse K in abs(K) into cluster abs(K)
+//- PtCall childof FnF
 //- FnF childof CBody
-//- CBody childof AbsC
-//- @C defines/binding AbsC
+//- @C defines/binding CBody
 template <typename T, typename S> struct C { bool f(T* t) { return g(); } };
 
 //- TsCall childof SpecF

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_blame_spec.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_blame_spec.cc
@@ -1,18 +1,17 @@
 // We blame function specializations.
 //- @g defines/binding FnG
 bool g() { return false; }
-//- @f defines/binding AbsF
+//- @f defines/binding FnF
 //- PtCall=@"g()" ref/call FnG
-//- PtCall childof FnF  // We should collapse K in abs(K) into cluster abs(K)
-//- FnF childof AbsF
-//- FIntImp instantiates TAppAbsFInt
+//- PtCall childof FnF
+//- FIntImp instantiates TAppFInt
 //- FIntImpCall=@"g()" ref/call/implicit FnG  // Aliasing is off by default.
 //- FIntImpCall childof FIntImp
 template <typename T> bool f(T* t) { return g(); }
-//- TheCall=@"f(&i)" ref/call TAppAbsFInt
+//- TheCall=@"f(&i)" ref/call TAppFInt
 //- @h defines/binding FnH
 //- TheCall childof FnH
-//- TAppAbsFInt param.0 AbsF
-//- TAppAbsFInt param.1 Int
+//- TAppFInt param.0 FnF
+//- TAppFInt param.1 Int
 //- @int ref Int
 bool h(int i) { return f(&i); }

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_blame_spec_member.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_blame_spec_member.cc
@@ -4,8 +4,7 @@ bool g() { return false; }
 //- PtCall=@"g()" ref/call FnG
 //- PtCall childof FnF  // We should collapse K in abs(K) into cluster abs(K)
 //- FnF childof CBody
-//- CBody childof AbsC
-//- @C defines/binding AbsC
+//- @C defines/binding CBody
 template <typename T> struct C { bool f(T* t) { return g(); } };
 
 //- @f defines/binding SpecF

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_class_defn.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_class_defn.cc
@@ -1,7 +1,7 @@
 // Checks that references to a complete template class point to the right node.
 template
 <typename X>
-//- @C defines/binding Abs
+//- @C defines/binding ClassC
 class C {};
 
 //- @U defines/binding AliasNode
@@ -9,7 +9,5 @@ using U =
 C<int>;
 
 //- AliasNode aliases TApp
-//- TApp param.0 Abs
-//- Abs.node/kind abs
-//- ClassC childof Abs
+//- TApp param.0 ClassC
 //- ClassC.node/kind record

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_class_inner.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_class_inner.cc
@@ -1,7 +1,6 @@
 // Checks that inner defns are children of outer classes.
 template <typename T>
-//- @C defines/binding AbsC
-//- ClassC childof AbsC
+//- @C defines/binding ClassC
 class C {
   //- @R defines/binding EnumR
   //- EnumR childof ClassC

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_class_template_ctor.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_class_template_ctor.cc
@@ -8,8 +8,7 @@ class C {
   template <typename T>
   //- FooCall=@"foo()" ref/call FnFoo
   //- FooCall childof CtorC
-  //- @C defines/binding AbsCtorC
-  //- CtorC childof AbsCtorC
+  //- @C defines/binding CtorC
   //- !{ BarCall childof CtorC }
   //- BarCallJ childof CtorC
   C(T) : i(foo()) { }

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_depname_inst_class.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_depname_inst_class.cc
@@ -1,18 +1,17 @@
 // Checks the representation of resolved dependent names.
 template
 <template <typename> class T>
-//- @C defines/binding AbsC
+//- @C defines/binding StructC
 struct C {
 using S = typename T<int>::D;
 };
 template
 <typename Q>
-//- @Z defines/binding AbsZ
+//- @Z defines/binding StructZ
 struct Z {
 using D = Q;
 };
 // Somewhere we need to close the loop wrt the substitutions here.
 using U = C<Z>::S;
-//- AbsC.node/kind abs
-//- AbsZ.node/kind abs
-
+//- StructC.node/kind record
+//- StructZ.node/kind record

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_field.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_field.cc
@@ -1,7 +1,6 @@
 // Checks that we index references to member variables of templates.
 //- @f defines/binding PField
-//- @S defines/binding SAbs
-//- SBody childof SAbs
+//- @S defines/binding SBody
 //- SBody.node/kind record
 //- PField childof SBody
 template <typename T> struct S { int f; };

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_fn_decl.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_fn_decl.cc
@@ -1,9 +1,7 @@
 // Tests basic support for function template declarations.
 template <typename T>
 T
-//- @id defines/binding Abs
+//- @id defines/binding IdDecl
 id(T x);
-//- Abs.node/kind abs
-//- IdDecl childof Abs
 //- IdDecl.node/kind function
 //- IdDecl.complete incomplete

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_fn_decl_defn.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_fn_decl_defn.cc
@@ -1,19 +1,15 @@
 // Tests basic support for function template declarations and definitions.
 template <typename T>
 T
-//- @id defines/binding AbsDecl
+//- @id defines/binding Decl
 id(T x);
 
 template <typename T>
 T
-//- @id defines/binding AbsDefn
-//- @id completes/uniquely AbsDecl
+//- @id defines/binding Defn
+//- @id completes/uniquely Decl
 id(T x)
 { return x; }
-//- AbsDecl.node/kind abs
-//- AbsDefn.node/kind abs
-//- Decl childof AbsDecl
-//- Defn childof AbsDefn
 //- Decl.node/kind function
 //- Defn.node/kind function
 //- Decl.complete incomplete

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_fn_defn.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_fn_defn.cc
@@ -3,11 +3,9 @@
 //- TT.node/kind tvar
 template <typename T>
 T
-//- @id defines/binding Abs
+//- @id defines/binding IdFun
 id(T x)
 { return x; }
-//- Abs.node/kind abs
-//- IdFun childof Abs
 //- IdFun.node/kind function
 //- IdFun.complete definition
 //- IdFun tparam.0 TT

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_fn_implicit_spec.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_fn_implicit_spec.cc
@@ -7,5 +7,5 @@ int y = id(42);
 //- SpecId specializes TAppAbsInt
 //- TAppAbsInt.node/kind tapp
 //- TAppAbsInt param.0 AbsId
-//- AbsId.node/kind abs
+//- AbsId.node/kind function
 //- TAppAbsInt param.1 vname("int#builtin",_,_,_,_)

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_fn_overload.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_fn_overload.cc
@@ -7,10 +7,8 @@ void f(T t) { }
 template <typename T>
 //- @f defines/binding FPtr
 void f(T* t) { }
-//- FNoPtrFn childof FNoPtr
-//- FPtrFn childof FPtr
-//- FNoPtrFn typed TAppFnT
+//- FNoPtr typed TAppFnT
 //- TAppFnT param.2 FNoPtrT
-//- FPtrFn typed TAppFnTPtr
+//- FPtr typed TAppFnTPtr
 //- TAppFnTPtr param.2 FPtrTTy
 //- FPtrTTy param.1 FPtrT

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_nested_name.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_nested_name.cc
@@ -1,10 +1,10 @@
 // We emit references to nodes in nested names.
 template <typename T>
-//- @S defines/binding AbsS
+//- @S defines/binding StructS
 struct S {
   static T x;
   template <typename U>
-//- @V defines/binding AbsV
+//- @V defines/binding StructV
   struct V {
     static U y;
   };
@@ -16,9 +16,8 @@ struct S {
 //- @float ref Float
 double z = S<int>::V<float>::y;
 
-// Interestingly, we don't get the definition of V here:
 //- SInt instantiates AppSInt
 //- VFloat instantiates AppVFloat
-//- AppSInt param.0 AbsS
+//- AppSInt param.0 StructS
 //- AppVFloat param.0 NominalV
-//- NominalV.node/kind tnominal
+//- NominalV.node/kind record

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_pack_fn_pack_call.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_pack_fn_pack_call.cc
@@ -7,8 +7,7 @@ void S(Ts... ts);
 
 //- @Ts defines/binding GTs
 template <typename... Ts>
-//- @g defines/binding AbsG
-//- FnTG childof AbsG
+//- @g defines/binding FnTG
 void g(Ts... ts) {
   //- SCall childof FnTG
   //- SCall ref/call LookupS

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_pack_rec_pack_call.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_pack_rec_pack_call.cc
@@ -2,15 +2,14 @@
 
 //- @Ts defines/binding FTs
 template <typename... Ts>
-//- @S defines/binding AbsS
+//- @S defines/binding StructS
 struct S {
   S(Ts... ts);
 };
 
 //- @Ts defines/binding GTs
 template <typename... Ts>
-//- @g defines/binding AbsG
-//- FnTG childof AbsG
+//- @g defines/binding FnTG
 void g(Ts... ts) {
   //- CtorCall ref/call CtorLookup
   //- CtorCall childof FnTG
@@ -20,5 +19,5 @@ void g(Ts... ts) {
 //- CtorLookup.node/kind lookup
 //- CtorLookup.text "#ctor"
 //- CtorLookup param.0 TAppAbsSTs
-//- TAppAbsSTs param.0 AbsS
+//- TAppAbsSTs param.0 StructS
 //- TAppAbsSTs param.1 GTs

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_ps_decl.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_ps_decl.cc
@@ -1,7 +1,7 @@
 // Checks that single-variable specialization decls are recorded.
 template
 <typename T>
-//- @C defines/binding CDecl
+//- @C defines/binding IncompleteC
 class C;
 
 template
@@ -13,7 +13,6 @@ class C
 //- PCDecl specializes TAppNomCInt
 //- TAppNomCInt.node/kind tapp
 //- TAppNomCInt param.0 NominalC
-//- IncompleteC childof CDecl
 //- IncompleteC.node/kind record
 //- IncompleteC.complete incomplete
 //- PCDecl.node/kind record

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_ps_defn.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_ps_defn.cc
@@ -14,10 +14,9 @@ template <typename T> class C { };
 //- @C completes/uniquely FwdSpec
 template <> class C <int> { };
 
-//- FwdTemplate.node/kind abs
+//- FwdTemplate.node/kind record
 //- FwdSpec.node/kind record
 //- FwdSpec.complete incomplete
-//- Fwd.node/kind abs
 //- Spec.node/kind record
 //- Spec.complete definition
 //- Spec specializes TAppCInt

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_ps_multiple_decl.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_ps_multiple_decl.cc
@@ -21,6 +21,6 @@ class C
 //- CVDecl specializes TAppCNameV
 //- TAppCNameW.node/kind tapp
 //- TAppCNameV.node/kind tapp
-//- TAppCNameW param.0 NominalC
-//- TAppCNameV param.0 NominalC
-//- NominalC.node/kind tnominal
+//- TAppCNameW param.0 CDecl
+//- TAppCNameV param.0 CDecl
+//- CDecl.node/kind record

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_ps_twovar_decl.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_ps_twovar_decl.cc
@@ -7,13 +7,12 @@ class C;
 template
 //- @U defines/binding TU
 <typename U>
-//- @C defines/binding APCDecl
+//- @C defines/binding PCDecl
 class C
 <int, U>;
 
 //- APCDecl specializes TAppCDeclIntAbsU
 //- TAppCDeclIntAbsU.node/kind tapp
 //- TAppCDeclIntAbsU param.2 TU
-//- PCDecl childof APCDecl
 //- PCDecl tparam.0 TU
 //- TAppCDeclIntAbsU param.0 CNominal

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_rec_member_abs.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_rec_member_abs.cc
@@ -1,7 +1,6 @@
 // Checks that we don't draw spurious childof edges when aliasing is on.
 template <typename T>
-//- @C defines/binding AbsC
-//- ClassC childof AbsC
+//- @C defines/binding ClassC
 //- @F defines/binding CiF  // aliased.
 //- CiF childof ClassC
 struct C { void F() { } };
@@ -9,5 +8,3 @@ struct C { void F() { } };
 //- CiF instantiates TAppCiFNil
 //- TAppCiFNil param.0 CiF
 void g() { C<int> ci; ci.F(); }
-
-//- !{ CiF childof AbsC }  // The bug in question.

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_rec_override_root_aliasing.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_rec_override_root_aliasing.cc
@@ -1,7 +1,6 @@
 // We point at the correct abs nodes in overrides when aliasing is on.
 //- @f defines/binding CF
-//- @C defines/binding TemplateC
-//- ClassC childof TemplateC
+//- @C defines/binding ClassC
 //- CF childof ClassC
 //- !{CF overrides/root _}
 template <typename T> class C { virtual void f() { } };

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_two_arg_spec.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_two_arg_spec.cc
@@ -1,14 +1,13 @@
-// Checks that record nodes underneath abstractions are given distinct names.
+// Checks that specializations of record nodes underneath abstractions are
+// given distinct names.
 // (This test's verifier load is mainly in the well-formedness checks.)
 
-//- @C defines/binding TemplateC
-//- TemplateC.node/kind abs
-//- TemplaceCBody childof TemplateC
+//- @C defines/binding TemplateCBody
 //- TemplaceCBody.node/kind record
 template <typename T, typename S> class C { };
 
 //- @C defines/binding PartialSpecializationC
-//- PartialSpecializationC.node/kind abs
+//- PartialSpecializationC.node/kind record
 template <typename U> class C<int, U> { };
 
 //- @C defines/binding TotalSpecializationC

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_unresolved_ctor_expr.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_unresolved_ctor_expr.cc
@@ -2,8 +2,7 @@
 //   see also CXXUnresolvedConstructExpr.
 //- @T defines/binding TyvarT
 template<typename T, typename A1>
-//- @make_a defines/binding AbsMakeA
-//- MakeA childof AbsMakeA
+//- @make_a defines/binding MakeA
 //- MakeA.node/kind function
 inline T make_a(const A1& a1) {
   //- CallAnchor=@"T(a1)" ref/call LookupCtorT

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_var_constexpr.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_var_constexpr.cc
@@ -1,12 +1,12 @@
 // We index constexpr variable templates.
-//- VariableTemplate defines/binding VTAbs
-//- VTAbs.node/kind abs
+//- VariableTemplate defines/binding VT
+//- VT.node/kind variable
 template <typename T> constexpr T VariableTemplate{};
-//- @VariableTemplate ref VTVar
+//- @VariableTemplate ref VT
 //- @auto ref IntBuiltin
 auto TemplateValue = VariableTemplate<int>;
 //- TApp.node/kind tapp
-//- TApp param.0 VTAbs
+//- TApp param.0 VT
 //- TApp param.1 IntBuiltin
 //- VTVar.node/kind variable
 //- VTVar instantiates TApp

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_var_decl.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_var_decl.cc
@@ -2,10 +2,8 @@
 //- @T defines/binding TyvarT
 template <typename T>
 //- @T ref TyvarT
-//- @y defines/binding VarY
+//- @y defines/binding VarYBody
 extern T y;
-//- VarY.node/kind abs
-//- VarYBody childof VarY
 //- VarYBody.node/kind variable
 //- VarYBody typed TyvarT
 //- VarYBody.complete incomplete

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_var_defn.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_var_defn.cc
@@ -2,10 +2,8 @@
 //- @T defines/binding TyvarT
 template <typename T>
 //- @T ref TyvarT
-//- @y defines/binding VarY
+//- @y defines/binding VarYBody
 T y;
-//- VarY.node/kind abs
-//- VarYBody childof VarY
 //- VarYBody.node/kind variable
 //- VarYBody typed TyvarT
 //- VarYBody.complete definition

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_var_defn_completes.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_var_defn_completes.cc
@@ -1,5 +1,5 @@
 // Checks that variable template defns complete variable template decls.
-//- @z defines/binding VarZAbsDecl
+//- @z defines/binding VarZDecl
 template <typename T> extern T z;
-//- @z completes/uniquely VarZAbsDecl
+//- @z completes/uniquely VarZDecl
 template <typename T> T z;

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_var_ps.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_var_ps.cc
@@ -5,7 +5,7 @@ template <typename T, typename S> T v;
 template <typename U>
 //- @v defines/binding VarPSU
 U v<U, int>;
-//- VarPSU.node/kind abs
+//- VarPSU.node/kind variable
 //- VarPSU specializes TAppVarV
 //- TAppVarV.node/kind tapp
 //- TAppVarV param.0 VarV

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_var_ps_implicit_spec.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_var_ps_implicit_spec.cc
@@ -2,16 +2,15 @@
 //- @v defines/binding Prim
 template <typename T, typename S, typename V> T v;
 template <typename U>
-//- @v defines/binding Ps
+//- @v defines/binding V
 U v<int, U, long>;
-//- Ps.node/kind abs
 //- @v ref Spec
 float w = v<int, float, long>;
 //- Spec specializes TAppPrim
-//- Spec instantiates TAppPs
+//- Spec instantiates TAppV
 //- TAppPrim param.0 Prim
 //- TAppPrim param.1 vname("int#builtin",_,_,_,_)
 //- TAppPrim param.2 vname("float#builtin",_,_,_,_)
 //- TAppPrim param.3 vname("long#builtin",_,_,_,_)
-//- TAppPs param.0 Ps
-//- TAppPs param.1 vname("float#builtin",_,_,_,_)
+//- TAppV param.0 V
+//- TAppV param.1 vname("float#builtin",_,_,_,_)

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_var_ref_ps.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_var_ref_ps.cc
@@ -1,13 +1,11 @@
 /// Tests that references to ps var templates go to the ps and not the primary.
 //- @v defines/binding Primary
 template <typename T, typename S> T v = S();
-//- @v defines/binding Partial
-//- Partial.node/kind abs
 //- @v defines/binding PartialVar
 //- PartialVar.node/kind variable
 template <typename U> U v<U, int> = 3;
 //- @v ref Spec
 int w = v<int,int>;
 //- Spec.node/kind variable
-//- Spec instantiates TAppPartial
-//- TAppPartial param.0 Partial
+//- Spec instantiates TAppPartialVar
+//- TAppPartialVar param.0 PartialVar


### PR DESCRIPTION
Note that there are a few remaining issues to be solved in
followup PRs. In particular, there may be problems with
documents edges and some non-template tests may fail with
abs nodes disabled. There should be no functional change
with abs nodes enabled (the default).