### PR TITLE
fix(cxx_indexer): remove another source of corpusless nodes

### DIFF
--- a/kythe/cxx/indexer/cxx/KytheGraphObserver.cc
+++ b/kythe/cxx/indexer/cxx/KytheGraphObserver.cc
@@ -261,6 +261,8 @@ kythe::proto::VName KytheGraphObserver::VNameFromRange(
       out_name.CopyFrom(VNameFromFileEntry(file_entry));
     } else if (range.Kind == GraphObserver::Range::RangeKind::Wraith) {
       VNameRefFromNodeId(range.Context).Expand(&out_name);
+    } else {
+      out_name.set_corpus(default_token_.vname().corpus());
     }
     size_t begin_offset = SourceManager->getFileOffset(begin);
     size_t end_offset = SourceManager->getFileOffset(end);


### PR DESCRIPTION
In some instances, a c++ symbol/node is not associated with a file and ends up with an empty corpus. This seems to happen when a macro is defined on the command line (i.e. "-DMY_MACRO=1"), then later referred to in the source code. This change sets the corpus to the default value (from the compilation unit) instead.

TODO: test this - it works in google3 localrun, but getting the issue to reproduce in the oss project is tricky