### PR TITLE
chore: only download selected Bazel files

### DIFF
--- a/external.bzl
+++ b/external.bzl
@@ -9,6 +9,7 @@ load("@rules_jvm_external//:defs.bzl", "maven_install")
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
 load("@io_kythe//:setup.bzl", "github_archive")
 load("@io_kythe//tools:build_rules/shims.bzl", "go_repository")
+load("@io_kythe//third_party/bazel:bazel_repository_files.bzl", "bazel_repository_files")
 load("@io_kythe//third_party/leiningen:lein_repo.bzl", "lein_repository")
 load("@io_kythe//tools/build_rules/lexyacc:lexyacc.bzl", "lexyacc_configure")
 load("@io_kythe//tools/build_rules/build_event_stream:repo.bzl", "build_event_stream_repository")
@@ -280,10 +281,16 @@ def _cc_dependencies():
 
 def _java_dependencies():
     maybe(
-        git_repository,
+        bazel_repository_files,
         name = "io_bazel",
         commit = "20c4596365d6e198ce9e4559a372190ceedff3f5",
-        remote = "https://github.com/bazelbuild/bazel",
+        files = [
+            "src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/JavacOptions.java",
+            "src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/WerrorCustomOption.java",
+        ],
+        overlay = {
+            "@io_kythe//third_party/bazel:javac_options.BUILD": "src/java_tools/buildjar/java/com/google/devtools/build/buildjar/BUILD",
+        },
     )
     maven_install(
         name = "maven",

--- a/third_party/bazel/bazel_repository_files.bzl
+++ b/third_party/bazel/bazel_repository_files.bzl
@@ -1,0 +1,24 @@
+"""Repository rule for downloading selected files from Bazel's github repository."""
+
+_URL_TEMPLATE = "https://raw.githubusercontent.com/bazelbuild/bazel/{commit}/{path}"
+
+def _impl(repository_ctx):
+    commit = repository_ctx.attr.commit
+    for path in repository_ctx.attr.files:
+        repository_ctx.download(
+            url = _URL_TEMPLATE.format(commit = commit, path = path),
+            output = path,
+            canonical_id = "{commit}/{path}".format(commit = commit, path = path),
+        )
+
+    for src, dest in repository_ctx.attr.overlay.items():
+        repository_ctx.symlink(src, dest)
+
+bazel_repository_files = repository_rule(
+    implementation = _impl,
+    attrs = {
+        "commit": attr.string(mandatory = True),
+        "files": attr.string_list(mandatory = True),
+        "overlay": attr.label_keyed_string_dict(),
+    },
+)

--- a/third_party/bazel/javac_options.BUILD
+++ b/third_party/bazel/javac_options.BUILD
@@ -1,0 +1,30 @@
+java_library(
+    name = "javac_options",
+    srcs = [
+        "javac/JavacOptions.java",
+        "javac/WerrorCustomOption.java",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":autovalue",
+        "@io_kythe//third_party/guava",
+    ],
+)
+
+java_library(
+    name = "autovalue",
+    exported_plugins = [":auto_plugin"],
+    exports = [
+        "@maven//:com_google_auto_value_auto_value_annotations",
+        "@maven//:org_apache_tomcat_tomcat_annotations_api",
+    ],
+)
+
+java_plugin(
+    name = "auto_plugin",
+    processor_class = "com.google.auto.value.processor.AutoValueProcessor",
+    deps = [
+        "@maven//:com_google_auto_auto_common",
+        "@maven//:com_google_auto_value_auto_value",
+    ],
+)


### PR DESCRIPTION
Rather than downloading all of the Bazel github repository for 2 files, download those 2 files.

This also fixes a variety of occasional issues around `bazel query` requiring repositories we don't define (because bazel does, upstream).