### PR TITLE
fix(rust_common): fix rustc_lib location in release

### DIFF
--- a/kythe/release/bazel_rust_extractor_script.sh
+++ b/kythe/release/bazel_rust_extractor_script.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Add the Rust compiler shared library path
-LIBRARY_DIR="external/rust_linux_x86_64/lib/rustlib/x86_64-unknown-linux-gnu/lib"
+LIBRARY_DIR="external/rust_linux_x86_64__x86_64-unknown-linux-gnu_tools/lib/rustlib/x86_64-unknown-linux-gnu/lib"
 export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$LIBRARY_DIR"
 
 exec external/kythe_release/extractors/bazel_rust_extractor "$@"

--- a/kythe/release/release.BUILD
+++ b/kythe/release/release.BUILD
@@ -256,7 +256,7 @@ extractor_action(
     data = [
         ":bazel_rust_extractor",
         ":vnames_config",
-        "@rust_linux_x86_64//:rustc_lib",
+        "@rust_linux_x86_64__x86_64-unknown-linux-gnu_tools//:rustc_lib",
     ],
     extractor = ":bazel_rust_extractor_script",
     mnemonics = [


### PR DESCRIPTION
Fixes the file location and data target of `rustc_lib` in our releases. This fixes issues with our Docker image and users of the `extractor_actions` from the release.