### PR TITLE
feat(java_common): add function to render signature as plaintext

### DIFF
--- a/kythe/java/com/google/devtools/kythe/doc/MarkedSourceRenderer.java
+++ b/kythe/java/com/google/devtools/kythe/doc/MarkedSourceRenderer.java
@@ -51,6 +51,20 @@ public class MarkedSourceRenderer {
   }
 
   /**
+   * Render {@code signature} a full signature as plaintext.
+   *
+   * @param signature the {@link MarkedSource} to render.
+   */
+  public static String renderSignatureText(MarkedSource signature) {
+    return new RenderSimpleIdentifierState(null)
+        .renderText(
+            signature,
+            Sets.immutableEnumSet(
+                MarkedSource.Kind.IDENTIFIER, MarkedSource.Kind.TYPE, MarkedSource.Kind.PARAMETER),
+            0);
+  }
+
+  /**
    * Extract and render a plaintext initializer from {@code signature}.
    *
    * @param makeLink if provided, this function will be used to generate link URIs from semantic

--- a/kythe/javatests/com/google/devtools/kythe/doc/MarkedSourceRendererTest.java
+++ b/kythe/javatests/com/google/devtools/kythe/doc/MarkedSourceRendererTest.java
@@ -81,6 +81,8 @@ public class MarkedSourceRendererTest extends TestCase {
         .isEqualTo(
             "<span>void H(<a href=\"a\">String </a>message, <a href=\"b\">Throwable"
                 + " </a>cause)</span>");
+    assertThat(MarkedSourceRenderer.renderSignatureText(markedSource))
+        .isEqualTo("void H(String message, Throwable cause)");
   }
 
   public void testRenderingLists() throws IOException {


### PR DESCRIPTION
Currently you can only render a Marked Source signature as HTML. This PR adds a function to render a signature as plaintext. Also adds an associated test case.