### PR TITLE
chore(cxx_indexer): Add optional flag to emit binding with un-stamped anchors

### DIFF
--- a/kythe/cxx/indexer/cxx/GraphObserver.h
+++ b/kythe/cxx/indexer/cxx/GraphObserver.h
@@ -668,6 +668,9 @@ class GraphObserver {
       const Range& SourceRange, const NodeId& DeclId,
       const absl::optional<NodeId>& DefnId = absl::nullopt) {}
 
+  /// \brief Should an anchor be stamped
+  enum class Stamped { No, Yes };
+
   /// \brief Records that a particular `Range` contains the declaration
   /// of the node called `DeclId` (with possible full definition `DefnId`).
   ///
@@ -677,7 +680,7 @@ class GraphObserver {
   virtual void recordDefinitionBindingRange(
       const Range& BindingRange, const NodeId& DeclId,
       const absl::optional<NodeId>& DefnId = absl::nullopt,
-      bool stamped = true) {}
+      Stamped stamped = Stamped::Yes) {}
 
   /// \brief Records that a particular `Range` contains the declaration
   /// of the node called `DeclId` (with possible full definition `DefnId`).

--- a/kythe/cxx/indexer/cxx/GraphObserver.h
+++ b/kythe/cxx/indexer/cxx/GraphObserver.h
@@ -669,7 +669,7 @@ class GraphObserver {
       const absl::optional<NodeId>& DefnId = absl::nullopt) {}
 
   /// \brief Should an anchor be stamped
-  enum class Stamped { No, Yes };
+  enum class Stamping { Unstamped, Stamped };
 
   /// \brief Records that a particular `Range` contains the declaration
   /// of the node called `DeclId` (with possible full definition `DefnId`).
@@ -680,7 +680,7 @@ class GraphObserver {
   virtual void recordDefinitionBindingRange(
       const Range& BindingRange, const NodeId& DeclId,
       const absl::optional<NodeId>& DefnId = absl::nullopt,
-      Stamped stamped = Stamped::Yes) {}
+      Stamping stamping = Stamping::Stamped) {}
 
   /// \brief Records that a particular `Range` contains the declaration
   /// of the node called `DeclId` (with possible full definition `DefnId`).

--- a/kythe/cxx/indexer/cxx/GraphObserver.h
+++ b/kythe/cxx/indexer/cxx/GraphObserver.h
@@ -676,7 +676,8 @@ class GraphObserver {
   /// we would `recordDefinitionBindingRange` on the range for `C`.
   virtual void recordDefinitionBindingRange(
       const Range& BindingRange, const NodeId& DeclId,
-      const absl::optional<NodeId>& DefnId = absl::nullopt) {}
+      const absl::optional<NodeId>& DefnId = absl::nullopt,
+      bool stamped = true) {}
 
   /// \brief Records that a particular `Range` contains the declaration
   /// of the node called `DeclId` (with possible full definition `DefnId`).

