### PR TITLE
feat(typescript_indexer): use ref/id for destructuring variables

### DIFF
--- a/kythe/typescript/indexer.ts
+++ b/kythe/typescript/indexer.ts
@@ -1843,7 +1843,7 @@ class Visitor {
     const vname = this.host.getSymbolName(propertyOnType, TSNamespace.VALUE);
     if (vname == null) return;
     const anchor = this.newAnchor(prop);
-    this.emitEdge(anchor, EdgeKind.REF, vname);
+    this.emitEdge(anchor, EdgeKind.REF_ID, vname);
   }
 
   /**

--- a/kythe/typescript/kythe.ts
+++ b/kythe/typescript/kythe.ts
@@ -76,6 +76,7 @@ export enum EdgeKind {
   REF_EXPANDS_TRANSITIVE = '/kythe/edge/ref/expands/transitive',
   REF_FILE = '/kythe/edge/ref/file',
   REF_IMPORTS = '/kythe/edge/ref/imports',
+  REF_ID = '/kythe/edge/ref/id',
   REF_INCLUDES = '/kythe/edge/ref/includes',
   REF_INIT = '/kythe/edge/ref/init',
   REF_INIT_IMPLICIT = '/kythe/edge/ref/init/implicit',

--- a/kythe/typescript/testdata/interface.ts
+++ b/kythe/typescript/testdata/interface.ts
@@ -10,16 +10,16 @@ interface Person {
 }
 
 const p: Person = {
-  //- @name ref Name
+  //- @name ref/id Name
   name: 'Alice',
-  //- @getAge ref GetAge
+  //- @getAge ref/id GetAge
   getAge() {}
 };
 
 const p2 = {
-  //- @name ref Name
+  //- @name ref/id Name
   name: 'Alice',
-  //- @getAge ref GetAge
+  //- @getAge ref/id GetAge
   getAge() {}
 } as Person;
 
@@ -29,28 +29,28 @@ p.name;
 //- @getAge ref GetAge
 p.getAge();
 
-//- @getAge ref GetAge
+//- @getAge ref/id GetAge
 const {getAge} = p;
 
-//- @name ref Name
-//- @getAge ref GetAge
+//- @name ref/id Name
+//- @getAge ref/id GetAge
 function takesPerson({name, getAge: newGetAge}: Person) {}
 
-//- @name ref Name
-//- @getAge ref GetAge
+//- @name ref/id Name
+//- @getAge ref/id GetAge
 takesPerson({name: 'Alice', getAge() {}});
 
 class PersonTaker {
   constructor(p: Person) {}
 }
 
-//- @name ref Name
-//- @getAge ref GetAge
+//- @name ref/id Name
+//- @getAge ref/id GetAge
 new PersonTaker({name: 'Alice', getAge() {}});
 
 function returnPerson(): Person {
-  //- @name ref Name
-  //- @getAge ref GetAge
+  //- @name ref/id Name
+  //- @getAge ref/id GetAge
   return {name: 'Alice', getAge() {}};
 }
 
@@ -58,7 +58,7 @@ function returnPerson(): Person {
 {
   const name = 'Alice';
   const getAge = () = {};
-  //- @name ref Name
-  //- @getAge ref GetAge
+  //- @name ref/id Name
+  //- @getAge ref/id GetAge
   const p3: Person = {name, getAge};
 }


### PR DESCRIPTION
It also affects object literal properties that reference inteface fields.
Those should use `override` instead but it requires extra work and will
be done as follow up.