### PR TITLE
fix(cxx_extractor): the main source file should be marked always_process

### DIFF
--- a/kythe/cxx/extractor/cxx_extractor.cc
+++ b/kythe/cxx/extractor/cxx_extractor.cc
@@ -548,7 +548,7 @@ void ExtractorPPCallbacks::FileChanged(
   if (Reason == EnterFile) {
     if (last_inclusion_directive_path_.empty()) {
       current_files_.push(FileState{std::string(GetMainFile()->getName()),
-                                    ClaimDirective::NoDirectivesFound});
+                                    ClaimDirective::AlwaysClaim});
     } else {
       CHECK(!current_files_.empty());
       current_files_.top().last_include_offset = last_inclusion_offset_;

--- a/kythe/cxx/extractor/testdata/alternate_platform_test.cc
+++ b/kythe/cxx/extractor/testdata/alternate_platform_test.cc
@@ -40,6 +40,7 @@ required_input {
     [type.googleapis.com/kythe.proto.ContextDependentVersion] {
       row {
         source_context: "hash0"
+        always_process: true
       }
     }
   }

--- a/kythe/cxx/extractor/testdata/build_config_test.cc
+++ b/kythe/cxx/extractor/testdata/build_config_test.cc
@@ -41,6 +41,7 @@ required_input {
     [type.googleapis.com/kythe.proto.ContextDependentVersion] {
       row {
         source_context: "hash0"
+        always_process: true
       }
     }
   }

--- a/kythe/cxx/extractor/testdata/extract_transcript_test.cc
+++ b/kythe/cxx/extractor/testdata/extract_transcript_test.cc
@@ -39,6 +39,7 @@ required_input {
     [type.googleapis.com/kythe.proto.ContextDependentVersion] {
       row {
         source_context: "hash0"
+        always_process: true
         column {
           offset: 20
           linked_context: "hash1"

--- a/kythe/cxx/extractor/testdata/has_include_test.cc
+++ b/kythe/cxx/extractor/testdata/has_include_test.cc
@@ -39,6 +39,7 @@ required_input {
     [type.googleapis.com/kythe.proto.ContextDependentVersion] {
       row {
         source_context: "hash0"
+        always_process: true
       }
     }
   }

--- a/kythe/cxx/extractor/testdata/indirect_has_include_test.cc
+++ b/kythe/cxx/extractor/testdata/indirect_has_include_test.cc
@@ -39,6 +39,7 @@ required_input {
     [type.googleapis.com/kythe.proto.ContextDependentVersion] {
       row {
         source_context: "hash0"
+        always_process: true
         column {
           offset: 35
           linked_context: "hash1"

--- a/kythe/cxx/extractor/testdata/installed_dir_test.cc
+++ b/kythe/cxx/extractor/testdata/installed_dir_test.cc
@@ -39,6 +39,7 @@ required_input {
     [type.googleapis.com/kythe.proto.ContextDependentVersion] {
       row {
         source_context: "hash0"
+        always_process: true
         column {
           linked_context: "hash1"
         }

--- a/kythe/cxx/extractor/testdata/main_source_file_env_dep_test.cc
+++ b/kythe/cxx/extractor/testdata/main_source_file_env_dep_test.cc
@@ -41,6 +41,7 @@ required_input {
     [type.googleapis.com/kythe.proto.ContextDependentVersion] {
       row {
         source_context: "hash0"
+        always_process: true
       }
     }
   }

--- a/kythe/cxx/extractor/testdata/main_source_file_no_env_dep_test.cc
+++ b/kythe/cxx/extractor/testdata/main_source_file_no_env_dep_test.cc
@@ -41,6 +41,7 @@ required_input {
     [type.googleapis.com/kythe.proto.ContextDependentVersion] {
       row {
         source_context: "hash0"
+        always_process: true
       }
     }
   }

--- a/kythe/cxx/extractor/testdata/metadata_test.cc
+++ b/kythe/cxx/extractor/testdata/metadata_test.cc
@@ -39,6 +39,7 @@ required_input {
     [type.googleapis.com/kythe.proto.ContextDependentVersion] {
       row {
         source_context: "hash0"
+        always_process: true
       }
     }
   }

--- a/kythe/cxx/extractor/testdata/modules_test.cc
+++ b/kythe/cxx/extractor/testdata/modules_test.cc
@@ -41,6 +41,7 @@ required_input {
     [type.googleapis.com/kythe.proto.ContextDependentVersion] {
       row {
         source_context: "hash0"
+        always_process: true
       }
     }
   }

--- a/kythe/cxx/extractor/testdata/root_directory_test.cc
+++ b/kythe/cxx/extractor/testdata/root_directory_test.cc
@@ -48,6 +48,7 @@ required_input {
     [type.googleapis.com/kythe.proto.ContextDependentVersion] {
       row {
         source_context: "hash0"
+        always_process: true
       }
     }
   }


### PR DESCRIPTION
There is some argument to be made that this logic should (also?) go in the indexer as the indexer should always process the primary source file, regardless of claiming, but we already have a facility for this in the extractor and just need to change one place so that the primary source file is always processed.

Background: when using dynamic claiming, prospective claims are issued with a timeout, but if a given compilation unit abandoned midway through indexing it can sometimes be retried before the previous prospective claims have expired, thus skipping files which it should index.  While this is problematic for header files as well, it is most troublesome for source files which are unlikely to be indexed at all as a result. Header files may potentially be included by another compilation unit and therefore indexed separately.

Pros of this approach: very small change, uses pre-existing facility.
Cons: 
 * This arguably belongs in the indexer itself
 * can't be flag-controlled in extractor
 * need to update all of the tests due to the change in the resulting proto files