### PR TITLE
feat(typescript): add option to pass only source files to program initialization

### DIFF
--- a/kythe/typescript/indexer.ts
+++ b/kythe/typescript/indexer.ts
@@ -1,4 +1,4 @@
-/*
+ /*
  * Copyright 2017 The Kythe Authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -43,7 +43,7 @@ export interface CompilationUnit {
   srcs: string[];
 
   /** List of all files, both srcs and deps. */
-  allFiles: string[];
+  allFiles?: string[];
 }
 
 /**
@@ -2650,7 +2650,8 @@ class Visitor {
  */
 export function index(compilationUnit: CompilationUnit, options: IndexingOptions): ts.Diagnostic[] {
   const program = ts.createProgram({
-    rootNames: options.passOnlySrcsToCreateProgram ? compilationUnit.srcs : compilationUnit.allFiles,
+    rootNames: options.passOnlySrcsToCreateProgram ? compilationUnit.srcs :
+                                                     compilationUnit.allFiles!,
     options: options.compilerOptions,
     host: options.compilerHost,
   });

--- a/kythe/typescript/indexer.ts
+++ b/kythe/typescript/indexer.ts
@@ -76,6 +76,12 @@ export interface IndexingOptions {
    * is used.
    */
   readFile?: (path: string) => Buffer;
+
+  /**
+   * When set to true only CompilationUnit.srcs will be used to create TS program as roots.
+   * Other files will be loaded by TS compiler lazily.
+   */
+  passOnlySrcsToCreateProgram?: boolean;
 }
 
 /**
@@ -2644,7 +2650,7 @@ class Visitor {
  */
 export function index(compilationUnit: CompilationUnit, options: IndexingOptions): ts.Diagnostic[] {
   const program = ts.createProgram({
-    rootNames: compilationUnit.allFiles,
+    rootNames: options.passOnlySrcsToCreateProgram ? compilationUnit.srcs : compilationUnit.allFiles,
     options: options.compilerOptions,
     host: options.compilerHost,
   });

--- a/kythe/typescript/test.ts
+++ b/kythe/typescript/test.ts
@@ -124,6 +124,7 @@ function verify(
         verifier.stdin.write(JSON.stringify(obj) + '\n');
       },
       plugins,
+      passOnlySrcsToCreateProgram: true,
     });
   } finally {
     // Ensure we close stdin on the verifier even on crashes, or otherwise


### PR DESCRIPTION
Passing all files to `createProgram` should not be necessary as TS compiler can load necessary dependencies lazily. It is done through CompilerHost. 