### PR TITLE
chore: fix release_test java failures

### DIFF
--- a/kythe/java/com/google/devtools/kythe/extractors/java/standalone/javac-wrapper.sh
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/standalone/javac-wrapper.sh
@@ -40,16 +40,21 @@
 #   KYTHE_EXTRACT_ONLY: if set, suppress the call to javac after extraction
 
 if [[ -z "$JAVA_HOME" ]]; then
-  readonly JAVABIN="$(command -v java)"
+  JAVABIN="$(command -v java)"
 else
-  readonly JAVABIN="$JAVA_HOME/bin/java"
+  JAVABIN="$JAVA_HOME/bin/java"
 fi
+readonly JAVABIN
+
 if [[ -z "$REAL_JAVAC" ]]; then
-  readonly REAL_JAVAC="$(dirname "$(readlink -e "$0")")/javac.real"
+  REAL_JAVAC="$(dirname "$(readlink -e "$0")")/javac.real"
 fi
+readonly REAL_JAVAC
+
 if [[ -z "$JAVAC_EXTRACTOR_JAR" ]]; then
-  readonly JAVAC_EXTRACTOR_JAR="/opt/kythe/extractors/javac_extractor.jar"
+  JAVAC_EXTRACTOR_JAR="/opt/kythe/extractors/javac_extractor.jar"
 fi
