### PR TITLE
feat(java extractor): use default value if corpus is ambiguous

### DIFF
--- a/kythe/java/com/google/devtools/kythe/extractors/java/JavaCompilationUnitExtractor.java
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/JavaCompilationUnitExtractor.java
@@ -304,10 +304,13 @@ public class JavaCompilationUnitExtractor {
       unit.addSourceFile(sourceFile);
       sourceFileCorpora.add(inputCorpus.getOrDefault(sourceFile, ""));
     }
-    if (sourceFileCorpora.size() == 1) {
-      // Attribute the source files' corpus to the CompilationUnit if it is unambiguous.
-      unit.getVNameBuilder().setCorpus(Iterables.getOnlyElement(sourceFileCorpora));
-    }
+    // Attribute the source files' corpus to the CompilationUnit if it is unambiguous. Otherwise use
+    // the default corpus.
+    String cuCorpus =
+        sourceFileCorpora.size() == 1
+            ? Iterables.getOnlyElement(sourceFileCorpora)
+            : fileVNames.getDefaultCorpus();
+    unit.getVNameBuilder().setCorpus(cuCorpus);
     unit.setOutputKey(outputPath);
     unit.setWorkingDirectory(stableRoot(rootDirectory, options, requiredInputs));
     unit.addDetails(

--- a/kythe/java/com/google/devtools/kythe/extractors/shared/FileVNames.java
+++ b/kythe/java/com/google/devtools/kythe/extractors/shared/FileVNames.java
@@ -171,6 +171,10 @@ public class FileVNames {
         .build();
   }
 
+  public String getDefaultCorpus() {
+    return defaultCorpus.get();
+  }
+
   /** Base {@link VName} to use for files matching {@code pattern}. */
   private static class BaseFileVName {
     public final Pattern pattern;

--- a/kythe/javatests/com/google/devtools/kythe/extractors/java/JavaExtractorTest.java
+++ b/kythe/javatests/com/google/devtools/kythe/extractors/java/JavaExtractorTest.java
@@ -120,7 +120,7 @@ public class JavaExtractorTest extends TestCase {
         java.extract(TARGET1, sources, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, "output");
 
     CompilationUnit unit = description.getCompilationUnit();
-    assertThat(unit.getVName().getCorpus()).isEmpty(); // source files are from different corpora
+    assertThat(unit.getVName().getCorpus()).isEqualTo("kythe"); // source files are from different corpora, so unit is assigned default corpus of "kythe"
     assertThat(unit.getWorkingDirectory()).isEqualTo("/root");
     assertThat(unit).isNotNull();
     assertThat(unit.getVName().getSignature()).isEqualTo(TARGET1);

--- a/kythe/javatests/com/google/devtools/kythe/extractors/java/JavaExtractorTest.java
+++ b/kythe/javatests/com/google/devtools/kythe/extractors/java/JavaExtractorTest.java
@@ -120,7 +120,8 @@ public class JavaExtractorTest extends TestCase {
         java.extract(TARGET1, sources, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, "output");
 
     CompilationUnit unit = description.getCompilationUnit();
-    assertThat(unit.getVName().getCorpus()).isEqualTo("kythe"); // source files are from different corpora, so unit is assigned default corpus of "kythe"
+    // source files are from different corpora, so unit is assigned default corpus of "kythe"
+    assertThat(unit.getVName().getCorpus()).isEqualTo("kythe");
     assertThat(unit.getWorkingDirectory()).isEqualTo("/root");
     assertThat(unit).isNotNull();
     assertThat(unit.getVName().getSignature()).isEqualTo(TARGET1);


### PR DESCRIPTION
Before this change, java CUs don't receive a corpus if the required_inputs are not all in the same corpus. With this change, instead of assigning the empty corpus, the CU is assigned a corpus from the KYTHE_CORPUS environment variable.