### PR TITLE
feat(verifier): add a flag to elide nodes not bound as goals

### DIFF
--- a/kythe/cxx/verifier/verifier.cc
+++ b/kythe/cxx/verifier/verifier.cc
@@ -1547,7 +1547,7 @@ void Verifier::DumpAsDot() {
     }
   };
   auto ElideNode = [&](AstNode* node) {
-    if (show_unlabled_) {
+    if (show_unlabeled_) {
       return false;
     }
     return GetLabel(node).empty();

--- a/kythe/cxx/verifier/verifier.cc
+++ b/kythe/cxx/verifier/verifier.cc
@@ -1546,6 +1546,12 @@ void Verifier::DumpAsDot() {
       return std::string();
     }
   };
+  auto ElideNode = [&](AstNode* node) {
+    if (show_unlabled_) {
+      return false;
+    }
+    return GetLabel(node).empty();
+  };
   std::sort(facts_.begin(), facts_.end(), GraphvizSortOrder);
   FileHandlePrettyPrinter printer(stdout);
   QuoteEscapingPrettyPrinter quote_printer(printer);
@@ -1555,11 +1561,7 @@ void Verifier::DumpAsDot() {
   for (size_t i = 0; i < facts_.size(); ++i) {
     AstNode* fact = facts_[i];
     Tuple* t = fact->AsApp()->rhs()->AsTuple();
-    printer.Print("\"");
-    t->element(0)->Dump(symbol_table_, &quote_printer);
-    printer.Print("\"");
     if (t->element(1) == empty_string_id()) {
-      std::string label = GetLabel(t->element(0));
       // Node. We sorted these above st all the facts should come subsequent.
       // Figure out if the node is an anchor.
       bool is_anchor_node = false;
@@ -1582,6 +1584,14 @@ void Verifier::DumpAsDot() {
           }
         }
       }
+      if (ElideNode(t->element(0))) {
+        --i;
+        continue;
+      }
+      printer.Print("\"");
+      t->element(0)->Dump(symbol_table_, &quote_printer);
+      printer.Print("\"");
+      std::string label = GetLabel(t->element(0));
       if (is_anchor_node && !show_anchors_) {
         printer.Print(" [ shape=circle, label=\"@");
         printer.Print(label);
@@ -1625,6 +1635,12 @@ void Verifier::DumpAsDot() {
       --i;  // Don't skip the fact following the block.
     } else {
       // Edge.
+      if (ElideNode(t->element(0)) || ElideNode(t->element(2))) {
+        continue;
+      }
+      printer.Print("\"");
+      t->element(0)->Dump(symbol_table_, &quote_printer);
+      printer.Print("\"");
       printer.Print(" -> \"");
       t->element(2)->Dump(symbol_table_, &quote_printer);
       printer.Print("\" [ label=\"");

--- a/kythe/cxx/verifier/verifier.h
+++ b/kythe/cxx/verifier/verifier.h
@@ -183,7 +183,7 @@ class Verifier {
   void ShowAnchors() { show_anchors_ = true; }
 
   /// \brief Elide unlabeled nodes from graph dumps.
-  void ElideUnlabeled() { show_unlabled_ = false; }
+  void ElideUnlabeled() { show_unlabeled_ = false; }
 
   /// \brief Check for singleton EVars.
   /// \return true if there were singletons.

--- a/kythe/cxx/verifier/verifier.h
+++ b/kythe/cxx/verifier/verifier.h
@@ -183,7 +183,7 @@ class Verifier {
   void ShowAnchors() { show_anchors_ = true; }
 
   /// \brief Elide unlabeled nodes from graph dumps.
-  void ElideUnlabled() { show_unlabled_ = false; }
+  void ElideUnlabeled() { show_unlabled_ = false; }
 
   /// \brief Check for singleton EVars.
   /// \return true if there were singletons.
@@ -340,7 +340,7 @@ class Verifier {
   bool show_anchors_ = false;
 
   /// If true, show unlabeled nodes in graph dumps.
-  bool show_unlabled_ = true;
+  bool show_unlabeled_ = true;
 
   /// Identifier for MarkedSource child edges.
   AstNode* marked_source_child_id_;

--- a/kythe/cxx/verifier/verifier.h
+++ b/kythe/cxx/verifier/verifier.h
@@ -182,6 +182,9 @@ class Verifier {
   /// \brief Show anchor locations in graph dumps (instead of @).
   void ShowAnchors() { show_anchors_ = true; }
 
+  /// \brief Elide unlabeled nodes from graph dumps.
+  void ElideUnlabled() { show_unlabled_ = false; }
+
   /// \brief Check for singleton EVars.
   /// \return true if there were singletons.
   bool CheckForSingletonEVars() { return parser_.CheckForSingletonEVars(); }
@@ -335,6 +338,9 @@ class Verifier {
 
   /// If true, show anchor locations in graph dumps (instead of @).
   bool show_anchors_ = false;
+
+  /// If true, show unlabeled nodes in graph dumps.
+  bool show_unlabled_ = true;
 
   /// Identifier for MarkedSource child edges.
   AstNode* marked_source_child_id_;

--- a/kythe/cxx/verifier/verifier_main.cc
+++ b/kythe/cxx/verifier/verifier_main.cc
@@ -41,6 +41,8 @@ ABSL_FLAG(bool, graphviz, false,
           "Only dump facts as a GraphViz-compatible graph");
 ABSL_FLAG(bool, annotated_graphviz, false,
           "Solve and annotate a GraphViz graph.");
+ABSL_FLAG(bool, minimal_graphviz, false,
+          "Solve and dump a GraphViz graph eliding unused nodes.");
 ABSL_FLAG(std::string, goal_prefix, "//-", "Denote goals with this string.");
 ABSL_FLAG(bool, use_file_nodes, false,
           "Look for assertions in UTF8 file nodes.");
@@ -89,6 +91,11 @@ Example:
 
   if (absl::GetFlag(FLAGS_annotated_graphviz)) {
     v.SaveEVarAssignments();
+  }
+
+  if (absl::GetFlag(FLAGS_minimal_graphviz)) {
+    v.SaveEVarAssignments();
+    v.ElideUnlabled();
   }
 
   if (absl::GetFlag(FLAGS_use_file_nodes)) {
@@ -176,7 +183,8 @@ Example:
   }
 
   if (absl::GetFlag(FLAGS_graphviz) ||
-      absl::GetFlag(FLAGS_annotated_graphviz)) {
+      absl::GetFlag(FLAGS_annotated_graphviz) ||
+      absl::GetFlag(FLAGS_minimal_graphviz)) {
     v.DumpAsDot();
   }
 

--- a/kythe/cxx/verifier/verifier_main.cc
+++ b/kythe/cxx/verifier/verifier_main.cc
@@ -95,7 +95,7 @@ Example:
 
   if (absl::GetFlag(FLAGS_minimal_graphviz)) {
     v.SaveEVarAssignments();
-    v.ElideUnlabled();
+    v.ElideUnlabeled();
   }
 
   if (absl::GetFlag(FLAGS_use_file_nodes)) {


### PR DESCRIPTION
For even simple code the resulting graph can be pretty daunting.  While there are definitely circumstances which call for viewing that graph in all its glorious complexity, it makes producing minimal representations quite challenging.  These minimal representations aid in understanding the specific corner of the graph being investigated without all of the associated clutter.

This PR adds a `--minimal_graphviz` which includes only the nodes bound to goals and the edges between them.