### PR TITLE
fix(kzip_info): don't count c++ stdlib includes as invalid absolute paths

### DIFF
--- a/kythe/go/platform/kzip/info/info.go
+++ b/kythe/go/platform/kzip/info/info.go
@@ -86,8 +86,10 @@ func (a *Accumulator) Accumulate(u *kzip.Unit) {
 	var srcCorpora stringset.Set
 	srcsWithRI := stringset.New()
 	for _, ri := range u.Proto.RequiredInput {
-		if strings.HasPrefix(ri.GetVName().GetPath(), "/") && !strings.HasPrefix(ri.GetVName().GetPath(), "/kythe_builtins/") {
-			a.KzipInfo.AbsolutePaths = append(a.KzipInfo.AbsolutePaths, ri.GetVName().GetPath())
+		if strings.HasPrefix(ri.GetVName().GetPath(), "/") {
+			if !strings.HasPrefix(ri.GetVName().GetPath(), "/kythe_builtins/") && !strings.HasPrefix(ri.GetVName().GetPath(), "/usr/include/c++/") {
+				a.KzipInfo.AbsolutePaths = append(a.KzipInfo.AbsolutePaths, ri.GetVName().GetPath())
+			}
 		}
 
 		riCorpus := requiredInputCorpus(u, ri)


### PR DESCRIPTION
In general, paths in the kzip should be relative (to the root of the repo), so we count absolute paths as errors. in some cases like c++ stdlib includes, these are expected and should not count as errors. There are likely other exceptions to the rule that we'll want to add in the future.