### PR TITLE
fix(rust_common): upgrade and address compatibility with 2022-12-21

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -10,18 +10,18 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.66"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
+checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
 
 [[package]]
 name = "atty"
@@ -29,7 +29,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc",
  "winapi",
 ]
@@ -69,9 +69,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
+checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
 
 [[package]]
 name = "bzip2"
@@ -96,9 +96,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.74"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581f5dba903aac52ea3feb5ec4810848460ee833876f1f9b0fdeab1f19091574"
+checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
 
 [[package]]
 name = "cfg-if"
@@ -197,9 +197,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.11"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f916dfc5d356b0ed9dae65f1db9fc9770aa2851d2662b988ccf4fe3516e86348"
+checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
 dependencies = [
  "autocfg",
  "cfg-if",
@@ -210,9 +210,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
+checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
 dependencies = [
  "cfg-if",
 ]
@@ -240,9 +240,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -283,9 +283,9 @@ checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "flate2"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
+checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -341,6 +341,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -348,9 +357,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "indexmap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -376,9 +385,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
+checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "json"
@@ -394,9 +403,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.137"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "lock_api"
@@ -425,29 +434,29 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memoffset"
-version = "0.6.5"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "miniz_oxide"
-version = "0.5.4"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
 dependencies = [
  "adler",
 ]
 
 [[package]]
 name = "num_cpus"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc",
 ]
 
@@ -459,9 +468,9 @@ checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "os_str_bytes"
-version = "6.3.1"
+version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3baf96e39c5359d2eb0dd6ccb42c62b91d9678aa68160d261b9e0ccbf9e9dea9"
+checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
 name = "parking_lot"
@@ -476,9 +485,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
 dependencies = [
  "cfg-if",
  "instant",
@@ -526,9 +535,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
 dependencies = [
  "unicode-ident",
 ]
@@ -559,9 +568,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
@@ -596,21 +605,19 @@ checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rayon"
-version = "1.5.3"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
+checksum = "6db3a213adf02b3bcfd2d3846bb41cb22857d131789e01df434fb7e7bc0759b7"
 dependencies = [
- "autocfg",
- "crossbeam-deque",
  "either",
  "rayon-core",
 ]
 
 [[package]]
 name = "rayon-core"
-version = "1.9.3"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
+checksum = "cac410af5d00ab6884528b4ab69d1e8e146e8d471201800fa1b4524126de6ad3"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -638,9 +645,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -649,9 +656,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.27"
+version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
+checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "remove_dir_all"
@@ -700,15 +707,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
+checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
 
 [[package]]
 name = "ryu"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
 name = "scopeguard"
@@ -718,18 +725,18 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.147"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
+checksum = "97fed41fc1a24994d044e6db6935e69511a1153b52c15eb42493b26fa87feba0"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.147"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
+checksum = "255abe9a125a985c05190d687b320c12f9b1f0b99445e608c21ba0782c719ad8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -738,9 +745,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.87"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
+checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
 dependencies = [
  "itoa",
  "ryu",
@@ -796,9 +803,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.103"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -832,18 +839,18 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -852,9 +859,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
 dependencies = [
  "libc",
  "wasi",
@@ -863,15 +870,15 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "version_check"

--- a/cargo-bazel-lock.json
+++ b/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "792e8fa881df4baac48b2ea39405d65048d5f61bc495c53f5f0ab7cbabe88f0f",
+  "checksum": "bbb6a25632b3207fab7195fbc9094c2a9503d0f3cdb7b748162dc79a51a9a0fe",
   "crates": {
     "adler 1.0.2": {
       "name": "adler",
@@ -34,13 +34,13 @@
       },
       "license": "0BSD OR MIT OR Apache-2.0"
     },
-    "aho-corasick 0.7.19": {
+    "aho-corasick 0.7.20": {
       "name": "aho-corasick",
-      "version": "0.7.19",
+      "version": "0.7.20",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/aho-corasick/0.7.19/download",
-          "sha256": "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
+          "url": "https://crates.io/api/v1/crates/aho-corasick/0.7.20/download",
+          "sha256": "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
         }
       },
       "targets": [
@@ -76,17 +76,17 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.7.19"
+        "version": "0.7.20"
       },
-      "license": "Unlicense/MIT"
+      "license": "Unlicense OR MIT"
     },
-    "anyhow 1.0.66": {
+    "anyhow 1.0.68": {
       "name": "anyhow",
-      "version": "1.0.66",
+      "version": "1.0.68",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/anyhow/1.0.66/download",
-          "sha256": "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
+          "url": "https://crates.io/api/v1/crates/anyhow/1.0.68/download",
+          "sha256": "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
         }
       },
       "targets": [
@@ -127,14 +127,14 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.66",
+              "id": "anyhow 1.0.68",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.66"
+        "version": "1.0.68"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -182,7 +182,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.137",
+                "id": "libc 0.2.139",
                 "target": "libc"
               }
             ],
@@ -384,13 +384,13 @@
       },
       "license": "Unlicense OR MIT"
     },
-    "bytes 1.2.1": {
+    "bytes 1.3.0": {
       "name": "bytes",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/bytes/1.2.1/download",
-          "sha256": "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
+          "url": "https://crates.io/api/v1/crates/bytes/1.3.0/download",
+          "sha256": "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
         }
       },
       "targets": [
@@ -417,7 +417,7 @@
           "std"
         ],
         "edition": "2018",
-        "version": "1.2.1"
+        "version": "1.3.0"
       },
       "license": "MIT"
     },
@@ -456,7 +456,7 @@
               "target": "bzip2_sys"
             },
             {
-              "id": "libc 0.2.137",
+              "id": "libc 0.2.139",
               "target": "libc"
             }
           ],
@@ -514,7 +514,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "libc 0.2.137",
+              "id": "libc 0.2.139",
               "target": "libc"
             }
           ],
