### PR TITLE
refactor(cxx_indexer): move lazy parent map to a distinct type

### DIFF
--- a/kythe/cxx/indexer/cxx/BUILD
+++ b/kythe/cxx/indexer/cxx/BUILD
@@ -230,6 +230,8 @@ cc_library(
     deps = [
         "//kythe/cxx/common:scope_guard",
         "@com_github_google_glog//:glog",
+        "@com_google_absl//absl/base",
+        "@com_google_absl//absl/functional:any_invocable",
         "@llvm-project//clang:ast",
         "@llvm-project//llvm:Support",
     ],


### PR DESCRIPTION
This enables refactoring some of the places which *use* this map, without sacrificing the laziness.