### PR TITLE
chore(textproto_indexer): add recordio textformat support (#5528)

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -38,3 +38,4 @@ Jay Sachs <jsachs@google.com>
 Alexander Bezzubov <alex@sourced.tech>
 Ayaz Hafiz <ayaz.hafiz.1@gmail.com>
 Nick Gonzalez <nickgonzalez@google.com>
+Chuthan Vijay <chuthan20@gmail.com>

--- a/kythe/cxx/extractor/textproto/textproto_extractor.cc
+++ b/kythe/cxx/extractor/textproto/textproto_extractor.cc
@@ -47,6 +47,9 @@ ABSL_FLAG(std::string, proto_message, "",
 ABSL_FLAG(std::vector<std::string>, proto_files, {},
           "A comma-separated list of proto files needed to fully define "
           "the textproto's schema.");
+ABSL_FLAG(std::string, record_separator, "",
+          "Delimitates each record within a recordio file. Presence of this"
+          "flag indicates this is a recordio formatted file.");
 
 namespace kythe {
 namespace lang_textproto {
@@ -80,7 +83,8 @@ Examples:
   export KYTHE_OUTPUT_FILE=foo.kzip
   textproto_extractor foo.pbtxt
   textproto_extractor foo.pbtxt --proto_message MyMessage --proto_files foo.proto,bar.proto
-  textproto_extractor foo.pbtxt --proto_message MyMessage --proto_files foo.proto -- --proto_path dir/with/my/deps")");
+  textproto_extractor foo.pbtxt --proto_message MyMessage --proto_files foo.proto -- --proto_path dir/with/my/deps
+  textproto_extractor foo.recordiotxt --proto_message MyMessage --proto_files foo.proto --record_separator @@@ -- --proto_path dir/with/my/deps")");
   std::vector<char*> remain = absl::ParseCommandLine(argc, argv);
   std::vector<std::string> final_args(remain.begin() + 1, remain.end());
 
@@ -150,6 +154,11 @@ Examples:
   compilation.mutable_unit()->add_argument(textproto_filename);
   compilation.mutable_unit()->add_argument("--proto_message");
   compilation.mutable_unit()->add_argument(std::string(schema.proto_message));
+  std::string record_separator = absl::GetFlag(FLAGS_record_separator);
+  if (!record_separator.empty()) {
+    compilation.mutable_unit()->add_argument("--record_separator");
+    compilation.mutable_unit()->add_argument(record_separator);
+  }
   // Add protoc args.
   if (!proto_extractor.path_substitutions.empty()) {
     compilation.mutable_unit()->add_argument("--");

--- a/kythe/cxx/indexer/textproto/BUILD
+++ b/kythe/cxx/indexer/textproto/BUILD
@@ -29,6 +29,7 @@ cc_library(
     hdrs = ["analyzer.h"],
     deps = [
         ":plugin",
+        ":recordio_textparser",
         "//kythe/cxx/common:lib",
         "//kythe/cxx/common:path_utils",
         "//kythe/cxx/common:utf8_line_index",
@@ -73,5 +74,29 @@ cc_library(
         "@com_google_absl//absl/flags:flag",
         "@com_google_absl//absl/strings",
         "@com_google_protobuf//:protobuf",
+    ],
+)
+
+cc_library(
+    name = "recordio_textparser",
+    srcs = ["recordio_textparser.cc"],
+    hdrs = ["recordio_textparser.h"],
+    deps = [
+        "@com_github_google_glog//:glog",
+        "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/types:optional",
+        "@com_google_protobuf//:protobuf",
+    ],
+)
+
+cc_test(
+    name = "recordio_textparser_test",
+    srcs = ["recordio_textparser_test.cc"],
+    deps = [
+        ":recordio_textparser",
+        "//third_party:gtest",
+        "//third_party:gtest_main",
+        "@com_google_absl//absl/strings",
     ],
 )

--- a/kythe/cxx/indexer/textproto/analyzer.cc
+++ b/kythe/cxx/indexer/textproto/analyzer.cc
@@ -44,6 +44,7 @@
 #include "kythe/cxx/indexer/proto/source_tree.h"
 #include "kythe/cxx/indexer/proto/vname_util.h"
 #include "kythe/cxx/indexer/textproto/plugin.h"
+#include "kythe/cxx/indexer/textproto/recordio_textparser.h"
 #include "kythe/proto/analysis.pb.h"
 #include "re2/re2.h"
 
@@ -95,6 +96,13 @@ proto::VName LookupVNameForFullPath(absl::string_view full_path,
   return proto::VName{};
 }
 
+// The TreeInfo contains the ParseInfoTree from proto2 textformat parser
+// and line offset of the textproto within a file.
+struct TreeInfo {
+  const TextFormat::ParseInfoTree* parse_tree;
+  int line_offset = 0;
+};
+
 // The TextprotoAnalyzer maintains state needed across indexing operations and
 // provides some relevant helper methods.
 class TextprotoAnalyzer : public PluginApi {
@@ -122,14 +130,14 @@ class TextprotoAnalyzer : public PluginApi {
   absl::Status AnalyzeMessage(const proto::VName& file_vname,
                               const Message& proto,
                               const Descriptor& descriptor,
-                              const TextFormat::ParseInfoTree& parse_tree);
+                              const TreeInfo& tree_info);
 
   // Analyzes the message contained inside a google.protobuf.Any field. The
   // parse location of the field (if nonzero) is used to add an anchor for the
   // Any's type specifier (i.e. [some.url/mypackage.MyMessage]).
   absl::Status AnalyzeAny(const proto::VName& file_vname, const Message& proto,
                           const Descriptor& descriptor,
-                          const TextFormat::ParseInfoTree& parse_tree,
+                          const TreeInfo& tree_info,
                           TextFormat::ParseLocation field_loc);
 
   absl::StatusOr<proto::VName> AnalyzeAnyTypeUrl(
@@ -178,8 +186,7 @@ class TextprotoAnalyzer : public PluginApi {
 
  private:
   absl::Status AnalyzeField(const proto::VName& file_vname,
-                            const Message& proto,
-                            const TextFormat::ParseInfoTree& parse_tree,
+                            const Message& proto, const TreeInfo& parse_tree,
                             const FieldDescriptor& field, int field_index);
 
   std::vector<StringToken> ReadStringTokens(absl::string_view input);
@@ -228,9 +235,10 @@ proto::VName TextprotoAnalyzer::VNameForRelPath(
   return LookupVNameForFullPath(full_path, *unit_);
 }
 
-absl::Status TextprotoAnalyzer::AnalyzeMessage(
-    const proto::VName& file_vname, const Message& proto,
-    const Descriptor& descriptor, const TextFormat::ParseInfoTree& parse_tree) {
+absl::Status TextprotoAnalyzer::AnalyzeMessage(const proto::VName& file_vname,
+                                               const Message& proto,
+                                               const Descriptor& descriptor,
+                                               const TreeInfo& tree_info) {
   const Reflection* reflection = proto.GetReflection();
 
   // Iterate across all fields in the message. For proto1 and 2, each field has
@@ -249,11 +257,11 @@ absl::Status TextprotoAnalyzer::AnalyzeMessage(
 
       // Add a ref for each instance of the repeated field.
       for (int i = 0; i < count; i++) {
-        auto s = AnalyzeField(file_vname, proto, parse_tree, field, i);
+        auto s = AnalyzeField(file_vname, proto, tree_info, field, i);
         if (!s.ok()) return s;
       }
     } else {
-      auto s = AnalyzeField(file_vname, proto, parse_tree, field,
+      auto s = AnalyzeField(file_vname, proto, tree_info, field,
                             kNonRepeatedFieldIndex);
       if (!s.ok()) return s;
     }
@@ -271,11 +279,11 @@ absl::Status TextprotoAnalyzer::AnalyzeMessage(
     if (field->is_repeated()) {
       const size_t count = reflection->FieldSize(proto, field);
       for (size_t i = 0; i < count; i++) {
-        auto s = AnalyzeField(file_vname, proto, parse_tree, *field, i);
+        auto s = AnalyzeField(file_vname, proto, tree_info, *field, i);
         if (!s.ok()) return s;
       }
     } else {
-      auto s = AnalyzeField(file_vname, proto, parse_tree, *field,
+      auto s = AnalyzeField(file_vname, proto, tree_info, *field,
                             kNonRepeatedFieldIndex);
       if (!s.ok()) return s;
     }
@@ -342,7 +350,7 @@ absl::StatusOr<proto::VName> TextprotoAnalyzer::AnalyzeAnyTypeUrl(
 // matches fields up with the ParseInfoTree.
 absl::Status TextprotoAnalyzer::AnalyzeAny(
     const proto::VName& file_vname, const Message& proto,
-    const Descriptor& descriptor, const TextFormat::ParseInfoTree& parse_tree,
+    const Descriptor& descriptor, const TreeInfo& tree_info,
     TextFormat::ParseLocation field_loc) {
   CHECK(descriptor.full_name() == "google.protobuf.Any");
 
@@ -353,7 +361,7 @@ absl::Status TextprotoAnalyzer::AnalyzeAny(
   // assume it's a directly-specified Any and defer to AnalyzeMessage.
   auto s = AnalyzeAnyTypeUrl(file_vname, field_loc);
   if (!s.ok()) {
-    return AnalyzeMessage(file_vname, proto, descriptor, parse_tree);
+    return AnalyzeMessage(file_vname, proto, descriptor, tree_info);
   }
   const proto::VName type_url_anchor = *s;
 
@@ -399,7 +407,7 @@ absl::Status TextprotoAnalyzer::AnalyzeAny(
   }
 
   // Analyze the message contained in the Any.
-  return AnalyzeMessage(file_vname, *value_proto, *msg_desc, parse_tree);
+  return AnalyzeMessage(file_vname, *value_proto, *msg_desc, tree_info);
 }
 
 // Trims whitespace (including newlines) and comments from the start of the
@@ -597,17 +605,20 @@ absl::Status TextprotoAnalyzer::AnalyzeStringValue(
 
 // Analyzes the field and returns the number of values indexed. Typically this
 // is 1, but it could be 1+ when list syntax is used in the textproto.
-absl::Status TextprotoAnalyzer::AnalyzeField(
-    const proto::VName& file_vname, const Message& proto,
-    const TextFormat::ParseInfoTree& parse_tree, const FieldDescriptor& field,
-    int field_index) {
-  TextFormat::ParseLocation loc = parse_tree.GetLocation(&field, field_index);
+absl::Status TextprotoAnalyzer::AnalyzeField(const proto::VName& file_vname,
+                                             const Message& proto,
+                                             const TreeInfo& tree_info,
+                                             const FieldDescriptor& field,
+                                             int field_index) {
+  TextFormat::ParseLocation loc =
+      tree_info.parse_tree->GetLocation(&field, field_index);
+  // Location of field that does not exists in the txt format returns -1.
   // GetLocation() returns 0-indexed values, but UTF8LineIndex expects
   // 1-indexed line numbers.
-  loc.line++;
+  loc.line += tree_info.line_offset + 1;
 
   bool add_anchor_node = true;
-  if (loc.line == 0) {
+  if (loc.line == tree_info.line_offset) {
     // When AnalyzeField() is called for repeated fields or extensions, we know
     // the field was actually present in the input textproto. In the case of
     // repeated fields, the presence of only one location entry but multiple
@@ -672,8 +683,13 @@ absl::Status TextprotoAnalyzer::AnalyzeField(
 
   // Handle submessage.
   if (field.type() == FieldDescriptor::TYPE_MESSAGE) {
-    const TextFormat::ParseInfoTree& subtree =
-        *parse_tree.GetTreeForNested(&field, field_index);
+    const TextFormat::ParseInfoTree* subtree =
+        tree_info.parse_tree->GetTreeForNested(&field, field_index);
+    if (subtree == nullptr) {
+      return absl::OkStatus();
+    }
+    TreeInfo subtree_info{subtree, tree_info.line_offset};
+
     const Reflection* reflection = proto.GetReflection();
     const Message& submessage =
         field_index == kNonRepeatedFieldIndex
@@ -686,10 +702,11 @@ absl::Status TextprotoAnalyzer::AnalyzeField(
       // url and add an anchor node.
       TextFormat::ParseLocation field_loc =
           add_anchor_node ? loc : TextFormat::ParseLocation{};
-      return AnalyzeAny(file_vname, submessage, subdescriptor, subtree,
+      return AnalyzeAny(file_vname, submessage, subdescriptor, subtree_info,
                         field_loc);
     } else {
-      return AnalyzeMessage(file_vname, submessage, subdescriptor, subtree);
+      return AnalyzeMessage(file_vname, submessage, subdescriptor,
+                            subtree_info);
     }
   }
 
@@ -768,12 +785,12 @@ void TextprotoAnalyzer::EmitDiagnostic(const proto::VName& file_vname,
                      VNameRef(dn_vname));
 }
 
-// Find and return the argument after --proto_message. Removes the flag and
+// Find and return the argument after given argname. Removes the flag and
 // argument from @args if found.
-absl::optional<std::string> ParseProtoMessageArg(
-    std::vector<std::string>* args) {
+absl::optional<std::string> FindArg(std::vector<std::string>* args,
+                                    std::string argname) {
   for (auto iter = args->begin(); iter != args->end(); iter++) {
-    if (*iter == "--proto_message") {
+    if (*iter == argname) {
       if (iter + 1 < args->end()) {
         std::string v = *(iter + 1);
         args->erase(iter, iter + 2);
@@ -861,14 +878,10 @@ absl::Status AnalyzeCompilationUnit(PluginLoadCallback plugin_loader,
                                               &path_substitutions, &args);
 
   // Find --proto_message in args.
-  std::string message_name;
-  {
-    auto opt_message_name = ParseProtoMessageArg(&args);
-    if (!opt_message_name.has_value()) {
-      return absl::UnknownError(
-          "Compilation unit arguments must specify --proto_message");
-    }
-    message_name = *opt_message_name;
+  std::string message_name = FindArg(&args, "--proto_message").value_or("");
+  if (message_name.empty()) {
+    return absl::UnknownError(
+        "Compilation unit arguments must specify --proto_message");
   }
   LOG(INFO) << "Proto message name: " << message_name;
 
@@ -927,34 +940,25 @@ absl::Status AnalyzeCompilationUnit(PluginLoadCallback plugin_loader,
         "Unable to find proto message in descriptor pool: ", message_name));
   }
 
-  for (auto& source : file_data_by_path) {
+  // Only recordio format specifies record_separator.
+  // Presense of record_separator flag indicates it's recordio file format.
+  absl::optional<std::string> record_separator =
+      FindArg(&args, "--record_separator");
+  bool is_recordio = record_separator.has_value();
+  for (auto& [filepath, filecontent] : file_data_by_path) {
     // Use reflection to create an instance of the top-level proto message.
     // note: msg_factory must outlive any protos created from it.
     google::protobuf::DynamicMessageFactory msg_factory;
     std::unique_ptr<Message> proto(msg_factory.GetPrototype(descriptor)->New());
 
-    // Parse textproto into @proto, recording input locations to @parse_tree.
-    TextFormat::ParseInfoTree parse_tree;
-    {
-      TextFormat::Parser parser;
-      parser.WriteLocationsTo(&parse_tree);
-      // Relax parser restrictions - even if the proto is partially ill-defined,
-      // we'd like to analyze the parts that are good.
-      parser.AllowPartialMessage(true);
-      parser.AllowUnknownExtension(true);
-      if (!parser.ParseFromString(source.second->content(), proto.get())) {
-        return absl::UnknownError("Failed to parse text proto");
-      }
-    }
-
     // Emit file node.
-    proto::VName file_vname = LookupVNameForFullPath(source.first, unit);
+    proto::VName file_vname = LookupVNameForFullPath(filepath, unit);
     recorder->AddProperty(VNameRef(file_vname), NodeKindID::kFile);
     // Record source text as a fact.
     recorder->AddProperty(VNameRef(file_vname), PropertyID::kText,
-                          source.second->content());
+                          filecontent->content());
 
-    TextprotoAnalyzer analyzer(&unit, source.second->content(),
+    TextprotoAnalyzer analyzer(&unit, filecontent->content(),
                                &file_substitution_cache, recorder,
                                descriptor_pool);
 
@@ -970,10 +974,43 @@ absl::Status AnalyzeCompilationUnit(PluginLoadCallback plugin_loader,
       analyzer.EmitDiagnostic(file_vname, "schema_comments", msg);
     }
 
-    auto s =
-        analyzer.AnalyzeMessage(file_vname, *proto, *descriptor, parse_tree);
-    if (!s.ok()) {
-      return s;
+    TextFormat::Parser parser;
+    // Relax parser restrictions - even if the proto is partially ill-defined,
+    // we'd like to analyze the parts that are good.
+    parser.AllowPartialMessage(true);
+    parser.AllowUnknownExtension(true);
+
+    auto analyzeMessage = [&](absl::string_view chunk, int start_line) {
+      LOG(INFO) << "Analyze chunk at line: " << start_line;
+      // Parse textproto into @proto, recording input locations to @parse_tree.
+      TextFormat::ParseInfoTree parse_tree;
+      parser.WriteLocationsTo(&parse_tree);
+
+      if (!parser.ParseFromString(std::string(chunk), proto.get())) {
+        return absl::UnknownError("Failed to parse text proto");
+      }
+
+      TreeInfo tree_info{&parse_tree, start_line};
+      auto s =
+          analyzer.AnalyzeMessage(file_vname, *proto, *descriptor, tree_info);
+      if (!s.ok()) {
+        return s;
+      }
+    };
+
+    if (is_recordio) {
+      LOG(INFO) << "Analyzing recordio fileformat with delimiter: "
+                << record_separator.value_or("<none>");
+      kythe::lang_textproto::ParseRecordioTextChunks(
+          filecontent->content(), record_separator.value(),
+          [&](absl::string_view chunk, int line_offset) {
+            analyzeMessage(chunk, line_offset);
+            LOG(ERROR) << "Failed to parse record starting at line "
+                       << line_offset << ": " << status;
+          });
+      return absl::OkStatus();
+    } else {
+      analyzeMessage(filecontent->content(), 0);
     }
   }
 

--- a/kythe/cxx/indexer/textproto/recordio_textparser.cc
+++ b/kythe/cxx/indexer/textproto/recordio_textparser.cc
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2023 The Kythe Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "kythe/cxx/indexer/textproto/recordio_textparser.h"
+
+#include <sstream>
+
+#include "absl/strings/ascii.h"
+#include "absl/strings/match.h"
+#include "absl/strings/str_split.h"
+#include "absl/strings/string_view.h"
+#include "absl/types/optional.h"
+#include "glog/logging.h"
+
+namespace kythe {
+namespace lang_textproto {
+
+void ParseRecordioTextChunks(
+    std::string content, std::string record_delimiter,
+    std::function<void(absl::string_view chunk, int chunk_start_line)>
+        callback) {
+  absl::string_view trimmed_delimiter =
+      absl::StripAsciiWhitespace(record_delimiter);
+  std::vector<std::string> lines = absl::StrSplit(content, absl::ByChar('\n'));
+
+  std::ostringstream chunk;
+  int currentline = 0, chunk_begin_line = 0;
+  // Keep track of whether any lines in the chunk contains textproto data
+  // and not all the lines in the chunk are only comment/empty line.
+  bool seen_proto_chunk = false;
+  for (const auto& line : lines) {
+    currentline++;
+    const auto& trimmed = absl::StripAsciiWhitespace(line);
+    if (seen_proto_chunk && (trimmed == trimmed_delimiter)) {
+      LOG(INFO) << "Read chunk at " << chunk_begin_line;
+      callback(chunk.str(), chunk_begin_line);
+
+      chunk.str("\0");
+      chunk.clear();
+      seen_proto_chunk = false;
+      chunk_begin_line = currentline;
+      continue;
+    }
+    if (absl::StartsWith(trimmed, "#") || trimmed.empty()) {
+      chunk << line << "\n";
+      continue;
+    }
+    // Textproto data, so append it to chunk.
+    seen_proto_chunk = true;
+    chunk << line << "\n";
+  }
+  // Last line might contains textproto data.
+  if (seen_proto_chunk) {
+    callback(chunk.str(), chunk_begin_line);
+  }
+}
+
+}  // namespace lang_textproto
+}  // namespace kythe

--- a/kythe/cxx/indexer/textproto/recordio_textparser.h
+++ b/kythe/cxx/indexer/textproto/recordio_textparser.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2023 The Kythe Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef KYTHE_CXX_INDEXER_TEXTPROTO_RECORDIO_TEXTPARSER_H_
+#define KYTHE_CXX_INDEXER_TEXTPROTO_RECORDIO_TEXTPARSER_H_
+
+#include "absl/strings/string_view.h"
+#include "absl/types/optional.h"
+#include "google/protobuf/descriptor.h"
+#include "google/protobuf/dynamic_message.h"
+#include "google/protobuf/text_format.h"
+
+namespace kythe {
+namespace lang_textproto {
+
+// Parses recordio text-formatted content separated by record delimiter.
+// Callback is invoked for each chunk that is parsed into proto message along
+// with the line offset of where that chunk begins in the file.
+//
+// Empty lines can be record delimiter and they can also separate two chunks
+// of comments. Always gather chunk of comments into one big chunk along
+// with next message. For example:
+// 1.  // FooBar
+// 2.  // Bar
+// 3.
+// 4.  // BarBar
+// 5.  name: "hello"
+//
+// In the above example, line 1-5 should be read as one chunk even if the
+// delimiter is empty line. Also, note that last record usually does not have
+// delimiter specified and the record ends at EOF.
+// Also, note that delimiter could start with '#' which is also for the
+// comment.
+void ParseRecordioTextChunks(
+    std::string content, std::string record_delimiter,
+    std::function<void(absl::string_view chunk, int chunk_start_line)>
+        callback);
+
+}  // namespace lang_textproto
+}  // namespace kythe
+
+#endif  // KYTHE_CXX_INDEXER_TEXTPROTO_RECORDIO_TEXTPARSER_H_

--- a/kythe/cxx/indexer/textproto/recordio_textparser_test.cc
+++ b/kythe/cxx/indexer/textproto/recordio_textparser_test.cc
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2023 The Kythe Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "kythe/cxx/indexer/textproto/recordio_textparser.h"
+
+#include "absl/strings/str_join.h"
+#include "absl/strings/string_view.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace kythe {
+namespace {
+using ::testing::ElementsAre;
+using ::testing::Pair;
+
+std::vector<std::pair<int, std::string>> ParsedChunks(std::string content,
+                                                      std::string separator) {
+  std::vector<std::pair<int, std::string>> chunks;
+  lang_textproto::ParseRecordioTextChunks(
+      content, separator, [&](absl::string_view chunk, int chunk_start_line) {
+        chunks.emplace_back(chunk_start_line, std::string(chunk));
+      });
+  return chunks;
+}
+
+TEST(RecordioTextparserTest, TwoRecordSeparated) {
+  std::string content = absl::StrJoin({"item: 1", "---", "item: 2"}, "\n");
+  std::vector<std::pair<int, std::string>> chunks =
+      ParsedChunks(content, "---");
+
+  EXPECT_THAT(chunks, ElementsAre(Pair(0, "item: 1\n"), Pair(2, "item: 2\n")));
+}
+
+TEST(RecordioTextparserTest, CommentsAlsoSeparatedByNewline) {
+  std::string content = absl::StrJoin(
+      {"# Comment1", "", "# Comment2", "item: 1", "", "# Comment3", "item: 2"},
+      "\n");
+  std::vector<std::pair<int, std::string>> chunks = ParsedChunks(content, "\n");
+
+  EXPECT_THAT(chunks,
+              ElementsAre(Pair(0, "# Comment1\n\n# Comment2\nitem: 1\n"),
+                          Pair(5, "# Comment3\nitem: 2\n")));
+}
+
+TEST(RecordioTextparserTest, SeparatorStartsWithComment) {
+  std::string content =
+      absl::StrJoin({"# Comment1", " # --- ", "# Comment2", "item: 1",
+                     " # --- ", "# Comment3", "item: 2"},
+                    "\n");
+  std::vector<std::pair<int, std::string>> chunks =
+      ParsedChunks(content, "# ---");
+
+  EXPECT_THAT(chunks,
+              ElementsAre(Pair(0, "# Comment1\n # --- \n# Comment2\nitem: 1\n"),
+                          Pair(5, "# Comment3\nitem: 2\n")));
+}
+
+TEST(RecordioTextparserTest, EndsWithComment) {
+  std::string content = absl::StrJoin(
+      {"# Comment1", "item: 1", "", "item: 2", "# Comment2"}, "\n");
+  std::vector<std::pair<int, std::string>> chunks = ParsedChunks(content, "\n");
+
+  EXPECT_THAT(chunks, ElementsAre(Pair(0, "# Comment1\nitem: 1\n"),
+                                  Pair(3, "item: 2\n# Comment2\n")));
+}
+
+}  // namespace
+}  // namespace kythe

--- a/kythe/cxx/indexer/textproto/testdata/BUILD
+++ b/kythe/cxx/indexer/textproto/testdata/BUILD
@@ -86,6 +86,20 @@ textproto_verifier_test(
     textprotos = ["schema_comments.pbtxt"],
 )
 
+textproto_verifier_test(
+    name = "recordio_basics_test",
+    protos = [":example_proto"],
+    textprotos = ["recordio_basics.recordiotxt"],
+    extractor_opts = ["--record_separator", "@@@@@@@@@@@@@@@@"],
+)
+
+textproto_verifier_test(
+    name = "recordio_emptyline_delimiter_test",
+    protos = [":example_proto"],
+    textprotos = ["recordio_emptyline_delimiter.recordiotxt"],
+    extractor_opts = ["--record_separator", "\n"],
+)
+
 bzl_library(
     name = "textproto_verifier_test_bzl",
     srcs = ["textproto_verifier_test.bzl"],

--- a/kythe/cxx/indexer/textproto/testdata/recordio_basics.recordiotxt
+++ b/kythe/cxx/indexer/textproto/testdata/recordio_basics.recordiotxt
@@ -1,0 +1,32 @@
+# proto-file: kythe/cxx/indexer/textproto/testdata/example.proto
+# proto-message: example.Message2
+
+#- @field1 ref Field1
+field1: "hello"
+#- @repeated_message ref RepeatedMessage
+repeated_message {
+    #- @str_field ref Message1StrField
+    str_field: "hello"
+}
+# The message below is indented with tabs to test that they are handled
+# correctly by the indexer.
+#- @repeated_message ref RepeatedMessage
+	repeated_message {
+		#- @str_field ref Message1StrField
+		str_field: "hello"
+	}
+
+@@@@@@@@@@@@@@@@
+
+#- @field1 ref Field1
+field1: "hello"
+#- @repeated_message ref RepeatedMessage
+repeated_message {
+    #- @str_field ref Message1StrField
+    str_field: "hello"
+}
+
+@@@@@@@@@@@@@@@@
+
+#- @field1 ref Field1
+field1: "hello"

--- a/kythe/cxx/indexer/textproto/testdata/recordio_emptyline_delimiter.recordiotxt
+++ b/kythe/cxx/indexer/textproto/testdata/recordio_emptyline_delimiter.recordiotxt
@@ -1,0 +1,30 @@
+# proto-file: kythe/cxx/indexer/textproto/testdata/example.proto
+# proto-message: example.Message2
+
+#- @field1 ref Field1
+field1: "hello"
+#- @repeated_message ref RepeatedMessage
+repeated_message {
+    #- @str_field ref Message1StrField
+    str_field: "hello"
+}
+# The message below is indented with tabs to test that they are handled
+# correctly by the indexer.
+#- @repeated_message ref RepeatedMessage
+	repeated_message {
+		#- @str_field ref Message1StrField
+		str_field: "hello"
+	}
+
+#- @field1 ref Field1
+field1: "hello"
+#- @repeated_message ref RepeatedMessage
+repeated_message {
+    #- @str_field ref Message1StrField
+    str_field: "hello"
+}
+
+#- @field1 ref Field1
+field1: "hello"
+
+# end of chunks with a comment.

--- a/kythe/cxx/indexer/textproto/testdata/textproto_verifier_test.bzl
+++ b/kythe/cxx/indexer/textproto/testdata/textproto_verifier_test.bzl
@@ -36,8 +36,8 @@ def _textproto_extract_kzip_impl(ctx):
     toplevel_proto_srcs, all_proto_srcs, pathopt = get_proto_files_and_proto_paths(ctx.attr.protos)
 
     args = ctx.actions.args()
-    args.add("--")
     args.add_all(ctx.attr.opts)
+    args.add("--")
     args.add_all(pathopt, before_each = "--proto_path")
 
     extract(
@@ -82,6 +82,7 @@ def textproto_verifier_test(
         protos,
         size = "small",
         tags = [],
+        extractor_opts = [],
         indexer_opts = [],
         verifier_opts = [],
         convert_marked_source = False,
@@ -95,6 +96,7 @@ def textproto_verifier_test(
       protos: Proto libraries that define the textproto's schema
       size: Test size
       tags: Test tags
+      extractor_opts: List of options passed to the textproto extractor
       indexer_opts: List of options passed to the textproto indexer
       verifier_opts: List of options passed to the verifier tool
       convert_marked_source: Whether the verifier should convert marked source.
@@ -119,6 +121,7 @@ def textproto_verifier_test(
             visibility = visibility,
             vnames_config = vnames_config,
             protos = protos,
+            opts = extractor_opts,
         )
 
         # index textproto


### PR DESCRIPTION
Parse each recordio of textformat using the specified record separator and index it. Recordio textformat parser function also uses proto2::TextFormat::Parser but keeps track of line offset where that record begins in the file.

By default, empty line is the record separator, although user can specify custom separator.