@@ -530,7 +530,7 @@
         "deps": {
           "common": [
             {
-              "id": "cc 1.0.74",
+              "id": "cc 1.0.78",
               "target": "cc"
             },
             {
@@ -544,13 +544,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "cc 1.0.74": {
+    "cc 1.0.78": {
       "name": "cc",
-      "version": "1.0.74",
+      "version": "1.0.78",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/cc/1.0.74/download",
-          "sha256": "581f5dba903aac52ea3feb5ec4810848460ee833876f1f9b0fdeab1f19091574"
+          "url": "https://crates.io/api/v1/crates/cc/1.0.78/download",
+          "sha256": "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
         }
       },
       "targets": [
@@ -585,7 +585,7 @@
           "**"
         ],
         "edition": "2018",
-        "version": "1.0.74"
+        "version": "1.0.78"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -689,7 +689,7 @@
               "target": "clap_lex"
             },
             {
-              "id": "indexmap 1.9.1",
+              "id": "indexmap 1.9.2",
               "target": "indexmap"
             },
             {
@@ -767,15 +767,15 @@
               "target": "proc_macro_error"
             },
             {
-              "id": "proc-macro2 1.0.47",
+              "id": "proc-macro2 1.0.49",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.21",
+              "id": "quote 1.0.23",
               "target": "quote"
             },
             {
-              "id": "syn 1.0.103",
+              "id": "syn 1.0.107",
               "target": "syn"
             }
           ],
@@ -817,7 +817,7 @@
         "deps": {
           "common": [
             {
-              "id": "os_str_bytes 6.3.1",
+              "id": "os_str_bytes 6.4.1",
               "target": "os_str_bytes"
             }
           ],
@@ -914,19 +914,19 @@
           "selects": {
             "aarch64-apple-darwin": [
               {
-                "id": "libc 0.2.137",
+                "id": "libc 0.2.139",
                 "target": "libc"
               }
             ],
             "aarch64-linux-android": [
               {
-                "id": "libc 0.2.137",
+                "id": "libc 0.2.139",
                 "target": "libc"
               }
             ],
             "cfg(all(target_arch = \"aarch64\", target_os = \"linux\"))": [
               {
-                "id": "libc 0.2.137",
+                "id": "libc 0.2.139",
                 "target": "libc"
               }
             ]
@@ -1044,7 +1044,7 @@
               "target": "cfg_if"
             },
             {
-              "id": "crossbeam-utils 0.8.12",
+              "id": "crossbeam-utils 0.8.14",
               "target": "crossbeam_utils"
             }
           ],
@@ -1096,11 +1096,11 @@
               "target": "cfg_if"
             },
             {
-              "id": "crossbeam-epoch 0.9.11",
+              "id": "crossbeam-epoch 0.9.13",
               "target": "crossbeam_epoch"
             },
             {
-              "id": "crossbeam-utils 0.8.12",
+              "id": "crossbeam-utils 0.8.14",
               "target": "crossbeam_utils"
             }
           ],
@@ -1111,13 +1111,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "crossbeam-epoch 0.9.11": {
+    "crossbeam-epoch 0.9.13": {
       "name": "crossbeam-epoch",
-      "version": "0.9.11",
+      "version": "0.9.13",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/crossbeam-epoch/0.9.11/download",
-          "sha256": "f916dfc5d356b0ed9dae65f1db9fc9770aa2851d2662b988ccf4fe3516e86348"
+          "url": "https://crates.io/api/v1/crates/crossbeam-epoch/0.9.13/download",
+          "sha256": "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
         }
       },
       "targets": [
@@ -1162,15 +1162,15 @@
               "target": "cfg_if"
             },
             {
-              "id": "crossbeam-epoch 0.9.11",
+              "id": "crossbeam-epoch 0.9.13",
               "target": "build_script_build"
             },
             {
-              "id": "crossbeam-utils 0.8.12",
+              "id": "crossbeam-utils 0.8.14",
               "target": "crossbeam_utils"
             },
             {
-              "id": "memoffset 0.6.5",
+              "id": "memoffset 0.7.1",
               "target": "memoffset"
             },
             {
@@ -1181,7 +1181,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.9.11"
+        "version": "0.9.13"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -1199,13 +1199,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "crossbeam-utils 0.8.12": {
+    "crossbeam-utils 0.8.14": {
       "name": "crossbeam-utils",
-      "version": "0.8.12",
+      "version": "0.8.14",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/crossbeam-utils/0.8.12/download",
-          "sha256": "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
+          "url": "https://crates.io/api/v1/crates/crossbeam-utils/0.8.14/download",
+          "sha256": "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
         }
       },
       "targets": [
@@ -1250,14 +1250,14 @@
               "target": "cfg_if"
             },
             {
-              "id": "crossbeam-utils 0.8.12",
+              "id": "crossbeam-utils 0.8.14",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.8.12"
+        "version": "0.8.14"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -1304,7 +1304,7 @@
               "target": "generic_array"
             },
             {
-              "id": "typenum 1.15.0",
+              "id": "typenum 1.16.0",
               "target": "typenum"
             }
           ],
@@ -1350,15 +1350,15 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.47",
+              "id": "proc-macro2 1.0.49",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.21",
+              "id": "quote 1.0.23",
               "target": "quote"
             },
             {
-              "id": "syn 1.0.103",
+              "id": "syn 1.0.107",
               "target": "syn"
             }
           ],
@@ -1369,13 +1369,13 @@
       },
       "license": "MIT"
     },
-    "digest 0.10.5": {
+    "digest 0.10.6": {
       "name": "digest",
-      "version": "0.10.5",
+      "version": "0.10.6",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/digest/0.10.5/download",
-          "sha256": "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
+          "url": "https://crates.io/api/v1/crates/digest/0.10.6/download",
+          "sha256": "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
         }
       },
       "targets": [
@@ -1418,7 +1418,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.10.5"
+        "version": "0.10.6"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -1448,7 +1448,7 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.66",
+              "id": "anyhow 1.0.68",
               "target": "anyhow"
             },
             {
@@ -1492,11 +1492,11 @@
               "target": "quick_error"
             },
             {
-              "id": "rayon 1.5.3",
+              "id": "rayon 1.6.1",
               "target": "rayon"
             },
             {
-              "id": "regex 1.6.0",
+              "id": "regex 1.7.0",
               "target": "regex"
             },
             {
@@ -1508,11 +1508,11 @@
               "target": "rls_data"
             },
             {
-              "id": "serde 1.0.147",
+              "id": "serde 1.0.151",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.87",
+              "id": "serde_json 1.0.91",
               "target": "serde_json"
             },
             {
@@ -1575,13 +1575,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "flate2 1.0.24": {
+    "flate2 1.0.25": {
       "name": "flate2",
-      "version": "1.0.24",
+      "version": "1.0.25",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/flate2/1.0.24/download",
-          "sha256": "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
+          "url": "https://crates.io/api/v1/crates/flate2/1.0.25/download",
+          "sha256": "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
         }
       },
       "targets": [
@@ -1614,21 +1614,21 @@
               "target": "crc32fast"
             },
             {
-              "id": "miniz_oxide 0.5.4",
+              "id": "miniz_oxide 0.6.2",
               "target": "miniz_oxide"
             }
           ],
           "selects": {
             "cfg(all(target_arch = \"wasm32\", not(target_os = \"emscripten\")))": [
               {
-                "id": "miniz_oxide 0.5.4",
+                "id": "miniz_oxide 0.6.2",
                 "target": "miniz_oxide"
               }
             ]
           }
         },
         "edition": "2018",
-        "version": "1.0.24"
+        "version": "1.0.25"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -1774,7 +1774,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "typenum 1.15.0",
+              "id": "typenum 1.16.0",
               "target": "typenum"
             }
           ],
@@ -1938,7 +1938,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.137",
+              "id": "libc 0.2.139",
               "target": "libc"
             }
           ],
