### PR TITLE
chore: use stable debian for extractor image

### DIFF
--- a/kythe/extractors/bazel/Dockerfile
+++ b/kythe/extractors/bazel/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:sid
+FROM debian:stable-slim
 
 # Install C++ compilers and other deps
 # note that openjdk-11-jdk-headless is a dependency of the java extractor


### PR DESCRIPTION
We've been having issues with updates failing to install on our current extractor Docker image, which uses the unstable `debian:sid` base image. This PR changes the base image to `debian:stable-slim` which should stop these issues.