### PR TITLE
fix(go_indexer): fix go package marked source

### DIFF
--- a/kythe/go/indexer/markedsource.go
+++ b/kythe/go/indexer/markedsource.go
@@ -298,7 +298,7 @@ func (e *emitter) emitPackageMarkedSource(pi *PackageInfo) {
 				Kind:    cpb.MarkedSource_IDENTIFIER,
 				PreText: ipath[:p],
 			}},
-			PostChildText: "/",
+			PostText: "/",
 		}}, ms.Child...)
 	}
 	e.emitCode(pi.VName, ms)


### PR DESCRIPTION
This PR fixes the generated Marked Source for Go packages. The `CONTEXT` child has only one child of it's own, so `PostChildText` is not appended. This meant that the generated qualified name for a Go package looks like `import/directorypackagename`. Changing to `PostText` ensures that the slash is appended after the directory so that the qualified name is `import/directory/packagename`.