### PR TITLE
fix(cxx_indexer): emit non-implicit refs to explicit template specializations

### DIFF
--- a/kythe/cxx/indexer/cxx/testdata/template/template_class_inst_explicit.cc
+++ b/kythe/cxx/indexer/cxx/testdata/template/template_class_inst_explicit.cc
@@ -4,6 +4,8 @@ using ExternalDef = int;
 template <typename T> struct C {
   using X = ExternalDef;
 };
+//- @C defines/binding CInstantiation
+//- @C ref CInstantiation
 template struct C<int>;
 //- ExplicitC.node/kind record
 //- XAnchor childof/context ExplicitC

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_class_inst_explicit.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_class_inst_explicit.cc
@@ -4,6 +4,8 @@ using ExternalDef = int;
 template <typename T> struct C {
   using X = ExternalDef;
 };
+//- @C defines/binding ExplicitC
+//- @C ref ExplicitC
 template struct C<int>;
 //- ExplicitC.node/kind record
 //- XAnchor childof/context ExplicitC


### PR DESCRIPTION
Obnoxiously, we don't want *all* of the nodes visited during a traversal of a class template specialization to be within it's context.  For explicit instantiations, we want the test of the instantiation itself to remain explicit.