### PR TITLE
fix(extraction): fix javac9 extractor path

### DIFF
--- a/kythe/extractors/openjdk11/extract/extract.go
+++ b/kythe/extractors/openjdk11/extract/extract.go
@@ -50,7 +50,7 @@ const (
 	runfilesPrefix        = "${RUNFILES}"
 	runfilesWrapperPath   = "kythe/extractors/openjdk11/java_wrapper/java_wrapper"
 	runfilesVNamesPath    = "kythe/extractors/openjdk11/vnames.json"
-	runfilesExtractorPath = "kythe/java/com/google/devtools/kythe/extractors/java/standalone/javac9_extractor_deploy.jar"
+	runfilesExtractorPath = "kythe/java/com/google/devtools/kythe/extractors/java/standalone/javac_extractor_deploy.jar"
 )
 
 var (


### PR DESCRIPTION
Fix for the now-defunct javac9 extractor path in the OpenJDK11 extraction rules.