### PR TITLE
fix(rust_extractor): set extractor_test script as executable

### DIFF
--- a/kythe/rust/extractor/extractor_test.bzl
+++ b/kythe/rust/extractor/extractor_test.bzl
@@ -72,6 +72,7 @@ def _rust_extractor_test_impl(ctx):
     ctx.actions.write(
         output = ctx.outputs.executable,
         content = script,
+        is_executable = True,
     )
 
     runfiles = ctx.runfiles(


### PR DESCRIPTION
Set the `is_executable` flag when writing the script for the Rust extractor test. This fixes an issue where a `permission denied` error is thrown when attempting to run the test using `local_strategy` internally.