### PR TITLE
fix(typescript): emit code/json not code facts; remove proto dependency

### DIFF
--- a/kythe/typescript/BUILD
+++ b/kythe/typescript/BUILD
@@ -25,9 +25,7 @@ ts_library(
     tsconfig = ":tsconfig",
     deps = [
         ":kythe",
-        "//kythe/proto:common_ts_proto",
         "@npm//@types/node",
-        "@npm//google-protobuf",
         "@npm//typescript",
     ],
 )

--- a/kythe/typescript/indexer.ts
+++ b/kythe/typescript/indexer.ts
@@ -20,7 +20,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as ts from 'typescript';
 
-import {EdgeKind, FactName, JSONEdge, JSONFact, JSONMarkedSource, makeOrdinalEdge, NodeKind, OrdinalEdge, Subkind, VName} from './kythe';
+import {EdgeKind, FactName, JSONEdge, JSONFact, JSONMarkedSource, makeOrdinalEdge, MarkedSourceKind, NodeKind, OrdinalEdge, Subkind, VName} from './kythe';
 import * as utf8 from './utf8';
 
 const LANGUAGE = 'typescript';
@@ -1729,12 +1729,12 @@ class Visitor {
     }
     const ty = this.typeChecker.getTypeAtLocation(decl);
     const tyStr = this.typeChecker.typeToString(ty, decl);
-    codeParts.push({kind: 'CONTEXT', pre_text: fmtMarkedSource(declKw)});
-    codeParts.push({kind: 'BOX', pre_text: ' '});
+    codeParts.push({kind: MarkedSourceKind.CONTEXT, pre_text: fmtMarkedSource(declKw)});
+    codeParts.push({kind: MarkedSourceKind.BOX, pre_text: ' '});
     codeParts.push(
-      {kind: 'IDENTIFIER', pre_text: fmtMarkedSource(decl.name.getText())});
+      {kind: MarkedSourceKind.IDENTIFIER, pre_text: fmtMarkedSource(decl.name.getText())});
     codeParts.push(
-      {kind: 'TYPE', pre_text: ': ', post_text: fmtMarkedSource(tyStr)});
+      {kind: MarkedSourceKind.TYPE, pre_text: ': ', post_text: fmtMarkedSource(tyStr)});
     if ('initializer' in varDecl && varDecl.initializer) {
       let init: ts.Node = varDecl.initializer;
 
@@ -1745,12 +1745,12 @@ class Visitor {
         init = narrowedInit || init;
       }
 
-      codeParts.push({kind: 'BOX', pre_text: ' = '});
+      codeParts.push({kind: MarkedSourceKind.BOX, pre_text: ' = '});
       codeParts.push(
-        {kind: 'INITIALIZER', pre_text: fmtMarkedSource(init.getText())});
+        {kind: MarkedSourceKind.INITIALIZER, pre_text: fmtMarkedSource(init.getText())});
     }
 
-    const markedSource = ({kind: 'BOX', child: codeParts});
+    const markedSource = ({kind: MarkedSourceKind.BOX, child: codeParts});
     this.emitFact(declVName, FactName.CODE_JSON, JSON.stringify(markedSource));
   }
 

