### PR TITLE
fix(chore): switch to toplevel for rbe downloads

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -50,8 +50,8 @@ build:remote --jobs=50
 build:remote --remote_timeout=3600
 build:remote --remote_cache=grpcs://remotebuildexecution.googleapis.com
 build:remote --remote_executor=grpcs://remotebuildexecution.googleapis.com
-# Avoid fetchiing unnecessary intermediate files locally.
-build:remote --remote_download_minimal
+# Avoid fetching unnecessary intermediate files locally.
+build:remote --remote_download_toplevel
 
 # TODO(schroederc): add buildeventservice
 # build:remote --bes_backend="buildeventservice.googleapis.com"


### PR DESCRIPTION
Using `--remote_download_minimal` results in built targets not being saved locally, so `--remote_download_toplevel` is the better choice for development. We could still potentially use `--remote_download_minimal` in the Pre-Submit if we wanted to.