### PR TITLE
feat(java_indexer): implement ref/writes edges

### DIFF
--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Annotations.java
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Annotations.java
@@ -15,7 +15,7 @@ public @interface Annotations {
 @Annotations(
   //- @C ref C
   //- @Annotations ref Annotation
-  //- @classes ref ClassesM
+  //- @classes ref/writes ClassesM
   classes = {C.class, Annotations.class}
 )
 //- @Deprecated ref Deprecated

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/BUILD
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/BUILD
@@ -538,6 +538,16 @@ java_verifier_test(
     ],
 )
 
+java_library(
+    name = "writes",
+    srcs = ["Writes.java"],
+)
+
+java_verifier_test(
+    name = "writes_test",
+    compilation = ":writes",
+)
+
 empty_corpus_test(
     name = "empty_corpus_test",
     # TODO(justinbuchanan): adjust extractor to assign 'kythe' instead of

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Definitions.java
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Definitions.java
@@ -52,7 +52,7 @@ public class Definitions {
     //- PuncDef.loc/end @$";"
     String punctuation;
 
-    //- @punctuation ref PuncVar
+    //- @punctuation ref/writes PuncVar
     punctuation = "!";
 
     System.out.printf("%s %s%s\n", HELLO, name, punctuation);

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Selectors.java
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Selectors.java
@@ -14,7 +14,7 @@ public class Selectors {
     if (maybe.isPresent()) {
       //- @maybe ref Param
       //- @get ref _GetMethod
-      //- @field ref Field
+      //- @field ref/writes Field
       //- @this ref This
       this.field = maybe.get();
     }

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Writes.java
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Writes.java
@@ -105,11 +105,13 @@ public class Writes {
 
     public Subclass() {}
 
+    //- @x defines/binding X
     public void inc(int x) {
       //- @#0a ref/writes MemberA
       //- !{ @#0a ref MemberA }
       //- @#1a ref MemberA
       //- !{ @#1a ref/writes MemberA }
+      //- @x ref X
       this.a = this.a + x;
     }
   }

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Writes.java
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Writes.java
@@ -24,9 +24,13 @@ public class Writes {
     //- !{ @#1a ref/writes A }
     a = a + 1;
 
+    //- @b defines/binding B
     //- @a ref A
     //- !{ @a ref/writes A }
     int b = a;
+
+    //- @c defines/binding C
+    int c = 2;
 
     //- @sc ref SC
     //- !{ @sc ref/writes SC }
@@ -55,6 +59,31 @@ public class Writes {
     //- @a ref MemberA
     //- @a ref/writes MemberA
     sc.a += 1;
+
+    //
+    // Test chained writes and writes on the right-hand side
+    //
+
+    //- !{ @a ref A }
+    //- @a ref/writes A
+    //- @b ref B
+    //- @b ref/writes B
+    //- @c ref C
+    //- @c ref/writes C
+    a = b = c++;
+
+    //- @a ref A
+    //- @a ref/writes A
+    //- @#0c ref C
+    //- @#0c ref/writes C
+    //- @#1c ref C
+    //- !{ @#1c ref/writes C }
+    a += c++ + 1 + ~c;
+
+    //- @#0a ref/writes A
+    //- @#1a ref A
+    //- @#1a ref/writes A
+    a = (a++ + 1) + 1;
 
     //
     // Test unary operations

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Writes.java
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Writes.java
@@ -23,7 +23,7 @@ public class Writes {
     //- @#1a ref A
     //- !{ @#1a ref/writes A }
     a = a + 1;
-    
+
     //- @a ref A
     //- !{ @a ref/writes A }
     int b = a;
@@ -104,5 +104,13 @@ public class Writes {
     public Subclass sub = new Subclass();
 
     public Subclass() {}
+
+    public void inc(int x) {
+      //- @#0a ref/writes MemberA
+      //- !{ @#0a ref MemberA }
+      //- @#1a ref MemberA
+      //- !{ @#1a ref/writes MemberA }
+      this.a = this.a + x;
+    }
   }
 }

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Writes.java
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Writes.java
@@ -1,0 +1,108 @@
+package pkg;
+
+// Check that variable and class member writes are properly marked as ref/writes
+
+@SuppressWarnings("unused")
+public class Writes {
+  private Writes() {
+    //- @a defines/binding A
+    int a = 1;
+    //- @sc defines/binding SC
+    Subclass sc = new Subclass();
+
+    //
+    // Test JCAssign
+    //
+
+    //- @a ref/writes A
+    //- !{ @a ref A }
+    a = 2;
+
+    //- @#0a ref/writes A
+    //- !{ @#0a ref A }
+    //- @#1a ref A
+    //- !{ @#1a ref/writes A }
+    a = a + 1;
+    
+    //- @a ref A
+    //- !{ @a ref/writes A }
+    int b = a;
+
+    //- @sc ref SC
+    //- !{ @sc ref/writes SC }
+    //- @a ref/writes MemberA
+    //- !{ @a ref MemberA }
+    sc.a = 2;
+
+    //- @#0a ref/writes MemberA
+    //- !{ @#0a ref MemberA }
+    //- @#1a ref MemberA
+    //- !{ @#1a ref/writes MemberA }
+    sc.a = sc.a + 1;
+
+    //- @a ref MemberA
+    //- !{ @a ref/writes MemberA }
+    b = sc.a;
+
+    //
+    // Test JCAssignOp
+    //
+
+    //- @a ref A
+    //- @a ref/writes A
+    a += 1;
+
+    //- @a ref MemberA
+    //- @a ref/writes MemberA
+    sc.a += 1;
+
+    //
+    // Test unary operations
+    //
+
+    //- @a ref A
+    //- @a ref/writes A
+    a++;
+    //- @a ref A
+    //- @a ref/writes A
+    a--;
+    //- @a ref A
+    //- @a ref/writes A
+    ++a;
+    //- @a ref A
+    //- @a ref/writes A
+    --a;
+
+    //- @a ref/writes MemberA
+    sc.a++;
+    //- @a ref/writes MemberA
+    sc.a--;
+    //- @a ref/writes MemberA
+    ++sc.a;
+    //- @a ref/writes MemberA
+    --sc.a;
+
+    //
+    // Test chained selects
+    //
+
+    //- @sub ref MemberSub
+    //- !{ @sub ref/writes MemberSub }
+    //- @#0a ref/writes MemberA
+    //- @#1a ref MemberA
+    sc.sub.a = sc.a;
+    //- @a ref MemberA
+    //- !{ @a ref/writes MemberA }
+    b = sc.sub.a;
+  }
+
+  class Subclass {
+    //- @a defines/binding MemberA
+    public int a = 1;
+
+    //- @sub defines/binding MemberSub
+    public Subclass sub = new Subclass();
+
+    public Subclass() {}
+  }
+}


### PR DESCRIPTION
This PR adds support for `ref/writes` edges to the Java indexer. The edges are emitted for variables and class members. See the verifier test for a full representation of when `ref`, `ref/writes`, or both edges are emitted.