### PR TITLE
fix(cxx_indexer): fix crash when logging non-identifier names

### DIFF
--- a/kythe/cxx/indexer/cxx/ProtoLibrarySupport.cc
+++ b/kythe/cxx/indexer/cxx/ProtoLibrarySupport.cc
@@ -195,7 +195,7 @@ bool ParseTextProtoHandler::ParseMsg(const clang::CXXRecordDecl& MsgDecl,
             FindAccessorDeclWithName(MsgDecl, ToStringRef(Token.text));
         if (!AccessorDecl) {
           LOG(ERROR) << "Cannot find field " << Token.text << " for message "
-                     << MsgDecl.getName().str();
+                     << MsgDecl.getDeclName().getAsString();
           return false;
         }
         if (Token.line < 0) {

--- a/kythe/cxx/indexer/cxx/ProtoLibrarySupport.cc
+++ b/kythe/cxx/indexer/cxx/ProtoLibrarySupport.cc
@@ -126,9 +126,11 @@ class ParseTextProtoHandler {
 const clang::CXXMethodDecl* FindAccessorDeclWithName(
     const clang::CXXRecordDecl& MsgDecl, llvm::StringRef Name) {
   for (const clang::CXXMethodDecl* Method : MsgDecl.methods()) {
-    // Accessors are user-provided, skip any compiler-generated operator/ctor.
-    if (Method->isUserProvided()) {
-      const auto MethodName = Method->getName();
+    // Accessors are user-provided, skip any compiler-generated or
+    // non-identifier operator/ctor.
+    if (const auto* II = Method->getIdentifier();
+        II && Method->isUserProvided()) {
+      const auto MethodName = II->getName();
       // Field accessors will either be the same as the field name or, if they
       // conflict with a language keyword, the field name with a trailing
       // underscore.


### PR DESCRIPTION
An assert in `clang::NamedDecl::getName` will fire in the same 