### PR TITLE
fix(java): do not emit doc nodes for non-javadoc commits by default

### DIFF
--- a/kythe/java/com/google/devtools/kythe/analyzers/java/JavaIndexerConfig.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/JavaIndexerConfig.java
@@ -32,6 +32,11 @@ public class JavaIndexerConfig extends IndexerConfig {
     TPARAM;
   }
 
+  @Parameter(
+      names = "--emit_doc_for_non_javadoc",
+      description = "Emit documentation nodes for non-javadoc comments")
+  private boolean emitDocForNonJavadoc;
+
   @Parameter(names = "--emit_jvm_signatures", description = "Generate vnames with jvm signatures.")
   private boolean emitJvmSignatures;
 
@@ -100,6 +105,10 @@ public class JavaIndexerConfig extends IndexerConfig {
     return overrideJdkCorpus;
   }
 
+  public boolean getEmitDocForNonJavadoc() {
+    return emitDocForNonJavadoc;
+  }
+
   public boolean getEmitJvmSignatures() {
     return emitJvmSignatures;
   }
@@ -138,6 +147,11 @@ public class JavaIndexerConfig extends IndexerConfig {
 
   public JavaIndexerConfig setEmitAnchorScopes(boolean emitAnchorScopes) {
     this.emitAnchorScopes = emitAnchorScopes;
+    return this;
+  }
+
+  public JavaIndexerConfig setEmitDocForNonJavadoc(boolean emitDocForNonJavadoc) {
+    this.emitDocForNonJavadoc = emitDocForNonJavadoc;
     return this;
   }
 

--- a/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
@@ -1090,6 +1090,9 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
   }
 
   boolean emitCommentsOnLine(int line, VName node, int defLine) {
+    if (!config.getEmitDocForNonJavadoc()) {
+      return false;
+    }
     List<Comment> lst = comments.get(line);
     if (lst == null || commentClaims.computeIfAbsent(line, l -> defLine) != defLine) {
       return false;

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/AnnotationComments.java
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/AnnotationComments.java
@@ -1,11 +1,11 @@
 package pkg;
 
-//- @+3AnnotationComments defines/binding AnnotationComments
+//- @+4AnnotationComments defines/binding AnnotationComments
 
-@Deprecated // TODO(#3459): This should not annotate the class, but does.
+// This isn't documentation.
+@Deprecated // This does not document AnnotationComments
 public class AnnotationComments {
-  //- { _ documents AnnotationComments }
-  // The above test is broken and should be '!{ _ documents ...' instead
+  //- !{ _ documents AnnotationComments }
 
   //- @+3fooString defines/binding FooString
 

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Comments.java
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Comments.java
@@ -1,11 +1,11 @@
-// - @pkg ref Package
+//- @pkg ref Package
 package pkg;
 
-// - @+8"java.lang.Integer" ref/doc IntegerClass
-// - @+7String ref/doc StringClass
-// - @+7Inner ref/doc InnerClass
-// - @+6pkg ref/doc Package
-// - @+7Comments defines/binding CommentsClass
+//- @+7"java.lang.Integer" ref/doc IntegerClass
+//- @+6String ref/doc StringClass
+//- @+5Inner ref/doc InnerClass
+//- @+5pkg ref/doc Package
+//- @#0+7Comments defines/binding CommentsClass
 
 /**
  * This is a Javadoc comment with links to {@link String}, {@link java.lang.Integer}, {@link Inner},
@@ -14,118 +14,105 @@ package pkg;
 @SuppressWarnings({"unused", "MultiVariableDeclaration"})
 public class Comments implements Comparable<Comments> {
 
-  // - @long ref/doc LongBuiltin
-  // - LongBuiltin.node/kind tbuiltin
+  //- @+8IM_A_LONG defines/binding LongConstant
+  //- @+6long ref/doc LongBuiltin
+  //- LongBuiltin.node/kind tbuiltin
+  //- LongDocNode.node/kind doc
+  //- LongDocNode.subkind "javadoc"
+  //- LongDocNode documents LongConstant
+  //- LongDocNode.text "This is a {@link [long]} with a value of {@value}. "
   /** This is a {@link long} with a value of {@value}. */
   public static final long IM_A_LONG = 4;
 
   public static final int BLAH80 = 4;
 
-  // - DocNode.node/kind doc
-  // - DocNode.subkind "javadoc"
-  // - DocNode documents CommentsClass
-  // - DocNode param.0 StringClass
-  // - DocNode param.1 IntegerClass
-  // - DocNode param.2 InnerClass
-  // - DocNode param.3 Package
-  // - DocNode.text " This is a Javadoc comment with links to {@link [String]}, {@link
-  // [java.lang.Integer]},\n {@link [Inner]}, and {@link [pkg]}. It references {@value
-  // [IM_A_LONG]}.\n"
+  //- DocNode.node/kind doc
+  //- DocNode.subkind "javadoc"
+  //- DocNode documents CommentsClass
+  //- DocNode param.0 StringClass
+  //- DocNode param.1 IntegerClass
+  //- DocNode param.2 InnerClass
+  //- DocNode param.3 Package
+  //- DocNode.text " This is a Javadoc comment with links to {@link [String]}, {@link [java.lang.Integer]}, {@link [Inner]},\n and {@link [pkg]}. It references {@value [IM_A_LONG]}.\n"
 
   // - @fieldOne defines/binding _FieldOne
   private static int fieldOne; // inline comment here
 
-  // - FieldTwoDoc documents FieldTwo
-  // - FieldTwoDoc.node/kind doc
-  // - !{ FieldTwoDoc.subkind _AnySubkind }
-  // - FieldTwoDoc.text "fieldTwo represents the universe"
-  // - @+3fieldTwo defines/binding FieldTwo
+  //- !{_ documents FieldTwo}
+  //- @+3fieldTwo defines/binding FieldTwo
 
   // fieldTwo represents the universe
   private static String fieldTwo;
 
-  // - @+3fieldThree defines/binding FieldThree
-  // - @+3fieldFour defines/binding FieldFour
+  //- @+3fieldThree defines/binding FieldThree
+  //- @+3fieldFour defines/binding FieldFour
 
   private static int fieldThree; // EOL comment
   private static int fieldFour;
 
-  // - FieldThreeDoc documents FieldThree
-  // - FieldThreeDoc.node/kind doc
-  // - FieldThreeDoc.text "EOL comment"
-  // - !{ _FieldFourDoc documents FieldFour }
+  //- !{_ documents FieldThree}
+  //- !{_ documents FieldFour }
 
-  // - @+3fieldFive defines/binding FieldFive
-  // - @+2fieldSix defines/binding FieldSix
+  //- @+3fieldFive defines/binding FieldFive
+  //- @+2fieldSix defines/binding FieldSix
 
   private static int fieldFive, fieldSix; // EOL comment both
 
-  // - FieldBothInlineDoc documents FieldFive
-  // - FieldBothInlineDoc documents FieldSix
-  // - FieldBothInlineDoc.text "EOL comment both"
+  //- !{_ documents FieldFive}
+  //- !{_ documents FieldSix}
 
-  // - @+4fieldSeven defines/binding FieldSeven
-  // - @+3fieldEight defines/binding FieldEight
+  //- @+4fieldSeven defines/binding FieldSeven
+  //- @+3fieldEight defines/binding FieldEight
 
   // above comment both
   private static int fieldSeven, fieldEight;
 
-  // - FieldBothAboveDoc documents FieldSeven
-  // - FieldBothAboveDoc documents FieldEight
-  // - FieldBothAboveDoc.text "above comment both"
+  //- !{_ documents FieldSeven}
+  //- !{_ documents FieldEight}
 
-  // - InnerDoc documents InnerClass
-  // - InnerDoc.node/kind doc
-  // - InnerDoc.text "This comments the Inner class."
-  // - @+3Inner defines/binding InnerClass
+  //- !{_ documents InnerClass}
+  //- @+3Inner defines/binding InnerClass
 
-  // This comments the Inner class.
+  // This comments but does not document the Inner class.
   public static class Inner {}
 
-  // - InnerIDoc documents InnerI
-  // - InnerIDoc.node/kind doc
-  // - InnerIDoc.text "This comments the InnerI interface."
-  // - InnerIWeirdDoc documents InnerI
-  // - InnerIWeirdDoc.node/kind doc
-  // - InnerIWeirdDoc.text "a second, weirdly-placed comment"
-  // - @+3InnerI defines/binding InnerI
+  //- !{_ documents InnerI}
+  //- @+4InnerI defines/binding InnerI
 
   /* This comments the InnerI interface. */
   // a second, weirdly-placed comment
   static interface InnerI {} // this also comments the interface
 
-  // - @+3InnerE ref/doc InnerE
-  // - @+3InnerE defines/binding InnerE
+  //- @+3InnerE ref/doc InnerE
+  //- @+3InnerE defines/binding InnerE
 
   /** This comments the {@link InnerE} enum. */
   static enum InnerE {
 
-    // - InnerEDoc documents InnerE
-    // - InnerEDoc.node/kind doc
-    // - InnerEDoc param.0 InnerE
-    // - InnerEDoc.text "This comments the {@link [InnerE]} enum. "
+    //- InnerEDoc documents InnerE
+    //- InnerEDoc.node/kind doc
+    //- InnerEDoc param.0 InnerE
+    //- InnerEDoc.text "This comments the {@link [InnerE]} enum. "
 
-    // - SomeValDoc documents SomeValue
-    // - SomeValDoc.node/kind doc
-    // - SomeValDoc.text "This comments SOME_VALUE."
-    // - @+3SOME_VALUE defines SomeValue
+    //- !{_ documents SomeValue}
+    //- @+3SOME_VALUE defines SomeValue
 
     // This comments SOME_VALUE.
     SOME_VALUE,
 
-    // - AnotherValDoc documents AnotherValue
-    // - AnotherValDoc.node/kind doc
-    // - AnotherValDoc.text "This documents {@link [ANOTHER_VALUE]}. "
-    // - @+3ANOTHER_VALUE defines AnotherValue
+    //- AnotherValDoc documents AnotherValue
+    //- AnotherValDoc.node/kind doc
+    //- AnotherValDoc.text "This documents {@link [ANOTHER_VALUE]}. "
+    //- @+3ANOTHER_VALUE defines AnotherValue
 
     /** This documents {@link ANOTHER_VALUE}. */
     ANOTHER_VALUE;
   }
 
-  // - ToStringDoc documents ToString
-  // - ToStringDoc.node/kind doc
-  // - ToStringDoc.text "This documents {@link [#toString()]}. "
-  // - @+3toString defines/binding ToString
+  //- ToStringDoc documents ToString
+  //- ToStringDoc.node/kind doc
+  //- ToStringDoc.text "This documents {@link [#toString()]}. "
+  //- @+4toString defines/binding ToString
 
   /** This documents {@link #toString()}. */
   @Override
@@ -133,25 +120,23 @@ public class Comments implements Comparable<Comments> {
     return "null";
   }
 
-  // - @+4compareTo defines/binding CompareTo
+  //- @+4compareTo defines/binding CompareTo
 
   /** This documents {@link #compareTo(Comments)} over {@link Override}. */
   @Override
   public int compareTo(Comments o) {
     return 0;
   }
-  // - OverrideDoc documents CompareTo
-  // - OverrideDoc.node/kind doc
-  // - OverrideDoc param.0 _Override
-  // - OverrideDoc.text "This documents {@link #compareTo(Comments)} over {@link [Override]}. "
+  //- OverrideDoc documents CompareTo
+  //- OverrideDoc.node/kind doc
+  //- OverrideDoc param.0 _Override
+  //- OverrideDoc.text "This documents {@link [#compareTo(Comments)]} over {@link [Override]}. "
 
-  // - @+3fooFunction defines/binding FooFunction
+  //- @+3fooFunction defines/binding FooFunction
 
   // This documents FooFunction
   void fooFunction() {
     return;
   }
-  // - FooFunctionDoc documents FooFunction
-  // - FooFunctionDoc.node/kind doc
-  // - FooFunctionDoc.text "This documents FooFunction"
+  //- !{_ documents FooFunction}
 }


### PR DESCRIPTION
* leave a configuration knob to preserve existing behavior to emit doc nodes for non-javadoc comments
* update and re-enable doc node tests