### PR TITLE
chore(rust_common): rustfmt improvements

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -95,11 +95,10 @@ build:clang-tidy --copt=-Wundefined-bool-conversion --copt=-Wunreachable-code --
 build:clang-tidy --copt=-Wunused-function --copt=-Wunused-lambda-capture --copt=-Wunused-local-typedef
 build:clang-tidy --copt=-Wunused-private-field --copt=-Wuser-defined-warnings
 
-# Support user-provided user.bazelrc
-try-import %workspace%/user.bazelrc
-    .
-
 # Enable rustfmt tests on all Rust targets
 build --@rules_rust//:rustfmt.toml=//tools/rust:rustfmt.toml
 build --aspects=@rules_rust//rust:defs.bzl%rustfmt_aspect
 build --output_groups=+rustfmt_checks
+
+# Support user-provided user.bazelrc
+try-import %workspace%/user.bazelrc

--- a/.bazelrc
+++ b/.bazelrc
@@ -98,3 +98,8 @@ build:clang-tidy --copt=-Wunused-private-field --copt=-Wuser-defined-warnings
 # Support user-provided user.bazelrc
 try-import %workspace%/user.bazelrc
     .
+
+# Enable rustfmt tests on all Rust targets
+build --@rules_rust//:rustfmt.toml=//tools/rust:rustfmt.toml
+build --aspects=@rules_rust//rust:defs.bzl%rustfmt_aspect
+build --output_groups=+rustfmt_checks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -90,8 +90,7 @@ repos:
         name: Format w/ rustfmt
         description: Runs `rustfmt` on Rust files
         language: system
-        entry: rustfmt
-        args: [--config-path, tools/rust/rustfmt.toml]
+        entry: tools/rust/rustfmt.sh
         types: [rust]
         exclude: '^(kythe/proto/.*|third_party/.*)'
 exclude: '(.*/testdata/.*|third_party/.*|tools/platforms/configs/rbe_default/.*)$'

--- a/kythe/release/cloudbuild/pre-commit/Dockerfile
+++ b/kythe/release/cloudbuild/pre-commit/Dockerfile
@@ -22,13 +22,17 @@ RUN apt-get update \
                 # pre-commit dependencies
                 python3 python3-dev python3-pip \
                 # Linter dependencies