@@ -1946,6 +1946,51 @@
         },
         "edition": "2018",
         "version": "0.1.19"
+      },
+      "license": "MIT/Apache-2.0"
+    },
+    "hermit-abi 0.2.6": {
+      "name": "hermit-abi",
+      "version": "0.2.6",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/hermit-abi/0.2.6/download",
+          "sha256": "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "hermit_abi",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "hermit_abi",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "default"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "libc 0.2.139",
+              "target": "libc"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.2.6"
       },
       "license": "MIT/Apache-2.0"
     },
@@ -1987,13 +2032,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "indexmap 1.9.1": {
+    "indexmap 1.9.2": {
       "name": "indexmap",
-      "version": "1.9.1",
+      "version": "1.9.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/indexmap/1.9.1/download",
-          "sha256": "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+          "url": "https://crates.io/api/v1/crates/indexmap/1.9.2/download",
+          "sha256": "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
         }
       },
       "targets": [
@@ -2037,14 +2082,14 @@
               "target": "hashbrown"
             },
             {
-              "id": "indexmap 1.9.1",
+              "id": "indexmap 1.9.2",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.9.1"
+        "version": "1.9.2"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -2151,13 +2196,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "itoa 1.0.4": {
+    "itoa 1.0.5": {
       "name": "itoa",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/itoa/1.0.4/download",
-          "sha256": "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
+          "url": "https://crates.io/api/v1/crates/itoa/1.0.5/download",
+          "sha256": "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
         }
       },
       "targets": [
@@ -2180,7 +2225,7 @@
           "**"
         ],
         "edition": "2018",
-        "version": "1.0.4"
+        "version": "1.0.5"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -2250,13 +2295,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "libc 0.2.137": {
+    "libc 0.2.139": {
       "name": "libc",
-      "version": "0.2.137",
+      "version": "0.2.139",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/libc/0.2.137/download",
-          "sha256": "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
+          "url": "https://crates.io/api/v1/crates/libc/0.2.139/download",
+          "sha256": "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
         }
       },
       "targets": [
@@ -2297,14 +2342,14 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.137",
+              "id": "libc 0.2.139",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2015",
-        "version": "0.2.137"
+        "version": "0.2.139"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -2511,13 +2556,13 @@
       },
       "license": "Unlicense/MIT"
     },
-    "memoffset 0.6.5": {
+    "memoffset 0.7.1": {
       "name": "memoffset",
-      "version": "0.6.5",
+      "version": "0.7.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/memoffset/0.6.5/download",
-          "sha256": "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+          "url": "https://crates.io/api/v1/crates/memoffset/0.7.1/download",
+          "sha256": "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
         }
       },
       "targets": [
@@ -2557,14 +2602,14 @@
         "deps": {
           "common": [
             {
-              "id": "memoffset 0.6.5",
+              "id": "memoffset 0.7.1",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2015",
-        "version": "0.6.5"
+        "version": "0.7.1"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -2582,13 +2627,13 @@
       },
       "license": "MIT"
     },
-    "miniz_oxide 0.5.4": {
+    "miniz_oxide 0.6.2": {
       "name": "miniz_oxide",
-      "version": "0.5.4",
+      "version": "0.6.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/miniz_oxide/0.5.4/download",
-          "sha256": "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
+          "url": "https://crates.io/api/v1/crates/miniz_oxide/0.6.2/download",
+          "sha256": "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
         }
       },
       "targets": [
@@ -2610,6 +2655,9 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": [
+          "with-alloc"
+        ],
         "deps": {
           "common": [
             {
@@ -2620,17 +2668,17 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.5.4"
+        "version": "0.6.2"
       },
       "license": "MIT OR Zlib OR Apache-2.0"
     },
-    "num_cpus 1.14.0": {
+    "num_cpus 1.15.0": {
       "name": "num_cpus",
-      "version": "1.14.0",
+      "version": "1.15.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/num_cpus/1.14.0/download",
-          "sha256": "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
+          "url": "https://crates.io/api/v1/crates/num_cpus/1.15.0/download",
+          "sha256": "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
         }
       },
       "targets": [
@@ -2657,20 +2705,20 @@
           "selects": {
             "cfg(all(any(target_arch = \"x86_64\", target_arch = \"aarch64\"), target_os = \"hermit\"))": [
               {
-                "id": "hermit-abi 0.1.19",
+                "id": "hermit-abi 0.2.6",
                 "target": "hermit_abi"
               }
             ],
             "cfg(not(windows))": [
               {
-                "id": "libc 0.2.137",
+                "id": "libc 0.2.139",
                 "target": "libc"
               }
             ]
           }
         },
         "edition": "2015",
-        "version": "1.14.0"
+        "version": "1.15.0"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -2713,13 +2761,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "os_str_bytes 6.3.1": {
+    "os_str_bytes 6.4.1": {
       "name": "os_str_bytes",
-      "version": "6.3.1",
+      "version": "6.4.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/os_str_bytes/6.3.1/download",
-          "sha256": "3baf96e39c5359d2eb0dd6ccb42c62b91d9678aa68160d261b9e0ccbf9e9dea9"
+          "url": "https://crates.io/api/v1/crates/os_str_bytes/6.4.1/download",
+          "sha256": "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
         }
       },
       "targets": [
@@ -2745,7 +2793,7 @@
           "raw_os_str"
         ],
         "edition": "2021",
-        "version": "6.3.1"
+        "version": "6.4.1"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -2791,7 +2839,7 @@
               "target": "lock_api"
             },
             {
-              "id": "parking_lot_core 0.8.5",
+              "id": "parking_lot_core 0.8.6",
               "target": "parking_lot_core"
             }
           ],
@@ -2802,13 +2850,13 @@
       },
       "license": "Apache-2.0/MIT"
     },
-    "parking_lot_core 0.8.5": {
+    "parking_lot_core 0.8.6": {
       "name": "parking_lot_core",
-      "version": "0.8.5",
+      "version": "0.8.6",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/parking_lot_core/0.8.5/download",
-          "sha256": "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
+          "url": "https://crates.io/api/v1/crates/parking_lot_core/0.8.6/download",
+          "sha256": "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
         }
       },
       "targets": [
@@ -2853,7 +2901,7 @@
               "target": "instant"
             },
             {
-              "id": "parking_lot_core 0.8.5",
+              "id": "parking_lot_core 0.8.6",
               "target": "build_script_build"
             },
             {
@@ -2870,7 +2918,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.137",
+                "id": "libc 0.2.139",
                 "target": "libc"
               }
             ],
@@ -2883,7 +2931,7 @@
           }
         },
         "edition": "2018",
-        "version": "0.8.5"
+        "version": "0.8.6"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -3010,15 +3058,15 @@
               "target": "build_script_build"
             },
             {
-              "id": "proc-macro2 1.0.47",
+              "id": "proc-macro2 1.0.49",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.21",
+              "id": "quote 1.0.23",
               "target": "quote"
             },
             {
-              "id": "syn 1.0.103",
+              "id": "syn 1.0.107",
               "target": "syn"
             }
           ],