+readonly JAVAC_EXTRACTOR_JAR
 
 fix_permissions() {
   local dir="${1:?missing path}"
@@ -68,7 +73,10 @@ if [[ -n "$DOCKER_CLEANUP" ]]; then
   trap cleanup EXIT ERR INT
 fi
 
-"$JAVABIN" "${KYTHE_JAVA_RUNTIME_OPTIONS[@]}" \
+# We do not want to inhibit word splitting here.
+# shellcheck disable=SC2086
+"$JAVABIN" \
+  $KYTHE_JAVA_RUNTIME_OPTIONS \
   -jar "$JAVAC_EXTRACTOR_JAR" "$@" \
   1> >(sed -e 's/^/EXTRACT OUT: /') \
   2> >(sed -e 's/^/EXTRACT ERR: /' >&2)

--- a/kythe/release/release_test.sh
+++ b/kythe/release/release_test.sh
@@ -27,17 +27,17 @@ TEST_REPOSRCDIR="$PWD"
 
 # The Java extractor and indexer need access to various packages in the jdk.compiler module.
 JAVA_EXPORTS=(
-  jdk.compiler/com.sun.tools.javac.api
-  jdk.compiler/com.sun.tools.javac.code
-  jdk.compiler/com.sun.tools.javac.file
-  jdk.compiler/com.sun.tools.javac.main
-  jdk.compiler/com.sun.tools.javac.model
-  jdk.compiler/com.sun.tools.javac.parser
-  jdk.compiler/com.sun.tools.javac.tree
-  jdk.compiler/com.sun.tools.javac.util
+  --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+  --add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+  --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+  --add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
+  --add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
+  --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+  --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+  --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
 )
 
-export KYTHE_JAVA_RUNTIME_OPTIONS="${JAVA_EXPORTS[*]/*/--add-exports=&=ALL-UNNAMED}"
+export KYTHE_JAVA_RUNTIME_OPTIONS="${JAVA_EXPORTS[*]}"
 
 jq() { "$TEST_REPOSRCDIR/external/com_github_stedolan_jq/jq" "$@"; }
 

--- a/kythe/release/release_test.sh
+++ b/kythe/release/release_test.sh
@@ -25,9 +25,23 @@ TEST_PORT=9898
 ADDR=localhost:$TEST_PORT
 TEST_REPOSRCDIR="$PWD"
 
+# The Java extractor and indexer need access to various packages in the jdk.compiler module.
+JAVA_EXPORTS=(
+  jdk.compiler/com.sun.tools.javac.api
+  jdk.compiler/com.sun.tools.javac.code
+  jdk.compiler/com.sun.tools.javac.file
+  jdk.compiler/com.sun.tools.javac.main
+  jdk.compiler/com.sun.tools.javac.model
+  jdk.compiler/com.sun.tools.javac.parser
+  jdk.compiler/com.sun.tools.javac.tree
+  jdk.compiler/com.sun.tools.javac.util
+)
+
+export KYTHE_JAVA_RUNTIME_OPTIONS="${JAVA_EXPORTS[*]/*/--add-exports=&=ALL-UNNAMED}"
+
 jq() { "$TEST_REPOSRCDIR/external/com_github_stedolan_jq/jq" "$@"; }
 
-if ! command -v curl >/dev/null; then
+if ! command -v curl > /dev/null; then
   echo "Test requires curl command" >&2
   exit 1
 fi
@@ -49,12 +63,12 @@ cd "$TMPDIR/release"
 cd kythe-*
 
 # Ensure the various tools work on test inputs
-tools/kzip view "$TEST_REPOSRCDIR/kythe/testdata/test.kzip" | \
-  jq . >/dev/null
-tools/entrystream < "$TEST_REPOSRCDIR/kythe/testdata/test.entries" | \
-  tools/entrystream --write_format=json | \
-  tools/entrystream --read_format=json --entrysets >/dev/null
-tools/triples < "$TEST_REPOSRCDIR/kythe/testdata/test.entries" >/dev/null
+tools/kzip view "$TEST_REPOSRCDIR/kythe/testdata/test.kzip" |
+  jq . > /dev/null
+tools/entrystream < "$TEST_REPOSRCDIR/kythe/testdata/test.entries" |
+  tools/entrystream --write_format=json |
+  tools/entrystream --read_format=json --entrysets > /dev/null
+tools/triples < "$TEST_REPOSRCDIR/kythe/testdata/test.entries" > /dev/null
 
 # TODO(zarko): add cxx extractor tests
 
@@ -66,30 +80,33 @@ JAVAC_EXTRACTOR_JAR=$PWD/extractors/javac_extractor.jar \
   extractors/javac-wrapper.sh \
   "$TEST_REPOSRCDIR/kythe/java/com/google/devtools/kythe/util"/*.java
 test -r "$KYTHE_OUTPUT_FILE"
-java "${KYTHE_JAVA_RUNTIME_OPTIONS[@]}" \
-  -jar indexers/java_indexer.jar "$KYTHE_OUTPUT_FILE" | \
+# We do not want to inhibit word splitting here.
+# shellcheck disable=SC2086
+java $KYTHE_JAVA_RUNTIME_OPTIONS \
+  -jar indexers/java_indexer.jar "$KYTHE_OUTPUT_FILE" |
   tools/entrystream --count
 
 # Ensure the Java indexer works on a curated test compilation
-java "${KYTHE_JAVA_RUNTIME_OPTIONS[@]}"  \
+# We do not want to inhibit word splitting here.
+# shellcheck disable=SC2086
+java $KYTHE_JAVA_RUNTIME_OPTIONS \
   -jar indexers/java_indexer.jar "$TEST_REPOSRCDIR/kythe/testdata/test.kzip" > entries
 # TODO(zarko): add C++ test kzip entries
 
 # Ensure basic Kythe pipeline toolset works
-tools/dedup_stream < entries | \
+tools/dedup_stream < entries |
   tools/write_entries --graphstore gs
 tools/write_tables --graphstore gs --out srv
 
-tools/read_entries --graphstore gs | \
-  tools/entrystream --sort >/dev/null
+tools/read_entries --graphstore gs |
+  tools/entrystream --sort > /dev/null
 
 # Smoke test the verifier
 echo "//- _ childof _" > any_childof_any2
 tools/verifier --nofile_vnames --ignore_dups --show_goals any_childof_any2 \
-    < entries
+  < entries
 echo "//- _ noSuchEdge _" > any_nosuchedge_any2
-if tools/verifier --nofile_vnames --ignore_dups any_nosuchedge_any2 < entries;\
-    then
+if tools/verifier --nofile_vnames --ignore_dups any_nosuchedge_any2 < entries; then
   echo "ERROR: verifier found a non-existent edge" >&2
   exit 1
 fi
@@ -102,20 +119,20 @@ tools/http_server \
 pid=$!
 trap "kill $pid; kill -9 $pid" EXIT ERR INT
 
-while ! curl -s $ADDR >/dev/null; do
+while ! curl -s $ADDR > /dev/null; do
   echo "Waiting for http_server..."
   sleep 0.5
 done
 
 # Ensure basic HTTP handlers work
-curl -sf $ADDR/corpusRoots | jq . >/dev/null
-curl -sf $ADDR/dir | jq . >/dev/null
-curl -sf $ADDR/decorations -d '{"location": {"ticket": "kythe://kythe?path=kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Names.java"}, "source_text": true, "references": true}' | \
+curl -sf $ADDR/corpusRoots | jq . > /dev/null
+curl -sf $ADDR/dir | jq . > /dev/null
+curl -sf $ADDR/decorations -d '{"location": {"ticket": "kythe://kythe?path=kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Names.java"}, "source_text": true, "references": true}' |
   jq -e '(.reference | length) > 0
      and (.nodes | length) == 0
      and (.source_text | type) == "string"
      and (.source_text | length) > 0'
-curl -sf $ADDR/decorations -d '{"location": {"ticket": "kythe://kythe?path=kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Names.java"}, "references": true, "filter": ["**"]}' | \
+curl -sf $ADDR/decorations -d '{"location": {"ticket": "kythe://kythe?path=kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Names.java"}, "references": true, "filter": ["**"]}' |
   jq -e '(.reference | length) > 0
      and (.nodes | length) > 0
      and (.source_text | length) == 0'


### PR DESCRIPTION
This also changes the use of KYTHE_JAVA_RUNTIME_OPTIONS because you can't actually export an array to a bash script, it will just be a single-element array with the entire value, which isn't actually useful.

It would be nice if Java was less ... Java about this, but I don't know of any better solutions.