--- a/kythe/cxx/indexer/cxx/KytheGraphObserver.cc
+++ b/kythe/cxx/indexer/cxx/KytheGraphObserver.cc
@@ -816,8 +816,8 @@ void KytheGraphObserver::recordFullDefinitionRange(
 
 void KytheGraphObserver::recordDefinitionBindingRange(
     const GraphObserver::Range& binding_range, const NodeId& node_decl,
-    const absl::optional<NodeId>& node_def, bool stamped) {
-  if (stamped) {
+    const absl::optional<NodeId>& node_def, Stamped stamped) {
+  if (stamped == Stamped::Yes) {
     RecordStampedAnchor(binding_range, node_decl, node_def,
                         EdgeKindID::kDefinesBinding, node_decl);
     return;

--- a/kythe/cxx/indexer/cxx/KytheGraphObserver.cc
+++ b/kythe/cxx/indexer/cxx/KytheGraphObserver.cc
@@ -816,8 +816,8 @@ void KytheGraphObserver::recordFullDefinitionRange(
 
 void KytheGraphObserver::recordDefinitionBindingRange(
     const GraphObserver::Range& binding_range, const NodeId& node_decl,
-    const absl::optional<NodeId>& node_def, Stamped stamped) {
-  if (stamped == Stamped::Yes) {
+    const absl::optional<NodeId>& node_def, Stamping stamping) {
+  if (stamping == Stamping::Stamped) {
     RecordStampedAnchor(binding_range, node_decl, node_def,
                         EdgeKindID::kDefinesBinding, node_decl);
     return;

--- a/kythe/cxx/indexer/cxx/KytheGraphObserver.cc
+++ b/kythe/cxx/indexer/cxx/KytheGraphObserver.cc
@@ -816,9 +816,14 @@ void KytheGraphObserver::recordFullDefinitionRange(
 
 void KytheGraphObserver::recordDefinitionBindingRange(
     const GraphObserver::Range& binding_range, const NodeId& node_decl,
-    const absl::optional<NodeId>& node_def) {
-  RecordStampedAnchor(binding_range, node_decl, node_def,
-                      EdgeKindID::kDefinesBinding, node_decl);
+    const absl::optional<NodeId>& node_def, bool stamped) {
+  if (stamped) {
+    RecordStampedAnchor(binding_range, node_decl, node_def,
+                        EdgeKindID::kDefinesBinding, node_decl);
+    return;
+  }
+  RecordAnchor(binding_range, node_decl, EdgeKindID::kDefinesBinding,
+               Claimability::Unclaimable);
 }
 
 void KytheGraphObserver::recordDefinitionRangeWithBinding(

--- a/kythe/cxx/indexer/cxx/KytheGraphObserver.h
+++ b/kythe/cxx/indexer/cxx/KytheGraphObserver.h
@@ -292,7 +292,7 @@ class KytheGraphObserver : public GraphObserver {
   void recordDefinitionBindingRange(const Range& binding_range,
                                     const NodeId& node_decl,
                                     const absl::optional<NodeId>& node_def,
-                                    bool stamped = true) override;
+                                    Stamped stamped = Stamped::Yes) override;
 
   void recordDefinitionRangeWithBinding(
       const Range& source_range, const Range& binding_range,

--- a/kythe/cxx/indexer/cxx/KytheGraphObserver.h
+++ b/kythe/cxx/indexer/cxx/KytheGraphObserver.h
@@ -289,10 +289,10 @@ class KytheGraphObserver : public GraphObserver {
       const Range& source_range, const NodeId& node_decl,
       const absl::optional<NodeId>& node_def) override;
 
-  void recordDefinitionBindingRange(const Range& binding_range,
-                                    const NodeId& node_decl,
-                                    const absl::optional<NodeId>& node_def,
-                                    Stamped stamped = Stamped::Yes) override;
+  void recordDefinitionBindingRange(
+      const Range& binding_range, const NodeId& node_decl,
+      const absl::optional<NodeId>& node_def,
+      Stamping stamping = Stamping::Stamped) override;
 
   void recordDefinitionRangeWithBinding(
       const Range& source_range, const Range& binding_range,

--- a/kythe/cxx/indexer/cxx/KytheGraphObserver.h
+++ b/kythe/cxx/indexer/cxx/KytheGraphObserver.h
@@ -289,9 +289,10 @@ class KytheGraphObserver : public GraphObserver {
       const Range& source_range, const NodeId& node_decl,
       const absl::optional<NodeId>& node_def) override;
 
-  void recordDefinitionBindingRange(
-      const Range& binding_range, const NodeId& node_decl,
-      const absl::optional<NodeId>& node_def) override;
+  void recordDefinitionBindingRange(const Range& binding_range,
+                                    const NodeId& node_decl,
+                                    const absl::optional<NodeId>& node_def,
+                                    bool stamped = true) override;
 
   void recordDefinitionRangeWithBinding(
       const Range& source_range, const Range& binding_range,


### PR DESCRIPTION
Some anchors (e.g. the extra anchors bind to artificial semantic nodes generated by TF library plugin) don't need to be stamped.