--- a/kythe/typescript/kythe.ts
+++ b/kythe/typescript/kythe.ts
@@ -143,7 +143,7 @@ export enum NodeKind {
  */
 export enum FactName {
   BUILD_CONFIG = '/kythe/build/config',
-  CODE = '/kythe/code',
+  CODE_JSON = '/kythe/code/json',
   COMPLETE = '/kythe/complete',
   CONTEXT_URL = '/kythe/context/url',
   DETAILS = '/kythe/details',
@@ -231,4 +231,41 @@ export interface JSONEdge {
   target: VName;
   edge_kind: EdgeKind|OrdinalEdge;
   fact_name: '/';
+}
+
+// export enum MarkedSourceKind {
+//   BOX = 0,
+//   TYPE = 1,
+//   PARAMETER = 2,
+//   IDENTIFIER = 3,
+//   CONTEXT = 4,
+//   INITIALIZER = 5,
+//   PARAMETER_LOOKUP_BY_PARAM = 6,
+//   LOOKUP_BY_PARAM = 7,
+//   PARAMETER_LOOKUP_BY_PARAM_WITH_DEFAULTS = 8,
+//   LOOKUP_BY_TYPED = 9,
+//   PARAMETER_LOOKUP_BY_TPARAM = 10,
+//   LOOKUP_BY_TPARAM = 11,
+// }
+
+/*
+ * Kythe marked source Linkd expressed in the schema JSON-style encoding.
+ */
+export interface JSONLink {
+  definition: string[];
+}
+
+/*
+ * Kythe MarkedSource expressed in the schema JSON-style encoding.
+ */
+export interface JSONMarkedSource {
+  kind: string; // MarkedSourceKind;
+  pre_text?: string;
+  child?: JSONMarkedSource[];
+  post_child_text?: string;
+  post_text?: string;
+  lookup_index?: number;
+  default_children_count?: number;
+  add_final_list_token?: boolean;
+  link?: JSONLink[];
 }

--- a/kythe/typescript/kythe.ts
+++ b/kythe/typescript/kythe.ts
@@ -233,21 +233,6 @@ export interface JSONEdge {
   fact_name: '/';
 }
 
-// export enum MarkedSourceKind {
-//   BOX = 0,
-//   TYPE = 1,
-//   PARAMETER = 2,
-//   IDENTIFIER = 3,
-//   CONTEXT = 4,
-//   INITIALIZER = 5,
-//   PARAMETER_LOOKUP_BY_PARAM = 6,
-//   LOOKUP_BY_PARAM = 7,
-//   PARAMETER_LOOKUP_BY_PARAM_WITH_DEFAULTS = 8,
-//   LOOKUP_BY_TYPED = 9,
-//   PARAMETER_LOOKUP_BY_TPARAM = 10,
-//   LOOKUP_BY_TPARAM = 11,
-// }
-
 /*
  * Kythe marked source Linkd expressed in the schema JSON-style encoding.
  */
@@ -256,10 +241,29 @@ export interface JSONLink {
 }
 
 /*
+ * Enum corresponding to Kythe MarkedSource.Kind proto enum.
+ */
+export enum MarkedSourceKind {
+  BOX,
+  TYPE,
+  PARAMETER,
+  IDENTIFIER,
+  CONTEXT,
+  INITIALIZER,
+  PARAMETER_LOOKUP_BY_PARAM,
+  LOOKUP_BY_PARAM,
+  PARAMETER_LOOKUP_BY_PARAM_WITH_DEFAULTS,
+  LOOKUP_BY_TYPED,
+  PARAMETER_LOOKUP_BY_TPARAM,
+  LOOKUP_BY_TPARAM,
+}
+
+
+/*
  * Kythe MarkedSource expressed in the schema JSON-style encoding.
  */
 export interface JSONMarkedSource {
-  kind: string; // MarkedSourceKind;
+  kind: MarkedSourceKind;
   pre_text?: string;
   child?: JSONMarkedSource[];
   post_child_text?: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1093,11 +1093,6 @@
         "ini": "^1.3.4"
       }
     },
-    "google-protobuf": {
-      "version": "3.15.6",
-      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.15.6.tgz",
-      "integrity": "sha512-p65NyhIZFHFUxbIPOm6cygg2rCjK+2uDCxruOG3RaWKM9R4rBGX0STmlJoSOhoyAG8Fha7U8FP4pQomAV1JXsA=="
-    },
     "graceful-fs": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "jasmine-core": "^3.7.1"
   },
   "dependencies": {
-    "google-protobuf": "^3.15.6",
     "source-map-support": "^0.5.19",
     "typescript": "~3.8"
   },


### PR DESCRIPTION
Adjusted package-lock.json manually since it's in an old format and didn't want to go through the hassle of getting an old version of `nodejs` / `npm` working, and once we're on the new rulesets we'll be using modern versions of those.