### PR TITLE
fix(textproto): workaround upstream proto path bug

### DIFF
--- a/kythe/cxx/indexer/textproto/testdata/BUILD
+++ b/kythe/cxx/indexer/textproto/testdata/BUILD
@@ -47,6 +47,15 @@ textproto_verifier_test(
 )
 
 textproto_verifier_test(
+    name = "imports_generated_test",
+    protos = [
+        ":generated_proto",
+        ":imports_generated_proto",
+    ],
+    textprotos = ["generated_imports.pbtxt"],
+)
+
+textproto_verifier_test(
     name = "extensions_test",
     protos = [":extensions_proto"],
     textprotos = ["extensions.pbtxt"],
@@ -107,4 +116,22 @@ proto_library(
 proto_library(
     name = "repeated_extension_proto",
     srcs = ["repeated_extension.proto"],
+)
+
+genrule(
+    name = "generate_proto",
+    srcs = ["example.proto"],
+    outs = ["generated.proto"],
+    cmd = "cp $< $@",
+)
+
+proto_library(
+    name = "generated_proto",
+    srcs = [":generated.proto"],
+)
+
+proto_library(
+    name = "imports_generated_proto",
+    srcs = ["imports_generated.proto"],
+    deps = [":generated_proto"],
 )

--- a/kythe/cxx/indexer/textproto/testdata/generated_imports.pbtxt
+++ b/kythe/cxx/indexer/textproto/testdata/generated_imports.pbtxt
@@ -1,0 +1,8 @@
+# proto-message: example2.OuterMessage
+# proto-file: kythe/cxx/indexer/textproto/testdata/imports_generated.proto
+
+#- @inner_msg ref OuterMessageInnerMsg
+inner_msg {
+    #- @field1 ref Field1
+    field1: "hello"
+}

--- a/kythe/cxx/indexer/textproto/testdata/imports_generated.proto
+++ b/kythe/cxx/indexer/textproto/testdata/imports_generated.proto
@@ -1,0 +1,10 @@
+syntax = "proto2";
+
+package example2;
+
+import "kythe/cxx/indexer/textproto/testdata/generated.proto";
+
+message OuterMessage {
+  //- @inner_msg defines/binding OuterMessageInnerMsg?
+  optional example.Message2 inner_msg = 1;
+};

--- a/kythe/cxx/indexer/textproto/testdata/imports_generated.proto
+++ b/kythe/cxx/indexer/textproto/testdata/imports_generated.proto
@@ -5,6 +5,6 @@ package example2;
 import "kythe/cxx/indexer/textproto/testdata/generated.proto";
 
 message OuterMessage {
-  //- @inner_msg defines/binding OuterMessageInnerMsg?
+  //- @inner_msg defines/binding OuterMessageInnerMsg
   optional example.Message2 inner_msg = 1;
 };


### PR DESCRIPTION
Works around https://github.com/bazelbuild/bazel/issues/7964 by calculating the proto path roots from the source file roots directly. Blech, but functional.