@@ -3099,11 +3147,11 @@
               "target": "build_script_build"
             },
             {
-              "id": "proc-macro2 1.0.47",
+              "id": "proc-macro2 1.0.49",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.21",
+              "id": "quote 1.0.23",
               "target": "quote"
             }
           ],
@@ -3128,13 +3176,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "proc-macro2 1.0.47": {
+    "proc-macro2 1.0.49": {
       "name": "proc-macro2",
-      "version": "1.0.47",
+      "version": "1.0.49",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/proc-macro2/1.0.47/download",
-          "sha256": "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+          "url": "https://crates.io/api/v1/crates/proc-macro2/1.0.49/download",
+          "sha256": "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
         }
       },
       "targets": [
@@ -3175,18 +3223,18 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.47",
+              "id": "proc-macro2 1.0.49",
               "target": "build_script_build"
             },
             {
-              "id": "unicode-ident 1.0.5",
+              "id": "unicode-ident 1.0.6",
               "target": "unicode_ident"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.47"
+        "version": "1.0.49"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -3242,7 +3290,7 @@
         "deps": {
           "common": [
             {
-              "id": "bytes 1.2.1",
+              "id": "bytes 1.3.0",
               "target": "bytes"
             },
             {
@@ -3361,13 +3409,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "quote 1.0.21": {
+    "quote 1.0.23": {
       "name": "quote",
-      "version": "1.0.21",
+      "version": "1.0.23",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/quote/1.0.21/download",
-          "sha256": "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+          "url": "https://crates.io/api/v1/crates/quote/1.0.23/download",
+          "sha256": "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
         }
       },
       "targets": [
@@ -3408,18 +3456,18 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.47",
+              "id": "proc-macro2 1.0.49",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.21",
+              "id": "quote 1.0.23",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.21"
+        "version": "1.0.23"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -3482,7 +3530,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.137",
+                "id": "libc 0.2.139",
                 "target": "libc"
               }
             ],
@@ -3574,13 +3622,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "rayon 1.5.3": {
+    "rayon 1.6.1": {
       "name": "rayon",
-      "version": "1.5.3",
+      "version": "1.6.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/rayon/1.5.3/download",
-          "sha256": "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
+          "url": "https://crates.io/api/v1/crates/rayon/1.6.1/download",
+          "sha256": "6db3a213adf02b3bcfd2d3846bb41cb22857d131789e01df434fb7e7bc0759b7"
         }
       },
       "targets": [
@@ -3588,18 +3636,6 @@
           "Library": {
             "crate_name": "rayon",
             "crate_root": "src/lib.rs",
-            "srcs": {
-              "include": [
-                "**/*.rs"
-              ],
-              "exclude": []
-            }
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
             "srcs": {
               "include": [
                 "**/*.rs"
@@ -3617,50 +3653,28 @@
         "deps": {
           "common": [
             {
-              "id": "crossbeam-deque 0.8.2",
-              "target": "crossbeam_deque"
-            },
-            {
               "id": "either 1.8.0",
               "target": "either"
             },
             {
-              "id": "rayon 1.5.3",
-              "target": "build_script_build"
-            },
-            {
-              "id": "rayon-core 1.9.3",
+              "id": "rayon-core 1.10.1",
               "target": "rayon_core"
             }
           ],
           "selects": {}
         },
-        "edition": "2018",
-        "version": "1.5.3"
-      },
-      "build_script_attrs": {
-        "data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "autocfg 1.1.0",
-              "target": "autocfg"
-            }
-          ],
-          "selects": {}
-        }
+        "edition": "2021",
+        "version": "1.6.1"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "rayon-core 1.9.3": {
+    "rayon-core 1.10.1": {
       "name": "rayon-core",
-      "version": "1.9.3",
+      "version": "1.10.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/rayon-core/1.9.3/download",
-          "sha256": "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
+          "url": "https://crates.io/api/v1/crates/rayon-core/1.10.1/download",
+          "sha256": "cac410af5d00ab6884528b4ab69d1e8e146e8d471201800fa1b4524126de6ad3"
         }
       },
       "targets": [
@@ -3705,22 +3719,22 @@
               "target": "crossbeam_deque"
             },
             {
-              "id": "crossbeam-utils 0.8.12",
+              "id": "crossbeam-utils 0.8.14",
               "target": "crossbeam_utils"
             },
             {
-              "id": "num_cpus 1.14.0",
+              "id": "num_cpus 1.15.0",
               "target": "num_cpus"
             },
             {
-              "id": "rayon-core 1.9.3",
+              "id": "rayon-core 1.10.1",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
-        "edition": "2018",
-        "version": "1.9.3"
+        "edition": "2021",
+        "version": "1.10.1"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -3818,13 +3832,13 @@
       },
       "license": "MIT"
     },
-    "regex 1.6.0": {
+    "regex 1.7.0": {
       "name": "regex",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/regex/1.6.0/download",
-          "sha256": "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+          "url": "https://crates.io/api/v1/crates/regex/1.7.0/download",
+          "sha256": "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
         }
       },
       "targets": [
@@ -3868,7 +3882,7 @@
         "deps": {
           "common": [
             {
-              "id": "aho-corasick 0.7.19",
+              "id": "aho-corasick 0.7.20",
               "target": "aho_corasick"
             },
             {
@@ -3876,24 +3890,24 @@
               "target": "memchr"
             },
             {
-              "id": "regex-syntax 0.6.27",
+              "id": "regex-syntax 0.6.28",
               "target": "regex_syntax"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.6.0"
+        "version": "1.7.0"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "regex-syntax 0.6.27": {
+    "regex-syntax 0.6.28": {
       "name": "regex-syntax",
-      "version": "0.6.27",
+      "version": "0.6.28",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/regex-syntax/0.6.27/download",
-          "sha256": "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
+          "url": "https://crates.io/api/v1/crates/regex-syntax/0.6.28/download",
+          "sha256": "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
         }
       },
       "targets": [
@@ -3927,7 +3941,7 @@
           "unicode-segment"
         ],
         "edition": "2018",
-        "version": "0.6.27"
+        "version": "0.6.28"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -4033,11 +4047,11 @@
               "target": "rls_span"
             },
             {
-              "id": "serde 1.0.147",
+              "id": "serde 1.0.151",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.87",
+              "id": "serde_json 1.0.91",
               "target": "serde_json"
             }
           ],
@@ -4096,7 +4110,7 @@
               "target": "rls_span"
             },
             {
-              "id": "serde 1.0.147",
+              "id": "serde 1.0.151",
               "target": "serde"
             }
           ],
@@ -4142,7 +4156,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.147",
+              "id": "serde 1.0.151",
               "target": "serde"
             }
           ],
@@ -4153,13 +4167,13 @@
       },
       "license": "Apache-2.0/MIT"
     },
