### PR TITLE
chore: remove uses of map_util.h

### DIFF
--- a/kythe/cxx/indexer/proto/file_descriptor_walker.cc
+++ b/kythe/cxx/indexer/proto/file_descriptor_walker.cc
@@ -25,7 +25,6 @@
 #include "glog/logging.h"
 #include "google/protobuf/descriptor.h"
 #include "google/protobuf/repeated_field.h"
-#include "google/protobuf/stubs/map_util.h"
 #include "kythe/cxx/common/kythe_metadata_file.h"
 #include "kythe/cxx/common/schema/edges.h"
 #include "kythe/cxx/indexer/proto/marked_source.h"
@@ -851,26 +850,30 @@ void FileDescriptorWalker::VisitNestedFields(const std::string& name_prefix,
 
 void FileDescriptorWalker::AddComments(const VName& v_name,
                                        const std::vector<int>& path) {
-  const auto* protoc_location =
-      google::protobuf::FindOrNull(path_location_map_, path);
+  auto protoc_iter = path_location_map_.find(path);
+  if (protoc_iter == path_location_map_.end()) {
+    return;
+  }
+  const auto& protoc_location = protoc_iter->second;
   absl::StatusOr<PartialLocation> readable_location =
       ParseLocation(location_map_[path]);
-  if (protoc_location != nullptr && readable_location.ok()) {
-    Location entity_location;
-    InitializeLocation(location_map_[path], &entity_location);
-    PartialLocation coordinates = *readable_location;
-    if (protoc_location->has_leading_comments()) {
-      Location comment_location = LocationOfLeadingComments(
-          entity_location, coordinates.start_line, coordinates.start_column,
-          protoc_location->leading_comments());
-      builder_->AddDocComment(v_name, comment_location);
-    }
-    if (protoc_location->has_trailing_comments()) {
-      Location comment_location = LocationOfTrailingComments(
-          entity_location, coordinates.start_line, coordinates.start_column,
-          protoc_location->trailing_comments());
-      builder_->AddDocComment(v_name, comment_location);
-    }
+  if (!readable_location.ok()) {
+    return;
+  }
+  Location entity_location;
+  InitializeLocation(location_map_[path], &entity_location);
+  PartialLocation coordinates = *readable_location;
+  if (protoc_location.has_leading_comments()) {
+    Location comment_location = LocationOfLeadingComments(
+        entity_location, coordinates.start_line, coordinates.start_column,
+        protoc_location.leading_comments());
+    builder_->AddDocComment(v_name, comment_location);
+  }
+  if (protoc_location.has_trailing_comments()) {
+    Location comment_location = LocationOfTrailingComments(
+        entity_location, coordinates.start_line, coordinates.start_column,
+        protoc_location.trailing_comments());
+    builder_->AddDocComment(v_name, comment_location);
   }
 }
 

--- a/kythe/cxx/indexer/proto/proto_analyzer.cc
+++ b/kythe/cxx/indexer/proto/proto_analyzer.cc
@@ -19,15 +19,12 @@
 #include "absl/container/flat_hash_map.h"
 #include "absl/strings/string_view.h"
 #include "glog/logging.h"
-#include "google/protobuf/stubs/map_util.h"
 #include "kythe/cxx/indexer/proto/file_descriptor_walker.h"
 
 namespace kythe {
 namespace lang_proto {
 
 using ::google::protobuf::FileDescriptorProto;
-using ::google::protobuf::FindWithDefault;
-using ::google::protobuf::InsertIfNotPresent;
 using ::kythe::proto::VName;
 
 // TODO: it seems very likely that a lot of the path-mangling
@@ -58,7 +55,7 @@ bool ProtoAnalyzer::AnalyzeFile(const std::string& rel_path,
   // claiming.  Formerly this helped avoid issues with cyclic dependencies, but
   // now only the reused proto2 infrastructure descends into dependencies and
   // thus only it is exposed to cyclic dependency risks.
-  if (!InsertIfNotPresent(&visited_files_, rel_path)) {
+  if (!visited_files_.insert(rel_path).second) {
     return true;
   }
 
@@ -104,9 +101,12 @@ bool ProtoAnalyzer::Parse(const std::string& proto_file,
 
 VName ProtoAnalyzer::VNameFromRelPath(
     const std::string& simplified_path) const {
-  std::string full_path = FindWithDefault(*path_substitution_cache_,
-                                          simplified_path, simplified_path);
-  return VNameFromFullPath(full_path);
+  const std::string* full_path = &simplified_path;
+  if (auto iter = path_substitution_cache_->find(simplified_path);
+      iter != path_substitution_cache_->end()) {
+    full_path = &iter->second;
+  }
+  return VNameFromFullPath(*full_path);
 }
 
 VName ProtoAnalyzer::VNameFromFullPath(const std::string& path) const {

--- a/kythe/cxx/indexer/proto/source_tree.cc
+++ b/kythe/cxx/indexer/proto/source_tree.cc
@@ -24,15 +24,9 @@
 #include "absl/strings/strip.h"
 #include "glog/logging.h"
 #include "google/protobuf/io/zero_copy_stream_impl_lite.h"
-#include "google/protobuf/stubs/map_util.h"
 #include "kythe/cxx/common/path_utils.h"
 
 namespace kythe {
-
-using ::google::protobuf::FindOrDie;
-using ::google::protobuf::FindOrNull;
-using ::google::protobuf::InsertIfNotPresent;
-
 namespace {
 
 // TODO(justbuchanan): why isn't there a replace_all=false version of
@@ -49,25 +43,26 @@ std::string StringReplaceFirst(absl::string_view s, absl::string_view oldsub,
 bool PreloadedProtoFileTree::AddFile(const std::string& filename,
                                      const std::string& contents) {
   VLOG(1) << filename << " added to PreloadedProtoFileTree";
-  return InsertIfNotPresent(&file_map_, filename, contents);
+  return file_map_.try_emplace(filename, contents).second;
 }
 
 google::protobuf::io::ZeroCopyInputStream* PreloadedProtoFileTree::Open(
     const std::string& filename) {
   last_error_ = "";
 
-  const std::string* cached_path = FindOrNull(*file_mapping_cache_, filename);
-  if (cached_path != nullptr) {
-    std::string* stored_contents = FindOrNull(file_map_, *cached_path);
-    if (stored_contents == nullptr) {
+  if (auto iter = file_mapping_cache_->find(filename);
+      iter != file_mapping_cache_->end()) {
+    const std::string& cached_path = iter->second;
+    auto contents = file_map_.find(cached_path);
+    if (contents == file_map_.end()) {
       last_error_ = absl::StrCat("Proto file Open(", filename,
                                  ") failed:", " cached mapping to ",
-                                 *cached_path, "no longer valid.");
+                                 cached_path, "no longer valid.");
       LOG(ERROR) << last_error_;
       return nullptr;
     }
-    return new google::protobuf::io::ArrayInputStream(stored_contents->data(),
-                                                      stored_contents->size());
+    return new google::protobuf::io::ArrayInputStream(contents->second.data(),
+                                                      contents->second.size());
   }
   for (auto& substitution : *substitutions_) {
     std::string found_path;
@@ -79,29 +74,26 @@ google::protobuf::io::ZeroCopyInputStream* PreloadedProtoFileTree::Open(
       found_path = CleanPath(StringReplaceFirst(filename, substitution.first,
                                                 substitution.second));
     }
-    std::string* stored_contents =
-        found_path.empty() ? nullptr : FindOrNull(file_map_, found_path);
-    if (stored_contents != nullptr) {
+    if (auto iter = file_map_.find(found_path); iter != file_map_.end()) {
       VLOG(1) << "Proto file Open(" << filename << ") under ["
               << substitution.first << "->" << substitution.second << "]";
-      if (auto [unused, inserted] =
+      if (auto [mapped_iter, inserted] =
               file_mapping_cache_->emplace(filename, found_path);
           !inserted) {
         LOG(ERROR) << "Redundant/contradictory data in index or internal bug."
                    << "  \"" << filename << "\" is mapped twice, first to \""
-                   << FindOrDie(*file_mapping_cache_, filename)
-                   << "\" and now to \"" << found_path << "\".  Aborting "
+                   << mapped_iter->second << "\" and now to \"" << found_path
+                   << "\".  Aborting "
                    << "new remapping...";
       }
-      return new google::protobuf::io::ArrayInputStream(
-          stored_contents->data(), stored_contents->size());
+      return new google::protobuf::io::ArrayInputStream(iter->second.data(),
+                                                        iter->second.size());
     }
   }
-  std::string* stored_contents = FindOrNull(file_map_, filename);
-  if (stored_contents != nullptr) {
+  if (auto iter = file_map_.find(filename); iter != file_map_.end()) {
     VLOG(1) << "Proto file Open(" << filename << ") at root";
-    return new google::protobuf::io::ArrayInputStream(stored_contents->data(),
-                                                      stored_contents->size());
+    return new google::protobuf::io::ArrayInputStream(iter->second.data(),
+                                                      iter->second.size());
   }
   last_error_ = absl::StrCat("Proto file Open(", filename, ") failed because '",
                              filename, "' not recognized by indexer");


### PR DESCRIPTION
newer versions of protobuf do no export this header and most of the functions which exist therein are questionable anyway.