### PR TITLE
feat(rust_indexer): add flag to disable emitting xrefs for stdlib

### DIFF
--- a/kythe/rust/indexer/BUILD
+++ b/kythe/rust/indexer/BUILD
@@ -36,6 +36,7 @@ rust_binary(
     deps = [
         ":kythe_rust_indexer",
         "//kythe/rust/cargo:anyhow",
+        "//kythe/rust/cargo:clap",
         "@rules_rust//proto/raze:protobuf",
     ],
 )
@@ -52,6 +53,7 @@ rust_binary(
         "//kythe/proto:analysis_rust_proto",
         "//kythe/rust/cargo:anyhow",
         "//kythe/rust/cargo:base64",
+        "//kythe/rust/cargo:clap",
         "//kythe/rust/cargo:serde_json",
         "@rules_rust//proto/raze:protobuf",
     ],

--- a/kythe/rust/indexer/src/bin/bazel/main.rs
+++ b/kythe/rust/indexer/src/bin/bazel/main.rs
@@ -16,7 +16,7 @@ use kythe_rust_indexer::{indexer::KytheIndexer, providers::*, writer::CodedOutpu
 
 use anyhow::{Context, Result};
 use clap::{App, Arg};
-use std::{env, fs::File};
+use std::fs::File;
 
 fn main() -> Result<()> {
     // Returns 0 if ok or 1 if error

--- a/kythe/rust/indexer/src/bin/bazel/main.rs
+++ b/kythe/rust/indexer/src/bin/bazel/main.rs
@@ -15,22 +15,30 @@ extern crate kythe_rust_indexer;
 use kythe_rust_indexer::{indexer::KytheIndexer, providers::*, writer::CodedOutputStreamWriter};
 
 use anyhow::{Context, Result};
-use std::{env, fs::File, path::Path};
+use clap::{App, Arg};
+use std::{env, fs::File};
 
 fn main() -> Result<()> {
-    // Accepts kzip path as an argument
-    // Calls indexer on each compilation unit
     // Returns 0 if ok or 1 if error
-    let args: Vec<String> = env::args().collect();
-    if args.len() < 2 {
-        eprintln!("Not enough arguments! Usage: rust_indexer <kzip path>");
-        std::process::exit(1);
-    } else if args.len() > 3 {
-        eprintln!("Too many arguments! Usage: rust_indexer <kzip path>")
-    }
+    let matches = App::new("Kythe Rust Bazel Indexer")
+        .arg(
+            Arg::with_name("kzip_path")
+                .required(true)
+                .index(1)
+                .help("The path to the kzip to be indexed"),
+        )
+        .arg(
+            Arg::with_name("no_emit_std_lib")
+                .long("no_emit_std_lib")
+                .required(false)
+                .help("Disables emitting cross references to the standard library"),
+        )
+        .get_matches();
+    let emit_std_lib = !matches.is_present("no_emit_std_lib");
 
     // Get kzip path from argument and use it to create a KzipFileProvider
-    let kzip_path = Path::new(&args[1]);
+    // Unwrap is safe because the parameter is required
+    let kzip_path = matches.value_of("kzip_path").unwrap();
     let kzip_file = File::open(kzip_path).context("Provided path does not exist")?;
     let mut kzip_provider =
         KzipFileProvider::new(kzip_file).context("Failed to open kzip archive")?;
@@ -44,7 +52,7 @@ fn main() -> Result<()> {
     let mut indexer = KytheIndexer::new(&mut writer);
 
     for unit in compilation_units {
-        indexer.index_cu(&unit, &mut kzip_provider)?;
+        indexer.index_cu(&unit, &mut kzip_provider, emit_std_lib)?;
     }
     Ok(())
 }

--- a/kythe/rust/indexer/src/indexer/mod.rs
+++ b/kythe/rust/indexer/src/indexer/mod.rs
@@ -41,6 +41,7 @@ impl<'a> KytheIndexer<'a> {
         &mut self,
         unit: &CompilationUnit,
         provider: &mut dyn FileProvider,
+        emit_std_lib: bool,
     ) -> Result<(), KytheError> {
         let analysis_file = Self::get_analysis_file(unit, provider)?;
         let mut generator = UnitAnalyzer::new(unit, self.writer, provider)?;
@@ -49,7 +50,7 @@ impl<'a> KytheIndexer<'a> {
             // First, create file nodes for all of the source files in the CompilationUnit
             generator.handle_files()?;
             // Then index the crate
-            generator.index_crate(analysis)?;
+            generator.index_crate(analysis, emit_std_lib)?;
         } else {
             return Err(KytheError::IndexerError(
                 "Failed to deserialize save-analysis file".to_string(),


### PR DESCRIPTION
Open Source Code Search has a strange bug where, occasionally, anchors for cross-references can be clickable even when the definition node (including an anchor node) for the target of the cross reference does not exist. Clicking the cross reference anchor brings up the References panel which shows an error because the definition node does not exist (we don't index the Rust standard library, so we can't emit definition nodes and anchors for it). An example of this is here: https://cs.opensource.google/fuchsia/fuchsia/+/main:src/connectivity/network/dns/src/main.rs;l=30;bpv=0;bpt=1 (hover over the "std" and try clicking on it)

This PR adds an optional flag to the Rust indexer that disables emitting any cross references to the standard library, which should mitigate this issue.