### PR TITLE
chore: update llvm

### DIFF
--- a/kythe/cxx/extractor/testlib.cc
+++ b/kythe/cxx/extractor/testlib.cc
@@ -207,8 +207,7 @@ bool ExecuteAndWait(const std::string& program,
   std::string error;
   bool execution_failed = false;
   int exit_code = llvm::sys::ExecuteAndWait(
-      program, VectorForExecute(argv),
-      llvm::makeArrayRef(VectorForExecute(env)),
+      program, VectorForExecute(argv), VectorForExecute(env),
       /* Redirects */ std::nullopt,
       /* SecondsToWait */ 0, /* MemoryLimit */ 0, &error, &execution_failed);
   if (!error.empty() || execution_failed || exit_code != 0) {

--- a/kythe/cxx/indexer/cxx/semantic_hash.cc
+++ b/kythe/cxx/indexer/cxx/semantic_hash.cc
@@ -74,7 +74,8 @@ uint64_t SemanticHash::Hash(const clang::TemplateArgument& arg) const {
     case TemplateArgument::Integral: {
       auto value = arg.getAsIntegral();
       if (value.getMinSignedBits() <= sizeof(uint64_t) * CHAR_BIT) {
-        return static_cast<uint64_t>(value.getExtValue());
+        return static_cast<uint64_t>(value.isSigned() ? value.getSExtValue()
+                                                      : value.getZExtValue());
       } else {
         return std::hash<std::string>()(llvm::toString(value, 10));
       }

--- a/setup.bzl
+++ b/setup.bzl
@@ -163,8 +163,8 @@ def kythe_rule_repositories():
     maybe(
         github_archive,
         repo_name = "llvm/llvm-project",
-        commit = "77fad4c31e9c32a61da78946f41e8db28ec6a6a7",
-        sha256 = "f8c74e9cec4b7993b5845a446a7b24f5597ead2c2ee9e0c80ab1fe9cca31fe2a",
+        commit = "171e7b83122734788c6329d8a699877415cc9a48",
+        sha256 = "304fcf647018d0f0b3ac12ba85161ffc87adf9f232dc13036833b41c2b437ee6",
         name = "llvm-project-raw",
         build_file_content = "#empty",
         patch_args = ["-p1"],

--- a/third_party/llvm-bazel-glob.patch
+++ b/third_party/llvm-bazel-glob.patch
@@ -10,6 +10,15 @@ index 6a61b99f9..5cce43bb1 100644
  load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
  load("//llvm:tblgen.bzl", "gentbl")
  load("//llvm:binary_alias.bzl", "binary_alias")
+@@ -17,7 +18,7 @@
+
+ package(
+     default_visibility = ["//visibility:public"],
+-    features = ["layering_check"],
++    features = ["-layering_check"],
+ )
+
+ licenses(["notice"])
 diff --git a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
 index 93e905260..2c3cedcd9 100644
 --- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -19,6 +28,15 @@ index 93e905260..2c3cedcd9 100644
  # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 +load("@io_kythe//tools:build_rules/support.bzl", glob = "allow_empty_glob")
+ load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
  load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
  load(":tblgen.bzl", "gentbl")
- load(":config.bzl", "llvm_config_defines")
+@@ -12,7 +13,7 @@
+
+ package(
+     default_visibility = ["//visibility:public"],
+-    features = ["layering_check"],
++    features = ["-layering_check"],
+ )
+
+ licenses(["notice"])


### PR DESCRIPTION
Upstream LLVM enabled layering_check (which is great), but broke our use of an intermediate target for `zlib`. I've removed that feature from the LLVM build files, since they're layering doesn't have any impact on us.