### PR TITLE
chore: clean up some iteration logic in DumpAsDot

### DIFF
--- a/kythe/cxx/verifier/verifier.h
+++ b/kythe/cxx/verifier/verifier.h
@@ -155,6 +155,12 @@ class Verifier {
   /// \brief The fact kind used to assign a node its kind (eg /kythe/node/kind).
   AstNode* kind_id() { return kind_id_; }
 
+  /// \brief The fact kind used for an anchor.
+  AstNode* anchor_id() { return anchor_id_; }
+
+  /// \brief The fact kind used for a file.
+  AstNode* file_id() { return file_id_; }
+
   /// \brief Object for parsing and storing assertions.
   AssertionParser* parser() { return &parser_; }
 


### PR DESCRIPTION
Remove a few local variables and the incidental manipulation of the loop counter to make future changes easier.