### PR TITLE
feat(typescript_indexer): emit edges from object literals to corresponding types

### DIFF
--- a/kythe/typescript/testdata/interface.ts
+++ b/kythe/typescript/testdata/interface.ts
@@ -1,0 +1,55 @@
+/**
+ * @fileoverview File that test that interface properties are indexed correctly.
+ */
+
+interface Person {
+  //- @name defines/binding Name
+  name: string;
+  //- @getAge defines/binding GetAge
+  getAge(): void;
+}
+
+const p: Person = {
+  //- @name ref Name
+  name: 'Alice',
+  //- @getAge ref GetAge
+  getAge() {}
+};
+
+const p2 = {
+  //- @name ref Name
+  name: 'Alice',
+  //- @getAge ref GetAge
+  getAge() {}
+} as Person;
+
+//- @name ref Name
+p.name;
+
+//- @getAge ref GetAge
+p.getAge();
+
+//- @getAge ref GetAge
+const {getAge} = p;
+
+//- @name ref Name
+//- @getAge ref GetAge
+function takesPerson({name, getAge: newGetAge}: Person) {}
+
+//- @name ref Name
+//- @getAge ref GetAge
+takesPerson({name: 'Alice', getAge() {}});
+
+class PersonTaker {
+  constructor(p: Person) {}
+}
+
+//- @name ref Name
+//- @getAge ref GetAge
+new PersonTaker({name: 'Alice', getAge() {}});
+
+function returnPerson(): Person {
+  //- @name ref Name
+  //- @getAge ref GetAge
+  return {name: 'Alice', getAge() {}};
+}

--- a/kythe/typescript/testdata/interface.ts
+++ b/kythe/typescript/testdata/interface.ts
@@ -53,3 +53,12 @@ function returnPerson(): Person {
   //- @getAge ref GetAge
   return {name: 'Alice', getAge() {}};
 }
+
+// test property shorthands
+{
+  const name = 'Alice';
+  const getAge = () = {};
+  //- @name ref Name
+  //- @getAge ref GetAge
+  const p3: Person = {name, getAge};
+}


### PR DESCRIPTION
This change emits `ref` edges from properties on object literals and destructuring to fields of the corresponding types, if type is known. Example:

```typescript
interface Person {
  name: string;
}

const p: Person = {name: 'Alice'};
const {name} = p;
```
With this change there will be two new `ref` edges from `name` properties in object literal and destructuring to `Person.name` field. 

This change supports object literals returned from functions, passed as function arguments and type casting. See examples in `testdata/interface.ts` test. It doesn't support more tricky cases that require deeper type checking, for example the following case won't have refs:

```typescript
const p: Person = isAlice ? {name: 'Alice'} : {name: 'Bob'};
```