### PR TITLE
feat(verifier): allow simplifying graph output data

### DIFF
--- a/kythe/cxx/verifier/BUILD
+++ b/kythe/cxx/verifier/BUILD
@@ -220,6 +220,7 @@ cc_library(
     srcs = ["pretty_printer.cc"],
     hdrs = ["pretty_printer.h"],
     deps = [
+        "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:str_format",
     ],
 )

--- a/kythe/cxx/verifier/pretty_printer.h
+++ b/kythe/cxx/verifier/pretty_printer.h
@@ -18,7 +18,8 @@
 #define KYTHE_CXX_VERIFIER_PRETTY_PRINTER_H_
 
 #include <sstream>
-#include <string>
+
+#include "absl/strings/string_view.h"
 
 namespace kythe {
 namespace verifier {
@@ -27,7 +28,7 @@ namespace verifier {
 class PrettyPrinter {
  public:
   /// \brief Prints `string`.
-  virtual void Print(const std::string& string) = 0;
+  virtual void Print(absl::string_view string) = 0;
 
   /// \brief Prints `string`.
   virtual void Print(const char* string) = 0;
@@ -41,9 +42,9 @@ class PrettyPrinter {
 /// \brief A `PrettyPrinter` using a `string` as its backing store.
 class StringPrettyPrinter : public PrettyPrinter {
  public:
-  /// \copydoc PrettyPrinter::Print(const std::string&)
-  void Print(const std::string& string) override;
-  /// \copydoc PrettyPrinter::Print(const char *)
+  /// \copydoc PrettyPrinter::Print(absl::string_view)
+  void Print(absl::string_view string) override;
+  /// \copydoc PrettyPrinter::Print(const char*)
   void Print(const char* string) override;
   /// \copydoc PrettyPrinter::Print(const void *)
   void Print(const void* ptr) override;
@@ -60,9 +61,9 @@ class FileHandlePrettyPrinter : public PrettyPrinter {
  public:
   /// \param file The file handle to print to.
   explicit FileHandlePrettyPrinter(FILE* file) : file_(file) {}
-  /// \copydoc PrettyPrinter::Print(const std::string&)
-  void Print(const std::string& string) override;
-  /// \copydoc PrettyPrinter::Print(const char *)
+  /// \copydoc PrettyPrinter::Print(absl::string_view)
+  void Print(absl::string_view string) override;
+  /// \copydoc PrettyPrinter::Print(const char*)
   void Print(const char* string) override;
   /// \copydoc PrettyPrinter::Print(const void *)
   void Print(const void* ptr) override;
@@ -79,9 +80,9 @@ class QuoteEscapingPrettyPrinter : public PrettyPrinter {
   /// sent.
   explicit QuoteEscapingPrettyPrinter(PrettyPrinter& wrapped)
       : wrapped_(wrapped) {}
-  /// \copydoc PrettyPrinter::Print(const std::string&)
-  void Print(const std::string& string) override;
-  /// \copydoc PrettyPrinter::Print(const char *)
+  /// \copydoc PrettyPrinter::Print(absl::string_view)
+  void Print(absl::string_view string) override;
+  /// \copydoc PrettyPrinter::Print(const char*)
   void Print(const char* string) override;
   /// \copydoc PrettyPrinter::Print(const void *)
   void Print(const void* ptr) override;
@@ -98,9 +99,9 @@ class HtmlEscapingPrettyPrinter : public PrettyPrinter {
   /// sent.
   explicit HtmlEscapingPrettyPrinter(PrettyPrinter& wrapped)
       : wrapped_(wrapped) {}
-  /// \copydoc PrettyPrinter::Print(const std::string&)
-  void Print(const std::string& string) override;
-  /// \copydoc PrettyPrinter::Print(const char *)
+  /// \copydoc PrettyPrinter::Print(absl::string_view)
+  void Print(absl::string_view string) override;
+  /// \copydoc PrettyPrinter::Print(const char*)
   void Print(const char* string) override;
   /// \copydoc PrettyPrinter::Print(const void *)
   void Print(const void* ptr) override;

--- a/kythe/cxx/verifier/verifier.h
+++ b/kythe/cxx/verifier/verifier.h
@@ -188,6 +188,12 @@ class Verifier {
   /// \brief Show anchor locations in graph dumps (instead of @).
   void ShowAnchors() { show_anchors_ = true; }
 
+  /// \brief Show VNames for nodes which also have labels in graph dumps.
+  void ShowLabeledVnames() { show_labeled_vnames_ = true; }
+
+  /// \brief Show the /kythe and /kythe/edge prefixes in graph dumps.
+  void ShowFactPrefix() { show_fact_prefix_ = true; }
+
   /// \brief Elide unlabeled nodes from graph dumps.
   void ElideUnlabeled() { show_unlabeled_ = false; }
 
@@ -347,6 +353,12 @@ class Verifier {
 
   /// If true, show unlabeled nodes in graph dumps.
   bool show_unlabeled_ = true;
+
+  /// If true, show VNames for labeled nodes in graph dumps.
+  bool show_labeled_vnames_ = false;
+
+  /// If true, include the /kythe and /kythe/edge prefix on facts and edges.
+  bool show_fact_prefix_ = false;
 
   /// Identifier for MarkedSource child edges.
   AstNode* marked_source_child_id_;

--- a/kythe/cxx/verifier/verifier_main.cc
+++ b/kythe/cxx/verifier/verifier_main.cc
@@ -53,6 +53,10 @@ ABSL_FLAG(std::string, goal_regex, "",
 ABSL_FLAG(bool, convert_marked_source, false,
           "Convert MarkedSource-valued facts to subgraphs.");
 ABSL_FLAG(bool, show_anchors, false, "Show anchor locations instead of @s");
+ABSL_FLAG(bool, show_vnames, true,
+          "Show VNames for nodes which also have labels.");
+ABSL_FLAG(bool, show_fact_prefix, true,
+          "Include the /kythe or /kythe/edge prefix on facts and edges.");
 ABSL_FLAG(bool, file_vnames, true,
           "Find file vnames by matching file content.");
 ABSL_FLAG(bool, use_fast_solver, false,
@@ -110,8 +114,16 @@ Example:
     v.ShowAnchors();
   }
 
+  if (absl::GetFlag(FLAGS_show_vnames)) {
+    v.ShowLabeledVnames();
+  }
+
   if (!absl::GetFlag(FLAGS_file_vnames)) {
     v.IgnoreFileVnames();
+  }
+
+  if (absl::GetFlag(FLAGS_show_fact_prefix)) {
+    v.ShowFactPrefix();
   }
 
   v.UseFastSolver(absl::GetFlag(FLAGS_use_fast_solver));


### PR DESCRIPTION
This adds two additional verifier flags which control removing the `/kythe/(edge/)?` prefix and hiding node VNames when dumping graphviz graphs.  This results in much more compact and readable graphs (to say nothing of the dot file itself).

This also incidentally updates the PrinterPrinter interface to use absl::string_view instead of `const std::string&`