### PR TITLE
chore: bump rules_rust to v0.8.1

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c02a4d71819009c192cf4872265391563fd6a84c81ff2c0f2a7026ca4c1d85c"
+checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -165,9 +165,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
 dependencies = [
  "cfg-if",
  "crossbeam-epoch",
@@ -176,9 +176,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07db9d94cbd326813772c968ccd25999e5f8ae22f4f8d1b11effa37ef6ce281d"
+checksum = "045ebe27666471bb549370b4b0b3e51b07f56325befa4284db65fc89c02511b1"
 dependencies = [
  "autocfg",
  "cfg-if",
@@ -190,9 +190,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d82ee10ce34d7bc12c2122495e7593a9c41347ecdd64185af4ecf72cb1a7f83"
+checksum = "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -477,9 +477,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.40"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
+checksum = "c278e965f1d8cf32d6e0e96de3d3e79712178ae67986d9cf9151f51e95aac89b"
 dependencies = [
  "unicode-ident",
 ]
@@ -562,9 +562,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.13"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags",
 ]

--- a/cargo-bazel-lock.json
+++ b/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "b8bd5da8b1dc4f8263cedad5a617557c4e0edb64cdce5064f7c36fc5797f3160",
+  "checksum": "e648ab4a6092efa4423a7d5bbbadfd78b7f87914a8f97508f3ebcc990a7f20d8",
   "crates": {
     "adler 1.0.2": {
       "name": "adler",
@@ -883,13 +883,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "crossbeam-channel 0.5.5": {
+    "crossbeam-channel 0.5.6": {
       "name": "crossbeam-channel",
-      "version": "0.5.5",
+      "version": "0.5.6",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/crossbeam-channel/0.5.5/download",
-          "sha256": "4c02a4d71819009c192cf4872265391563fd6a84c81ff2c0f2a7026ca4c1d85c"
+          "url": "https://crates.io/api/v1/crates/crossbeam-channel/0.5.6/download",
+          "sha256": "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
         }
       },
       "targets": [
@@ -923,24 +923,24 @@
               "target": "cfg_if"
             },
             {
-              "id": "crossbeam-utils 0.8.10",
+              "id": "crossbeam-utils 0.8.11",
               "target": "crossbeam_utils"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.5.5"
+        "version": "0.5.6"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "crossbeam-deque 0.8.1": {
+    "crossbeam-deque 0.8.2": {
       "name": "crossbeam-deque",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/crossbeam-deque/0.8.1/download",
-          "sha256": "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+          "url": "https://crates.io/api/v1/crates/crossbeam-deque/0.8.2/download",
+          "sha256": "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
         }
       },
       "targets": [
@@ -975,28 +975,28 @@
               "target": "cfg_if"
             },
             {
-              "id": "crossbeam-epoch 0.9.9",
+              "id": "crossbeam-epoch 0.9.10",
               "target": "crossbeam_epoch"
             },
             {
-              "id": "crossbeam-utils 0.8.10",
+              "id": "crossbeam-utils 0.8.11",
               "target": "crossbeam_utils"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.8.1"
+        "version": "0.8.2"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "crossbeam-epoch 0.9.9": {
+    "crossbeam-epoch 0.9.10": {
       "name": "crossbeam-epoch",
-      "version": "0.9.9",
+      "version": "0.9.10",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/crossbeam-epoch/0.9.9/download",
-          "sha256": "07db9d94cbd326813772c968ccd25999e5f8ae22f4f8d1b11effa37ef6ce281d"
+          "url": "https://crates.io/api/v1/crates/crossbeam-epoch/0.9.10/download",
+          "sha256": "045ebe27666471bb549370b4b0b3e51b07f56325befa4284db65fc89c02511b1"
         }
       },
       "targets": [
@@ -1042,11 +1042,11 @@
               "target": "cfg_if"
             },
             {
-              "id": "crossbeam-epoch 0.9.9",
+              "id": "crossbeam-epoch 0.9.10",
               "target": "build_script_build"
             },
             {
-              "id": "crossbeam-utils 0.8.10",
+              "id": "crossbeam-utils 0.8.11",
               "target": "crossbeam_utils"
             },
             {
@@ -1065,7 +1065,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.9.9"
+        "version": "0.9.10"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -1083,13 +1083,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "crossbeam-utils 0.8.10": {
+    "crossbeam-utils 0.8.11": {
       "name": "crossbeam-utils",
-      "version": "0.8.10",
+      "version": "0.8.11",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/crossbeam-utils/0.8.10/download",
-          "sha256": "7d82ee10ce34d7bc12c2122495e7593a9c41347ecdd64185af4ecf72cb1a7f83"
+          "url": "https://crates.io/api/v1/crates/crossbeam-utils/0.8.11/download",
+          "sha256": "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
         }
       },
       "targets": [
@@ -1135,7 +1135,7 @@
               "target": "cfg_if"
             },
             {
-              "id": "crossbeam-utils 0.8.10",
+              "id": "crossbeam-utils 0.8.11",
               "target": "build_script_build"
             },
             {
@@ -1146,7 +1146,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.8.10"
+        "version": "0.8.11"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -1239,7 +1239,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.40",
+              "id": "proc-macro2 1.0.42",
               "target": "proc_macro2"
             },
             {
@@ -2559,7 +2559,7 @@
           "selects": {
             "cfg(target_os = \"redox\")": [
               {
-                "id": "redox_syscall 0.2.13",
+                "id": "redox_syscall 0.2.16",
                 "target": "syscall"
               }
             ],
@@ -2705,7 +2705,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "proc-macro2 1.0.40",
+              "id": "proc-macro2 1.0.42",
               "target": "proc_macro2"
             },
             {
@@ -2794,7 +2794,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "proc-macro2 1.0.40",
+              "id": "proc-macro2 1.0.42",
               "target": "proc_macro2"
             },
             {
@@ -2823,13 +2823,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "proc-macro2 1.0.40": {
+    "proc-macro2 1.0.42": {
       "name": "proc-macro2",
-      "version": "1.0.40",
+      "version": "1.0.42",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/proc-macro2/1.0.40/download",
-          "sha256": "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
+          "url": "https://crates.io/api/v1/crates/proc-macro2/1.0.42/download",
+          "sha256": "c278e965f1d8cf32d6e0e96de3d3e79712178ae67986d9cf9151f51e95aac89b"
         }
       },
       "targets": [
@@ -2870,7 +2870,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.40",
+              "id": "proc-macro2 1.0.42",
               "target": "build_script_build"
             },
             {
@@ -2881,7 +2881,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.40"
+        "version": "1.0.42"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -2970,7 +2970,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.40",
+              "id": "proc-macro2 1.0.42",
               "target": "proc_macro2"
             },
             {
@@ -3179,7 +3179,7 @@
         "deps": {
           "common": [
             {
-              "id": "crossbeam-deque 0.8.1",
+              "id": "crossbeam-deque 0.8.2",
               "target": "crossbeam_deque"
             },
             {
@@ -3259,15 +3259,15 @@
         "deps": {
           "common": [
             {
-              "id": "crossbeam-channel 0.5.5",
+              "id": "crossbeam-channel 0.5.6",
               "target": "crossbeam_channel"
             },
             {
-              "id": "crossbeam-deque 0.8.1",
+              "id": "crossbeam-deque 0.8.2",
               "target": "crossbeam_deque"
             },
             {
-              "id": "crossbeam-utils 0.8.10",
+              "id": "crossbeam-utils 0.8.11",
               "target": "crossbeam_utils"
             },
             {
@@ -3338,13 +3338,13 @@
       },
       "license": "ISC"
     },
-    "redox_syscall 0.2.13": {
+    "redox_syscall 0.2.16": {
       "name": "redox_syscall",
-      "version": "0.2.13",
+      "version": "0.2.16",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/redox_syscall/0.2.13/download",
-          "sha256": "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
+          "url": "https://crates.io/api/v1/crates/redox_syscall/0.2.16/download",
+          "sha256": "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
         }
       },
       "targets": [
@@ -3376,7 +3376,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.2.13"
+        "version": "0.2.16"
       },
       "license": "MIT"
     },
@@ -3960,7 +3960,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.40",
+              "id": "proc-macro2 1.0.42",
               "target": "proc_macro2"
             },
             {
@@ -4156,7 +4156,7 @@
               "target": "proc_macro_error"
             },
             {
-              "id": "proc-macro2 1.0.40",
+              "id": "proc-macro2 1.0.42",
               "target": "proc_macro2"
             },
             {
@@ -4360,7 +4360,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.40",
+              "id": "proc-macro2 1.0.42",
               "target": "proc_macro2"
             },
             {
@@ -4549,7 +4549,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.40",
+              "id": "proc-macro2 1.0.42",
               "target": "proc_macro2"
             },
             {

--- a/kythe/rust/extractor/BUILD
+++ b/kythe/rust/extractor/BUILD
@@ -46,8 +46,8 @@ sh_binary(
     data = [
         ":extractor",
     ] + select({
-        "@platforms//os:linux": ["@rust_linux_x86_64//:rustc_lib"],
-        "@platforms//os:osx": ["@rust_darwin_x86_64//:rustc_lib"],
+        "@platforms//os:linux": ["@rust_linux_x86_64__x86_64-unknown-linux-gnu_tools//:rustc_lib"],
+        "@platforms//os:osx": ["@rust_darwin_x86_64__x86_64-apple-darwin_tools//:rustc_lib"],
     }),
 )
 

--- a/kythe/rust/extractor/extractor_script.sh
+++ b/kythe/rust/extractor/extractor_script.sh
@@ -16,10 +16,10 @@
 RUNFILES_DIR="$0.runfiles"
 
 # We have to call find ourselves because rlocation doesn't support wildcards
-PATTERN="$RUNFILES_DIR/rust_*_x86_64/lib/rustlib*lib/librustc_driver-*.*"
+PATTERN="$RUNFILES_DIR/rust_*_x86_64*_tools/lib/rustlib*lib/librustc_driver-*.*"
 # Find the Rust directory first so that our next find doesn't search the
 # entire runfiles directory
-RUST_RUNFILES_LOCATION="$(find "$RUNFILES_DIR" -type d -wholename "$RUNFILES_DIR/rust_*_x86_64")"
+RUST_RUNFILES_LOCATION="$(find "$RUNFILES_DIR" -type d -wholename "$RUNFILES_DIR/rust_*_x86_64*_tools")"
 LOCATION="$(find "$RUST_RUNFILES_LOCATION" -wholename "$PATTERN")"
 LIB_DIRNAME="$(dirname "$LOCATION")"
 

--- a/setup.bzl
+++ b/setup.bzl
@@ -109,10 +109,10 @@ def kythe_rule_repositories():
     maybe(
         http_archive,
         name = "rules_rust",
-        sha256 = "7fb9b4fe1a6fb4341bdf7c623e619460ecc0f52d5061cc56abc750111fba8a87",
+        sha256 = "05e15e536cc1e5fd7b395d044fc2dabf73d2b27622fbc10504b7e48219bb09bc",
         urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_rust/releases/download/0.7.0/rules_rust-v0.7.0.tar.gz",
-            "https://github.com/bazelbuild/rules_rust/releases/download/0.7.0/rules_rust-v0.7.0.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_rust/releases/download/0.8.1/rules_rust-v0.8.1.tar.gz",
+            "https://github.com/bazelbuild/rules_rust/releases/download/0.8.1/rules_rust-v0.8.1.tar.gz",
         ],
     )
 


### PR DESCRIPTION
Bumps `rules_rust` to v0.8.1 for the latest improvements. The Cargo lock files have changes because they must be regenerated each time `rules_rust` is updated. The location of the `rustc_lib` files has changed, this is reflected in the Rust extractor script.