### PR TITLE
Generate compilation database for workspace

### DIFF
--- a/tools/cpp/generate_compilation_database.sh
+++ b/tools/cpp/generate_compilation_database.sh
@@ -5,7 +5,7 @@
 
 set -e
 
-TARGETS=($(bazel query 'kind(cc_.*, //...) - attr(tags, manual, //...)'))
+mapfile -t TARGETS < <(bazel query 'kind(cc_.*, //...) - attr(tags, manual, //...)')
 bazel build \
   --experimental_action_listener=//kythe/cxx/tools/generate_compile_commands:extract_json \
   --noshow_progress \

--- a/tools/cpp/generate_compilation_database.sh
+++ b/tools/cpp/generate_compilation_database.sh
@@ -5,12 +5,13 @@
 
 set -e
 
+TARGETS=($(bazel query 'kind(cc_.*, //...) - attr(tags, manual, //...)'))
 bazel build \
   --experimental_action_listener=//kythe/cxx/tools/generate_compile_commands:extract_json \
   --noshow_progress \
   --noshow_loading_progress \
   --output_groups=compilation_outputs \
-  $(bazel query 'kind(cc_.*, //...) - attr(tags, manual, //...)') > /dev/null
+  "${TARGETS[@]}" > /dev/null
 
 BAZEL_ROOT="$(bazel info execution_root)"
 pushd "$BAZEL_ROOT" > /dev/null

--- a/tools/cpp/generate_compilation_database.sh
+++ b/tools/cpp/generate_compilation_database.sh
@@ -1,18 +1,16 @@
 #!/bin/bash
 
 # Generates a compile_commands.json file at $(bazel info execution_root) for
-# the given file path.
+# your Clang tooling needs.
 
 set -e
 
-FILENAME=${1:?Missing required source path}
 bazel build \
   --experimental_action_listener=//kythe/cxx/tools/generate_compile_commands:extract_json \
   --noshow_progress \
   --noshow_loading_progress \
   --output_groups=compilation_outputs \
-  --compile_one_dependency \
-  "$FILENAME" > /dev/null
+  $(bazel query 'kind(cc_.*, //...) - attr(tags, manual, //...)') > /dev/null
 
 BAZEL_ROOT="$(bazel info execution_root)"
 pushd "$BAZEL_ROOT" > /dev/null


### PR DESCRIPTION
Since [.ycm_extra_conf.py](https://github.com/kythe/kythe/blob/master/.ycm_extra_conf.py#L35) is calling `bazel print_action` directly, [generate_compilation_database.sh](https://github.com/kythe/kythe/blob/master/tools/cpp/generate_compilation_database.sh) is only called by [clang_tidy.sh](https://github.com/kythe/kythe/blob/master/tools/clang_tidy/clang_tidy.sh#L9) and this  call is broken as `clang_tidy` does not pass a certain file path to `generate_compilation_database.sh`. 

This PR fixes this by making `generate_compilation_database.sh` generate the compilation database for the project workspace and not require a file as input.