### PR TITLE
chore(java): remove unused deprecated methods from JvmGraph

### DIFF
--- a/kythe/java/com/google/devtools/kythe/analyzers/jvm/JvmGraph.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/jvm/JvmGraph.java
@@ -56,12 +56,6 @@ public class JvmGraph {
   }
 
   /** Returns the {@link VName} corresponding to the given class/enum/interface type. */
-  @Deprecated
-  public static VName getReferenceVName(Type.ReferenceType referenceType) {
-    return getReferenceVName(CorpusPath.EMPTY, referenceType);
-  }
-
-  /** Returns the {@link VName} corresponding to the given class/enum/interface type. */
   public static VName getReferenceVName(CorpusPath corpusPath, Type.ReferenceType referenceType) {
     return corpusPath
         .toVNameBuilder()
@@ -96,21 +90,6 @@ public class JvmGraph {
    * <p>Parameter indices are used because names are only optionally retained in class files and not
    * required by the spec.
    */
-  @Deprecated
-  public static VName getParameterVName(
-      Type.ReferenceType parentClass,
-      String methodName,
-      Type.MethodType methodType,
-      int parameterIndex) {
-    return getParameterVName(CorpusPath.EMPTY, parentClass, methodName, methodType, parameterIndex);
-  }
-
-  /**
-   * Returns the {@link VName} corresponding to the given parameter of a method type.
-   *
-   * <p>Parameter indices are used because names are only optionally retained in class files and not
-   * required by the spec.
-   */
   public static VName getParameterVName(
       CorpusPath corpusPath,
       Type.ReferenceType parentClass,
@@ -122,12 +101,6 @@ public class JvmGraph {
         .setSignature(parameterSignature(parentClass, methodName, methodType, parameterIndex))
         .setLanguage(JVM_LANGUAGE)
         .build();
-  }
-
-  /** Returns the {@link VName} corresponding to the given field type. */
-  @Deprecated
-  public static VName getFieldVName(Type.ReferenceType parentClass, String name) {
-    return getFieldVName(CorpusPath.EMPTY, parentClass, name);
   }
 
   /** Returns the {@link VName} corresponding to the given field type. */
@@ -154,32 +127,15 @@ public class JvmGraph {
   }
 
   /** Emits and returns a Kythe {@code record} node for a JVM class. */
-  @Deprecated
-  public VName emitClassNode(Type.ReferenceType refType) {
-    return emitClassNode(CorpusPath.EMPTY, refType);
-  }
-
-  /** Emits and returns a Kythe {@code record} node for a JVM class. */
   public VName emitClassNode(CorpusPath corpusPath, Type.ReferenceType refType) {
     return emitNode(
         NodeKind.RECORD_CLASS, getReferenceVName(corpusPath, refType), markedSource(refType));
   }
 
   /** Emits and returns a Kythe {@code interface} node for a JVM interface. */
-  @Deprecated
-  public VName emitInterfaceNode(Type.ReferenceType refType) {
-    return emitInterfaceNode(CorpusPath.EMPTY, refType);
-  }
-  /** Emits and returns a Kythe {@code interface} node for a JVM interface. */
   public VName emitInterfaceNode(CorpusPath corpusPath, Type.ReferenceType refType) {
     return emitNode(
         NodeKind.INTERFACE, getReferenceVName(corpusPath, refType), markedSource(refType));
-  }
-
-  /** Emits and returns a Kythe {@code sum} node for a JVM enum class. */
-  @Deprecated
-  public VName emitEnumNode(Type.ReferenceType refType) {
-    return emitEnumNode(CorpusPath.EMPTY, refType);
   }
 
   /** Emits and returns a Kythe {@code sum} node for a JVM enum class. */
@@ -189,21 +145,8 @@ public class JvmGraph {
   }
 
   /** Emits and returns a Kythe {@code variable} node for a JVM field. */
-  @Deprecated
-  public VName emitFieldNode(Type.ReferenceType parentClass, String name) {
-    return emitFieldNode(CorpusPath.EMPTY, parentClass, name);
-  }
-
-  /** Emits and returns a Kythe {@code variable} node for a JVM field. */
   public VName emitFieldNode(CorpusPath corpusPath, Type.ReferenceType parentClass, String name) {
     return emitNode(NodeKind.VARIABLE_FIELD, getFieldVName(corpusPath, parentClass, name));
-  }
-
-  /** Emits and returns a Kythe {@code function} node for a JVM method. */
-  @Deprecated
-  public VName emitMethodNode(
-      Type.ReferenceType parentClass, String methodName, Type.MethodType type) {
-    return emitMethodNode(CorpusPath.EMPTY, parentClass, methodName, type);
   }
 
   /** Emits and returns a Kythe {@code function} node for a JVM method. */
@@ -215,21 +158,6 @@ public class JvmGraph {
     return emitNode(
         methodName.equals("<init>") ? NodeKind.FUNCTION_CONSTRUCTOR : NodeKind.FUNCTION,
         getMethodVName(corpusPath, parentClass, methodName, type));
-  }
-
-  /**
-   * Emits and returns a Kythe {@code variable/local/parameter} node for a JVM parameter to a
-   * method.
-   *
-   * @see #getParameterVName(Type.ReferenceType, String, Type.MethodType, int)
-   */
-  @Deprecated
-  public VName emitParameterNode(
-      Type.ReferenceType parentClass,
-      String methodName,
-      Type.MethodType methodType,
-      int parameterIndex) {
-    return emitParameterNode(CorpusPath.EMPTY, parentClass, methodName, methodType, parameterIndex);
   }
 
   /**


### PR DESCRIPTION
These are unused in the github repo and google3 and have been deprecated for ~2 years.