### PR TITLE
chore(rust_indexer): change test to make text replacement easier

### DIFF
--- a/kythe/rust/indexer/tests/providers.rs
+++ b/kythe/rust/indexer/tests/providers.rs
@@ -25,8 +25,7 @@ use std::path::PathBuf;
 /// Get the path of the provided runfile
 fn get_runfile(file: &str) -> PathBuf {
     let r = Runfiles::create().unwrap();
-    let location = String::from("io_kythe/kythe/rust/indexer/tests/");
-    r.rlocation(location + file)
+    r.rlocation("io_kythe/kythe/rust/indexer/tests/".to_owned() + file)
 }
 
 #[test]


### PR DESCRIPTION
Other uses of `rlocation` have the path at the start of the argument. This PR updates this test's usage of `rlocation` to make to match, making text replacement of the path prefix simple.