### PR TITLE
fix(java_indexer): return null instead of throwing for unsupported attribute views

### DIFF
--- a/kythe/java/com/google/devtools/kythe/platform/shared/filesystem/CompilationUnitFileSystemProvider.java
+++ b/kythe/java/com/google/devtools/kythe/platform/shared/filesystem/CompilationUnitFileSystemProvider.java
@@ -131,7 +131,7 @@ final class CompilationUnitFileSystemProvider extends FileSystemProvider {
   @Override
   public <V extends FileAttributeView> V getFileAttributeView(
       Path path, Class<V> type, LinkOption... options) {
-    throw new UnsupportedOperationException();
+    return null;
   }
 
   @Override


### PR DESCRIPTION
unlike the other methods, getFileAttributeView is expected to return null, rather than throwing UnsupportedOperationException