### PR TITLE
fix(verifier): include @ in anchor labels and support EVars

### DIFF
--- a/kythe/cxx/verifier/assertions.cc
+++ b/kythe/cxx/verifier/assertions.cc
@@ -18,6 +18,7 @@
 
 #include <sstream>
 
+#include "absl/strings/str_cat.h"
 #include "kythe/cxx/common/file_utils.h"
 #include "verifier.h"
 
@@ -448,10 +449,9 @@ bool AssertionParser::ResolveLocations(const yy::location& end_of_line,
         break;
       case UnresolvedLocation::Kind::kAnchor:
         if (default_inspect_) {
-          inspections_.emplace_back(token + ":" +
-                                        std::to_string(location.begin.line) +
-                                        "." + std::to_string(col),
-                                    evar, Inspection::Kind::IMPLICIT);
+          inspections_.emplace_back(
+              absl::StrCat("@", token, ":", location.begin.line, ".", col),
+              evar, Inspection::Kind::IMPLICIT);
         }
         AppendGoal(group_id, verifier_.MakePredicate(
                                  location, verifier_.eq_id(),

--- a/kythe/cxx/verifier/verifier.cc
+++ b/kythe/cxx/verifier/verifier.cc
@@ -1553,22 +1553,18 @@ void Verifier::DumpAsDot() {
     return;
   }
   std::map<std::string, std::string> vname_labels;
-  for (const auto& label_vname : saved_assignments_) {
-    if (!label_vname.second) {
+  for (const auto& [label, vname] : saved_assignments_) {
+    if (!vname) {
       continue;
     }
-    if (App* a = label_vname.second->AsApp()) {
-      if (Tuple* t = a->rhs()->AsTuple()) {
-        StringPrettyPrinter printer;
-        QuoteEscapingPrettyPrinter quote_printer(printer);
-        label_vname.second->Dump(symbol_table_, &printer);
-        auto old_label = vname_labels.find(printer.str());
-        if (old_label == vname_labels.end()) {
-          vname_labels[printer.str()] = label_vname.first;
-        } else {
-          old_label->second += ", " + label_vname.first;
-        }
-      }
+    StringPrettyPrinter printer;
+    QuoteEscapingPrettyPrinter quote_printer(printer);
+    vname->Dump(symbol_table_, &printer);
+    auto old_label = vname_labels.find(printer.str());
+    if (old_label == vname_labels.end()) {
+      vname_labels[printer.str()] = label;
+    } else {
+      old_label->second += ", " + label;
     }
   }
   auto GetLabel = [&](AstNode* node) {
@@ -1646,9 +1642,11 @@ void Verifier::DumpAsDot() {
       PrintQuotedNodeId(t->element(0));
       std::string label = GetLabel(t->element(0));
       if (info.kind == NodeKind::kAnchor && !show_anchors_) {
-        printer.Print(" [ shape=circle, label=\"@");
-        printer.Print(label);
-        if (!label.empty()) {
+        printer.Print(" [ shape=circle, label=\"");
+        if (label.empty()) {
+          printer.Print("@");
+        } else {
+          printer.Print(label);
           printer.Print("\", color=\"blue");
         }
         printer.Print("\" ];\n");


### PR DESCRIPTION
Include the `@` directly in captured anchor labels and don't filter out EVar-typed labels when printing.  Without this the label to which an anchor may be bound via `=` was excluded, e.g.

```
//- ThingAnchor=@Thing ref ThingRef
Thing _;
```

The resulting graph labels would skip "ThingAnchor".  If these labels are included, it's hard to distinguish the "@"-bound label, so move that into the label itself rather than just when printing.