### PR TITLE
fix(textproto): use ref/file for proto-file schema comments

### DIFF
--- a/kythe/cxx/indexer/textproto/analyzer.cc
+++ b/kythe/cxx/indexer/textproto/analyzer.cc
@@ -723,7 +723,7 @@ absl::Status TextprotoAnalyzer::AnalyzeSchemaComments(
 
     // Add ref edge to file.
     proto::VName v = VNameForRelPath(file);
-    recorder_->AddEdge(VNameRef(anchor), EdgeKindID::kRef, VNameRef(v));
+    recorder_->AddEdge(VNameRef(anchor), EdgeKindID::kRefFile, VNameRef(v));
   }
 
   return absl::OkStatus();

--- a/kythe/cxx/indexer/textproto/testdata/schema_comments.pbtxt
+++ b/kythe/cxx/indexer/textproto/testdata/schema_comments.pbtxt
@@ -1,11 +1,11 @@
 
-#- @"kythe/cxx/indexer/textproto/testdata/example.proto" ref vname(_,_,"","kythe/cxx/indexer/textproto/testdata/example.proto",_)
+#- @"kythe/cxx/indexer/textproto/testdata/example.proto" ref/file vname(_,_,"","kythe/cxx/indexer/textproto/testdata/example.proto",_)
 # proto-file: kythe/cxx/indexer/textproto/testdata/example.proto
 
 #- @"example.Message2" ref Message2
 # proto-message: example.Message2
 
-#- @"kythe/cxx/indexer/textproto/testdata/example.proto" ref vname(_,_,"","kythe/cxx/indexer/textproto/testdata/example.proto",_)
+#- @"kythe/cxx/indexer/textproto/testdata/example.proto" ref/file vname(_,_,"","kythe/cxx/indexer/textproto/testdata/example.proto",_)
 # proto-import: kythe/cxx/indexer/textproto/testdata/example.proto
 
 #- @field1 ref Field1


### PR DESCRIPTION
"ref" was used previously, but "ref/file" is slightly more correct since the target vname is a file