-    "rustversion 1.0.9": {
+    "rustversion 1.0.11": {
       "name": "rustversion",
-      "version": "1.0.9",
+      "version": "1.0.11",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/rustversion/1.0.9/download",
-          "sha256": "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
+          "url": "https://crates.io/api/v1/crates/rustversion/1.0.11/download",
+          "sha256": "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
         }
       },
       "targets": [
@@ -4196,14 +4210,14 @@
         "deps": {
           "common": [
             {
-              "id": "rustversion 1.0.9",
+              "id": "rustversion 1.0.11",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.9"
+        "version": "1.0.11"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -4212,13 +4226,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "ryu 1.0.11": {
+    "ryu 1.0.12": {
       "name": "ryu",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/ryu/1.0.11/download",
-          "sha256": "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+          "url": "https://crates.io/api/v1/crates/ryu/1.0.12/download",
+          "sha256": "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
         }
       },
       "targets": [
@@ -4241,7 +4255,7 @@
           "**"
         ],
         "edition": "2018",
-        "version": "1.0.11"
+        "version": "1.0.12"
       },
       "license": "Apache-2.0 OR BSL-1.0"
     },
@@ -4278,13 +4292,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "serde 1.0.147": {
+    "serde 1.0.151": {
       "name": "serde",
-      "version": "1.0.147",
+      "version": "1.0.151",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/serde/1.0.147/download",
-          "sha256": "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
+          "url": "https://crates.io/api/v1/crates/serde/1.0.151/download",
+          "sha256": "97fed41fc1a24994d044e6db6935e69511a1153b52c15eb42493b26fa87feba0"
         }
       },
       "targets": [
@@ -4327,7 +4341,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.147",
+              "id": "serde 1.0.151",
               "target": "build_script_build"
             }
           ],
@@ -4337,13 +4351,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "serde_derive 1.0.147",
+              "id": "serde_derive 1.0.151",
               "target": "serde_derive"
             }
           ],
           "selects": {}
         },
-        "version": "1.0.147"
+        "version": "1.0.151"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -4352,13 +4366,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "serde_derive 1.0.147": {
+    "serde_derive 1.0.151": {
       "name": "serde_derive",
-      "version": "1.0.147",
+      "version": "1.0.151",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/serde_derive/1.0.147/download",
-          "sha256": "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
+          "url": "https://crates.io/api/v1/crates/serde_derive/1.0.151/download",
+          "sha256": "255abe9a125a985c05190d687b320c12f9b1f0b99445e608c21ba0782c719ad8"
         }
       },
       "targets": [
@@ -4398,26 +4412,26 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.47",
+              "id": "proc-macro2 1.0.49",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.21",
+              "id": "quote 1.0.23",
               "target": "quote"
             },
             {
-              "id": "serde_derive 1.0.147",
+              "id": "serde_derive 1.0.151",
               "target": "build_script_build"
             },
             {
-              "id": "syn 1.0.103",
+              "id": "syn 1.0.107",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2015",
-        "version": "1.0.147"
+        "version": "1.0.151"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -4426,13 +4440,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "serde_json 1.0.87": {
+    "serde_json 1.0.91": {
       "name": "serde_json",
-      "version": "1.0.87",
+      "version": "1.0.91",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/serde_json/1.0.87/download",
-          "sha256": "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
+          "url": "https://crates.io/api/v1/crates/serde_json/1.0.91/download",
+          "sha256": "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
         }
       },
       "targets": [
@@ -4473,26 +4487,26 @@
         "deps": {
           "common": [
             {
-              "id": "itoa 1.0.4",
+              "id": "itoa 1.0.5",
               "target": "itoa"
             },
             {
-              "id": "ryu 1.0.11",
+              "id": "ryu 1.0.12",
               "target": "ryu"
             },
             {
-              "id": "serde 1.0.147",
+              "id": "serde 1.0.151",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.87",
+              "id": "serde_json 1.0.91",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.87"
+        "version": "1.0.91"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -4594,15 +4608,15 @@
               "target": "proc_macro_error"
             },
             {
-              "id": "proc-macro2 1.0.47",
+              "id": "proc-macro2 1.0.49",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.21",
+              "id": "quote 1.0.23",
               "target": "quote"
             },
             {
-              "id": "syn 1.0.103",
+              "id": "syn 1.0.107",
               "target": "syn"
             }
           ],
@@ -4612,7 +4626,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "rustversion 1.0.9",
+              "id": "rustversion 1.0.11",
               "target": "rustversion"
             }
           ],
@@ -4661,7 +4675,7 @@
               "target": "cfg_if"
             },
             {
-              "id": "digest 0.10.5",
+              "id": "digest 0.10.6",
               "target": "digest"
             }
           ],
@@ -4745,13 +4759,13 @@
       },
       "license": "MIT"
     },
-    "syn 1.0.103": {
+    "syn 1.0.107": {
       "name": "syn",
-      "version": "1.0.103",
+      "version": "1.0.107",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/syn/1.0.103/download",
-          "sha256": "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
+          "url": "https://crates.io/api/v1/crates/syn/1.0.107/download",
+          "sha256": "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
         }
       },
       "targets": [
@@ -4798,26 +4812,26 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.47",
+              "id": "proc-macro2 1.0.49",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.21",
+              "id": "quote 1.0.23",
               "target": "quote"
             },
             {
-              "id": "syn 1.0.103",
+              "id": "syn 1.0.107",
               "target": "build_script_build"
             },
             {
-              "id": "unicode-ident 1.0.5",
+              "id": "unicode-ident 1.0.6",
               "target": "unicode_ident"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.103"
+        "version": "1.0.107"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -4949,13 +4963,13 @@
       },
       "license": "MIT"
     },
-    "thiserror 1.0.37": {
+    "thiserror 1.0.38": {
       "name": "thiserror",
-      "version": "1.0.37",
+      "version": "1.0.38",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/thiserror/1.0.37/download",
-          "sha256": "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
+          "url": "https://crates.io/api/v1/crates/thiserror/1.0.38/download",
+          "sha256": "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
         }
       },
       "targets": [
@@ -4992,7 +5006,7 @@
         "deps": {
           "common": [
             {
-              "id": "thiserror 1.0.37",
+              "id": "thiserror 1.0.38",
               "target": "build_script_build"
             }
           ],
@@ -5002,13 +5016,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "thiserror-impl 1.0.37",
+              "id": "thiserror-impl 1.0.38",
               "target": "thiserror_impl"
             }
           ],
           "selects": {}
         },
