### PR TITLE
chore(cxx_indexer): add a test for template instantiation as a base

### DIFF
--- a/kythe/cxx/indexer/cxx/testdata/BUILD
+++ b/kythe/cxx/indexer/cxx/testdata/BUILD
@@ -2547,6 +2547,13 @@ cc_indexer_test(
 )
 
 cc_indexer_test(
+    name = "tvar_template_rec_inherit",
+    srcs = ["tvar_template/template_rec_inherit.cc"],
+    ignore_dups = True,
+    tags = ["tvar_template"],
+)
+
+cc_indexer_test(
     name = "tvar_template_rec_override",
     srcs = ["tvar_template/template_rec_override.cc"],
     ignore_dups = True,

--- a/kythe/cxx/indexer/cxx/testdata/tvar_template/template_rec_inherit.cc
+++ b/kythe/cxx/indexer/cxx/testdata/tvar_template/template_rec_inherit.cc
@@ -1,0 +1,7 @@
+// Verifies that we emit a reference to template base classes.
+//- @C defines/binding TemplateC
+template <typename T> class C {};
+//- @C ref CInstInt
+//- CInstInt instantiates TAppCInt
+//- TAppCInt param.0 TemplateC
+struct S : C<int> {};


### PR DESCRIPTION
Note that this doesn't work with the experimental_alias_template_instantiations