### PR TITLE
chore(cxx_indexer): move typedef node emission to Visit

### DIFF
--- a/kythe/cxx/indexer/cxx/IndexerASTHooks.cc
+++ b/kythe/cxx/indexer/cxx/IndexerASTHooks.cc
@@ -3549,28 +3549,6 @@ bool IndexerASTVisitor::VisitFunctionDecl(clang::FunctionDecl* Decl) {
   return true;
 }
 
-absl::optional<GraphObserver::NodeId>
-IndexerASTVisitor::BuildNodeIdForTypedefNameDecl(
-    const clang::TypedefNameDecl* Decl) {
-  const auto Cached = DeclToNodeId.find(Decl);
-  if (Cached != DeclToNodeId.end()) {
-    return Cached->second;
-  }
-  clang::TypeSourceInfo* TSI = Decl->getTypeSourceInfo();
-  if (auto AliasedTypeId = BuildNodeIdForType(TSI->getTypeLoc())) {
-    auto Marks = MarkedSources.Generate(Decl);
-    Marks.set_implicit(Job->UnderneathImplicitTemplateInstantiation);
-    GraphObserver::NameId AliasNameId(BuildNameIdForDecl(Decl));
-    AssignUSR(AliasNameId, AliasedTypeId.value(), Decl);
-    return Observer.recordTypeAliasNode(
-        AliasNameId, AliasedTypeId.value(),
-        BuildNodeIdForType(FollowAliasChain(Decl)),
-        Marks.GenerateMarkedSource(Observer.nodeIdForTypeAliasNode(
-            AliasNameId, AliasedTypeId.value())));
-  }
-  return absl::nullopt;
-}
-
 bool IndexerASTVisitor::VisitObjCTypeParamDecl(
     const clang::ObjCTypeParamDecl* Decl) {
   auto Marks = MarkedSources.Generate(Decl);
@@ -3629,12 +3607,16 @@ bool IndexerASTVisitor::VisitCTypedef(const clang::TypedefNameDecl* Decl) {
     // Don't index __uint128_t, __builtin_va_list, __int128_t
     return true;
   }
-  if (auto InnerNodeId = BuildNodeIdForTypedefNameDecl(Decl)) {
-    GraphObserver::NodeId OuterNodeId = InnerNodeId.value();
+
+  if (const auto AliasedTypeId =
+          BuildNodeIdForType(Decl->getTypeSourceInfo()->getTypeLoc())) {
+    GraphObserver::NodeId InnerNodeId = BuildNodeIdForDecl(Decl);
+    GraphObserver::NodeId OuterNodeId = InnerNodeId;
+
     // If this is a template, we need to emit an abs node for it.
     if (auto* TA = dyn_cast_or_null<clang::TypeAliasDecl>(Decl)) {
       if (auto* TATD = TA->getDescribedAliasTemplate()) {
-        OuterNodeId = RecordTemplate(TATD, InnerNodeId.value());
+        OuterNodeId = RecordTemplate(TATD, InnerNodeId);
       }
     }
     SourceRange Range = RangeForNameOfDeclaration(Decl);
@@ -3643,6 +3625,13 @@ bool IndexerASTVisitor::VisitCTypedef(const clang::TypedefNameDecl* Decl) {
         OuterNodeId, absl::nullopt);
     AddChildOfEdgeToDeclContext(Decl, OuterNodeId);
     AssignUSR(OuterNodeId, Decl);
+
+    auto Marks = MarkedSources.Generate(Decl);
+    Marks.set_implicit(Job->UnderneathImplicitTemplateInstantiation);
+    AssignUSR(InnerNodeId, Decl);
+    Observer.recordTypeAliasNode(InnerNodeId, *AliasedTypeId,
+                                 BuildNodeIdForType(FollowAliasChain(Decl)),
+                                 Marks.GenerateMarkedSource(InnerNodeId));
   }
   return true;
 }
@@ -3981,9 +3970,12 @@ GraphObserver::NodeId IndexerASTVisitor::BuildNodeIdForDecl(
       !isa<clang::ObjCTypeParamDecl>(Decl)) {
     // There's a special way to name type aliases but we want to handle type
     // parameters for Objective-C as "normal" named decls.
-    if (auto TypedefNameId = BuildNodeIdForTypedefNameDecl(TND)) {
-      DeclToNodeId.insert({Decl, TypedefNameId.value()});
-      return TypedefNameId.value();
+    if (auto AliasedTypeId =
+            BuildNodeIdForType(TND->getTypeSourceInfo()->getTypeLoc())) {
+      GraphObserver::NodeId Id = Observer.nodeIdForTypeAliasNode(
+          BuildNameIdForDecl(TND), *AliasedTypeId);
+      DeclToNodeId.insert({Decl, Id});
+      return Id;
     }
   } else if (const auto* NS = dyn_cast<clang::NamespaceDecl>(Decl)) {
     // Namespaces are named according to their NameIDs.
@@ -4166,7 +4158,7 @@ IndexerASTVisitor::BuildNodeIdForTemplateName(const clang::TemplateName& Name) {
             return BuildNodeIdForType(clang::QualType(TDType, 0));
           } else if (const auto* TAlias = dyn_cast<clang::TypeAliasDecl>(TD)) {
             // The names for type alias types are the same for type alias nodes.
-            return BuildNodeIdForTypedefNameDecl(TAlias);
+            return BuildNodeIdForDecl(TAlias);
           } else {
             CHECK(options_.IgnoreUnimplemented)
                 << "Unknown case in BuildNodeIdForTemplateName";

--- a/kythe/cxx/indexer/cxx/IndexerASTHooks.h
+++ b/kythe/cxx/indexer/cxx/IndexerASTHooks.h
@@ -517,12 +517,6 @@ class IndexerASTVisitor : public RecursiveTypeVisitor<IndexerASTVisitor> {
     return absl::nullopt;
   }
 
-  /// \brief Builds a stable node ID for `TND`.
-  ///
-  /// \param Decl The declaration that is being identified.
-  absl::optional<GraphObserver::NodeId> BuildNodeIdForTypedefNameDecl(
-      const clang::TypedefNameDecl* Decl);
-
   /// \brief Builds a stable node ID for `Decl`.
   ///
   /// There is not a one-to-one correspondence between `Decl`s and nodes.


### PR DESCRIPTION
Further simplification of the C++ indexer node generation. Generally, Build* functions shouldn't be emitting nodes (with a few exceptions).