### PR TITLE
chore(typescript_indexer): consolidate indexer options in a single object

### DIFF
--- a/kythe/typescript/indexer.ts
+++ b/kythe/typescript/indexer.ts
@@ -32,6 +32,36 @@ enum RefType {
 }
 
 /**
+ * Various options that are required in order to perform indexing.
+ */
+export interface IndexingOptions {
+  /** A VName for the entire compilation, containing e.g. corpus name. */
+  compilationUnit: VName;
+
+  /** A map of file path to path-specific VName. */
+  pathVNames: Map<string, VName>;
+
+  /** Program object created from all inputs, source and dependencies. */
+  program: ts.Program;
+
+  /** Function that receives final kythe indexing data. */
+  emit: (obj: JSONFact|JSONEdge) => void;
+
+  /**
+   * If provided, a list of plugin indexers to run after the TypeScript program has been indexed.
+   */
+  plugins?: Plugin[];
+
+  /**
+   * If provided, a function that reads a file as bytes to a Node Buffer. It'd be nice to just
+   * reuse program.getSourceFile but unfortunately that returns a (Unicode) string and we need
+   * to get at each file's raw bytes for UTF-8<->UTF-16 conversions. If omitted - fs.readFileSync
+   * is used.
+   */
+  readFile?: (path: string) => Buffer;
+}
+
+/**
  * An indexer host holds information about the program indexing and methods
  * used by the TypeScript indexer that may also be useful to plugins, reducing
  * code duplication.
@@ -275,36 +305,6 @@ function isParameterPropertyDeclaration(
     node: ts.Node, parent: ts.Node): node is ts.ParameterPropertyDeclaration {
   // TODO: remove/inline once fully on TypeScript 3.6+
   return (ts.isParameterPropertyDeclaration as any)(node, parent);
-}
-
-/**
- * Various options that are required in order to perform indexing.
- */
-export interface IndexingOptions {
-  /** A VName for the entire compilation, containing e.g. corpus name. */
-  compilationUnit: VName;
-
-  /** A map of file path to path-specific VName. */
-  pathVNames: Map<string, VName>;
-
-  /** Program object created from all inputs, source and dependencies. */
-  program: ts.Program;
-
-  /** Function that receives final kythe indexing data. */
-  emit: (obj: JSONFact|JSONEdge) => void;
-
-  /**
-   * If provided, a list of plugin indexers to run after the TypeScript program has been indexed.
-   */
-  plugins?: Plugin[];
-
-  /**
-   * If provided, a function that reads a file as bytes to a Node Buffer. It'd be nice to just
-   * reuse program.getSourceFile but unfortunately that returns a (Unicode) string and we need
-   * to get at each file's raw bytes for UTF-8<->UTF-16 conversions. If omitted - fs.readFileSync
-   * is used.
-   */
-  readFile?: (path: string) => Buffer;
 }
 
 /**

--- a/kythe/typescript/indexer.ts
+++ b/kythe/typescript/indexer.ts
@@ -287,6 +287,7 @@ export interface IndexingOptions {
   /** A map of file path to path-specific VName. */
   pathVNames: Map<string, VName>;
 
+  /** Program object created from all inputs, source and dependencies. */
   program: ts.Program;
 
   /** Function that receives final kythe indexing data. */
@@ -296,6 +297,7 @@ export interface IndexingOptions {
    * If provided, a list of plugin indexers to run after the TypeScript program has been indexed.
    */
   plugins?: Plugin[];
+
   /**
    * If provided, a function that reads a file as bytes to a Node Buffer. It'd be nice to just
    * reuse program.getSourceFile but unfortunately that returns a (Unicode) string and we need

--- a/kythe/typescript/indexer.ts
+++ b/kythe/typescript/indexer.ts
@@ -155,12 +155,8 @@ export interface Plugin {
    * Indexes a TypeScript program with extra functionality.
    * Takes a indexer host, which provides useful properties and methods that
    * the plugin can defer to rather than reimplementing.
-   *
-   * TODO: migrate plugins to take paths explicitly rather than relying on context.paths.
-   *
-   * @param paths Files to index.
    */
-  index(context: IndexerHost, paths?: string[]): void;
+  index(context: IndexerHost): void;
 }
 
 /**

--- a/kythe/typescript/test.ts
+++ b/kythe/typescript/test.ts
@@ -243,8 +243,8 @@ async function testIndexer(filters: string[], plugins?: indexer.Plugin[]) {
 async function testPlugin() {
   const plugin: indexer.Plugin = {
     name: 'TestPlugin',
-    index(context: indexer.IndexerHost, paths: string[]) {
-      for (const testPath of paths) {
+    index(context: indexer.IndexerHost) {
+      for (const testPath of context.compilationUnit.srcs) {
         const pluginMod = {
           ...context.pathToVName(context.moduleName(testPath)),
           signature: 'plugin-module',


### PR DESCRIPTION
This is necessary to add more options in future. Currently each options requires new method argument and that hurts readability.

Also using this opportunity modify a bit API of index() function and plugins. Now we pass files to index as explicit `paths` array rather than it being part of IndexerHost. That way index methods are a bit easier to understand of *what* exactly they need to index.

Note: this change will require some google3 changes as it's changing arguments of index() method and there are few users. Changes should be trivial: converting list of arguments to an object.