### PR TITLE
feat(java_indexer): use ref/id in annotation utterance contexts

### DIFF
--- a/kythe/docs/schema/schema.txt
+++ b/kythe/docs/schema/schema.txt
@@ -165,7 +165,7 @@ Ordinals are used::
 
 [kythe,Java,"Classes can be annotated."]
 --------------------------------------------------------------------------------
-//- @Deprecated ref Deprecated
+//- @Deprecated ref/id Deprecated
 //- @E defines/binding Class
 //- Class annotatedby Deprecated
 @Deprecated public class E {}

--- a/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
@@ -272,7 +272,7 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
         filePositions
             .getSourceFile()
             .isNameCompatible(PACKAGE_INFO_NAME, JavaFileObject.Kind.SOURCE);
-    EdgeKind anchorKind = isPkgInfo ? EdgeKind.DEFINES_BINDING : EdgeKind.REF;
+    EdgeKind anchorKind = isPkgInfo ? EdgeKind.DEFINES_BINDING : getRefKind();
     emitAnchor(ctx, anchorKind, pkgNode);
 
     visitDocComment(pkgNode, null, /* modifiers= */ null);
@@ -767,7 +767,7 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
     // TODO(salguarnieri) Think about removing this since it isn't something that we have a use for.
     emitAnchor(
         ctx,
-        (owner.getTree() instanceof JCNewClass) ? EdgeKind.REF_ID : EdgeKind.REF,
+        (owner.getTree() instanceof JCNewClass) ? EdgeKind.REF_ID : getRefKind(),
         typeNode.getVName());
 
     return new JavaNode(typeNode, childWildcards.build());
@@ -851,7 +851,7 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
           ctx,
           sym,
           field.name.contentEquals("class") ? Keyword.CLASS : field.name,
-          imprt != null ? EdgeKind.REF_IMPORTS : EdgeKind.REF);
+          imprt != null ? EdgeKind.REF_IMPORTS : getRefKind());
     }
   }
 

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Annotations.java
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Annotations.java
@@ -11,28 +11,28 @@ public @interface Annotations {
 }
 
 @SuppressWarnings("unused")
-//- @Annotations ref Annotation
+//- @Annotations ref/id Annotation
 @Annotations(
   //- @C ref C
   //- @Annotations ref Annotation
   //- @classes ref ClassesM
   classes = {C.class, Annotations.class}
 )
-//- @Deprecated ref Deprecated
+//- @Deprecated ref/id Deprecated
 @Deprecated
 //- @C defines/binding C
 //- C annotatedby Deprecated
 class C {
 
-  //- @Deprecated ref Deprecated
+  //- @Deprecated ref/id Deprecated
   @Deprecated
   //- @field defines/binding Field
   //- Field annotatedby Deprecated
   //- @String ref StringClass
   private String field;
 
-  //- @Deprecated ref Deprecated
-  //- @Override ref Override
+  //- @Deprecated ref/id Deprecated
+  //- @Override ref/id Override
   @Override @Deprecated
   //- @toString defines/binding Method
   //- Method annotatedby Deprecated

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Interfaces.java
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Interfaces.java
@@ -112,7 +112,7 @@ public interface Interfaces {
   }
 
   // TODO(mazurak): should @FunctionalInterface classes interact with calleables in some way?
-  //- @FunctionalInterface ref FunctionalAnnotation
+  //- @FunctionalInterface ref/id FunctionalAnnotation
   //- @Reducer defines/binding ReducerInterfaceAbs
   //- ReducerInterface childof ReducerInterfaceAbs
   //- ReducerInterface annotatedby FunctionalAnnotation

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/package-info.java
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/package-info.java
@@ -1,5 +1,5 @@
 //- @+5pkg defines/binding Package
-//- @+3ParametersAreNonnullByDefault ref Annotation
+//- @+3ParametersAreNonnullByDefault ref/id Annotation
 
 /** Classes used to verify the Kythe Java indexer and its output. */
 @ParametersAreNonnullByDefault


### PR DESCRIPTION
This PR makes it easier to distinguish actual Java annotation use sites from other places those annotations are used.