### PR TITLE
chore: make it easier to transition Riegeli proto APIs

### DIFF
--- a/kythe/go/util/riegeli/riegeli_test.go
+++ b/kythe/go/util/riegeli/riegeli_test.go
@@ -388,9 +388,8 @@ func TestRecordsMetadata(t *testing.T) {
 		Transpose:   true,
 		Compression: BrotliCompression(4),
 	}
-	expected := &rmpb.RecordsMetadata{
-		RecordWriterOptions: proto.String(opts.String()),
-	}
+	expected := rmpb.RecordsMetadata{}
+	expected.RecordWriterOptions = proto.String(opts.String())
 
 	buf := writeStrings(t, opts, 128)
 	rd := NewReader(bytes.NewReader(buf.Bytes()))

--- a/kythe/go/util/riegeli/writer.go
+++ b/kythe/go/util/riegeli/writer.go
@@ -52,10 +52,10 @@ func (w *Writer) ensureFileHeader() error {
 		tw := &talliedRecordWriter{recordWriter: rw}
 		if err != nil {
 			return err
-		} else if _, err := tw.PutProto(&rmpb.RecordsMetadata{
-			// TODO(schroederc): add support for full RecordsMetadata
-			RecordWriterOptions: proto.String(opts),
-		}); err != nil {
+		}
+		metadata := rmpb.RecordsMetadata{}
+		metadata.RecordWriterOptions = proto.String(opts)
+		if _, err := tw.PutProto(&metadata); err != nil {
 			return err
 		}
 		data, err := tw.Encode()

--- a/kythe/go/util/riegeli/writer.go
+++ b/kythe/go/util/riegeli/writer.go
@@ -54,6 +54,7 @@ func (w *Writer) ensureFileHeader() error {
 			return err
 		}
 		metadata := rmpb.RecordsMetadata{}
+		// TODO(schroederc): add support for full RecordsMetadata
 		metadata.RecordWriterOptions = proto.String(opts)
 		if _, err := tw.PutProto(&metadata); err != nil {
 			return err


### PR DESCRIPTION
Internally, Riegeli wants to switch to a different API for the generated protobuf code, but that API isn't available externally yet.  This PR changes the internal use of those protocol buffers so that they are easier to transform during imports.