### PR TITLE
feat(cxx_indexer): support r/w and influence for user-defined operators

### DIFF
--- a/kythe/cxx/indexer/cxx/IndexerASTHooks.h
+++ b/kythe/cxx/indexer/cxx/IndexerASTHooks.h
@@ -195,6 +195,7 @@ class IndexerASTVisitor : public RecursiveTypeVisitor<IndexerASTVisitor> {
   bool VisitCXXPseudoDestructorExpr(const clang::CXXPseudoDestructorExpr* E);
   bool VisitCXXUnresolvedConstructExpr(
       const clang::CXXUnresolvedConstructExpr* E);
+  bool TraverseCXXOperatorCallExpr(clang::CXXOperatorCallExpr* E);
   bool VisitCallExpr(const clang::CallExpr* Expr);
   bool VisitMemberExpr(const clang::MemberExpr* Expr);
   bool VisitCXXDependentScopeMemberExpr(

--- a/kythe/cxx/indexer/cxx/testdata/BUILD
+++ b/kythe/cxx/indexer/cxx/testdata/BUILD
@@ -4388,6 +4388,30 @@ cc_indexer_test(
 )
 
 cc_indexer_test(
+    name = "df_operatoreq",
+    srcs = ["df/df_operatoreq.cc"],
+    experimental_record_dataflow_edges = True,
+    ignore_dups = True,
+    tags = ["df"],
+)
+
+cc_indexer_test(
+    name = "df_operatorpluseq",
+    srcs = ["df/df_operatorpluseq.cc"],
+    experimental_record_dataflow_edges = True,
+    ignore_dups = True,
+    tags = ["df"],
+)
+
+cc_indexer_test(
+    name = "df_operatorplusplus",
+    srcs = ["df/df_operatorplusplus.cc"],
+    experimental_record_dataflow_edges = True,
+    ignore_dups = True,
+    tags = ["df"],
+)
+
+cc_indexer_test(
     name = "df_unary",
     srcs = ["df/df_unary.cc"],
     experimental_record_dataflow_edges = True,

--- a/kythe/cxx/indexer/cxx/testdata/df/df_operatoreq.cc
+++ b/kythe/cxx/indexer/cxx/testdata/df/df_operatoreq.cc
@@ -1,0 +1,14 @@
+// We treat calls to operator= the same way we treat primitive assignment.
+struct S { S& operator=(const S&) = default; };
+
+void f() {
+  //- @a defines/binding Sa
+  //- @b defines/binding Sb
+  S a, b;
+  //- @a ref/writes Sa
+  //- @b ref Sb
+  //- Sb influences Sa
+  //- !{Sa influences Sa}
+  //- !{@b ref/writes _}
+  a = b;
+}

--- a/kythe/cxx/indexer/cxx/testdata/df/df_operatorpluseq.cc
+++ b/kythe/cxx/indexer/cxx/testdata/df/df_operatorpluseq.cc
@@ -1,0 +1,25 @@
+// We treat calls to operator+= the same way we treat primitive assignment.
+struct S { S& operator+=(const S&); };
+S& operator-=(S&, const S&);
+
+void f() {
+  //- @a defines/binding Sa
+  //- @b defines/binding Sb
+  //- @c defines/binding Sc
+  //- @d defines/binding Sd
+  S a, b, c, d;
+  //- @a ref/writes Sa
+  //- @b ref Sb
+  //- Sb influences Sa
+  //- Sa influences Sa
+  //- !{Sb influences Sb}
+  //- !{@b ref/writes _}
+  a += b;
+  //- @c ref/writes Sc
+  //- @d ref Sd
+  //- Sd influences Sc
+  //- Sc influences Sc
+  //- !{Sd influences Sd}
+  //- !{@d ref/writes _}
+  c -= d;
+}

--- a/kythe/cxx/indexer/cxx/testdata/df/df_operatorplusplus.cc
+++ b/kythe/cxx/indexer/cxx/testdata/df/df_operatorplusplus.cc
@@ -1,0 +1,15 @@
+// We treat calls to operator++ the same way we treat primitive assignment.
+struct S { S& operator++(); };
+S operator--(S&);
+
+void f() {
+  //- @a defines/binding Sa
+  //- @b defines/binding Sb
+  S a, b;
+  //- @a ref/writes Sa
+  //- Sa influences Sa
+  ++a;
+  //- @b ref/writes Sb
+  //- Sb influences Sb
+  --b;
+}


### PR DESCRIPTION
We make the assumption that users do not abuse operator definitions.
That is, one can trust that `operator=` is an assignment;
operators of the flavor `+=` are assignments with an additional
dependency on the value being assigned.