### PR TITLE
chore: enable layering_check for C++

### DIFF
--- a/kythe/cxx/common/testdata/BUILD
+++ b/kythe/cxx/common/testdata/BUILD
@@ -1,6 +1,9 @@
 load("//tools:build_rules/testing.bzl", "shell_tool_test")
 
-package(default_visibility = ["//kythe:default_visibility"])
+package(
+    default_visibility = ["//kythe:default_visibility"],
+    features = ["layering_check"],
+)
 
 filegroup(
     name = "start_http_service",

--- a/kythe/cxx/extractor/proto/testdata/BUILD
+++ b/kythe/cxx/extractor/proto/testdata/BUILD
@@ -1,6 +1,8 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load(":proto_extractor_test.bzl", "extractor_golden_test")
 
+package(features = ["layering_check"])
+
 extractor_golden_test(
     name = "relative_imports",
     srcs = ["relative_imports.proto"],

--- a/kythe/cxx/extractor/testdata/BUILD
+++ b/kythe/cxx/extractor/testdata/BUILD
@@ -6,7 +6,10 @@ load(
 )
 load("//tools:build_rules/testing.bzl", "shell_tool_test")
 
-package(default_visibility = ["//kythe:default_visibility"])
+package(
+    default_visibility = ["//kythe:default_visibility"],
+    features = ["layering_check"],
+)
 
 filegroup(
     name = "skip",
@@ -23,7 +26,8 @@ cc_test(
         "//kythe/cxx/common:path_utils",
         "//kythe/cxx/extractor:testlib",
         "//kythe/proto:analysis_cc_proto",
-        "//third_party:gtest_main",
+        "//third_party:gmock_main",
+        "//third_party:gtest",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/types:optional",
     ],
@@ -36,7 +40,8 @@ cc_test(
     deps = [
         "//kythe/cxx/extractor:testlib",
         "//kythe/proto:analysis_cc_proto",
-        "//third_party:gtest_main",
+        "//third_party:gmock_main",
+        "//third_party:gtest",
         "@com_google_absl//absl/strings",
     ],
 )
@@ -50,7 +55,8 @@ cc_test(
     deps = [
         "//kythe/cxx/extractor:testlib",
         "//kythe/proto:analysis_cc_proto",
-        "//third_party:gtest_main",
+        "//third_party:gmock_main",
+        "//third_party:gtest",
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/strings",
     ],
@@ -65,7 +71,8 @@ cc_test(
     deps = [
         "//kythe/cxx/extractor:testlib",
         "//kythe/proto:analysis_cc_proto",
-        "//third_party:gtest_main",
+        "//third_party:gmock_main",
+        "//third_party:gtest",
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/strings",
     ],
@@ -82,7 +89,8 @@ cc_test(
     deps = [
         "//kythe/cxx/extractor:testlib",
         "//kythe/proto:analysis_cc_proto",
-        "//third_party:gtest_main",
+        "//third_party:gmock_main",
+        "//third_party:gtest",
         "@com_google_absl//absl/strings",
     ],
 )
@@ -145,7 +153,8 @@ cc_test(
     deps = [
         "//kythe/cxx/extractor:testlib",
         "//kythe/proto:analysis_cc_proto",
-        "//third_party:gtest_main",
+        "//third_party:gmock_main",
+        "//third_party:gtest",
         "@com_google_absl//absl/strings",
     ],
 )
@@ -161,7 +170,8 @@ cc_test(
     deps = [
         "//kythe/cxx/extractor:testlib",
         "//kythe/proto:analysis_cc_proto",
-        "//third_party:gtest_main",
+        "//third_party:gmock_main",
+        "//third_party:gtest",
         "@com_google_absl//absl/strings",
     ],
 )
@@ -176,7 +186,8 @@ cc_test(
     deps = [
         "//kythe/cxx/extractor:testlib",
         "//kythe/proto:analysis_cc_proto",
-        "//third_party:gtest_main",
+        "//third_party:gmock_main",
+        "//third_party:gtest",
         "@com_google_absl//absl/strings",
     ],
 )
@@ -192,7 +203,8 @@ cc_test(
     deps = [
         "//kythe/cxx/extractor:testlib",
         "//kythe/proto:analysis_cc_proto",
-        "//third_party:gtest_main",
+        "//third_party:gmock_main",
+        "//third_party:gtest",
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/strings",
     ],
@@ -208,7 +220,8 @@ cc_test(
         "//kythe/cxx/extractor:testlib",
         "//kythe/proto:analysis_cc_proto",
         "//kythe/proto:buildinfo_cc_proto",
-        "//third_party:gtest_main",
+        "//third_party:gmock_main",
+        "//third_party:gtest",
         "@com_google_absl//absl/strings",
         "@com_google_protobuf//:protobuf",
     ],
@@ -227,7 +240,8 @@ cc_test(
     deps = [
         "//kythe/cxx/extractor:testlib",
         "//kythe/proto:analysis_cc_proto",
-        "//third_party:gtest_main",
+        "//third_party:gmock_main",
+        "//third_party:gtest",
         "@com_google_absl//absl/strings",
     ],
 )

--- a/kythe/cxx/extractor/testdata/build_config_test.cc
+++ b/kythe/cxx/extractor/testdata/build_config_test.cc
@@ -15,7 +15,6 @@
  */
 
 #include "absl/strings/string_view.h"
-#include "glog/logging.h"
 #include "gmock/gmock.h"
 #include "google/protobuf/message.h"
 #include "gtest/gtest.h"

--- a/kythe/cxx/extractor/textproto/testdata/BUILD
+++ b/kythe/cxx/extractor/textproto/testdata/BUILD
@@ -1,6 +1,8 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load(":textproto_extractor_test.bzl", "textproto_extractor_golden_test")
 
+package(features = ["layering_check"])
+
 textproto_extractor_golden_test(
     name = "simple",
     srcs = ["simple.pbtxt"],

--- a/kythe/cxx/indexer/cxx/testdata/BUILD
+++ b/kythe/cxx/indexer/cxx/testdata/BUILD
@@ -7,7 +7,10 @@ load(
 )
 load("//kythe/go/test/tools/empty_corpus_checker:empty_corpus_test.bzl", "empty_corpus_test")
 
-package(default_visibility = ["//kythe:default_visibility"])
+package(
+    default_visibility = ["//kythe:default_visibility"],
+    features = ["layering_check"],
+)
 
 exports_files(
     ["test_vnames.json"],

--- a/kythe/cxx/indexer/cxx/testdata/proto/BUILD
+++ b/kythe/cxx/indexer/cxx/testdata/proto/BUILD
@@ -1,6 +1,8 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load(":cc_proto_verifier_test.bzl", "cc_proto_verifier_test")
 
+package(features = ["layering_check"])
+
 cc_proto_verifier_test(
     name = "proto_test",
     size = "medium",

--- a/kythe/cxx/indexer/proto/testdata/BUILD
+++ b/kythe/cxx/indexer/proto/testdata/BUILD
@@ -2,6 +2,8 @@ load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load(":proto_verifier_test.bzl", "proto_verifier_test")
 
+package(features = ["layering_check"])
+
 licenses(["notice"])  # Apache 2.0
 
 exports_files(["LICENSE"])

--- a/kythe/cxx/indexer/textproto/testdata/BUILD
+++ b/kythe/cxx/indexer/textproto/testdata/BUILD
@@ -1,6 +1,8 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load(":textproto_verifier_test.bzl", "textproto_verifier_test")
 
+package(features = ["layering_check"])
+
 textproto_verifier_test(
     name = "basics_test",
     protos = [":example_proto"],

--- a/kythe/cxx/tools/BUILD
+++ b/kythe/cxx/tools/BUILD
@@ -1,4 +1,7 @@
-package(default_visibility = ["//kythe:default_visibility"])
+package(
+    default_visibility = ["//kythe:default_visibility"],
+    features = ["layering_check"],
+)
 
 cc_binary(
     name = "static_claim",

--- a/kythe/cxx/tools/fyi/testdata/BUILD
+++ b/kythe/cxx/tools/fyi/testdata/BUILD
@@ -2,7 +2,10 @@ load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("//tools:build_rules/testing.bzl", "shell_tool_test")
 load(":compile_commands.bzl", "compile_commands")
 
-package(default_visibility = ["//kythe:default_visibility"])
+package(
+    default_visibility = ["//kythe:default_visibility"],
+    features = ["layering_check"],
+)
 
 compile_commands(
     name = "compile_commands",

--- a/kythe/cxx/tools/testdata/BUILD
+++ b/kythe/cxx/tools/testdata/BUILD
@@ -1,6 +1,9 @@
 load("//tools:build_rules/testing.bzl", "shell_tool_test")
 
-package(default_visibility = ["//kythe:default_visibility"])
+package(
+    default_visibility = ["//kythe:default_visibility"],
+    features = ["layering_check"],
+)
 
 shell_tool_test(
     name = "test_claim_tool_kzip",

--- a/kythe/cxx/verifier/BUILD
+++ b/kythe/cxx/verifier/BUILD
@@ -3,7 +3,10 @@ load("//tools/build_rules/lexyacc:lexyacc.bzl", "genlex", "genyacc")
 
 package(
     default_visibility = ["//kythe:default_visibility"],
-    features = ["layering_check"],
+    features = [
+        "layering_check",
+        "parse_headers",
+    ],
 )
 
 genyacc(

--- a/kythe/cxx/verifier/BUILD
+++ b/kythe/cxx/verifier/BUILD
@@ -5,7 +5,6 @@ package(
     default_visibility = ["//kythe:default_visibility"],
     features = [
         "layering_check",
-        "parse_headers",
     ],
 )
 

--- a/kythe/cxx/verifier/testdata/BUILD
+++ b/kythe/cxx/verifier/testdata/BUILD
@@ -1,4 +1,7 @@
-package(default_visibility = ["//kythe:default_visibility"])
+package(
+    default_visibility = ["//kythe:default_visibility"],
+    features = ["layering_check"],
+)
 
 sh_test(
     name = "basic",


### PR DESCRIPTION
Note: because `parse_headers` isn't implemented for Bazel yet, this is only a partial solution.