-        "version": "1.0.37"
+        "version": "1.0.38"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -5017,13 +5031,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "thiserror-impl 1.0.37": {
+    "thiserror-impl 1.0.38": {
       "name": "thiserror-impl",
-      "version": "1.0.37",
+      "version": "1.0.38",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/thiserror-impl/1.0.37/download",
-          "sha256": "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
+          "url": "https://crates.io/api/v1/crates/thiserror-impl/1.0.38/download",
+          "sha256": "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
         }
       },
       "targets": [
@@ -5048,32 +5062,32 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.47",
+              "id": "proc-macro2 1.0.49",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.21",
+              "id": "quote 1.0.23",
               "target": "quote"
             },
             {
-              "id": "syn 1.0.103",
+              "id": "syn 1.0.107",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.37"
+        "version": "1.0.38"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "time 0.1.44": {
+    "time 0.1.45": {
       "name": "time",
-      "version": "0.1.44",
+      "version": "0.1.45",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/time/0.1.44/download",
-          "sha256": "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+          "url": "https://crates.io/api/v1/crates/time/0.1.45/download",
+          "sha256": "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
         }
       },
       "targets": [
@@ -5098,7 +5112,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.137",
+              "id": "libc 0.2.139",
               "target": "libc"
             }
           ],
@@ -5118,17 +5132,17 @@
           }
         },
         "edition": "2015",
-        "version": "0.1.44"
+        "version": "0.1.45"
       },
       "license": "MIT/Apache-2.0"
     },
-    "typenum 1.15.0": {
+    "typenum 1.16.0": {
       "name": "typenum",
-      "version": "1.15.0",
+      "version": "1.16.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/typenum/1.15.0/download",
-          "sha256": "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+          "url": "https://crates.io/api/v1/crates/typenum/1.16.0/download",
+          "sha256": "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
         }
       },
       "targets": [
@@ -5165,14 +5179,14 @@
         "deps": {
           "common": [
             {
-              "id": "typenum 1.15.0",
+              "id": "typenum 1.16.0",
               "target": "build_script_main"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.15.0"
+        "version": "1.16.0"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -5181,13 +5195,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "unicode-ident 1.0.5": {
+    "unicode-ident 1.0.6": {
       "name": "unicode-ident",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/unicode-ident/1.0.5/download",
-          "sha256": "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+          "url": "https://crates.io/api/v1/crates/unicode-ident/1.0.6/download",
+          "sha256": "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
         }
       },
       "targets": [
@@ -5210,7 +5224,7 @@
           "**"
         ],
         "edition": "2018",
-        "version": "1.0.5"
+        "version": "1.0.6"
       },
       "license": "(MIT OR Apache-2.0) AND Unicode-DFS-2016"
     },
@@ -5588,15 +5602,15 @@
               "target": "crc32fast"
             },
             {
-              "id": "flate2 1.0.24",
+              "id": "flate2 1.0.25",
               "target": "flate2"
             },
             {
-              "id": "thiserror 1.0.37",
+              "id": "thiserror 1.0.38",
               "target": "thiserror"
             },
             {
-              "id": "time 0.1.44",
+              "id": "time 0.1.45",
               "target": "time"
             }
           ],
@@ -5609,7 +5623,7 @@
     }
   },
   "binary_crates": [
-    "cc 1.0.74",
+    "cc 1.0.78",
     "clap 3.2.23",
     "protobuf-codegen 2.27.1"
   ],

--- a/external.bzl
+++ b/external.bzl
@@ -38,7 +38,7 @@ def _rule_dependencies():
     rules_proto_dependencies()
     py_repositories()
     rules_rust_dependencies()
-    rust_register_toolchains(version = "nightly", iso_date = "2022-11-02", dev_components = True, include_rustc_srcs = True)
+    rust_register_toolchains(version = "nightly", iso_date = "2022-12-21", dev_components = True, include_rustc_srcs = True)
     rust_proto_repositories(register_default_toolchain = False)
     rust_analyzer_deps()
     crate_universe_dependencies()

--- a/kythe/rust/extractor/src/bin/save_analysis.rs
+++ b/kythe/rust/extractor/src/bin/save_analysis.rs
@@ -21,13 +21,9 @@ use std::path::{Path, PathBuf};
 ///
 /// * `arguments` - The Bazel arguments extracted from the extra action protobuf
 /// * `output_dir` - The base directory to output the save_analysis
