### PR TITLE
fix(cxx_indexer): don't traverse field decls in lambdas

### DIFF
--- a/kythe/cxx/indexer/cxx/IndexerASTHooks.h
+++ b/kythe/cxx/indexer/cxx/IndexerASTHooks.h
@@ -988,6 +988,10 @@ class IndexerASTVisitor : public RecursiveTypeVisitor<IndexerASTVisitor> {
                            const clang::Decl* Decl) const;
   void LogErrorWithASTDump(absl::string_view msg,
                            const clang::Expr* Expr) const;
+  void LogErrorWithASTDump(absl::string_view msg,
+                           const clang::Type* Type) const;
+  void LogErrorWithASTDump(absl::string_view msg, clang::TypeLoc Type) const;
+  void LogErrorWithASTDump(absl::string_view msg, clang::QualType Type) const;
 
   /// \brief This is used to handle the visitation of a clang::TypedefDecl
   /// or a clang::TypeAliasDecl.

--- a/kythe/cxx/indexer/cxx/testdata/BUILD
+++ b/kythe/cxx/indexer/cxx/testdata/BUILD
@@ -1098,6 +1098,24 @@ cc_indexer_test(
 )
 
 cc_indexer_test(
+    name = "function_lambda_explicit_this",
+    srcs = ["function/function_lambda_explicit_this.cc"],
+    ignore_dups = True,
+    tags = [
+        "function",
+    ],
+)
+
+cc_indexer_test(
+    name = "function_lambda_implicit_this",
+    srcs = ["function/function_lambda_implicit_this.cc"],
+    ignore_dups = True,
+    tags = [
+        "function",
+    ],
+)
+
+cc_indexer_test(
     name = "function_constexpr_lambda",
     srcs = ["function/function_constexpr_lambda.cc"],
     ignore_dups = True,

--- a/kythe/cxx/indexer/cxx/testdata/function/function_lambda_explicit_this.cc
+++ b/kythe/cxx/indexer/cxx/testdata/function/function_lambda_explicit_this.cc
@@ -1,9 +1,10 @@
-// We index lambdas which capture this by value via `*this`.
+// We index lambdas which explicitly capture `this`.
 
 //- @S defines/binding StructS
 struct S {
   void f() const {
-    [*this] {
+    //- !{ @this ref StructS }
+    [this] {
       //- @g ref MethodG
       //- @m ref FieldM
       //- !{ @g ref StructS }

--- a/kythe/cxx/indexer/cxx/testdata/function/function_lambda_implicit_this.cc
+++ b/kythe/cxx/indexer/cxx/testdata/function/function_lambda_implicit_this.cc
@@ -1,9 +1,15 @@
-// We index lambdas which capture this by value via `*this`.
+// We index lambdas which implicitly capture this via either `=` or `&`.
 
 //- @S defines/binding StructS
 struct S {
   void f() const {
-    [*this] {
+    [&] {
+      //- @g ref MethodG
+      //- @m ref FieldM
+      //- !{ @g ref StructS }
+      g() + m;
+    };
+    [=] {
       //- @g ref MethodG
       //- @m ref FieldM
       //- !{ @g ref StructS }


### PR DESCRIPTION
This is internal bug b/219843754 (spurious references to the enclosing class at uses of members of a captured `this`).

This change is a bit of a blunt instrument. There may in fact be reasons to traverse these field definitions, but I can't think of a good one and there aren't tests which fail as a result.