### PR TITLE
feat(java_common): include reflective fallback for compatibility shims

### DIFF
--- a/kythe/java/com/google/devtools/kythe/extractors/java/standalone/AbstractJavacWrapper.java
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/standalone/AbstractJavacWrapper.java
@@ -20,7 +20,6 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Ordering;
 import com.google.common.flogger.FluentLogger;
 import com.google.common.hash.Hashing;
@@ -39,7 +38,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.ServiceLoader;
 
 /**
  * General logic for a javac-based {@link CompilationUnit} extractor.
@@ -63,8 +61,7 @@ import java.util.ServiceLoader;
  */
 public abstract class AbstractJavacWrapper {
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();
-  protected static final JdkCompatibilityShims shims =
-      Iterables.find(ServiceLoader.load(JdkCompatibilityShims.class), s -> s != null);
+  protected static final JdkCompatibilityShims shims = JdkCompatibilityShims.loadBest().get();
 
   protected abstract Collection<CompilationDescription> processCompilation(
       String[] arguments, JavaCompilationUnitExtractor javaCompilationUnitExtractor)

--- a/kythe/java/com/google/devtools/kythe/extractors/java/standalone/BUILD
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/standalone/BUILD
@@ -40,6 +40,7 @@ java_library(
     ],
     deps = [
         ":jdk_compatibility_shims",
+        ":reflective_jdk_compatibility_shims",
         "//kythe/java/com/google/devtools/kythe/extractors/java",
         "//kythe/java/com/google/devtools/kythe/extractors/shared",
         "//kythe/java/com/google/devtools/kythe/extractors/shared:environment",
@@ -60,6 +61,8 @@ java_library(
     javacopts = [
         "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
     ],
+    visibility = ["//visibility:private"],
+    deps = ["//kythe/java/com/google/devtools/kythe/util:ordered_compatibility_service"],
 )
 
 java_library(
@@ -72,9 +75,11 @@ java_library(
         "//buildenv/java:language_version_11": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
+    visibility = ["//visibility:private"],
     deps = [
         ":jdk_compatibility_shims",
         "//kythe/java/com/google/devtools/kythe/common:autoservice",
+        "//kythe/java/com/google/devtools/kythe/util:ordered_compatibility_service",
         "//third_party/guava",
     ],
 )
@@ -92,10 +97,26 @@ java_library(
         "//buildenv/java:language_version_17": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
+    visibility = ["//visibility:private"],
     deps = [
         ":jdk_compatibility_shims",
         "//kythe/java/com/google/devtools/kythe/common:autoservice",
+        "//kythe/java/com/google/devtools/kythe/util:ordered_compatibility_service",
         "//third_party/guava",
+    ],
+)
+
+java_library(
+    name = "reflective_jdk_compatibility_shims",
+    srcs = ["ReflectiveJdkCompatibilityShims.java"],
+    javacopts = [
+        "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
+    ],
+    visibility = ["//visibility:private"],
+    deps = [
+        ":jdk_compatibility_shims",
+        "//kythe/java/com/google/devtools/kythe/common:autoservice",
+        "//kythe/java/com/google/devtools/kythe/util:ordered_compatibility_service",
     ],
 )
 

--- a/kythe/java/com/google/devtools/kythe/extractors/java/standalone/Jdk15CompatibilityShims.java
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/standalone/Jdk15CompatibilityShims.java
@@ -27,7 +27,19 @@ import java.util.List;
 /** JdkCompatibilityShims implementation for JDK15-compatible releases. */
 @AutoService(JdkCompatibilityShims.class)
 public final class Jdk15CompatibilityShims implements JdkCompatibilityShims {
+  private static final Runtime.Version minVersion = Runtime.Version.parse("15");
+
   public Jdk15CompatibilityShims() {}
+
+  @Override
+  public CompatibilityClass getCompatibility() {
+    Runtime.Version version = Runtime.version();
+    if (version.compareToIgnoreOptional(minVersion) >= 0) {
+      // We don't know when this class will cease being compatible.
+      return CompatibilityClass.COMPATIBLE;
+    }
+    return CompatibilityClass.INCOMPATIBLE;
+  }
 
   @Override
   public List<String> parseCompilerArguments(String[] args) throws IOException {

--- a/kythe/java/com/google/devtools/kythe/extractors/java/standalone/Jdk9CompatibilityShims.java
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/standalone/Jdk9CompatibilityShims.java
@@ -26,8 +26,20 @@ import java.util.List;
 /** JdkCompatibilityShims implementation for JDK9-compatible releases. */
 @AutoService(JdkCompatibilityShims.class)
 public final class Jdk9CompatibilityShims implements JdkCompatibilityShims {
+  private static final Runtime.Version minVersion = Runtime.Version.parse("9");
+  private static final Runtime.Version maxVersion = Runtime.Version.parse("15");
 
   public Jdk9CompatibilityShims() {}
+
+  @Override
+  public CompatibilityClass getCompatibility() {
+    Runtime.Version version = Runtime.version();
+    if (version.compareToIgnoreOptional(minVersion) >= 0
+        && version.compareToIgnoreOptional(maxVersion) < 0) {
+      return CompatibilityClass.COMPATIBLE;
+    }
+    return CompatibilityClass.INCOMPATIBLE;
+  }
 
   @Override
   public List<String> parseCompilerArguments(String[] args) throws IOException {

--- a/kythe/java/com/google/devtools/kythe/extractors/java/standalone/JdkCompatibilityShims.java
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/standalone/JdkCompatibilityShims.java
@@ -16,12 +16,19 @@
 
 package com.google.devtools.kythe.extractors.java.standalone;
 
+import com.google.devtools.kythe.util.OrderedCompatibilityService;
 import com.sun.tools.javac.main.Arguments;
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 
 /** Shims for providing source-level compatibility between JDK versions. */
-interface JdkCompatibilityShims {
+public interface JdkCompatibilityShims extends OrderedCompatibilityService {
+  /** Loads the best service provider for this interface, if any. */
+  public static Optional<JdkCompatibilityShims> loadBest() {
+    return OrderedCompatibilityService.loadBest(JdkCompatibilityShims.class);
+  }
+
   /** Parse the compiler arguments and returns them as an expanded list. */
   List<String> parseCompilerArguments(String[] args) throws IOException;
 

--- a/kythe/java/com/google/devtools/kythe/extractors/java/standalone/ReflectiveJdkCompatibilityShims.java
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/standalone/ReflectiveJdkCompatibilityShims.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2022 The Kythe Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.devtools.kythe.extractors.java.standalone;
+
+import com.google.auto.service.AutoService;
+import com.sun.tools.javac.main.Arguments;
+import com.sun.tools.javac.main.CommandLine;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.List;
+
+/** JdkCompatibilityShims implementation for JDK9-compatible releases. */
+@AutoService(JdkCompatibilityShims.class)
+public final class ReflectiveJdkCompatibilityShims implements JdkCompatibilityShims {
+  private static final Runtime.Version minVersion = Runtime.Version.parse("9");
+
+  public ReflectiveJdkCompatibilityShims() {}
+
+  @Override
+  public CompatibilityClass getCompatibility() {
+    Runtime.Version version = Runtime.version();
+    if (version.compareToIgnoreOptional(minVersion) >= 0) {
+      return CompatibilityClass.FALLBACK;
+    }
+    return CompatibilityClass.INCOMPATIBLE;
+  }
+
+  @Override
+  public List<String> parseCompilerArguments(String[] args) throws IOException {
+    try {
+      try {
+        // JDK15+: the signature is
+        //     List<String> parse(List<String> args)
+        return (List<String>)
+            CommandLine.class
+                .getMethod("parse", List.class)
+                .invoke(null, (Object) Arrays.asList(args));
+      } catch (NoSuchMethodException nsme) {
+        // 9 <= JDK < 15: the signature is
+        //     String[] parse(String[] args)
+        return Arrays.asList(
+            (String[])
+                CommandLine.class.getMethod("parse", String[].class).invoke(null, (Object) args));
+      }
+    } catch (ClassCastException
+        | InvocationTargetException
+        | IllegalAccessException
+        | NoSuchMethodException ex) {
+      throw new LinkageError(ex.getMessage(), ex);
+    }
+  }
+
+  @Override
+  public void initializeArguments(Arguments arguments, String[] args) {
+    try {
+      try {
+        // JDK15+: the signature is
+        //     init(String, Iterable<String> args);
+        arguments
+            .getClass()
+            .getMethod("init", String.class, Iterable.class)
+            .invoke(arguments, "kythe_javac", (Object) Arrays.asList(args));
+      } catch (NoSuchMethodException nsme) {
+        // pre-JDK15:
+        //     init(String, String...);
+        arguments
+            .getClass()
+            .getMethod("init", String.class, String[].class)
+            .invoke(arguments, "kythe_javac", (Object) args);
+      }
+    } catch (ClassCastException
+        | InvocationTargetException
+        | IllegalAccessException
+        | NoSuchMethodException ex) {
+      throw new LinkageError(ex.getMessage(), ex);
+    }
+  }
+}

--- a/kythe/java/com/google/devtools/kythe/extractors/java/standalone/ReflectiveJdkCompatibilityShims.java
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/standalone/ReflectiveJdkCompatibilityShims.java
@@ -41,6 +41,7 @@ public final class ReflectiveJdkCompatibilityShims implements JdkCompatibilitySh
   }
 
   @Override
+  @SuppressWarnings("CheckedExceptionNotThrown")
   public List<String> parseCompilerArguments(String[] args) throws IOException {
     try {
       try {

--- a/kythe/java/com/google/devtools/kythe/platform/java/helpers/BUILD
+++ b/kythe/java/com/google/devtools/kythe/platform/java/helpers/BUILD
@@ -21,6 +21,7 @@ java_library(
     ],
     deps = [
         ":jdk_compatibility_shims",
+        ":reflective_jdk_compatibility_shims",
         "//kythe/java/com/google/devtools/kythe/common:flogger",
         "//kythe/java/com/google/devtools/kythe/util:span",
         "//third_party/guava",
@@ -41,6 +42,7 @@ java_library(
         "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
     ],
     visibility = ["//visibility:private"],
+    deps = ["//kythe/java/com/google/devtools/kythe/util:ordered_compatibility_service"],
 )
 
 java_library(
@@ -58,6 +60,7 @@ java_library(
     deps = [
         ":jdk_compatibility_shims",
         "//kythe/java/com/google/devtools/kythe/common:autoservice",
+        "//kythe/java/com/google/devtools/kythe/util:ordered_compatibility_service",
         "//third_party/guava",
     ],
 )
@@ -79,5 +82,22 @@ java_library(
     deps = [
         ":jdk_compatibility_shims",
         "//kythe/java/com/google/devtools/kythe/common:autoservice",
+        "//kythe/java/com/google/devtools/kythe/util:ordered_compatibility_service",
+    ],
+)
+
+java_library(
+    name = "reflective_jdk_compatibility_shims",
+    srcs = ["ReflectiveJdkCompatibilityShims.java"],
+    javacopts = [
+        "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
+    ],
+    visibility = ["//visibility:private"],
+    deps = [
+        ":jdk_compatibility_shims",
+        "//kythe/java/com/google/devtools/kythe/common:autoservice",
+        "//kythe/java/com/google/devtools/kythe/util:ordered_compatibility_service",
+        "//third_party/guava",
     ],
 )

--- a/kythe/java/com/google/devtools/kythe/platform/java/helpers/JCTreeScanner.java
+++ b/kythe/java/com/google/devtools/kythe/platform/java/helpers/JCTreeScanner.java
@@ -16,7 +16,6 @@
 
 package com.google.devtools.kythe.platform.java.helpers;
 
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.sun.source.tree.AnnotatedTypeTree;
 import com.sun.source.tree.AnnotationTree;
@@ -143,12 +142,10 @@ import com.sun.tools.javac.tree.JCTree.JCWhileLoop;
 import com.sun.tools.javac.tree.JCTree.JCWildcard;
 import com.sun.tools.javac.tree.JCTree.LetExpr;
 import com.sun.tools.javac.tree.JCTree.TypeBoundKind;
-import java.util.ServiceLoader;
 
 /** A {@link TreeScanner} with the scan/reduce semantics of a {@link TreeVisitor}. */
 public class JCTreeScanner<R, P> extends SimpleTreeVisitor<R, P> {
-  protected static final JdkCompatibilityShims shims =
-      Iterables.find(ServiceLoader.load(JdkCompatibilityShims.class), s -> s != null);
+  protected static final JdkCompatibilityShims shims = JdkCompatibilityShims.loadBest().get();
 
   protected TreePath treePath;
 

--- a/kythe/java/com/google/devtools/kythe/platform/java/helpers/Jdk15CompatibilityShims.java
+++ b/kythe/java/com/google/devtools/kythe/platform/java/helpers/Jdk15CompatibilityShims.java
@@ -24,7 +24,19 @@ import java.util.List;
 /** Shims for providing source-level compatibility between JDK versions. */
 @AutoService(JdkCompatibilityShims.class)
 public final class Jdk15CompatibilityShims implements JdkCompatibilityShims {
+  private static final Runtime.Version minVersion = Runtime.Version.parse("15");
+
   public Jdk15CompatibilityShims() {}
+
+  @Override
+  public CompatibilityClass getCompatibility() {
+    Runtime.Version version = Runtime.version();
+    if (version.compareToIgnoreOptional(minVersion) >= 0) {
+      // We don't know when this class will cease being compatible.
+      return CompatibilityClass.COMPATIBLE;
+    }
+    return CompatibilityClass.INCOMPATIBLE;
+  }
 
   /** Return the list of expressions from a JCCase object */
   @Override

--- a/kythe/java/com/google/devtools/kythe/platform/java/helpers/JdkCompatibilityShims.java
+++ b/kythe/java/com/google/devtools/kythe/platform/java/helpers/JdkCompatibilityShims.java
@@ -16,12 +16,19 @@
 
 package com.google.devtools.kythe.platform.java.helpers;
 
+import com.google.devtools.kythe.util.OrderedCompatibilityService;
 import com.sun.tools.javac.tree.JCTree.JCCase;
 import com.sun.tools.javac.tree.JCTree.JCExpression;
 import java.util.List;
+import java.util.Optional;
 
 /** Shims for providing source-level compatibility between JDK versions. */
-interface JdkCompatibilityShims {
+public interface JdkCompatibilityShims extends OrderedCompatibilityService {
+  /** Loads the best service provider for this interface, if any. */
+  public static Optional<JdkCompatibilityShims> loadBest() {
+    return OrderedCompatibilityService.loadBest(JdkCompatibilityShims.class);
+  }
+
   /** Return the list of expressions from a JCCase object */
   List<JCExpression> getCaseExpressions(JCCase tree);
 }

--- a/kythe/java/com/google/devtools/kythe/util/BUILD
+++ b/kythe/java/com/google/devtools/kythe/util/BUILD
@@ -80,6 +80,11 @@ java_library(
     ],
 )
 
+java_library(
+    name = "ordered_compatibility_service",
+    srcs = ["OrderedCompatibilityService.java"],
+)
+
 # Sources used to test Java extraction in //kythe/release:release_test.
 filegroup(
     name = "test_srcs",

--- a/kythe/java/com/google/devtools/kythe/util/OrderedCompatibilityService.java
+++ b/kythe/java/com/google/devtools/kythe/util/OrderedCompatibilityService.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022 The Kythe Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.devtools.kythe.util;
+
+import java.util.Optional;
+import java.util.ServiceLoader;
+
+/**
+ * OrderedCompatibilityService defines shared functionality between between JdkCompatibilityShim
+ * interfaces.
+ */
+public interface OrderedCompatibilityService {
+
+  /** The compatibilty level of the provider. */
+  public enum CompatibilityClass {
+    /** This provider is incompatible with the current runtime. */
+    INCOMPATIBLE,
+    /**
+     * This provider is compatible with the current runtime and should be preferred over a fallback,
+     * if any.
+     */
+    COMPATIBLE,
+    /**
+     * This provider is compatible with the current runtime, but should only be used if a COMPATIBLE
+     * provider can't be found.
+     */
+    FALLBACK
+  };
+
+  /** Returns the compatibility level of the service provider. */
+  CompatibilityClass getCompatibility();
+
+  public static <S extends OrderedCompatibilityService> Optional<S> loadBest(Class<S> klass) {
+    S fallback = null;
+    for (S provider : ServiceLoader.load(klass)) {
+      if (provider == null) continue;
+      switch (provider.getCompatibility()) {
+        case INCOMPATIBLE:
+          continue;
+        case COMPATIBLE:
+          // Use the first compatible provider, if any.
+          return Optional.of(provider);
+        case FALLBACK:
+          if (fallback == null) fallback = provider;
+          break;
+      }
+    }
+    return Optional.ofNullable(fallback);
+  }
+}


### PR DESCRIPTION
Using new JRE's is easier internally than using newer Java language versions.

Add a reflective fallback implementation of the various shims.