### PR TITLE
fix(cxx_indexer): dereference member templates

### DIFF
--- a/kythe/cxx/indexer/cxx/clang_utils.h
+++ b/kythe/cxx/indexer/cxx/clang_utils.h
@@ -30,7 +30,17 @@ bool isObjCSelector(const clang::DeclarationName& DN);
 /// \brief If `decl` is an implicit template instantiation or specialization,
 /// returns the primary template or the partial specialization being
 /// instantiated. Otherwise, returns `decl`.
-const clang::Decl* FindSpecializedTemplate(const clang::Decl* decl);
+/// \param use_mts If true, also dereference member templates.
+/// (This parameter is temporary and is used for the abs deprecation.)
+const clang::Decl* FindSpecializedTemplate(const clang::Decl* decl,
+                                           bool use_mts);
+
+/// \brief Finds the root member template starting at `decl` (which can be
+/// any decl; if it's not a member template, returns `decl`).
+/// \param use_mts If false, always return `decl`. (This parameter is temporary
+/// and is used for the abs deprecation.)
+const clang::Decl* DereferenceMemberTemplates(const clang::Decl* decl,
+                                              bool use_mts);
 
 /// \return true if a reference to `decl` should be given blame context.
 bool ShouldHaveBlameContext(const clang::Decl* decl);

--- a/kythe/cxx/indexer/cxx/testdata/BUILD
+++ b/kythe/cxx/indexer/cxx/testdata/BUILD
@@ -2025,6 +2025,26 @@ cc_indexer_test(
 )
 
 cc_indexer_test(
+    name = "template_alias_tvar_class",
+    srcs = ["template/template_alias_tvar_class.cc"],
+    check_for_singletons = True,
+    experimental_alias_template_instantiations = True,
+    experimental_use_abs_nodes = False,
+    ignore_dups = True,
+    tags = ["template"],
+)
+
+cc_indexer_test(
+    name = "template_alias_tvar_alias",
+    srcs = ["template/template_alias_tvar_alias.cc"],
+    check_for_singletons = True,
+    experimental_alias_template_instantiations = True,
+    experimental_use_abs_nodes = False,
+    ignore_dups = True,
+    tags = ["template"],
+)
+
+cc_indexer_test(
     name = "template_arg_multiple_typename",
     srcs = ["template/template_arg_multiple_typename.cc"],
     tags = ["template"],

--- a/kythe/cxx/indexer/cxx/testdata/template/template_alias_tvar_alias.cc
+++ b/kythe/cxx/indexer/cxx/testdata/template/template_alias_tvar_alias.cc
@@ -1,0 +1,12 @@
+template <typename T2>
+class C {
+ public:
+  template <typename T>
+   //- @A defines/binding ADef
+   using A = T;
+};
+
+void g() {
+  //- @A ref ADef
+  C<int>::A<int> x;
+}

--- a/kythe/cxx/indexer/cxx/testdata/template/template_alias_tvar_class.cc
+++ b/kythe/cxx/indexer/cxx/testdata/template/template_alias_tvar_class.cc
@@ -1,0 +1,12 @@
+template <typename T2>
+class C {
+ public:
+  template <typename T>
+   //- @S defines/binding SDef
+  struct S {};
+};
+
+void g() {
+  //- @S ref SDef
+  C<int>::S<int> s;
+}


### PR DESCRIPTION
This PR also cleans up BuildNodeIdForTemplateName, since it no longer has to dereference member templates itself.