### PR TITLE
feat(cxx_indexer): support kTakeAlias semantics in simple alias exprs

### DIFF
--- a/kythe/cxx/common/protobuf_metadata_file.cc
+++ b/kythe/cxx/common/protobuf_metadata_file.cc
@@ -100,8 +100,7 @@ std::unique_ptr<kythe::MetadataFile> ProtobufMetadataSupport::ParseFile(
           absl::StartsWith(token, "release_")) {
         rule.semantic = kythe::MetadataFile::Semantic::kWrite;
       } else if (absl::StartsWith(token, "mutable_")) {
-        // TODO(zarko): kTakeAlias in a PR after #5538
-        rule.semantic = kythe::MetadataFile::Semantic::kReadWrite;
+        rule.semantic = kythe::MetadataFile::Semantic::kTakeAlias;
       }
     }
     rules.push_back(rule);

--- a/kythe/cxx/indexer/cxx/IndexerASTHooks.cc
+++ b/kythe/cxx/indexer/cxx/IndexerASTHooks.cc
@@ -571,7 +571,7 @@ bool IndexerASTVisitor::declDominatesPrunableSubtree(const clang::Decl* Decl) {
 const clang::Decl* IndexerASTVisitor::GetInfluencedDeclFromLValueHead(
     const clang::Expr* head) {
   if (head == nullptr) return nullptr;
-  head = SkipTrivialAliasing(head);
+  head = SkipTrivialAliasing(head).first;
   if (auto* expr = llvm::dyn_cast_or_null<clang::DeclRefExpr>(head);
       expr != nullptr && expr->getFoundDecl() != nullptr &&
       (expr->getFoundDecl()->getKind() == clang::Decl::Kind::Var ||
@@ -587,10 +587,10 @@ const clang::Decl* IndexerASTVisitor::GetInfluencedDeclFromLValueHead(
   return nullptr;
 }
 
-const clang::Expr* IndexerASTVisitor::SkipTrivialAliasing(
-    const clang::Expr* expr) {
+std::pair<const clang::Expr*, std::optional<GraphObserver::NodeId>>
+IndexerASTVisitor::SkipTrivialAliasing(const clang::Expr* expr) {
   // TODO(zarko): calls with alternate semantics
-  if (expr == nullptr) return nullptr;
+  if (expr == nullptr) return std::make_pair(nullptr, std::nullopt);
   if (const auto* star =
           llvm::dyn_cast_or_null<clang::UnaryOperator>(expr->IgnoreParens());
       star != nullptr && star->getOpcode() == clang::UO_Deref &&
@@ -603,11 +603,22 @@ const clang::Expr* IndexerASTVisitor::SkipTrivialAliasing(
       // star := *&var
       const auto* var = amp->getSubExpr()->IgnoreParens();
       if (const auto* dre = llvm::dyn_cast_or_null<clang::DeclRefExpr>(var)) {
-        return dre;
+        return std::make_pair(dre, std::nullopt);
+      }
+    }
+    if (const auto* call = llvm::dyn_cast_or_null<clang::CallExpr>(body);
+        call != nullptr && call->getCallee() != nullptr &&
+        call->getCalleeDecl() != nullptr) {
+      // star := *foo() || *x->foo()
+      // TODO(zarko): here and above: trace down deref/call chains?
+      // we don't currently handle x.y.z->mutable_foo()
+      if (const auto* as = AlternateSemanticForDecl(call->getCalleeDecl());
+          as != nullptr && as->use_kind == GraphObserver::UseKind::kTakeAlias) {
+        return std::make_pair(call->getCallee(), as->node);
       }
     }
   }
-  return expr;
+  return std::make_pair(expr, std::nullopt);
 }
 
 bool IndexerASTVisitor::IsDefinition(const clang::VarDecl* VD) {
@@ -1435,8 +1446,9 @@ bool IndexerASTVisitor::VisitMemberExpr(const clang::MemberExpr* E) {
     auto StmtId = BuildNodeIdForImplicitStmt(E);
     if (auto RCC = RangeInCurrentContext(StmtId, Range)) {
       RecordBlame(FieldDecl, *RCC);
+      auto use_kind = UseKindFor(E, BuildNodeIdForRefToDecl(FieldDecl));
       Observer.recordSemanticDeclUseLocation(
-          *RCC, BuildNodeIdForRefToDecl(FieldDecl), UseKindFor(E),
+          *RCC, use_kind.second, use_kind.first,
           GraphObserver::Claimability::Unclaimable, IsImplicit(*RCC));
       if (E->hasExplicitTemplateArgs()) {
         // We still want to link the template args.
@@ -1713,25 +1725,27 @@ bool IndexerASTVisitor::TraverseCXXOperatorCallExpr(
   auto arg_end = E->arg_end();
   if (arg_begin != arg_end && *arg_begin != nullptr) {
     // `this` is the first argument in the case of a member function.
-    auto* lvhead = FindLValueHead(*arg_begin);
-    if (E->getOperator() == clang::OO_Equal) {
-      UsedAsWrite(lvhead);
-    } else {
-      UsedAsReadWrite(lvhead);
-    }
+    auto* raw_lvhead = FindLValueHead(*arg_begin);
+    auto lvhead = (E->getOperator() == clang::OO_Equal)
+                      ? UsedAsWrite(raw_lvhead)
+                      : UsedAsReadWrite(raw_lvhead);
     if (!TraverseStmt(*arg_begin)) return false;
     auto scope_guard = PushScope(Job->InfluenceSets, {});
     for (++arg_begin; arg_begin != arg_end; ++arg_begin) {
       if (*arg_begin != nullptr && !TraverseStmt(*arg_begin)) return false;
     }
-    if (auto* influenced = GetInfluencedDeclFromLValueHead(lvhead)) {
+    auto influenced = lvhead.second;
+    if (!influenced) {
+      if (auto* from_expr = GetInfluencedDeclFromLValueHead(lvhead.first)) {
+        influenced = BuildNodeIdForDecl(from_expr);
+      }
+    }
+    if (influenced) {
       for (const auto* decl : Job->InfluenceSets.back()) {
-        Observer.recordInfluences(BuildNodeIdForDecl(decl),
-                                  BuildNodeIdForDecl(influenced));
+        Observer.recordInfluences(BuildNodeIdForDecl(decl), *influenced);
       }
       if (E->getOperator() != clang::OO_Equal) {
-        Observer.recordInfluences(BuildNodeIdForDecl(influenced),
-                                  BuildNodeIdForDecl(influenced));
+        Observer.recordInfluences(*influenced, *influenced);
       }
     }
     return true;
@@ -2354,16 +2368,21 @@ bool IndexerASTVisitor::TraverseBinaryOperator(clang::BinaryOperator* BO) {
   if (auto rhs = BO->getRHS(), lhs = BO->getLHS();
       lhs != nullptr && rhs != nullptr) {
     if (!WalkUpFromBinaryOperator(BO)) return false;
-    auto* lvhead = UsedAsWrite(FindLValueHead(lhs));
+    auto lvhead = UsedAsWrite(FindLValueHead(lhs));
     if (!TraverseStmt(lhs)) return false;
     auto scope_guard = PushScope(Job->InfluenceSets, {});
     if (!TraverseStmt(rhs)) {
       return false;
     }
-    if (auto* influenced = GetInfluencedDeclFromLValueHead(lvhead)) {
+    auto influenced = lvhead.second;
+    if (!influenced) {
+      if (auto* from_expr = GetInfluencedDeclFromLValueHead(lvhead.first)) {
+        influenced = BuildNodeIdForDecl(from_expr);
+      }
+    }
+    if (influenced) {
       for (const auto* decl : Job->InfluenceSets.back()) {
-        Observer.recordInfluences(BuildNodeIdForDecl(decl),
-                                  BuildNodeIdForDecl(influenced));
+        Observer.recordInfluences(BuildNodeIdForDecl(decl), *influenced);
       }
     }
     return true;
@@ -2379,19 +2398,23 @@ bool IndexerASTVisitor::TraverseCompoundAssignOperator(
   if (auto rhs = CAO->getRHS(), lhs = CAO->getLHS();
       lhs != nullptr && rhs != nullptr) {
     if (!WalkUpFromCompoundAssignOperator(CAO)) return false;
-    auto* lvhead = UsedAsReadWrite(FindLValueHead(lhs));
+    auto lvhead = UsedAsReadWrite(FindLValueHead(lhs));
     if (!TraverseStmt(lhs)) return false;
     auto scope_guard = PushScope(Job->InfluenceSets, {});
     if (!TraverseStmt(rhs)) {
       return false;
     }
-    if (auto* influenced = GetInfluencedDeclFromLValueHead(lvhead)) {
-      for (const auto* decl : Job->InfluenceSets.back()) {
-        Observer.recordInfluences(BuildNodeIdForDecl(decl),
-                                  BuildNodeIdForDecl(influenced));
+    auto influenced = lvhead.second;
+    if (!influenced) {
+      if (auto* from_expr = GetInfluencedDeclFromLValueHead(lvhead.first)) {
+        influenced = BuildNodeIdForDecl(from_expr);
       }
-      Observer.recordInfluences(BuildNodeIdForDecl(influenced),
-                                BuildNodeIdForDecl(influenced));
+    }
+    if (influenced) {
+      for (const auto* decl : Job->InfluenceSets.back()) {
+        Observer.recordInfluences(BuildNodeIdForDecl(decl), *influenced);
+      }
+      Observer.recordInfluences(*influenced, *influenced);
     }
     return true;
   }
@@ -2410,11 +2433,16 @@ bool IndexerASTVisitor::TraverseUnaryOperator(clang::UnaryOperator* UO) {
   }
   if (auto* lval = UO->getSubExpr(); lval != nullptr) {
     if (!WalkUpFromUnaryOperator(UO)) return false;
-    auto* lvhead = UsedAsReadWrite(FindLValueHead(lval));
+    auto lvhead = UsedAsReadWrite(FindLValueHead(lval));
     if (!TraverseStmt(lval)) return false;
-    if (auto* influenced = GetInfluencedDeclFromLValueHead(lvhead)) {
-      Observer.recordInfluences(BuildNodeIdForDecl(influenced),
-                                BuildNodeIdForDecl(influenced));
+    auto influenced = lvhead.second;
+    if (!influenced) {
+      if (auto* from_expr = GetInfluencedDeclFromLValueHead(lvhead.first)) {
+        influenced = BuildNodeIdForDecl(from_expr);
+      }
+    }
+    if (influenced) {
+      Observer.recordInfluences(*influenced, *influenced);
     }
     return true;
   }
@@ -2540,8 +2568,9 @@ bool IndexerASTVisitor::VisitDeclRefOrIvarRefExpr(
               this->IsImplicit(RCC.value()));
         }
       }
+      auto use_kind = UseKindFor(Expr, DeclId);
       Observer.recordSemanticDeclUseLocation(
-          *RCC, DeclId, UseKindFor(Expr),
+          *RCC, use_kind.second, use_kind.first,
           GraphObserver::Claimability::Unclaimable, this->IsImplicit(*RCC));
       for (const auto& S : Supports) {
         S->InspectDeclRef(*this, SL, *RCC, DeclId, FoundDecl);

--- a/kythe/cxx/indexer/cxx/KytheGraphObserver.cc
+++ b/kythe/cxx/indexer/cxx/KytheGraphObserver.cc
@@ -1119,7 +1119,8 @@ void KytheGraphObserver::recordSemanticDeclUseLocation(
     const GraphObserver::Range& source_range, const NodeId& node, UseKind kind,
     Claimability claimability, Implicit i) {
   if (kind == GraphObserver::UseKind::kUnknown ||
-      kind == GraphObserver::UseKind::kReadWrite) {
+      kind == GraphObserver::UseKind::kReadWrite ||
+      kind == GraphObserver::UseKind::kTakeAlias) {
     auto out_kind =
         (i == GraphObserver::Implicit::Yes ? EdgeKindID::kRefImplicit
                                            : EdgeKindID::kRef);

--- a/kythe/cxx/indexer/cxx/testdata/proto/proto_semantic.cc
+++ b/kythe/cxx/indexer/cxx/testdata/proto/proto_semantic.cc
@@ -33,6 +33,9 @@ void fn() {
 
   //- @mutable_nested_message ref/writes NestedMessageField
   *msg.mutable_nested_message() = nested;
+  //- @mutable_nested_message ref NestedMessageField
+  //- !{ @mutable_nested_message ref/writes NestedMessageField }
+  msg.mutable_nested_message();
   //- @nested_message ref CxxGetNestedMessageField
   msg.nested_message();
 


### PR DESCRIPTION
This PR supports marking writes to decls marked with kTakeAlias semantics (that may have indirect targets, as in proto fields). Materially, this means that in:

`*m->mutable_foo() = 4;`

`mutable_foo` will ref/write the proto field `foo` directly. In contrast, `m->mutable_foo()` on its own (e.g., not as the head of an lexpression) will only be marked as a simple ref of `foo`.

Handling decls with marked semantics and exprs with marked semantics appears to be converging somewhat and could do with a little refactoring. Part of the trouble is that different information about the context is available at different times (like when traversing through assignment versus visiting a declref at a leaf). One wonders how much longer we have until we end up with more than one and a half phases (maybe once templates are overhauled?)