### PR TITLE
feat(tests): switch c++ verifier tests to index at test time

### DIFF
--- a/kythe/cxx/indexer/cxx/testdata/BUILD
+++ b/kythe/cxx/indexer/cxx/testdata/BUILD
@@ -2241,7 +2241,7 @@ cc_indexer_test(
     check_for_singletons = True,
     ignore_dups = True,
     tags = ["template"],
-    template_instance_exclude_path_pattern = ".*exclude.*",
+    template_instance_exclude_path_pattern = ".*/exclude.*",
     deps = [
         "template/exclude_this_file.h",
         "template/include_this_file.h",
@@ -3016,7 +3016,7 @@ cc_indexer_test(
     experimental_use_abs_nodes = False,
     ignore_dups = True,
     tags = ["tvar_template"],
-    template_instance_exclude_path_pattern = ".*exclude.*",
+    template_instance_exclude_path_pattern = ".*/exclude.*",
     deps = [
         "tvar_template/exclude_this_file.h",
         "tvar_template/include_this_file.h",

--- a/kythe/cxx/indexer/textproto/testdata/textproto_verifier_test.bzl
+++ b/kythe/cxx/indexer/textproto/testdata/textproto_verifier_test.bzl
@@ -165,7 +165,6 @@ def textproto_verifier_test(
         verifier_test,
         name = name,
         size = size,
-        srcs = textproto_entries + [proto_entries],
         opts = vopts,
         tags = tags,
         visibility = visibility,

--- a/tools/build_rules/verifier_test/BUILD
+++ b/tools/build_rules/verifier_test/BUILD
@@ -3,7 +3,10 @@ load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 package(default_visibility = ["//visibility:public"])
 
-exports_files(["verifier_test.sh.in"])
+exports_files([
+    "verifier_test.sh.in",
+    "indexer.sh.in",
+])
 
 py_binary(
     name = "unbundle",

--- a/tools/build_rules/verifier_test/cc_indexer_test.bzl
+++ b/tools/build_rules/verifier_test/cc_indexer_test.bzl
@@ -181,16 +181,6 @@ def _split_flags(kwargs):
         fail("Unrecognized verifier flags: %s" % (kwargs.keys(),))
     return flags
 
-def _transitive_entries(deps):
-    files, compressed = [], []
-    for dep in deps:
-        if KytheEntries in dep:
-            files += dep[KytheEntries].files
-            compressed += dep[KytheEntries].compressed
-    if files or compressed:
-        print(files, compressed)
-    return KytheEntries(compressed = depset(transitive = compressed), files = depset(transitive = files))
-
 def _fix_path_for_generated_file(path):
     virtual_imports = "/_virtual_imports/"
     if virtual_imports in path:

--- a/tools/build_rules/verifier_test/indexer.sh.in
+++ b/tools/build_rules/verifier_test/indexer.sh.in
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright 2020 The Kythe Authors. All rights reserved.
+# Copyright 2022 The Kythe Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/build_rules/verifier_test/indexer.sh.in
+++ b/tools/build_rules/verifier_test/indexer.sh.in
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright 2016 The Kythe Authors. All rights reserved.
+# Copyright 2020 The Kythe Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,16 +15,10 @@
 # limitations under the License.
 #
 set -euo pipefail
-export RUNFILES_DIR="${RUNFILES_DIR:-${TEST_SRCDIR:-${0}.runfiles}}"
-export WORKSPACE_NAME="${TEST_WORKSPACE:-@WORKSPACE_NAME@}"
-cd "${RUNFILES_DIR}/${WORKSPACE_NAME}"
-
-ENTRIES=(@ENTRIES@)
-ENTRIES_GZ=(@ENTRIES_GZ@)
-(
-  @INDEXERS@
-  if (( ${#ENTRIES[@]} )); then cat "${ENTRIES[@]}"; fi
-  if (( ${#ENTRIES_GZ[@]} )); then gunzip -c "${ENTRIES_GZ[@]}"; fi
-) | (
-  if @INVERT@ @VERIFIER@ @ARGS@ "$@"; then exit 0; else exit 1; fi
+ENV=(@ENV@)
+ARGS=(
+  @INDEXER@
+  @ARGS@
 )
+export "${ENV[@]}"
+exec "${ARGS[@]}"

--- a/tools/build_rules/verifier_test/java_verifier_test.bzl
+++ b/tools/build_rules/verifier_test/java_verifier_test.bzl
@@ -375,8 +375,8 @@ def java_proto_verifier_test(
         name = name,
         size = size,
         srcs = [entries, proto_entries],
+        deps = [entries, proto_entries],
         opts = verifier_opts,
         tags = tags,
         visibility = visibility,
-        deps = [entries],
     )

--- a/tools/build_rules/verifier_test/java_verifier_test.bzl
+++ b/tools/build_rules/verifier_test/java_verifier_test.bzl
@@ -111,7 +111,7 @@ java_extract_kzip = rule(
         "extractor": attr.label(
             default = Label("@io_kythe//kythe/java/com/google/devtools/kythe/extractors/java/standalone:javac_extractor"),
             executable = True,
-            cfg = "host",
+            cfg = "exec",
         ),
         "opts": attr.string_list(),
         "vnames_config": attr.label(
@@ -284,12 +284,12 @@ _generate_java_proto = rule(
         "_protoc": attr.label(
             default = Label("@com_google_protobuf//:protoc"),
             executable = True,
-            cfg = "host",
+            cfg = "exec",
         ),
         "_singlejar": attr.label(
             default = Label("@bazel_tools//tools/jdk:singlejar"),
             executable = True,
-            cfg = "host",
+            cfg = "exec",
         ),
     },
     implementation = _generate_java_proto_impl,

--- a/tools/build_rules/verifier_test/jvm_verifier_test.bzl
+++ b/tools/build_rules/verifier_test/jvm_verifier_test.bzl
@@ -47,7 +47,7 @@ jvm_extract_kzip = rule(
         "extractor": attr.label(
             default = Label("//kythe/java/com/google/devtools/kythe/extractors/jvm:jar_extractor"),
             executable = True,
-            cfg = "host",
+            cfg = "exec",
         ),
         "opts": attr.string_list(),
         "vnames_config": attr.label(

--- a/tools/build_rules/verifier_test/kzip_archive.bzl
+++ b/tools/build_rules/verifier_test/kzip_archive.bzl
@@ -119,7 +119,7 @@ kzip_archive = rule(
             default = Label("//kythe/go/platform/tools/kzip"),
             allow_single_file = True,
             executable = True,
-            cfg = "host",
+            cfg = "exec",
         ),
     },
     implementation = _kzip_archive,

--- a/tools/build_rules/verifier_test/verifier_test.bzl
+++ b/tools/build_rules/verifier_test/verifier_test.bzl
@@ -298,9 +298,6 @@ def _verifier_test_impl(ctx):
     # we aren't provided explicit sources, assume `--use_file_nodes`.
     if not sources and "--use_file_nodes" not in args:
         args.append("--use_file_nodes")
-    if "--ignore_dups" not in args:
-        args.append("--ignore_dups")
-
     ctx.actions.expand_template(
         template = ctx.file._template,
         output = ctx.outputs.executable,

--- a/tools/build_rules/verifier_test/verifier_test.bzl
+++ b/tools/build_rules/verifier_test/verifier_test.bzl
@@ -109,22 +109,22 @@ atomize_entries = rule(
         "_atomizer": attr.label(
             default = Label("//kythe/go/test/tools/xrefs_atomizer"),
             executable = True,
-            cfg = "host",
+            cfg = "exec",
         ),
         "_entrystream": attr.label(
             default = Label("//kythe/go/platform/tools/entrystream"),
             executable = True,
-            cfg = "host",
+            cfg = "exec",
         ),
         "_postprocessor": attr.label(
             default = Label("//kythe/go/serving/tools/write_tables"),
             executable = True,
-            cfg = "host",
+            cfg = "exec",
         ),
         "_zcat": attr.label(
             default = Label("//tools:zcatext"),
             executable = True,
-            cfg = "host",
+            cfg = "exec",
         ),
     },
     outputs = {
@@ -244,11 +244,11 @@ index_compilation = rule(
         "indexer": attr.label(
             mandatory = True,
             executable = True,
-            cfg = "host",
+            cfg = "exec",
         ),
         "opts": attr.string_list(),
         "tools": attr.label_list(
-            cfg = "host",
+            cfg = "exec",
             allow_files = True,
         ),
         "deps": attr.label_list(


### PR DESCRIPTION
This adds a generic mechanism where rules can opt to have indexing run at test time, rather than build time.  It's a bit awkward, but means that the indexer can be built in the target configuration (opt, sanitizers, etc.) rather than just the host configuration.  It also potentially means that coverage data can be collected (but I've not looked in to that yet).