### PR TITLE
chore: update bazel remote flags

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -43,13 +43,15 @@ import %workspace%/tools/javacopts.bazelrc
 build:release --stamp -c opt --copt=-gmlt
 
 # Use the RBE instance in the kythe-repo project
-build:remote --remote_instance_name=projects/kythe-repo/instances/default_instance --project_id=kythe-repo
+build:remote --remote_instance_name=projects/kythe-repo/instances/default_instance --bes_instance_name=kythe-repo
 
-build:remote --auth_enabled=true
+build:remote --google_default_credentials=true
 build:remote --jobs=50
 build:remote --remote_timeout=3600
 build:remote --remote_cache=grpcs://remotebuildexecution.googleapis.com
 build:remote --remote_executor=grpcs://remotebuildexecution.googleapis.com
+# Avoid fetchiing unnecessary intermediate files locally.
+build:remote --remote_download_minimal
 
 # TODO(schroederc): add buildeventservice
 # build:remote --bes_backend="buildeventservice.googleapis.com"


### PR DESCRIPTION
`auth_enabled` and `project_id` have been renamed.  `remote_download_minimal` is an experiment to see if it helps.