### PR TITLE
feat(go_indexer): rework --use_compilation_corpus_as_default

### DIFF
--- a/kythe/go/indexer/BUILD
+++ b/kythe/go/indexer/BUILD
@@ -269,7 +269,7 @@ go_indexer_test(
 go_indexer_test(
     name = "tappcorpus_test",
     srcs = ["testdata/basic/tappcorpus.go"],
-    use_compilation_corpus_as_default = True,
+    use_compilation_corpus_for_all = True,
 )
 
 empty_corpus_test(
@@ -284,7 +284,7 @@ go_indexer_test(
         "--use_default_corpus_for_stdlib",
         "--corpus=kythe",
     ],
-    use_compilation_corpus_as_default = True,
+    use_compilation_corpus_for_all = True,
 )
 
 # Test that extracting and indexing a go package that imports standard libraries
@@ -303,7 +303,7 @@ go_indexer_test(
         "--corpus=kythe",
     ],
     override_stdlib_corpus = "STDLIB_OVERRIDE",
-    use_compilation_corpus_as_default = True,
+    use_compilation_corpus_for_all = True,
 )
 
 # load(":testdata/go_indexer_test.bzl", "go_integration_test")

--- a/kythe/go/indexer/cmd/go_indexer/go_indexer.go
+++ b/kythe/go/indexer/cmd/go_indexer/go_indexer.go
@@ -51,8 +51,8 @@ var (
 	onlyEmitDocURIsForStandardLibs = flag.Bool("only_emit_doc_uris_for_standard_libs", false, "If true, the doc/uri fact is only emitted for go std library packages")
 	verbose                        = flag.Bool("verbose", false, "Emit verbose log information")
 	contOnErr                      = flag.Bool("continue", false, "Log errors encountered during analysis but do not exit unsuccessfully")
-	useCompilationCorpusAsDefault  = flag.Bool("use_compilation_corpus_as_default", false, "Nodes that otherwise wouldn't have a corpus (such as tapps) are given the corpus of the compilation unit being indexed.")
-	overrideStdlibCorpus           = flag.String("override_stdlib_corpus", "", "If set, all stdlib nodes are assigned this corpus")
+	useCompilationCorpusForAll     = flag.Bool("use_compilation_corpus_for_all", false, "If enabled, all Entry VNames are given the corpus of the compilation unit being indexed. This includes items in the go std library and builtin types.")
+	overrideStdlibCorpus           = flag.String("override_stdlib_corpus", "", "If set, all stdlib nodes are assigned this corpus. Note that this takes precedence over --use_compilation_corpus_for_all")
 
 	writeEntry func(context.Context, *spb.Entry) error
 	docURL     *url.URL
@@ -160,7 +160,7 @@ func indexGo(ctx context.Context, unit *apb.CompilationUnit, f indexer.Fetcher) 
 		EmitLinkages:                   *metaSuffix != "",
 		DocBase:                        docURL,
 		OnlyEmitDocURIsForStandardLibs: *onlyEmitDocURIsForStandardLibs,
-		UseCompilationCorpusAsDefault:  *useCompilationCorpusAsDefault,
+		UseCompilationCorpusForAll:     *useCompilationCorpusForAll,
 		OverrideStdlibCorpus:           *overrideStdlibCorpus,
 	})
 }

