### PR TITLE
Adjust test for file objects in the system module path

### DIFF
--- a/kythe/java/com/google/devtools/kythe/extractors/java/JavaCompilationUnitExtractor.java
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/JavaCompilationUnitExtractor.java
@@ -88,7 +88,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.Set;
-import java.util.regex.Pattern;
 import javax.annotation.processing.Processor;
 import javax.tools.Diagnostic;
 import javax.tools.DiagnosticCollector;
@@ -115,7 +114,6 @@ public class JavaCompilationUnitExtractor {
 
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();
 
-  private static final Pattern JDK_MODULE_PATTERN = Pattern.compile("^/modules/(java|jdk)[.].*");
   private static final String MODULE_INFO_NAME = "module-info";
   private static final String SOURCE_JAR_ROOT = "!SOURCE_JAR!";
 
@@ -665,7 +663,8 @@ public class JavaCompilationUnitExtractor {
 
     // If the file was part of the JDK we do not store it as the JDK is tied
     // to the analyzer we'll run on this information later on.
-    if ((isJarPath && jarPath.startsWith(jdkJar)) || JDK_MODULE_PATTERN.matcher(path).matches()) {
+    if ((isJarPath && jarPath.startsWith(jdkJar))
+        || (location != null && location.getName().startsWith("SYSTEM_MODULES"))) {
       return;
     }
 


### PR DESCRIPTION
The paths for these file objects changes from e.g. `/modules/java.base/java/io/Serializable.class` to `/java.base/java/io/Serializable.class` in an upcoming version, breaking the existing regex.

This change instead tests for a location whose name starts with `SYSTEM_MODULES`. The location instance for these file objects is not one of the `StandardLocations` constants, it's a custom subclass, but the name reliably starts with `SYSTEM_MODULES`.