### PR TITLE
chore(cxx_indexer): add a test for protobuf enum generated code

### DIFF
--- a/kythe/cxx/indexer/cxx/testdata/proto/BUILD
+++ b/kythe/cxx/indexer/cxx/testdata/proto/BUILD
@@ -60,6 +60,15 @@ cc_proto_verifier_test(
     ],
 )
 
+cc_proto_verifier_test(
+    name = "enum_test",
+    size = "medium",
+    srcs = ["enum.cc"],
+    proto_libs = [
+        "//kythe/testdata/indexers/proto:enum_proto",
+    ],
+)
+
 bzl_library(
     name = "cc_proto_verifier_test_bzl",
     srcs = ["cc_proto_verifier_test.bzl"],

--- a/kythe/cxx/indexer/cxx/testdata/proto/enum.cc
+++ b/kythe/cxx/indexer/cxx/testdata/proto/enum.cc
@@ -1,0 +1,21 @@
+#include "kythe/testdata/indexers/proto/enum.pb.h"
+
+//- WrapperMessageProto generates WrapperMessageCpp
+//- EnumerationTypeProto generates EnumerationTypeCpp
+//- EnumeratorProto generates EnumeratorCpp
+
+//- @Wrapper ref WrapperMessageCpp
+//- // TODO(shahms): Uncomment the below when the alias is annotated.
+//- //@EnumerationType ref EnumerationAliasCpp
+//- //EnumerationTypeProto generates EnumerationAliasCpp
+::pkg::proto::Wrapper::EnumerationType get_alias();
+//- @Wrapper_EnumerationType ref EnumerationTypeCpp
+::pkg::proto::Wrapper_EnumerationType get_raw();
+
+void fn() {
+  //- @Wrapper ref WrapperMessageCpp
+  ::pkg::proto::Wrapper message;
+  //- @Wrapper ref WrapperMessageCpp
+  //- @ENUMERATOR ref EnumeratorCpp
+  message.set_field(::pkg::proto::Wrapper::ENUMERATOR);
+}

--- a/kythe/cxx/tools/BUILD
+++ b/kythe/cxx/tools/BUILD
@@ -15,6 +15,7 @@ cc_binary(
         "//kythe/cxx/common:init",
         "//kythe/cxx/common:kzip_reader",
         "//kythe/cxx/common:lib",
+        "//kythe/cxx/common:re2_flag",
         "//kythe/proto:analysis_cc_proto",
         "//kythe/proto:claim_cc_proto",
         "//kythe/proto:filecontext_cc_proto",

--- a/kythe/testdata/indexers/proto/BUILD
+++ b/kythe/testdata/indexers/proto/BUILD
@@ -1,36 +1,33 @@
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 
+package(default_visibility = ["//visibility:public"])
+
 exports_files(glob(["*.proto"]))
 
 proto_library(
     name = "testdata_proto",
     srcs = ["testdata.proto"],
-    visibility = ["//visibility:public"],
 )
 
 proto_library(
     name = "testdata2_proto",
     srcs = ["testdata2.proto"],
-    visibility = ["//visibility:public"],
 )
 
 proto_library(
     name = "testdata3a_proto",
     srcs = ["testdata3a.proto"],
-    visibility = ["//visibility:public"],
 )
 
 proto_library(
     name = "testdata3b_proto",
     srcs = ["testdata3b.proto"],
-    visibility = ["//visibility:public"],
 )
 
 proto_library(
     name = "testdata3_proto",
     srcs = ["testdata3.proto"],
-    visibility = ["//visibility:public"],
     deps = [
         ":testdata3a_proto",
         ":testdata3b_proto",
@@ -40,31 +37,33 @@ proto_library(
 proto_library(
     name = "testdata4a_proto",
     srcs = ["testdata4a.proto"],
-    visibility = ["//visibility:public"],
     deps = [":testdata4c_proto"],
 )
 
 proto_library(
     name = "testdata4b_proto",
     srcs = ["testdata4b.proto"],
-    visibility = ["//visibility:public"],
     deps = [":testdata4c_proto"],
 )
 
 proto_library(
     name = "testdata4c_proto",
     srcs = ["testdata4c.proto"],
-    visibility = ["//visibility:public"],
 )
 
 copy_file(
     name = "testdata5_generated",
     src = "testdata5.proto",
     out = "gen/testdata5.gen.proto",
+    visibility = ["//visibility:private"],
 )
 
 proto_library(
     name = "testdata5_proto",
     srcs = [":testdata5_generated"],
-    visibility = ["//visibility:public"],
+)
+
+proto_library(
+    name = "enum_proto",
+    srcs = ["enum.proto"],
 )

--- a/kythe/testdata/indexers/proto/enum.proto
+++ b/kythe/testdata/indexers/proto/enum.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+package pkg.proto;
+
+option java_package = "pkg.proto";
+
+//- @Wrapper defines/binding WrapperMessageProto
+message Wrapper {
+  //- @EnumerationType defines/binding EnumerationTypeProto
+  enum EnumerationType {
+    //- @ENUMERATOR defines/binding EnumeratorProto
+    ENUMERATOR = 0;
+  }
+  //- @EnumerationType ref EnumerationTypeProto
+  EnumerationType field = 1;
+}

--- a/tools/build_rules/verifier_test/cc_indexer_test.bzl
+++ b/tools/build_rules/verifier_test/cc_indexer_test.bzl
@@ -521,6 +521,12 @@ _bazel_extract_kzip = rule(
     implementation = _bazel_extract_kzip_impl,
 )
 
+def _expand_as_rootpath(ctx, option):
+    # Replace $(location X) and $(execpath X) with $(rootpath X).
+    return ctx.expand_location(
+        option.replace("$(location ", "$(rootpath ").replace("$(execpath ", "$(rootpath "),
+    )
+
 def _cc_index_source(ctx, src, test_runners):
     entries = ctx.actions.declare_file(
         ctx.label.name + "/" + src.basename + ".entries",
@@ -544,12 +550,12 @@ def _cc_index_source(ctx, src, test_runners):
         ctx,
         src,
         _INDEXER_LOGGING_ENV,
-        arguments = [ctx.expand_location(o) for o in ctx.attr.opts] + [
+        arguments = [_expand_as_rootpath(ctx, o) for o in ctx.attr.opts] + [
             "-i",
             src.short_path,
             "--",
             "-c",
-        ] + [ctx.expand_location(o) for o in ctx.attr.copts],
+        ] + [_expand_as_rootpath(ctx, o) for o in ctx.attr.copts],
     ))
     return entries
 
@@ -562,7 +568,7 @@ def _cc_index_compilation(ctx, compilation, test_runners):
     ctx.actions.run(
         mnemonic = "CcIndexCompilation",
         outputs = [entries],
-        inputs = [compilation],
+        inputs = [compilation] + ctx.files.deps,
         tools = [ctx.executable.indexer],
         executable = ctx.executable.indexer,
         arguments = [ctx.expand_location(o) for o in ctx.attr.opts] + [
@@ -575,7 +581,7 @@ def _cc_index_compilation(ctx, compilation, test_runners):
         ctx,
         compilation,
         _INDEXER_LOGGING_ENV,
-        arguments = [ctx.expand_location(o) for o in ctx.attr.opts] + [
+        arguments = [_expand_as_rootpath(ctx, o) for o in ctx.attr.opts] + [
             compilation.short_path,
         ],
     ))

--- a/tools/build_rules/verifier_test/cc_indexer_test.bzl
+++ b/tools/build_rules/verifier_test/cc_indexer_test.bzl
@@ -689,6 +689,7 @@ cc_index = rule(
             allow_files = [
                 ".h",
                 ".meta",  # Cross language metadata files.
+                ".claim",  # Static claim files.
             ],
         ),
         "indexer": attr.label(


### PR DESCRIPTION
Turns out the generally-preferred alias isn't current annotated.