--- a/kythe/go/indexer/emit.go
+++ b/kythe/go/indexer/emit.go
@@ -1003,22 +1003,30 @@ func (e *emitter) writeSatisfies(src, tgt types.Object) {
 }
 
 func (e *emitter) writeFact(src *spb.VName, name, value string) {
-	src = proto.Clone(src).(*spb.VName)
-	src.Corpus = e.rewrittenCorpusForVName(src)
+	if corpus := e.rewrittenCorpusForVName(src); corpus != src.GetCorpus() {
+		src = proto.Clone(src).(*spb.VName)
+		src.Corpus = corpus
+	}
 	e.check(e.sink.writeFact(e.ctx, src, name, value))
 }
 
 func (e *emitter) writeEdge(src, tgt *spb.VName, kind string) {
-	src = proto.Clone(src).(*spb.VName)
-	src.Corpus = e.rewrittenCorpusForVName(src)
-	tgt = proto.Clone(tgt).(*spb.VName)
-	tgt.Corpus = e.rewrittenCorpusForVName(tgt)
+	if corpus := e.rewrittenCorpusForVName(src); corpus != src.GetCorpus() {
+		src = proto.Clone(src).(*spb.VName)
+		src.Corpus = corpus
+	}
+	if corpus := e.rewrittenCorpusForVName(tgt); corpus != tgt.GetCorpus() {
+		tgt = proto.Clone(tgt).(*spb.VName)
+		tgt.Corpus = corpus
+	}
 	e.check(e.sink.writeEdge(e.ctx, src, tgt, kind))
 }
 
 func (e *emitter) writeAnchor(node ast.Node, src *spb.VName, start, end int) {
-	src = proto.Clone(src).(*spb.VName)
-	src.Corpus = e.rewrittenCorpusForVName(src)
+	if corpus := e.rewrittenCorpusForVName(src); corpus != src.GetCorpus() {
+		src = proto.Clone(src).(*spb.VName)
+		src.Corpus = corpus
+	}
 	if _, ok := e.anchored[node]; ok {
 		return // this node already has an anchor
 	}
@@ -1027,8 +1035,10 @@ func (e *emitter) writeAnchor(node ast.Node, src *spb.VName, start, end int) {
 }
 
 func (e *emitter) writeDiagnostic(src *spb.VName, d diagnostic) {
-	src = proto.Clone(src).(*spb.VName)
-	src.Corpus = e.rewrittenCorpusForVName(src)
+	if corpus := e.rewrittenCorpusForVName(src); corpus != src.GetCorpus() {
+		src = proto.Clone(src).(*spb.VName)
+		src.Corpus = corpus
+	}
 	e.check(e.sink.writeDiagnostic(e.ctx, src, d))
 }
 

--- a/kythe/go/indexer/emit.go
+++ b/kythe/go/indexer/emit.go
@@ -65,11 +65,12 @@ type EmitOptions struct {
 	// If true, the doc/uri fact is only emitted for go std library packages.
 	OnlyEmitDocURIsForStandardLibs bool
 
-	// Nodes that otherwise wouldn't have a corpus (such as tapps) are given the
-	// corpus of the compilation unit being indexed.
-	UseCompilationCorpusAsDefault bool
+	// If enabled, all VNames emitted by the indexer are assigned the
+	// compilation unit's corpus.
+	UseCompilationCorpusForAll bool
 
-	// If set, all stdlib nodes are assigned this corpus.
+	// If set, all stdlib nodes are assigned this corpus. This takes precedence
+	// over UseCompilationCorpusForAll for stdlib nodes.
 	OverrideStdlibCorpus string
 }
 
@@ -304,12 +305,16 @@ func (e *emitter) visitFuncDecl(decl *ast.FuncDecl, stack stackFunc) {
 }
 
 // rewrittenCorpusForVName returns the new corpus that should be assigned to the
-// given vname based on the OverrideStdlibCorpus and UseCompilationCorpusAsDefault options
+// given vname based on the OverrideStdlibCorpus and UseCompilationCorpusForAll options
 func (e *emitter) rewrittenCorpusForVName(v *spb.VName) string {
 	if e.opts.OverrideStdlibCorpus != "" && v.GetCorpus() == govname.GolangCorpus {
 		return e.opts.OverrideStdlibCorpus
 	}
-	if e.opts.UseCompilationCorpusAsDefault {
+	if e.opts.UseCompilationCorpusForAll {
+		return e.pi.VName.GetCorpus()
+	}
+	if v.GetCorpus() == "" {
+		// If the VName doesn't specify a corpus, use the compilation unit's corpus
 		return e.pi.VName.GetCorpus()
 	}
 	return v.GetCorpus()
@@ -330,9 +335,7 @@ func (e *emitter) emitTApp(ms *cpb.MarkedSource, ctorKind string, ctor *spb.VNam
 		components = append(components, p)
 	}
 	v := &spb.VName{Language: govname.Language, Signature: hashSignature(components)}
-	if e.opts.UseCompilationCorpusAsDefault || e.opts.OverrideStdlibCorpus != "" {
-		v.Corpus = e.rewrittenCorpusForVName(v)
-	}
+	v.Corpus = e.rewrittenCorpusForVName(v)
 	if e.pi.typeEmitted.Add(v.Signature) {
 		e.writeFact(v, facts.NodeKind, nodes.TApp)
 		e.writeEdge(v, ctor, edges.ParamIndex(0))
@@ -1000,28 +1003,22 @@ func (e *emitter) writeSatisfies(src, tgt types.Object) {
 }
 
 func (e *emitter) writeFact(src *spb.VName, name, value string) {
-	if e.opts.UseCompilationCorpusAsDefault || e.opts.OverrideStdlibCorpus != "" {
-		src = proto.Clone(src).(*spb.VName)
-		src.Corpus = e.rewrittenCorpusForVName(src)
-	}
+	src = proto.Clone(src).(*spb.VName)
+	src.Corpus = e.rewrittenCorpusForVName(src)
 	e.check(e.sink.writeFact(e.ctx, src, name, value))
 }
 
 func (e *emitter) writeEdge(src, tgt *spb.VName, kind string) {
-	if e.opts.UseCompilationCorpusAsDefault || e.opts.OverrideStdlibCorpus != "" {
-		src = proto.Clone(src).(*spb.VName)
-		src.Corpus = e.rewrittenCorpusForVName(src)
-		tgt = proto.Clone(tgt).(*spb.VName)
-		tgt.Corpus = e.rewrittenCorpusForVName(tgt)
-	}
+	src = proto.Clone(src).(*spb.VName)
+	src.Corpus = e.rewrittenCorpusForVName(src)
+	tgt = proto.Clone(tgt).(*spb.VName)
+	tgt.Corpus = e.rewrittenCorpusForVName(tgt)
 	e.check(e.sink.writeEdge(e.ctx, src, tgt, kind))
 }
 
 func (e *emitter) writeAnchor(node ast.Node, src *spb.VName, start, end int) {
-	if e.opts.UseCompilationCorpusAsDefault || e.opts.OverrideStdlibCorpus != "" {
-		src = proto.Clone(src).(*spb.VName)
-		src.Corpus = e.rewrittenCorpusForVName(src)
-	}
+	src = proto.Clone(src).(*spb.VName)
+	src.Corpus = e.rewrittenCorpusForVName(src)
 	if _, ok := e.anchored[node]; ok {
 		return // this node already has an anchor
 	}
@@ -1030,10 +1027,8 @@ func (e *emitter) writeAnchor(node ast.Node, src *spb.VName, start, end int) {
 }
 
 func (e *emitter) writeDiagnostic(src *spb.VName, d diagnostic) {
-	if e.opts.UseCompilationCorpusAsDefault || e.opts.OverrideStdlibCorpus != "" {
-		src = proto.Clone(src).(*spb.VName)
-		src.Corpus = e.rewrittenCorpusForVName(src)
-	}
+	src = proto.Clone(src).(*spb.VName)
+	src.Corpus = e.rewrittenCorpusForVName(src)
 	e.check(e.sink.writeDiagnostic(e.ctx, src, d))
 }
 

--- a/kythe/go/indexer/markedsource.go
+++ b/kythe/go/indexer/markedsource.go
@@ -266,7 +266,7 @@ func rewriteMarkedSourceCorpus(ms *cpb.MarkedSource, corpus string) {
 // target, or logs a diagnostic.
 func (e *emitter) emitCode(target *spb.VName, ms *cpb.MarkedSource) {
 	if ms != nil {
-		if e.opts.UseCompilationCorpusAsDefault {
+		if e.opts.UseCompilationCorpusForAll {
 			rewriteMarkedSourceCorpus(ms, e.pi.VName.Corpus)
 		}
 		bits, err := proto.Marshal(ms)

--- a/kythe/go/indexer/testdata/basic/stdliboverride.go
+++ b/kythe/go/indexer/testdata/basic/stdliboverride.go
@@ -1,5 +1,5 @@
 // Package stdliboverride tests that corpus labels are assigned correctly when
-// the --override_stdlib_corpus and --use_compilation_corpus_as_default flags
+// the --override_stdlib_corpus and --use_compilation_corpus_for_all flags
 // are enabled.
 package stdliboverride
 

--- a/kythe/go/indexer/testdata/go_indexer_test.bzl
+++ b/kythe/go/indexer/testdata/go_indexer_test.bzl
@@ -169,8 +169,8 @@ def _go_entries(ctx):
     if ctx.attr.emit_anchor_scopes:
         iargs.append("-anchor_scopes")
 
-    if ctx.attr.use_compilation_corpus_as_default:
-        iargs.append("-use_compilation_corpus_as_default")
+    if ctx.attr.use_compilation_corpus_for_all:
+        iargs.append("-use_compilation_corpus_for_all")
 
     if ctx.attr.override_stdlib_corpus:
         iargs.append("-override_stdlib_corpus=%s" % ctx.attr.override_stdlib_corpus)
@@ -209,7 +209,7 @@ go_entries = rule(
 
         # The suffix used to recognize linkage metadata files, if non-empty.
         "metadata_suffix": attr.string(default = ""),
-        "use_compilation_corpus_as_default": attr.bool(default = False),
+        "use_compilation_corpus_for_all": attr.bool(default = False),
         "override_stdlib_corpus": attr.string(default = ""),
 
         # The location of the Go indexer binary.
@@ -258,7 +258,7 @@ def _go_indexer(
         has_marked_source = False,
         emit_anchor_scopes = False,
         allow_duplicates = False,
-        use_compilation_corpus_as_default = False,
+        use_compilation_corpus_for_all = False,
         override_stdlib_corpus= "",
         metadata_suffix = "",
         extra_extractor_args = []):
@@ -283,7 +283,7 @@ def _go_indexer(
         name = entries,
         has_marked_source = has_marked_source,
         emit_anchor_scopes = emit_anchor_scopes,
-        use_compilation_corpus_as_default = use_compilation_corpus_as_default,
+        use_compilation_corpus_for_all = use_compilation_corpus_for_all,
         override_stdlib_corpus = override_stdlib_corpus,
         kzip = ":" + kzip,
         metadata_suffix = metadata_suffix,
@@ -304,7 +304,7 @@ def go_indexer_test(
         has_marked_source = False,
         emit_anchor_scopes = False,
         allow_duplicates = False,
-        use_compilation_corpus_as_default = False,
+        use_compilation_corpus_for_all = False,
         override_stdlib_corpus= "",
         metadata_suffix = "",
         extra_extractor_args = []):
@@ -314,7 +314,7 @@ def go_indexer_test(
         data = data,
         has_marked_source = has_marked_source,
         emit_anchor_scopes = emit_anchor_scopes,
-        use_compilation_corpus_as_default = use_compilation_corpus_as_default,
+        use_compilation_corpus_for_all = use_compilation_corpus_for_all,
         override_stdlib_corpus=override_stdlib_corpus,
         importpath = import_path,
         metadata_suffix = metadata_suffix,


### PR DESCRIPTION
Most of this change is a flag/option rename. The most important bit is in `rewrittenCorpusForVName()` in emit.go.

The `--override_stdlib_corpus` wasn't working as intended in google3 because it identifies stdlib nodes by the 'golang.org' corpus, but in google3, these are assigned the 'google3/golib' corpus. I renamed `--use_compilation_corpus_as_default` to `--use_compilation_corpus_for_all` to better indicate it's function, which is to change the corpus of *all* VNames (including stdlib and builtin items) at emit time to that of the compilation corpus, which is what we want for oss repos. `rewrittenCorpusForVName()` has been changed so that when `--use_compilation_corpus_for_all` is disabled, the compilation unit's corpus is only used for items that don't already have a corpus set, which is what we want for google3 and google3/golib. Builtin types such as `string` or `bool` will still be assigned 'golang.org', which is what we were already doing before I started messing with corpus rewriting. We could use `--override_stdlib_corpus` to change these to 'golang.org', but I'm inclined to remove the override flag and just continue using 'golang.org' for builtins.