### PR TITLE
fix(empty_corpus_checker): ignore usr nodes

### DIFF
--- a/kythe/go/test/tools/empty_corpus_checker/empty_corpus_checker.go
+++ b/kythe/go/test/tools/empty_corpus_checker/empty_corpus_checker.go
@@ -68,6 +68,12 @@ func main() {
 			log.Fatalf("Error parsing ticket: %q, %v", src.GetTicket(), err)
 		}
 
+		// usr nodes are defined to have an empty corpus, ignore them for the
+		// purposes of this test
+		if r.URI.Language == "usr" {
+			return true
+		}
+
 		allCorpora.Add(r.URI.Corpus)
 
 		if r.URI.Corpus == "" {


### PR DESCRIPTION
these are defined to have an empty corpus