-pub fn generate_save_analysis(
-    arguments: Vec<String>,
-    output_dir: PathBuf,
-    output_file_name: &str,
-) -> Result<()> {
+pub fn generate_save_analysis(arguments: Vec<String>, output_dir: PathBuf) -> Result<()> {
     let rustc_arguments = generate_arguments(arguments, &output_dir)?;
-    kythe_rust_extractor::generate_analysis(rustc_arguments, output_dir, output_file_name)
+    kythe_rust_extractor::generate_analysis(rustc_arguments, output_dir)
         .map_err(|_| anyhow!("Failed to generate save_analysis"))?;
     Ok(())
 }
@@ -59,7 +55,7 @@ fn generate_arguments(arguments: Vec<String>, output_dir: &Path) -> Result<Vec<S
         .ok_or_else(|| anyhow!("Could not find the output directory argument: {:?}", arguments))?;
     let outdir_str =
         output_dir.to_str().ok_or_else(|| anyhow!("Couldn't convert temporary path to string"))?;
-    rustc_arguments[outdir_position] = format!("--out-dir={}", outdir_str);
+    rustc_arguments[outdir_position] = format!("--out-dir={outdir_str}");
 
     // Check if there is a file containing environment variables
     let env_file_position = arguments.iter().position(|arg| arg == "--env-file");

--- a/kythe/rust/extractor/tests/integration_test.rs
+++ b/kythe/rust/extractor/tests/integration_test.rs
@@ -46,16 +46,16 @@ fn main() -> Result<()> {
         "--".to_string(),
         "rustc".to_string(),
         rust_test_source.clone(),
-        format!("-L{}", sysroot),
+        format!("-L{sysroot}"),
         "--crate-name=test_crate".to_string(),
-        format!("--out-dir={}", temp_dir_str),
+        format!("--out-dir={temp_dir_str}"),
     ];
     spawn_info.set_argument(protobuf::RepeatedField::from_vec(arguments.clone()));
 
     let input_files: Vec<String> = vec![rust_test_source];
     spawn_info.set_input_file(protobuf::RepeatedField::from_vec(input_files));
 
-    let output_key = format!("{}/libtest_crate-1234", temp_dir_str);
+    let output_key = format!("{temp_dir_str}/libtest_crate-1234");
     let output_files: Vec<String> = vec![output_key.clone()];
     spawn_info.set_output_file(protobuf::RepeatedField::from_vec(output_files));
 
@@ -150,10 +150,10 @@ fn correct_arguments_succeed(
     let vnames_path = r.rlocation("io_kythe/external/io_kythe/kythe/data/vnames_config.json");
 
     let extractor_path = std::env::var("EXTRACTOR_PATH").expect("Couldn't find extractor path");
-    let kzip_path_str = format!("{}/output.kzip", temp_dir_str);
+    let kzip_path_str = format!("{temp_dir_str}/output.kzip");
     let exit_status = Command::new(extractor_path)
-        .arg(format!("--extra_action={}", extra_action_path_str))
-        .arg(format!("--output={}", kzip_path_str))
+        .arg(format!("--extra_action={extra_action_path_str}"))
+        .arg(format!("--output={kzip_path_str}"))
         .arg(format!("--vnames_config={}", vnames_path.to_string_lossy()))
         .status()
         .unwrap();
@@ -231,8 +231,7 @@ fn correct_arguments_succeed(
     let source_file_path = source_input.get_info().get_path();
     assert!(
         source_file_path.contains("kythe/rust/extractor/main.rs"),
-        "Path for the first required input doesn't contain \"kythe/rust/extractor/main.rs\": {}",
-        source_file_path
+        "Path for the first required input doesn't contain \"kythe/rust/extractor/main.rs\": {source_file_path}"
     );
     assert_eq!(
         source_input.get_info().get_digest(),
@@ -246,8 +245,7 @@ fn correct_arguments_succeed(
     let out_dir_input_path = out_dir_input.get_info().get_path();
     assert!(
         out_dir_input_path.contains("out_dir/input.rs"),
-        "Path for the second required input doesn't contain \"out_dir/input.rs\": {}",
-        out_dir_input_path
+        "Path for the second required input doesn't contain \"out_dir/input.rs\": {out_dir_input_path}"
     );
     assert_eq!(
         out_dir_input.get_info().get_digest(),
@@ -260,8 +258,7 @@ fn correct_arguments_succeed(
     let analysis_input = required_inputs.get(2).expect("Failed to get the third required input");
     let analysis_path = analysis_input.get_info().get_path();
     assert!(
-        analysis_path.contains("save-analysis/libtest_crate-1234.json"),
-        "Unexpected file path for save_analysis file: {}",
-        analysis_path
+        analysis_path.contains("save-analysis/test_crate.json"),
+        "Unexpected file path for save_analysis file: {analysis_path}"
     );
 }

--- a/kythe/rust/extractor/tests/test.rs
+++ b/kythe/rust/extractor/tests/test.rs
@@ -14,8 +14,7 @@
 
 use kythe_rust_extractor::{generate_analysis, vname_util};
 use std::env;
-use std::fs::File;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use tempdir::TempDir;
 
@@ -24,7 +23,7 @@ fn empty_args_fails() {
     let args: Vec<String> = Vec::new();
     let temp_dir = TempDir::new("extractor_test").expect("Could not create temporary directory");
     let analysis_directory = PathBuf::from(temp_dir.path());
-    let result = generate_analysis(args, analysis_directory, "lib");
+    let result = generate_analysis(args, analysis_directory);
     assert_eq!(result.unwrap_err(), "Arguments vector should not be empty".to_string());
 }
 
@@ -33,7 +32,7 @@ fn nonempty_string_first_fails() {
     let args: Vec<String> = vec!["nonempty".to_string()];
     let temp_dir = TempDir::new("extractor_test").expect("Could not create temporary directory");
     let analysis_directory = PathBuf::from(temp_dir.path());
-    let result = generate_analysis(args, analysis_directory, "lib");
+    let result = generate_analysis(args, analysis_directory);
     assert_eq!(result.unwrap_err(), "The first argument must be an empty string".to_string());
 }
 
@@ -55,12 +54,14 @@ fn correct_arguments_succeed() {
         format!("--out-dir={}", temp_dir.path().to_str().unwrap()),
     ];
     let analysis_directory = PathBuf::from(temp_dir.path());
-    let result = generate_analysis(args, analysis_directory, "lib");
+    let result = generate_analysis(args, analysis_directory);
     assert_eq!(result.unwrap(), (), "generate_analysis result wasn't void");
 
     // Ensure the save_analysis file exists
-    let _ = File::open(Path::new(temp_dir.path()).join("save-analysis/lib.json"))
-        .expect("save_analysis did not exist in the expected path");
+    assert!(
+        temp_dir.path().join("save-analysis/test_crate.json").exists(),
+        "save_analysis did not exist in the expected path"
+    );
 }
 
 #[test]

--- a/kythe/rust/indexer/src/bin/proxy/main.rs
+++ b/kythe/rust/indexer/src/bin/proxy/main.rs
@@ -81,7 +81,7 @@ fn request_compilation_unit() -> Result<CompilationUnit> {
 /// value, and the second sets the error message if the first argument is false.
 fn send_done(ok: bool, msg: String) -> Result<()> {
     let request = proxyrequests::done(ok, msg)?;
-    println!("{}", request);
+    println!("{request}");
     io::stdout().flush().context("Failed to flush stdout")?;
 
     // Grab the response, but we don't care what it is so just throw it away

--- a/kythe/rust/indexer/src/indexer/analyzers.rs
+++ b/kythe/rust/indexer/src/indexer/analyzers.rs
@@ -159,8 +159,7 @@ impl<'a> UnitAnalyzer<'a> {
                     let file_bytes = self.provider.contents(source_file, file_digest)?;
                     String::from_utf8(file_bytes).map_err(|_| {
                         KytheError::IndexerError(format!(
-                            "Failed to read file {} as UTF8 string",
-                            source_file
+                            "Failed to read file {source_file} as UTF8 string"
                         ))
                     })?
                 } else {
@@ -257,7 +256,7 @@ impl<'a, 'b> CrateAnalyzer<'a, 'b> {
         vname_template.set_language("rust".to_string());
         for t in types.iter() {
             let mut type_vname = vname_template.clone();
-            type_vname.set_signature(format!("{}#builtin", t));
+            type_vname.set_signature(format!("{t}#builtin"));
             type_vnames.insert(t.to_string(), type_vname);
         }
 
@@ -349,8 +348,7 @@ impl<'a, 'b> CrateAnalyzer<'a, 'b> {
             if let rls_data::RelationKind::Impl { id: impl_id, .. } = relation.kind {
                 let implementation = impl_map.get(&impl_id).ok_or_else(|| {
                     KytheError::IndexerError(format!(
-                        "Couldn't find implementation for relation {:?}",
-                        relation
+                        "Couldn't find implementation for relation {relation:?}"
                     ))
                 })?;
                 // Add all of the childred to the HashMap
@@ -455,8 +453,7 @@ impl<'a, 'b> CrateAnalyzer<'a, 'b> {
         for (child_id, parent_vname) in self.children_ids.iter() {
             let child_vname = self.definition_vnames.remove(child_id).ok_or_else(|| {
                 KytheError::IndexerError(format!(
-                    "Failed to get vname for child {:?} when emitting childof edge",
-                    child_id
+                    "Failed to get vname for child {child_id:?} when emitting childof edge"
                 ))
             })?;
             self.emitter.emit_edge(&child_vname, parent_vname, "/kythe/edge/childof")?;
@@ -529,7 +526,7 @@ impl<'a, 'b> CrateAnalyzer<'a, 'b> {
                         // Generate a diagnostic node indicating that we couldn't find the parent
                         let mut anchor_vname = def_vname.clone();
                         let def_signature = def_vname.get_signature();
-                        anchor_vname.set_signature(format!("{}_anchor", def_signature));
+                        anchor_vname.set_signature(format!("{def_signature}_anchor"));
                         self.emitter.emit_diagnostic(
                             &anchor_vname,
                             "Cross reference could not be generated",
@@ -754,7 +751,7 @@ impl<'a, 'b> CrateAnalyzer<'a, 'b> {
                 self.emitter.emit_diagnostic(
                     file_vname,
                     "Cross reference could not be generated",
-                    Some(&format!("Failed to generate cross reference for \"{:?}\" because the referenced crate could not be found", ref_id)),
+                    Some(&format!("Failed to generate cross reference for \"{ref_id:?}\" because the referenced crate could not be found")),
                     None
                 )?;
                 continue;
@@ -777,7 +774,7 @@ impl<'a, 'b> CrateAnalyzer<'a, 'b> {
                 self.emitter.emit_diagnostic(
                     file_vname,
                     "Failed to get file VName for reference",
-                    Some(format!("The Rust indexer was unable to locate the file VName for the reference in the file \"{}\"", file_name).as_ref()),
+                    Some(format!("The Rust indexer was unable to locate the file VName for the reference in the file \"{file_name}\"").as_ref()),
                     None,
                 )?;
                 continue;
@@ -830,7 +827,7 @@ impl<'a, 'b> CrateAnalyzer<'a, 'b> {
                 self.emitter.emit_diagnostic(
                     file_vname,
                     "Cross reference could not be generated",
-                    Some(&format!("Failed to generate cross reference for \"{:?}\" because the referenced crate could not be found", ref_id)),
+                    Some(&format!("Failed to generate cross reference for \"{ref_id:?}\" because the referenced crate could not be found")),
                     None
                 )?;
                 continue;
@@ -851,7 +848,7 @@ impl<'a, 'b> CrateAnalyzer<'a, 'b> {
                 self.emitter.emit_diagnostic(
                     &target_vname,
                     "Failed to get file VName for reference",
-                    Some(format!("The Rust indexer was unable to locate the file VName for the reference in the file \"{}\"", file_name).as_ref()),
+                    Some(format!("The Rust indexer was unable to locate the file VName for the reference in the file \"{file_name}\"").as_ref()),
                     None,
                 )?;
                 continue;
@@ -882,7 +879,7 @@ impl<'a, 'b> CrateAnalyzer<'a, 'b> {
     fn generate_def_vname(&self, crate_id: &rls_analysis::CrateId, index: u32) -> VName {
         let mut crate_vname = self.generate_crate_vname(crate_id);
         let crate_signature = crate_vname.get_signature().to_owned();
-        crate_vname.set_signature(format!("{}_def_{}", crate_signature, index));
+        crate_vname.set_signature(format!("{crate_signature}_def_{index}"));
         crate_vname
     }
 
@@ -909,8 +906,7 @@ impl<'a, 'b> CrateAnalyzer<'a, 'b> {
             .get_byte_offset(&file_name, span.line_end.0, span.column_end.0)
             .ok_or_else(|| {
                 KytheError::IndexerError(format!(
-                    "Failed to get ending offset for reference {:?}",
-                    ref_id
+                    "Failed to get ending offset for reference {ref_id:?}"
                 ))
             })?;
 

--- a/kythe/rust/indexer/src/providers.rs
+++ b/kythe/rust/indexer/src/providers.rs
@@ -160,25 +160,23 @@ impl ProxyFileProvider {
     fn file_request(&mut self, path: &str, digest: &str) -> Result<Value, KytheError> {
         // Submit the file request to the proxy
         let request = proxyrequests::file(path.to_string(), digest.to_string())?;
-        println!("{}", request);
-        io::stdout().flush().map_err(|err| {
-            KytheError::IndexerError(format!("Failed to flush stdout: {:?}", err))
-        })?;
+        println!("{request}");
+        io::stdout()
+            .flush()
+            .map_err(|err| KytheError::IndexerError(format!("Failed to flush stdout: {err:?}")))?;
 
         // Read the response from the proxy
         let mut response_string = String::new();
         io::stdin().read_line(&mut response_string).map_err(|err| {
             KytheError::IndexerError(format!(
-                "Failed to read proxy file response from stdin: {:?}",
-                err
+                "Failed to read proxy file response from stdin: {err:?}"
             ))
         })?;
 
         // Convert to json and extract information
         let response: Value = serde_json::from_str(&response_string).map_err(|err| {
             KytheError::IndexerError(format!(
-                "Failed to read proxy file response from stdin: {:?}",
-                err
+                "Failed to read proxy file response from stdin: {err:?}"
             ))
         })?;
         if response["rsp"].as_str().unwrap() == "error" {
@@ -216,8 +214,7 @@ impl FileProvider for ProxyFileProvider {
         let content_base64: &str = content_option.unwrap();
         let content: Vec<u8> = base64::decode(content_base64).map_err(|err| {
             KytheError::IndexerError(format!(
-                "Failed to convert base64 file contents response to bytes: {:?}",
-                err
+                "Failed to convert base64 file contents response to bytes: {err:?}"
             ))
         })?;
         Ok(content)

--- a/kythe/rust/indexer/src/writer.rs
+++ b/kythe/rust/indexer/src/writer.rs
@@ -114,25 +114,23 @@ impl KytheWriter for ProxyWriter {
         // Write the proxy command to output
         let request = proxyrequests::output(self.buffer.clone())?;
         self.buffer.clear();
-        println!("{}", request);
-        io::stdout().flush().map_err(|err| {
-            KytheError::IndexerError(format!("Failed to flush stdout: {:?}", err))
-        })?;
+        println!("{request}");
+        io::stdout()
+            .flush()
+            .map_err(|err| KytheError::IndexerError(format!("Failed to flush stdout: {err:?}")))?;
 
         // Read the response from the proxy
         let mut response_string = String::new();
         io::stdin().read_line(&mut response_string).map_err(|err| {
             KytheError::IndexerError(format!(
-                "Failed to read proxy file response from stdin: {:?}",
-                err
+                "Failed to read proxy file response from stdin: {err:?}"
             ))
         })?;
 
         // Convert to json and extract information
         let response: Value = serde_json::from_str(&response_string).map_err(|err| {
             KytheError::IndexerError(format!(
-                "Failed to read proxy file response from stdin: {:?}",
-                err
+                "Failed to read proxy file response from stdin: {err:?}"
             ))
         })?;
         if response["rsp"].as_str().unwrap() == "error" {


### PR DESCRIPTION
This PR updates the Rust version to 2022-12-21. The following changes were made to support this version:
- This version includes changes to how the save_analysis API is called so the extractor was refactored to support this.
- Format strings were refactored to use variable names inline if possible. This is in line with new default Clippy lints