### PR TITLE
chore: update LLVM yet again and robustify test fixes

### DIFF
--- a/kythe/cxx/indexer/cxx/IndexerASTHooks.h
+++ b/kythe/cxx/indexer/cxx/IndexerASTHooks.h
@@ -241,6 +241,8 @@ class IndexerASTVisitor : public RecursiveTypeVisitor<IndexerASTVisitor> {
   NodeSet RecordTypeLocSpellingLocation(clang::TypeLoc TL);
   NodeSet RecordTypeLocSpellingLocation(clang::TypeLoc Written,
                                         const clang::Type* Resolved);
+  NodeSet RecordTypeSpellingLocation(const clang::Type* Type,
+                                     clang::SourceRange Range);
 
   bool TraverseDeclarationNameInfo(clang::DeclarationNameInfo NameInfo);
 

--- a/kythe/cxx/indexer/cxx/testdata/basic/decltype_auto.cc
+++ b/kythe/cxx/indexer/cxx/testdata/basic/decltype_auto.cc
@@ -6,7 +6,7 @@ const int x = 42;
 // NB: "auto" doesn't refer to anything here; it's just taking up space.
 //- @v defines/binding VarV
 //- VarV typed ConstIntType
-//- @"decltype(auto)" ref ConstIntType
+//- @decltype ref ConstIntType
 decltype(auto) v = x;
 //- @auto ref IntType
 auto w = x;

--- a/setup.bzl
+++ b/setup.bzl
@@ -138,7 +138,7 @@ def kythe_rule_repositories():
     maybe(
         github_archive,
         repo_name = "llvm/llvm-project",
-        commit = "f77d115cc136585f39d30a78c741eb296f9e804d",
+        commit = "c490f8feb71e837dd7011e7a7d8a7928507c9c76",
         name = "llvm-project-raw",
         build_file_content = "#empty",
         patch_args = ["-p1"],


### PR DESCRIPTION
Upstream (and internal) clang reverted the change for which I had updated the tests.  As a result, they now fail.  This CL reverts the test change and adds code to keep the `decltype(auto)` range consistently over only `decltype` even when the upstream change is re-landed.  This keeps `decltype(expr)` and `decltype(auto)` consistent.