-                golang-go shellcheck clang-format-11 openjdk-11-jre-headless git \
+                golang-1.18-go shellcheck clang-format-11 openjdk-11-jre-headless git \
         && apt-get clean \
         && rm -rf /var/lib/apt/lists/*
 
 # Make clang-format-11 the default
 RUN update-alternatives \
       --install /usr/bin/clang-format clang-format /usr/bin/clang-format-11    100
+
+# Make go-1.18 the default
+RUN update-alternatives \
+      --install /usr/bin/go go /usr/lib/go-1.18/bin/go  100
 
 # Install pip-packages
 RUN pip3 install --upgrade pip \

--- a/kythe/release/cloudbuild/pre-commit/Dockerfile
+++ b/kythe/release/cloudbuild/pre-commit/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # docker build -t gcr.io/kythe-repo/pre-commit .
-FROM ubuntu:focal
+FROM ubuntu:22.04
 
 RUN apt-get update \
         && apt-get upgrade -y \
@@ -35,9 +35,9 @@ RUN pip3 install --upgrade pip \
  && pip3 install pre-commit
 
 # Install extra linters
-RUN go get github.com/bazelbuild/buildtools/buildifier \
- && go get golang.org/x/lint/golint \
- && go get honnef.co/go/tools/cmd/staticcheck
+RUN go install github.com/bazelbuild/buildtools/buildifier@latest \
+ && go install golang.org/x/lint/golint@latest \
+ && go install honnef.co/go/tools/cmd/staticcheck@latest
 
 # Fetch the latest version of google-java-format from GitHub
 RUN curl -s https://api.github.com/repos/google/google-java-format/releases/latest \
@@ -53,7 +53,7 @@ RUN curl -s https://api.github.com/repos/google/google-java-format/releases/late
 ENV RUSTUP_HOME=/root/.rustup
 ENV CARGO_HOME=/root/.cargo
 RUN curl -o /tmp/rustup.sh --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs && \
-        /bin/bash /tmp/rustup.sh --default-toolchain nightly --profile default -y && \
+        /bin/bash /tmp/rustup.sh --default-toolchain nightly-2022-07-27 --profile default -y && \
         rm /tmp/rustup.sh
 
 # Install go wrapper script

--- a/tools/rust/BUILD
+++ b/tools/rust/BUILD
@@ -1,0 +1,1 @@
+exports_files(["rustfmt.toml"])

--- a/tools/rust/rustfmt.sh
+++ b/tools/rust/rustfmt.sh
@@ -14,9 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Find the rustfmt binary that was distributed with rules_rust so that we
-# don't have to rely on the system binary, which may be out of date.
-RUSTFMT=$(find -L bazel-kythe/external -not \( -path "bazel-kythe/external/io_kythe" -prune \) -wholename "bazel-kythe/external/rust_*_x86_64*_tools/bin/rustfmt")
+# Find the rustfmt binary that was distributed with rules_rust so that we don't
+# have to rely on the system binary, which may be out of date. If rules_rust
+# is not present (which usually occurs if we are running in Cloud Build), we
+# use the version of rustfmt installed on the system.
+if [[ -d "bazel-kythe/external/rules_rust" ]]; then
+    RUSTFMT=$(find -L bazel-kythe/external -not \( -path "bazel-kythe/external/io_kythe" -prune \) -wholename "bazel-kythe/external/rust_*_x86_64*_tools/bin/rustfmt")
+else
+    RUSTFMT="rustfmt"
+fi
 
 # If no arguments are provided, format all Rust files. Otherwise, format the
 # specified file.

--- a/tools/rust/rustfmt.sh
+++ b/tools/rust/rustfmt.sh
@@ -14,9 +14,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-find kythe/rust/ tools/rust/ -name '*.rs' -not -wholename "*target/*" -not -wholename "*rust/*/testdata/*" -print0 | while read -r -d $'\0' f
-do
-    echo "Formatting $f";
-    rustfmt --config-path "$(dirname "${BASH_SOURCE[0]}")" "$@" "$f" &
-done
-wait
+# Find the rustfmt binary that was distributed with rules_rust so that we
+# don't have to rely on the system binary, which may be out of date.
+RUSTFMT=$(find -L bazel-kythe/external -not \( -path "bazel-kythe/external/io_kythe" -prune \) -wholename "bazel-kythe/external/rust_*_x86_64*_tools/bin/rustfmt")
+
+# If no arguments are provided, format all Rust files. Otherwise, format the
+# specified file.
+if [[ $# -eq 0 ]] ; then
+    find kythe/rust/ tools/rust/ -name '*.rs' -not -wholename "*target/*" -not -wholename "*rust/*/testdata/*" -print0 | while read -r -d $'\0' f
+    do
+        echo "Formatting $f";
+        $RUSTFMT --config-path "$(dirname "${BASH_SOURCE[0]}")" "$@" "$f" &
+    done
+    wait
+else
+    $RUSTFMT --config-path "$(dirname "${BASH_SOURCE[0]}")" "$1"
+fi


### PR DESCRIPTION
The `rustfmt` tool changes over time and our repo should always aim to use the binary related to our current version of Rust. This PR updates `tools/rust/rustfmt.sh` to use the binary included with `rules_rust`, falling back to the local version if necessary. Additionally, `.bazelrc` now configures the `rustfmt` aspect from `rules_rust` so that the checks occur automatically during builds.

The `Dockerfile` for our pre-commit cloudbuilder has been updated to ensure that the installed version of Rust matches our current toolchain, and this will need to be updated periodically. Other changes have been made to the `Dockerfile` related to our Go version, as `staticcheck` could not be installed with the version of Go available in Focal Fossa.