### PR TITLE
fix(java_indexer): assign all diagnostics a corpus

### DIFF
--- a/kythe/java/com/google/devtools/kythe/analyzers/base/KytheEntrySets.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/base/KytheEntrySets.java
@@ -202,7 +202,11 @@ public class KytheEntrySets {
 
   /** Emits and returns a DIAGNOSTIC node attached to no file. */
   public EntrySet emitDiagnostic(Diagnostic d) {
-    return emitDiagnostic(null, d);
+    VName fileVName =
+        useCompilationCorpusAsDefault
+            ? VName.newBuilder().setCorpus(compilationVName.getCorpus()).build()
+            : null;
+    return emitDiagnostic(fileVName, d);
   }
 
   /**

--- a/kythe/java/com/google/devtools/kythe/analyzers/base/KytheEntrySets.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/base/KytheEntrySets.java
@@ -222,14 +222,17 @@ public class KytheEntrySets {
     if (!d.getContextUrl().isEmpty()) {
       builder.setProperty("context/url", d.getContextUrl());
     }
-    EntrySet dn = emitAndReturn(builder);
     if (fileVName == null) {
       if (getUseCompilationCorpusAsDefault()) {
         builder.setCorpusPath(defaultCorpusPath());
       }
-      return dn;
     } else {
       builder.setCorpusPath(CorpusPath.fromVName(fileVName));
+    }
+    EntrySet dn = emitAndReturn(builder);
+    if (fileVName == null) {
+      return dn;
+    } else {
       if (d.hasSpan()) {
         Span s =
             new Span(d.getSpan().getStart().getByteOffset(), d.getSpan().getEnd().getByteOffset());

--- a/kythe/java/com/google/devtools/kythe/analyzers/base/KytheEntrySets.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/base/KytheEntrySets.java
@@ -87,6 +87,10 @@ public class KytheEntrySets {
     return useCompilationCorpusAsDefault;
   }
 
+  public final VName getCompilationVName() {
+    return compilationVName;
+  }
+
   /** Returns the {@link FactEmitter} used to emit generated {@link EntrySet}s. */
   public final FactEmitter getEmitter() {
     return emitter;

--- a/kythe/java/com/google/devtools/kythe/analyzers/base/KytheEntrySets.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/base/KytheEntrySets.java
@@ -87,10 +87,6 @@ public class KytheEntrySets {
     return useCompilationCorpusAsDefault;
   }
 
-  public final VName getCompilationVName() {
-    return compilationVName;
-  }
-
   /** Returns the {@link FactEmitter} used to emit generated {@link EntrySet}s. */
   public final FactEmitter getEmitter() {
     return emitter;
@@ -206,11 +202,7 @@ public class KytheEntrySets {
 
   /** Emits and returns a DIAGNOSTIC node attached to no file. */
   public EntrySet emitDiagnostic(Diagnostic d) {
-    VName fileVName =
-        useCompilationCorpusAsDefault
-            ? VName.newBuilder().setCorpus(compilationVName.getCorpus()).build()
-            : null;
-    return emitDiagnostic(fileVName, d);
+    return emitDiagnostic(null, d);
   }
 
   /**
@@ -232,6 +224,9 @@ public class KytheEntrySets {
     }
     EntrySet dn = emitAndReturn(builder);
     if (fileVName == null) {
+      if (getUseCompilationCorpusAsDefault()) {
+        builder.setCorpusPath(defaultCorpusPath());
+      }
       return dn;
     } else {
       builder.setCorpusPath(CorpusPath.fromVName(fileVName));

--- a/kythe/java/com/google/devtools/kythe/analyzers/java/JavaEntrySets.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/JavaEntrySets.java
@@ -159,8 +159,12 @@ public class JavaEntrySets extends KytheEntrySets {
       if (config.getVerboseLogging()) {
         logger.atWarning().log("%s", msg);
       }
-      Diagnostic.Builder d = Diagnostic.newBuilder().setMessage(msg);
-      return emitDiagnostic(d.build()).getVName();
+      Diagnostic d = Diagnostic.newBuilder().setMessage(msg).build();
+      VName dVName =
+          getUseCompilationCorpusAsDefault()
+              ? VName.newBuilder().setCorpus(getCompilationVName().getCorpus()).build()
+              : null;
+      return emitDiagnostic(dVName, d).getVName();
     } else {
       if (config.getIgnoreVNamePaths()) {
         v = v.toBuilder().setPath(enclClass != null ? enclClass.toString() : "").build();

--- a/kythe/java/com/google/devtools/kythe/analyzers/java/JavaEntrySets.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/JavaEntrySets.java
@@ -159,12 +159,8 @@ public class JavaEntrySets extends KytheEntrySets {
       if (config.getVerboseLogging()) {
         logger.atWarning().log("%s", msg);
       }
-      Diagnostic d = Diagnostic.newBuilder().setMessage(msg).build();
-      VName dVName =
-          getUseCompilationCorpusAsDefault()
-              ? VName.newBuilder().setCorpus(getCompilationVName().getCorpus()).build()
-              : null;
-      return emitDiagnostic(dVName, d).getVName();
+      Diagnostic.Builder d = Diagnostic.newBuilder().setMessage(msg);
+      return emitDiagnostic(d.build()).getVName();
     } else {
       if (config.getIgnoreVNamePaths()) {
         v = v.toBuilder().setPath(enclClass != null ? enclClass.toString() : "").build();


### PR DESCRIPTION
when use_compilation_corpus_as_default is enabled