### PR TITLE
rust: remove some needless borrows

### DIFF
--- a/kythe/rust/extractor/src/vname_util.rs
+++ b/kythe/rust/extractor/src/vname_util.rs
@@ -68,7 +68,7 @@ impl VNameRule {
     /// Processed vname rules defined in files
     pub fn parse_vname_rules(config_path: &PathBuf) -> Result<Vec<Self>> {
         let mut processed_rules = Vec::new();
-        let file = File::open(&config_path)
+        let file = File::open(config_path)
             .with_context(|| format!("Failed to open file: {}", config_path.to_string_lossy()))?;
         let reader = BufReader::new(file);
         let rules: Vec<RawRule> = serde_json::from_reader(reader)

--- a/kythe/rust/indexer/src/providers.rs
+++ b/kythe/rust/indexer/src/providers.rs
@@ -214,7 +214,7 @@ impl FileProvider for ProxyFileProvider {
             return Ok(vec![]);
         }
         let content_base64: &str = content_option.unwrap();
-        let content: Vec<u8> = base64::decode(&content_base64).map_err(|err| {
+        let content: Vec<u8> = base64::decode(content_base64).map_err(|err| {
             KytheError::IndexerError(format!(
                 "Failed to convert base64 file contents response to bytes: {:?}",
                 err


### PR DESCRIPTION
No functional changes intended.

New versions of Clippy warn about these.