### PR TITLE
chore: retain ability to pass the indexer binary for c++ indexer tests

### DIFF
--- a/tools/build_rules/verifier_test/cc_indexer_test.bzl
+++ b/tools/build_rules/verifier_test/cc_indexer_test.bzl
@@ -649,9 +649,8 @@ def _cc_index_impl(ctx):
                 files = (test_runners +
                          ctx.files.deps +
                          ctx.files.srcs +
-                         additional_kzips +
-                         [ctx.executable.test_indexer]),
-            ),
+                         additional_kzips),
+            ).merge(ctx.attr.test_indexer[DefaultInfo].default_runfiles),
         ),
     ]
 


### PR DESCRIPTION
And also correct the runfiles calculation. This is used internally for some tests of internal functionality.