### PR TITLE
Support skipping 'go mod vendor' invocation.

### DIFF
--- a/kythe/go/extractors/cmd/gotool/analyze_packages.sh
+++ b/kythe/go/extractors/cmd/gotool/analyze_packages.sh
@@ -65,7 +65,7 @@ if [ -n "$KYTHE_SKIP_MOD_VENDOR" ]; then
   fi
 fi
 
-if ! [ -n "$SKIP_MOD_VENDOR" ]; then
+if [ -z "$SKIP_MOD_VENDOR" ]; then
   echo "$PACKAGE: go mod vendor" >&2
   pushd "$GOPATH/src/$PACKAGE"
   go mod vendor

--- a/kythe/go/extractors/cmd/gotool/analyze_packages.sh
+++ b/kythe/go/extractors/cmd/gotool/analyze_packages.sh
@@ -56,10 +56,21 @@ if [ -n "$KYTHE_PRE_BUILD_STEP" ]; then
   eval "$KYTHE_PRE_BUILD_STEP"
 fi
 
-echo "$PACKAGE: go mod vendor" >&2
-pushd "$GOPATH/src/$PACKAGE"
-go mod vendor
-popd
+if [ -n "$KYTHE_SKIP_MOD_VENDOR" ]; then
+  if [ "$KYTHE_SKIP_MOD_VENDOR" == "1" ] || \
+     [ "$KYTHE_SKIP_MOD_VENDOR" == "True" ] || \
+     [ "$KYTHE_SKIP_MOD_VENDOR" == "true" ]; then
+    echo "$PACKAGE: Skipping 'go mod vendor' due to KYTHE_SKIP_MOD_VERSION=$KYTHE_SKIP_MOD_VENDOR" >&2
+    SKIP_MOD_VENDOR=true
+  fi
+fi
+
+if ! [ -n "$SKIP_MOD_VENDOR" ]; then
+  echo "$PACKAGE: go mod vendor" >&2
+  pushd "$GOPATH/src/$PACKAGE"
+  go mod vendor
+  popd
+fi
 
 echo "Extracting ${PACKAGE}" >&2
   extract_go --continue -v \

--- a/kythe/go/extractors/cmd/gotool/analyze_packages.sh
+++ b/kythe/go/extractors/cmd/gotool/analyze_packages.sh
@@ -60,7 +60,7 @@ if [ -n "$KYTHE_SKIP_MOD_VENDOR" ]; then
   if [ "$KYTHE_SKIP_MOD_VENDOR" == "1" ] || \
      [ "$KYTHE_SKIP_MOD_VENDOR" == "True" ] || \
      [ "$KYTHE_SKIP_MOD_VENDOR" == "true" ]; then
-    echo "$PACKAGE: Skipping 'go mod vendor' due to KYTHE_SKIP_MOD_VERSION=$KYTHE_SKIP_MOD_VENDOR" >&2
+    echo "$PACKAGE: Skipping 'go mod vendor' due to KYTHE_SKIP_MOD_VENDOR=$KYTHE_SKIP_MOD_VENDOR" >&2
     SKIP_MOD_VENDOR=true
   fi
 fi


### PR DESCRIPTION
In some customer go corpuses, it is customery to do `go mod vendor`
and check-in the vendor directory.  This may be due to accessing
protected vendor code.  So, support skipping 'go mod vendor' during
analyze_packages upon a envrionment variable.

ENV variable: KYTHE_SKIP_MOD_VENDOR set to one of values: ('1', 'True' or 'true')

Testing:
  - Built golang-extracter docker image
  - Ran the image on a sample corpus with KYTHE_SKIP_MOD_VENDOR env var set
  - Ensured that `go mod vendor` step is skipped.
  - Also, `bazel build //... && bazel test //...` and ensured success.