### PR TITLE
chore: use port of protobuf gMock matchers

### DIFF
--- a/external.bzl
+++ b/external.bzl
@@ -292,6 +292,13 @@ def _cc_dependencies():
         ],
     )
 
+    maybe(
+        github_archive,
+        name = "com_github_inazarenko_protobuf_matchers",
+        repo_name = "inazarenko/protobuf-matchers",
+        commit = "8edcd4f7cad4f35e9bd304ff9d45a035c50c9290",
+    )
+
     lexyacc_configure()
     cxx_extractor_register_toolchains()
 

--- a/kythe/cxx/common/BUILD
+++ b/kythe/cxx/common/BUILD
@@ -221,6 +221,7 @@ cc_test(
     deps = [
         ":file_vname_generator",
         "//third_party:gtest",
+        "@com_github_inazarenko_protobuf_matchers//protobuf-matchers",
         "@com_google_protobuf//:protobuf",
         "@com_googlesource_code_re2//:re2",
     ],
@@ -309,6 +310,7 @@ cc_library(
         ":vname_ordering",
         "//third_party:gtest",
         "@com_github_google_glog//:glog",
+        "@com_github_inazarenko_protobuf_matchers//protobuf-matchers",
         "@com_google_protobuf//:protobuf",
     ],
 )

--- a/kythe/cxx/common/kythe_uri_test.cc
+++ b/kythe/cxx/common/kythe_uri_test.cc
@@ -17,11 +17,14 @@
 #include "kythe/cxx/common/kythe_uri.h"
 
 #include "glog/logging.h"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "kythe/cxx/common/vname_ordering.h"
+#include "protobuf-matchers/protocol-buffer-matchers.h"
 
 namespace kythe {
 namespace {
+using ::protobuf_matchers::EqualsProto;
 
 struct MakeURI {
   const char* signature = "";
@@ -216,8 +219,7 @@ TEST(KytheUri, RoundTrip) {
   auto uri_roundtrip = URI::FromString(uri.uri().ToString());
   EXPECT_TRUE(uri_roundtrip.first);
   const auto& other_vname = uri_roundtrip.second.v_name();
-  EXPECT_TRUE(VNameEquals(uri.v_name(), other_vname))
-      << uri.v_name().DebugString() << " versus " << other_vname.DebugString();
+  EXPECT_THAT(uri.v_name(), EqualsProto(other_vname));
 }
 
 TEST(KytheUri, OneSlashRoundTrip) {
@@ -229,8 +231,7 @@ TEST(KytheUri, OneSlashRoundTrip) {
   auto uri_roundtrip = URI::FromString(uri.uri().ToString());
   EXPECT_TRUE(uri_roundtrip.first);
   const auto& other_vname = uri_roundtrip.second.v_name();
-  EXPECT_TRUE(VNameEquals(uri.v_name(), other_vname))
-      << uri.v_name().DebugString() << " versus " << other_vname.DebugString();
+  EXPECT_THAT(uri.v_name(), EqualsProto(other_vname));
 }
 
 TEST(KytheUri, TwoSlashRoundTrip) {
@@ -242,8 +243,7 @@ TEST(KytheUri, TwoSlashRoundTrip) {
   auto uri_roundtrip = URI::FromString(uri.uri().ToString());
   EXPECT_TRUE(uri_roundtrip.first);
   const auto& other_vname = uri_roundtrip.second.v_name();
-  EXPECT_TRUE(VNameEquals(uri.v_name(), other_vname))
-      << uri.v_name().DebugString() << " versus " << other_vname.DebugString();
+  EXPECT_THAT(uri.v_name(), EqualsProto(other_vname));
 }
 
 // TODO(zarko): Check the "////////" corpus once we settle whether corpus

--- a/kythe/cxx/extractor/testdata/BUILD
+++ b/kythe/cxx/extractor/testdata/BUILD
@@ -28,6 +28,7 @@ cc_test(
         "//kythe/proto:analysis_cc_proto",
         "//third_party:gmock_main",
         "//third_party:gtest",
+        "@com_github_inazarenko_protobuf_matchers//protobuf-matchers",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/types:optional",
     ],
@@ -42,6 +43,7 @@ cc_test(
         "//kythe/proto:analysis_cc_proto",
         "//third_party:gmock_main",
         "//third_party:gtest",
+        "@com_github_inazarenko_protobuf_matchers//protobuf-matchers",
         "@com_google_absl//absl/strings",
     ],
 )
@@ -57,6 +59,7 @@ cc_test(
         "//kythe/proto:analysis_cc_proto",
         "//third_party:gmock_main",
         "//third_party:gtest",
+        "@com_github_inazarenko_protobuf_matchers//protobuf-matchers",
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/strings",
     ],
@@ -73,6 +76,7 @@ cc_test(
         "//kythe/proto:analysis_cc_proto",
         "//third_party:gmock_main",
         "//third_party:gtest",
+        "@com_github_inazarenko_protobuf_matchers//protobuf-matchers",
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/strings",
     ],
@@ -91,6 +95,7 @@ cc_test(
         "//kythe/proto:analysis_cc_proto",
         "//third_party:gmock_main",
         "//third_party:gtest",
+        "@com_github_inazarenko_protobuf_matchers//protobuf-matchers",
         "@com_google_absl//absl/strings",
     ],
 )
@@ -158,6 +163,7 @@ cc_test(
         "//kythe/proto:analysis_cc_proto",
         "//third_party:gmock_main",
         "//third_party:gtest",
+        "@com_github_inazarenko_protobuf_matchers//protobuf-matchers",
         "@com_google_absl//absl/strings",
     ],
 )
@@ -175,6 +181,7 @@ cc_test(
         "//kythe/proto:analysis_cc_proto",
         "//third_party:gmock_main",
         "//third_party:gtest",
+        "@com_github_inazarenko_protobuf_matchers//protobuf-matchers",
         "@com_google_absl//absl/strings",
     ],
 )
@@ -191,6 +198,7 @@ cc_test(
         "//kythe/proto:analysis_cc_proto",
         "//third_party:gmock_main",
         "//third_party:gtest",
+        "@com_github_inazarenko_protobuf_matchers//protobuf-matchers",
         "@com_google_absl//absl/strings",
     ],
 )
@@ -208,6 +216,7 @@ cc_test(
         "//kythe/proto:analysis_cc_proto",
         "//third_party:gmock_main",
         "//third_party:gtest",
+        "@com_github_inazarenko_protobuf_matchers//protobuf-matchers",
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/strings",
     ],
@@ -228,6 +237,7 @@ cc_test(
         "//kythe/proto:buildinfo_cc_proto",
         "//third_party:gmock_main",
         "//third_party:gtest",
+        "@com_github_inazarenko_protobuf_matchers//protobuf-matchers",
         "@com_google_absl//absl/strings",
         "@com_google_protobuf//:protobuf",
     ],
@@ -248,6 +258,7 @@ cc_test(
         "//kythe/proto:analysis_cc_proto",
         "//third_party:gmock_main",
         "//third_party:gtest",
+        "@com_github_inazarenko_protobuf_matchers//protobuf-matchers",
         "@com_google_absl//absl/strings",
     ],
 )

--- a/kythe/cxx/extractor/testdata/alternate_platform_test.cc
+++ b/kythe/cxx/extractor/testdata/alternate_platform_test.cc
@@ -19,46 +19,43 @@
 #include "gtest/gtest.h"
 #include "kythe/cxx/extractor/testlib.h"
 #include "kythe/proto/analysis.pb.h"
+#include "protobuf-matchers/protocol-buffer-matchers.h"
 
 namespace kythe {
 namespace {
 using ::kythe::proto::CompilationUnit;
+using ::protobuf_matchers::EquivToProto;
 
-constexpr absl::string_view kExpectedCompilation = R"(
-v_name {
-  language: "c++"
-}
-required_input {
-  v_name {
-    path: "kythe/cxx/extractor/testdata/arm.cc"
-  }
-  info {
-    path: "./kythe/cxx/extractor/testdata/arm.cc"
-    digest: "122b0dc24be3e4d4360ceffdbc00bdd2d6c4ea0600befbad7fbeac1946a9c677"
-  }
-  details {
-    [type.googleapis.com/kythe.proto.ContextDependentVersion] {
-      row {
-        source_context: "hash0"
-        always_process: true
+CompilationUnit ExpectedCompilation() {
+  return ParseTextCompilationUnitOrDie(R"pb(
+    v_name { language: "c++" }
+    required_input {
+      v_name { path: "kythe/cxx/extractor/testdata/arm.cc" }
+      info {
+        path: "./kythe/cxx/extractor/testdata/arm.cc"
+        digest: "122b0dc24be3e4d4360ceffdbc00bdd2d6c4ea0600befbad7fbeac1946a9c677"
+      }
+      details {
+        [type.googleapis.com/kythe.proto.ContextDependentVersion] {
+          row { source_context: "hash0" always_process: true }
+        }
       }
     }
-  }
+    argument: "arm-none-linux-gnueabi-g++"
+    argument: "-target"
+    argument: "armv4t-none-linux-gnueabi"
+    argument: "-DKYTHE_IS_RUNNING=1"
+    argument: "-resource-dir"
+    argument: "/kythe_builtins"
+    argument: "--target=arm-none-linux-gnueabi"
+    argument: "--driver-mode=g++"
+    argument: "-Ikythe/cxx/extractor"
+    argument: "./kythe/cxx/extractor/testdata/arm.cc"
+    argument: "-fsyntax-only"
+    source_file: "./kythe/cxx/extractor/testdata/arm.cc"
+    working_directory: "/root"
+    entry_context: "hash0")pb");
 }
-argument: "arm-none-linux-gnueabi-g++"
-argument: "-target"
-argument: "armv4t-none-linux-gnueabi"
-argument: "-DKYTHE_IS_RUNNING=1"
-argument: "-resource-dir"
-argument: "/kythe_builtins"
-argument: "--target=arm-none-linux-gnueabi"
-argument: "--driver-mode=g++"
-argument: "-Ikythe/cxx/extractor"
-argument: "./kythe/cxx/extractor/testdata/arm.cc"
-argument: "-fsyntax-only"
-source_file: "./kythe/cxx/extractor/testdata/arm.cc"
-working_directory: "/root"
-entry_context: "hash0")";
 
 TEST(CxxExtractorTest, TestAlternatePlatformExtraction) {
   CompilationUnit unit = ExtractSingleCompilationOrDie(
@@ -70,7 +67,7 @@ TEST(CxxExtractorTest, TestAlternatePlatformExtraction) {
   CanonicalizeHashes(&unit);
   unit.clear_details();
 
-  EXPECT_THAT(unit, EquivToCompilation(kExpectedCompilation));
+  EXPECT_THAT(unit, EquivToProto(ExpectedCompilation()));
 }
 
 }  // namespace

--- a/kythe/cxx/extractor/testdata/build_config_test.cc
+++ b/kythe/cxx/extractor/testdata/build_config_test.cc
@@ -21,53 +21,50 @@
 #include "kythe/cxx/extractor/testlib.h"
 #include "kythe/proto/analysis.pb.h"
 #include "kythe/proto/buildinfo.pb.h"
+#include "protobuf-matchers/protocol-buffer-matchers.h"
 
 namespace kythe {
 namespace {
+using ::protobuf_matchers::EquivToProto;
 
-constexpr absl::string_view kExpectedCompilation = R"(
-v_name {
-  language: "c++"
-}
-required_input {
-  v_name {
-    path: "kythe/cxx/extractor/testdata/build_config.cc"
-  }
-  info {
-    path: "./kythe/cxx/extractor/testdata/build_config.cc"
-    digest: "49e4a60bd04c5ec2070a81f53d7a19db4a3538db6764e5804047c219be5f9309"
-  }
-  details {
-    [type.googleapis.com/kythe.proto.ContextDependentVersion] {
-      row {
-        source_context: "hash0"
-        always_process: true
+proto::CompilationUnit ExpectedCompilation() {
+  return ParseTextCompilationUnitOrDie(R"pb(
+    v_name { language: "c++" }
+    required_input {
+      v_name { path: "kythe/cxx/extractor/testdata/build_config.cc" }
+      info {
+        path: "./kythe/cxx/extractor/testdata/build_config.cc"
+        digest: "49e4a60bd04c5ec2070a81f53d7a19db4a3538db6764e5804047c219be5f9309"
+      }
+      details {
+        [type.googleapis.com/kythe.proto.ContextDependentVersion] {
+          row { source_context: "hash0" always_process: true }
+        }
       }
     }
-  }
+    argument: "/dummy/bin/g++"
+    argument: "-target"
+    argument: "dummy-target"
+    argument: "-DKYTHE_IS_RUNNING=1"
+    argument: "-resource-dir"
+    argument: "/kythe_builtins"
+    argument: "--driver-mode=g++"
+    argument: "-I./kythe/cxx/extractor"
+    argument: "./kythe/cxx/extractor/testdata/build_config.cc"
+    argument: "-fsyntax-only"
+    source_file: "./kythe/cxx/extractor/testdata/build_config.cc"
+    working_directory: "/root"
+    entry_context: "hash0"
+    details {
+      # The TextFormat parser does not like our custom type_url, but generally
+      # disregards the part before the type name.
+      [type.googleapis.com/kythe.proto.BuildDetails] {
+        build_target: "//this/is/a/build:target"
+        build_config: "test-build-config"
+      }
+    }
+  )pb");
 }
-argument: "/dummy/bin/g++"
-argument: "-target"
-argument: "dummy-target"
-argument: "-DKYTHE_IS_RUNNING=1"
-argument: "-resource-dir"
-argument: "/kythe_builtins"
-argument: "--driver-mode=g++"
-argument: "-I./kythe/cxx/extractor"
-argument: "./kythe/cxx/extractor/testdata/build_config.cc"
-argument: "-fsyntax-only"
-source_file: "./kythe/cxx/extractor/testdata/build_config.cc"
-working_directory: "/root"
-entry_context: "hash0"
-details {
-  # The TextFormat parser does not like our custom type_url, but generally
-  # disregards the part before the type name.
-  [type.googleapis.com/kythe.proto.BuildDetails] {
-    build_target: "//this/is/a/build:target"
-    build_config: "test-build-config"
-  }
-}
-)";
 
 TEST(CxxExtractorTest, TestBuildConfigExtraction) {
   google::protobuf::LinkMessageReflection<kythe::proto::BuildDetails>();
@@ -93,7 +90,7 @@ TEST(CxxExtractorTest, TestBuildConfigExtraction) {
           }),
       unit.mutable_details()->end());
 
-  EXPECT_THAT(unit, EquivToCompilation(kExpectedCompilation));
+  EXPECT_THAT(unit, EquivToProto(ExpectedCompilation()));
 }
 
 }  // namespace

--- a/kythe/cxx/extractor/testdata/extract_transcript_test.cc
+++ b/kythe/cxx/extractor/testdata/extract_transcript_test.cc
@@ -19,96 +19,74 @@
 #include "gtest/gtest.h"
 #include "kythe/cxx/extractor/testlib.h"
 #include "kythe/proto/analysis.pb.h"
+#include "protobuf-matchers/protocol-buffer-matchers.h"
 
 namespace kythe {
 namespace {
+using ::protobuf_matchers::EquivToProto;
 
-constexpr absl::string_view kExpectedCompilation = R"(
-v_name {
-  language: "c++"
-}
-required_input {
-  v_name {
-    path: "kythe/cxx/extractor/testdata/transcript_main.cc"
-  }
-  info {
-    path: "./kythe/cxx/extractor/testdata/transcript_main.cc"
-    digest: "a719ebca696362eb639992c5afd3b08ab6c1938bc5639fdfe1fde06fd86bd622"
-  }
-  details {
-    [type.googleapis.com/kythe.proto.ContextDependentVersion] {
-      row {
-        source_context: "hash0"
-        always_process: true
-        column {
-          offset: 20
-          linked_context: "hash1"
-        }
-        column {
-          offset: 46
-          linked_context: "hash2"
-        }
-        column {
-          offset: 72
-          linked_context: "hash3"
-        }
-        column {
-          offset: 98
-          linked_context: "hash2"
+proto::CompilationUnit ExpectedCompilation() {
+  return ParseTextCompilationUnitOrDie(R"pb(
+    v_name { language: "c++" }
+    required_input {
+      v_name { path: "kythe/cxx/extractor/testdata/transcript_main.cc" }
+      info {
+        path: "./kythe/cxx/extractor/testdata/transcript_main.cc"
+        digest: "a719ebca696362eb639992c5afd3b08ab6c1938bc5639fdfe1fde06fd86bd622"
+      }
+      details {
+        [type.googleapis.com/kythe.proto.ContextDependentVersion] {
+          row {
+            source_context: "hash0"
+            always_process: true
+            column { offset: 20 linked_context: "hash1" }
+            column { offset: 46 linked_context: "hash2" }
+            column { offset: 72 linked_context: "hash3" }
+            column { offset: 98 linked_context: "hash2" }
+          }
         }
       }
     }
-  }
-}
-required_input {
-  v_name {
-    path: "kythe/cxx/extractor/testdata/transcript_a.h"
-  }
-  info {
-    path: "./kythe/cxx/extractor/testdata/transcript_a.h"
-    digest: "15d3490610af31dff6f1be9948ef61e66db48a84fc8fd93a81a5433abab04309"
-  }
-  details {
-    [type.googleapis.com/kythe.proto.ContextDependentVersion] {
-      row {
-        source_context: "hash3"
+    required_input {
+      v_name { path: "kythe/cxx/extractor/testdata/transcript_a.h" }
+      info {
+        path: "./kythe/cxx/extractor/testdata/transcript_a.h"
+        digest: "15d3490610af31dff6f1be9948ef61e66db48a84fc8fd93a81a5433abab04309"
       }
-      row {
-        source_context: "hash1"
+      details {
+        [type.googleapis.com/kythe.proto.ContextDependentVersion] {
+          row { source_context: "hash3" }
+          row { source_context: "hash1" }
+        }
       }
     }
-  }
-}
-required_input {
-  v_name {
-    path: "kythe/cxx/extractor/testdata/transcript_b.h"
-  }
-  info {
-    path: "./kythe/cxx/extractor/testdata/transcript_b.h"
-    digest: "6904079b7b9d5d0586a08dbbdac2b08d35f00c1dbb4cc63721f22a347f52e2f7"
-  }
-  details {
-    [type.googleapis.com/kythe.proto.ContextDependentVersion] {
-      row {
-        source_context: "hash2"
+    required_input {
+      v_name { path: "kythe/cxx/extractor/testdata/transcript_b.h" }
+      info {
+        path: "./kythe/cxx/extractor/testdata/transcript_b.h"
+        digest: "6904079b7b9d5d0586a08dbbdac2b08d35f00c1dbb4cc63721f22a347f52e2f7"
+      }
+      details {
+        [type.googleapis.com/kythe.proto.ContextDependentVersion] {
+          row { source_context: "hash2" }
+        }
       }
     }
-  }
+    argument: "/dummy/bin/g++"
+    argument: "-target"
+    argument: "dummy-target"
+    argument: "-DKYTHE_IS_RUNNING=1"
+    argument: "-resource-dir"
+    argument: "/kythe_builtins"
+    argument: "--driver-mode=g++"
+    argument: "-I./kythe/cxx/extractor/testdata"
+    argument: "./kythe/cxx/extractor/testdata/transcript_main.cc"
+    argument: "-fsyntax-only"
+    source_file: "./kythe/cxx/extractor/testdata/transcript_main.cc"
+    working_directory: "/root"
+    entry_context: "hash0"
+  )pb");
 }
-argument: "/dummy/bin/g++"
-argument: "-target"
-argument: "dummy-target"
-argument: "-DKYTHE_IS_RUNNING=1"
-argument: "-resource-dir"
-argument: "/kythe_builtins"
-argument: "--driver-mode=g++"
-argument: "-I./kythe/cxx/extractor/testdata"
-argument: "./kythe/cxx/extractor/testdata/transcript_main.cc"
-argument: "-fsyntax-only"
-source_file: "./kythe/cxx/extractor/testdata/transcript_main.cc"
-working_directory: "/root"
-entry_context: "hash0"
-)";
 
 TEST(CxxExtractorTest, TextExtractedTranscript) {
   kythe::proto::CompilationUnit unit = ExtractSingleCompilationOrDie({{
@@ -121,7 +99,7 @@ TEST(CxxExtractorTest, TextExtractedTranscript) {
   unit.clear_details();
   unit.set_argument(2, "dummy-target");
 
-  EXPECT_THAT(unit, EquivToCompilation(kExpectedCompilation));
+  EXPECT_THAT(unit, EquivToProto(ExpectedCompilation()));
 }
 
 }  // namespace

--- a/kythe/cxx/extractor/testdata/has_include_test.cc
+++ b/kythe/cxx/extractor/testdata/has_include_test.cc
@@ -19,54 +19,49 @@
 #include "gtest/gtest.h"
 #include "kythe/cxx/extractor/testlib.h"
 #include "kythe/proto/analysis.pb.h"
+#include "protobuf-matchers/protocol-buffer-matchers.h"
 
 namespace kythe {
 namespace {
+using ::protobuf_matchers::EquivToProto;
 
-constexpr absl::string_view kExpectedCompilation = R"(
-v_name {
-  language: "c++"
-}
-required_input {
-  v_name {
-    path: "kythe/cxx/extractor/testdata/has_include.cc"
-  }
-  info {
-    path: "./kythe/cxx/extractor/testdata/has_include.cc"
-    digest: "e677eeace3b0ee0d5c67483c320c519d5c2add77fa67637ca78fabdb3729666e"
-  }
-  details {
-    [type.googleapis.com/kythe.proto.ContextDependentVersion] {
-      row {
-        source_context: "hash0"
-        always_process: true
+proto::CompilationUnit ExpectedCompilation() {
+  return ParseTextCompilationUnitOrDie(R"pb(
+    v_name { language: "c++" }
+    required_input {
+      v_name { path: "kythe/cxx/extractor/testdata/has_include.cc" }
+      info {
+        path: "./kythe/cxx/extractor/testdata/has_include.cc"
+        digest: "e677eeace3b0ee0d5c67483c320c519d5c2add77fa67637ca78fabdb3729666e"
+      }
+      details {
+        [type.googleapis.com/kythe.proto.ContextDependentVersion] {
+          row { source_context: "hash0" always_process: true }
+        }
       }
     }
-  }
+    required_input {
+      v_name { path: "kythe/cxx/extractor/testdata/has_include.h" }
+      info {
+        path: "./kythe/cxx/extractor/testdata/has_include.h"
+        digest: "ebebe3a0bf6fb1d21593bcf52d899124ea175ac04eae16a366ed0b9220ae0d06"
+      }
+    }
+    argument: "/dummy/bin/clang++"
+    argument: "-target"
+    argument: "dummy-target"
+    argument: "-DKYTHE_IS_RUNNING=1"
+    argument: "-resource-dir"
+    argument: "/kythe_builtins"
+    argument: "--driver-mode=g++"
+    argument: "-I./kythe/cxx/extractor"
+    argument: "./kythe/cxx/extractor/testdata/has_include.cc"
+    argument: "-fsyntax-only"
+    source_file: "./kythe/cxx/extractor/testdata/has_include.cc"
+    working_directory: "/root"
+    entry_context: "hash0"
+  )pb");
 }
-required_input {
-  v_name {
-    path: "kythe/cxx/extractor/testdata/has_include.h"
-  }
-  info {
-    path: "./kythe/cxx/extractor/testdata/has_include.h"
-    digest: "ebebe3a0bf6fb1d21593bcf52d899124ea175ac04eae16a366ed0b9220ae0d06"
-  }
-}
-argument: "/dummy/bin/clang++"
-argument: "-target"
-argument: "dummy-target"
-argument: "-DKYTHE_IS_RUNNING=1"
-argument: "-resource-dir"
-argument: "/kythe_builtins"
-argument: "--driver-mode=g++"
-argument: "-I./kythe/cxx/extractor"
-argument: "./kythe/cxx/extractor/testdata/has_include.cc"
-argument: "-fsyntax-only"
-source_file: "./kythe/cxx/extractor/testdata/has_include.cc"
-working_directory: "/root"
-entry_context: "hash0"
-)";
 
 TEST(CxxExtractorTest, TextHasIncludeExtraction) {
   kythe::proto::CompilationUnit unit = ExtractSingleCompilationOrDie({{
@@ -79,7 +74,7 @@ TEST(CxxExtractorTest, TextHasIncludeExtraction) {
   unit.clear_details();
   unit.set_argument(2, "dummy-target");
 
-  EXPECT_THAT(unit, EquivToCompilation(kExpectedCompilation));
+  EXPECT_THAT(unit, EquivToProto(ExpectedCompilation()));
 }
 
 }  // namespace

--- a/kythe/cxx/extractor/testdata/indirect_has_include_test.cc
+++ b/kythe/cxx/extractor/testdata/indirect_has_include_test.cc
@@ -19,84 +19,73 @@
 #include "gtest/gtest.h"
 #include "kythe/cxx/extractor/testlib.h"
 #include "kythe/proto/analysis.pb.h"
+#include "protobuf-matchers/protocol-buffer-matchers.h"
 
 namespace kythe {
 namespace {
+using ::protobuf_matchers::EquivToProto;
 
-constexpr absl::string_view kExpectedCompilation = R"(
-v_name {
-  language: "c++"
-}
-required_input {
-  v_name {
-    path: "kythe/cxx/extractor/testdata/indirect_has_include.cc"
-  }
-  info {
-    path: "./kythe/cxx/extractor/testdata/indirect_has_include.cc"
-    digest: "6b406c26560e435ba485a141440055fc21c55492b41653003e13715292b7d76d"
-  }
-  details {
-    [type.googleapis.com/kythe.proto.ContextDependentVersion] {
-      row {
-        source_context: "hash0"
-        always_process: true
-        column {
-          offset: 35
-          linked_context: "hash1"
+proto::CompilationUnit ExpectedCompilation() {
+  return ParseTextCompilationUnitOrDie(R"pb(
+    v_name { language: "c++" }
+    required_input {
+      v_name { path: "kythe/cxx/extractor/testdata/indirect_has_include.cc" }
+      info {
+        path: "./kythe/cxx/extractor/testdata/indirect_has_include.cc"
+        digest: "6b406c26560e435ba485a141440055fc21c55492b41653003e13715292b7d76d"
+      }
+      details {
+        [type.googleapis.com/kythe.proto.ContextDependentVersion] {
+          row {
+            source_context: "hash0"
+            always_process: true
+            column { offset: 35 linked_context: "hash1" }
+          }
         }
       }
     }
-  }
-}
-required_input {
-  v_name {
-    path: "kythe/cxx/extractor/testdata/has_include.h"
-  }
-  info {
-    path: "./kythe/cxx/extractor/testdata/./has_include.h"
-    digest: "ebebe3a0bf6fb1d21593bcf52d899124ea175ac04eae16a366ed0b9220ae0d06"
-  }
-  details {
-    [type.googleapis.com/kythe.proto.ContextDependentVersion] {
-      row {
-        source_context: "hash2"
+    required_input {
+      v_name { path: "kythe/cxx/extractor/testdata/has_include.h" }
+      info {
+        path: "./kythe/cxx/extractor/testdata/./has_include.h"
+        digest: "ebebe3a0bf6fb1d21593bcf52d899124ea175ac04eae16a366ed0b9220ae0d06"
       }
-    }
-  }
-}
-required_input {
-  v_name {
-    path: "kythe/cxx/extractor/testdata/indirect_has_include.h"
-  }
-  info {
-    path: "./kythe/cxx/extractor/testdata/indirect_has_include.h"
-    digest: "e92d9e48bed6844a99ebc827f38300af75762c2c2516b98dc560e680568a677a"
-  }
-  details {
-    [type.googleapis.com/kythe.proto.ContextDependentVersion] {
-      row {
-        source_context: "hash1"
-        column {
-          linked_context: "hash2"
+      details {
+        [type.googleapis.com/kythe.proto.ContextDependentVersion] {
+          row { source_context: "hash2" }
         }
       }
     }
-  }
+    required_input {
+      v_name { path: "kythe/cxx/extractor/testdata/indirect_has_include.h" }
+      info {
+        path: "./kythe/cxx/extractor/testdata/indirect_has_include.h"
+        digest: "e92d9e48bed6844a99ebc827f38300af75762c2c2516b98dc560e680568a677a"
+      }
+      details {
+        [type.googleapis.com/kythe.proto.ContextDependentVersion] {
+          row {
+            source_context: "hash1"
+            column { linked_context: "hash2" }
+          }
+        }
+      }
+    }
+    argument: "/dummy/bin/clang++"
+    argument: "-target"
+    argument: "dummy-target"
+    argument: "-DKYTHE_IS_RUNNING=1"
+    argument: "-resource-dir"
+    argument: "/kythe_builtins"
+    argument: "--driver-mode=g++"
+    argument: "-I./kythe/cxx/extractor"
+    argument: "./kythe/cxx/extractor/testdata/indirect_has_include.cc"
+    argument: "-fsyntax-only"
+    source_file: "./kythe/cxx/extractor/testdata/indirect_has_include.cc"
+    working_directory: "/root"
+    entry_context: "hash0"
+  )pb");
 }
-argument: "/dummy/bin/clang++"
-argument: "-target"
-argument: "dummy-target"
-argument: "-DKYTHE_IS_RUNNING=1"
-argument: "-resource-dir"
-argument: "/kythe_builtins"
-argument: "--driver-mode=g++"
-argument: "-I./kythe/cxx/extractor"
-argument: "./kythe/cxx/extractor/testdata/indirect_has_include.cc"
-argument: "-fsyntax-only"
-source_file: "./kythe/cxx/extractor/testdata/indirect_has_include.cc"
-working_directory: "/root"
-entry_context: "hash0"
-)";
 
 TEST(CxxExtractorTest, TextHasIncludeExtraction) {
   kythe::proto::CompilationUnit unit = ExtractSingleCompilationOrDie({{
@@ -109,7 +98,7 @@ TEST(CxxExtractorTest, TextHasIncludeExtraction) {
   unit.clear_details();
   unit.set_argument(2, "dummy-target");
 
-  EXPECT_THAT(unit, EquivToCompilation(kExpectedCompilation));
+  EXPECT_THAT(unit, EquivToProto(ExpectedCompilation()));
 }
 
 }  // namespace

--- a/kythe/cxx/extractor/testdata/installed_dir_test.cc
+++ b/kythe/cxx/extractor/testdata/installed_dir_test.cc
@@ -19,78 +19,74 @@
 #include "gtest/gtest.h"
 #include "kythe/cxx/extractor/testlib.h"
 #include "kythe/proto/analysis.pb.h"
+#include "protobuf-matchers/protocol-buffer-matchers.h"
 
 namespace kythe {
 namespace {
+using ::protobuf_matchers::EquivToProto;
 
-constexpr absl::string_view kExpectedCompilation = R"(
-v_name {
-  language: "c++"
-}
-required_input {
-  v_name {
-    path: "kythe/cxx/extractor/testdata/installed_dir.cc"
-  }
-  info {
-    path: "./kythe/cxx/extractor/testdata/installed_dir.cc"
-    digest: "fb21e5e71e3b8f54ebf5a84fc2955fb4f893111fdfa0d7fe8be936b32add3f56"
-  }
-  details {
-    [type.googleapis.com/kythe.proto.ContextDependentVersion] {
-      row {
-        source_context: "hash0"
-        always_process: true
-        column {
-          linked_context: "hash1"
+proto::CompilationUnit ExpectedCompilation() {
+  return ParseTextCompilationUnitOrDie(R"pb(
+    v_name { language: "c++" }
+    required_input {
+      v_name { path: "kythe/cxx/extractor/testdata/installed_dir.cc" }
+      info {
+        path: "./kythe/cxx/extractor/testdata/installed_dir.cc"
+        digest: "fb21e5e71e3b8f54ebf5a84fc2955fb4f893111fdfa0d7fe8be936b32add3f56"
+      }
+      details {
+        [type.googleapis.com/kythe.proto.ContextDependentVersion] {
+          row {
+            source_context: "hash0"
+            always_process: true
+            column { linked_context: "hash1" }
+          }
         }
       }
     }
-  }
-}
-required_input {
-  v_name {
-    path: "kythe/cxx/extractor/testdata/include/c++/v1/dummy"
-  }
-  info {
-    path: "kythe/cxx/extractor/testdata/bin/../include/c++/v1/dummy"
-    digest: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-  }
-  details {
-    [type.googleapis.com/kythe.proto.ContextDependentVersion] {
-      row {
-        source_context: "hash1"
+    required_input {
+      v_name { path: "kythe/cxx/extractor/testdata/include/c++/v1/dummy" }
+      info {
+        path: "kythe/cxx/extractor/testdata/bin/../include/c++/v1/dummy"
+        digest: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      }
+      details {
+        [type.googleapis.com/kythe.proto.ContextDependentVersion] {
+          row { source_context: "hash1" }
+        }
       }
     }
-  }
+    argument: "kythe/cxx/extractor/testdata/bin/clang++"
+    argument: "-target"
+    argument: "dummy-target"
+    argument: "-DKYTHE_IS_RUNNING=1"
+    argument: "-resource-dir"
+    argument: "/kythe_builtins"
+    argument: "--driver-mode=g++"
+    argument: "-stdlib=libc++"
+    argument: "-v"
+    argument: "./kythe/cxx/extractor/testdata/installed_dir.cc"
+    argument: "-fsyntax-only"
+    source_file: "./kythe/cxx/extractor/testdata/installed_dir.cc"
+    working_directory: "/root"
+    entry_context: "hash0"
+  )pb");
 }
-argument: "kythe/cxx/extractor/testdata/bin/clang++"
-argument: "-target"
-argument: "dummy-target"
-argument: "-DKYTHE_IS_RUNNING=1"
-argument: "-resource-dir"
-argument: "/kythe_builtins"
-argument: "--driver-mode=g++"
-argument: "-stdlib=libc++"
-argument: "-v"
-argument: "./kythe/cxx/extractor/testdata/installed_dir.cc"
-argument: "-fsyntax-only"
-source_file: "./kythe/cxx/extractor/testdata/installed_dir.cc"
-working_directory: "/root"
-entry_context: "hash0"
-)";
 
 TEST(CxxExtractorTest, TestInstalledClangExtraction) {
   kythe::proto::CompilationUnit unit = ExtractSingleCompilationOrDie({{
       "--with_executable",
       "kythe/cxx/extractor/testdata/bin/clang++",
-      "-stdlib=libc++","-E", "-v", // On failure, dump the search path.
+      "-stdlib=libc++",
+      "-E",
+      "-v",  // On failure, dump the search path.
       "./kythe/cxx/extractor/testdata/installed_dir.cc",
   }});
   CanonicalizeHashes(&unit);
   unit.set_argument(2, "dummy-target");
   unit.clear_details();
 
-  EXPECT_THAT(unit, EquivToCompilation(kExpectedCompilation));
+  EXPECT_THAT(unit, EquivToProto(ExpectedCompilation()));
 }
 
 }  // namespace

--- a/kythe/cxx/extractor/testdata/main_source_file_env_dep_test.cc
+++ b/kythe/cxx/extractor/testdata/main_source_file_env_dep_test.cc
@@ -20,47 +20,46 @@
 #include "gtest/gtest.h"
 #include "kythe/cxx/extractor/testlib.h"
 #include "kythe/proto/analysis.pb.h"
+#include "protobuf-matchers/protocol-buffer-matchers.h"
 
 namespace kythe {
 namespace {
 using ::kythe::proto::CompilationUnit;
+using ::protobuf_matchers::EquivToProto;
 
-constexpr absl::string_view kExpectedCompilation = R"(
-v_name {
-  language: "c++"
-}
-required_input {
-  v_name {
-    path: "kythe/cxx/extractor/testdata/main_source_file_env_dep.cc"
-  }
-  info {
-    path: "./kythe/cxx/extractor/testdata/main_source_file_env_dep.cc"
-    digest: "7fc8bce46febc9e8c660fdaa7caa9e27e64a9f85769d69ca9ecfc8a2ca751335"
-  }
-  details {
-    [type.googleapis.com/kythe.proto.ContextDependentVersion] {
-      row {
-        source_context: "hash0"
-        always_process: true
+proto::CompilationUnit ExpectedCompilation() {
+  return ParseTextCompilationUnitOrDie(R"pb(
+    v_name { language: "c++" }
+    required_input {
+      v_name {
+        path: "kythe/cxx/extractor/testdata/main_source_file_env_dep.cc"
+      }
+      info {
+        path: "./kythe/cxx/extractor/testdata/main_source_file_env_dep.cc"
+        digest: "7fc8bce46febc9e8c660fdaa7caa9e27e64a9f85769d69ca9ecfc8a2ca751335"
+      }
+      details {
+        [type.googleapis.com/kythe.proto.ContextDependentVersion] {
+          row { source_context: "hash0" always_process: true }
+        }
       }
     }
-  }
+    argument: "/dummy/bin/g++"
+    argument: "-target"
+    argument: "dummy-target"
+    argument: "-DKYTHE_IS_RUNNING=1"
+    argument: "-resource-dir"
+    argument: "/kythe_builtins"
+    argument: "--driver-mode=g++"
+    argument: "-I./kythe/cxx/extractor/testdata"
+    argument: "-DMACRO"
+    argument: "./kythe/cxx/extractor/testdata/main_source_file_env_dep.cc"
+    argument: "-fsyntax-only"
+    source_file: "./kythe/cxx/extractor/testdata/main_source_file_env_dep.cc"
+    working_directory: "/root"
+    entry_context: "hash0"
+  )pb");
 }
-argument: "/dummy/bin/g++"
-argument: "-target"
-argument: "dummy-target"
-argument: "-DKYTHE_IS_RUNNING=1"
-argument: "-resource-dir"
-argument: "/kythe_builtins"
-argument: "--driver-mode=g++"
-argument: "-I./kythe/cxx/extractor/testdata"
-argument: "-DMACRO"
-argument: "./kythe/cxx/extractor/testdata/main_source_file_env_dep.cc"
-argument: "-fsyntax-only"
-source_file: "./kythe/cxx/extractor/testdata/main_source_file_env_dep.cc"
-working_directory: "/root"
-entry_context: "hash0"
-)";
 
 TEST(CxxExtractorTest, TestSourceFileEnvDepWithoutMacro) {
   CompilationUnit unit = ExtractSingleCompilationOrDie(
@@ -74,13 +73,12 @@ TEST(CxxExtractorTest, TestSourceFileEnvDepWithoutMacro) {
   unit.set_argument(2, "dummy-target");
   unit.clear_details();
 
-  CompilationUnit expected =
-      ParseTextCompilationUnitOrDie(kExpectedCompilation);
+  CompilationUnit expected = ExpectedCompilation();
   // The only difference between the two is the lack of "-DMACRO" arguments.
   expected.mutable_argument()->erase(
       absl::c_find(*expected.mutable_argument(), "-DMACRO"));
 
-  EXPECT_THAT(unit, EquivToCompilation(expected));
+  EXPECT_THAT(unit, EquivToProto(expected));
 }
 
 TEST(CxxExtractorTest, TestSourceFileEnvDepWithMacro) {
@@ -95,7 +93,7 @@ TEST(CxxExtractorTest, TestSourceFileEnvDepWithMacro) {
   unit.set_argument(2, "dummy-target");
   unit.clear_details();
 
-  EXPECT_THAT(unit, EquivToCompilation(kExpectedCompilation));
+  EXPECT_THAT(unit, EquivToProto(ExpectedCompilation()));
 }
 
 }  // namespace

--- a/kythe/cxx/extractor/testdata/main_source_file_no_env_dep_test.cc
+++ b/kythe/cxx/extractor/testdata/main_source_file_no_env_dep_test.cc
@@ -20,47 +20,46 @@
 #include "gtest/gtest.h"
 #include "kythe/cxx/extractor/testlib.h"
 #include "kythe/proto/analysis.pb.h"
+#include "protobuf-matchers/protocol-buffer-matchers.h"
 
 namespace kythe {
 namespace {
 using ::kythe::proto::CompilationUnit;
+using ::protobuf_matchers::EquivToProto;
 
-constexpr absl::string_view kExpectedCompilation = R"(
-v_name {
-  language: "c++"
-}
-required_input {
-  v_name {
-    path: "kythe/cxx/extractor/testdata/main_source_file_no_env_dep.cc"
-  }
-  info {
-    path: "./kythe/cxx/extractor/testdata/main_source_file_no_env_dep.cc"
-    digest: "d4fbc426e39f838a6253845a50f0e0089207ed423f852b08c283e3627bc5d49f"
-  }
-  details {
-    [type.googleapis.com/kythe.proto.ContextDependentVersion] {
-      row {
-        source_context: "hash0"
-        always_process: true
+proto::CompilationUnit ExpectedCompilation() {
+  return ParseTextCompilationUnitOrDie(R"pb(
+    v_name { language: "c++" }
+    required_input {
+      v_name {
+        path: "kythe/cxx/extractor/testdata/main_source_file_no_env_dep.cc"
+      }
+      info {
+        path: "./kythe/cxx/extractor/testdata/main_source_file_no_env_dep.cc"
+        digest: "d4fbc426e39f838a6253845a50f0e0089207ed423f852b08c283e3627bc5d49f"
+      }
+      details {
+        [type.googleapis.com/kythe.proto.ContextDependentVersion] {
+          row { source_context: "hash0" always_process: true }
+        }
       }
     }
-  }
+    argument: "/dummy/bin/g++"
+    argument: "-target"
+    argument: "dummy-target"
+    argument: "-DKYTHE_IS_RUNNING=1"
+    argument: "-resource-dir"
+    argument: "/kythe_builtins"
+    argument: "--driver-mode=g++"
+    argument: "-I./kythe/cxx/extractor/testdata"
+    argument: "-DMACRO"
+    argument: "./kythe/cxx/extractor/testdata/main_source_file_no_env_dep.cc"
+    argument: "-fsyntax-only"
+    source_file: "./kythe/cxx/extractor/testdata/main_source_file_no_env_dep.cc"
+    working_directory: "/root"
+    entry_context: "hash0"
+  )pb");
 }
-argument: "/dummy/bin/g++"
-argument: "-target"
-argument: "dummy-target"
-argument: "-DKYTHE_IS_RUNNING=1"
-argument: "-resource-dir"
-argument: "/kythe_builtins"
-argument: "--driver-mode=g++"
-argument: "-I./kythe/cxx/extractor/testdata"
-argument: "-DMACRO"
-argument: "./kythe/cxx/extractor/testdata/main_source_file_no_env_dep.cc"
-argument: "-fsyntax-only"
-source_file: "./kythe/cxx/extractor/testdata/main_source_file_no_env_dep.cc"
-working_directory: "/root"
-entry_context: "hash0"
-)";
 
 TEST(CxxExtractorTest, TestSourceFileEnvDepWithoutMacro) {
   CompilationUnit unit = ExtractSingleCompilationOrDie(
@@ -74,13 +73,12 @@ TEST(CxxExtractorTest, TestSourceFileEnvDepWithoutMacro) {
   unit.set_argument(2, "dummy-target");
   unit.clear_details();
 
-  CompilationUnit expected =
-      ParseTextCompilationUnitOrDie(kExpectedCompilation);
+  CompilationUnit expected = ExpectedCompilation();
   // The only difference between the two is the lack of "-DMACRO" arguments.
   expected.mutable_argument()->erase(
       absl::c_find(*expected.mutable_argument(), "-DMACRO"));
 
-  EXPECT_THAT(unit, EquivToCompilation(expected));
+  EXPECT_THAT(unit, EquivToProto(expected));
 }
 
 TEST(CxxExtractorTest, TestSourceFileEnvDepWithMacro) {
@@ -95,7 +93,7 @@ TEST(CxxExtractorTest, TestSourceFileEnvDepWithMacro) {
   unit.set_argument(2, "dummy-target");
   unit.clear_details();
 
-  EXPECT_THAT(unit, EquivToCompilation(kExpectedCompilation));
+  EXPECT_THAT(unit, EquivToProto(ExpectedCompilation()));
 }
 
 }  // namespace

--- a/kythe/cxx/extractor/testdata/metadata_test.cc
+++ b/kythe/cxx/extractor/testdata/metadata_test.cc
@@ -19,54 +19,49 @@
 #include "gtest/gtest.h"
 #include "kythe/cxx/extractor/testlib.h"
 #include "kythe/proto/analysis.pb.h"
+#include "protobuf-matchers/protocol-buffer-matchers.h"
 
 namespace kythe {
 namespace {
+using ::protobuf_matchers::EquivToProto;
 
-constexpr absl::string_view kExpectedCompilation = R"(
-v_name {
-  language: "c++"
-}
-required_input {
-  v_name {
-    path: "kythe/cxx/extractor/testdata/metadata.cc"
-  }
-  info {
-    path: "./kythe/cxx/extractor/testdata/metadata.cc"
-    digest: "72269be69625ca9015a59bf7342dce1a30e96ddda51196c9f6ae6c4cbdefb7ea"
-  }
-  details {
-    [type.googleapis.com/kythe.proto.ContextDependentVersion] {
-      row {
-        source_context: "hash0"
-        always_process: true
+proto::CompilationUnit ExpectedCompilation() {
+  return ParseTextCompilationUnitOrDie(R"pb(
+    v_name { language: "c++" }
+    required_input {
+      v_name { path: "kythe/cxx/extractor/testdata/metadata.cc" }
+      info {
+        path: "./kythe/cxx/extractor/testdata/metadata.cc"
+        digest: "72269be69625ca9015a59bf7342dce1a30e96ddda51196c9f6ae6c4cbdefb7ea"
+      }
+      details {
+        [type.googleapis.com/kythe.proto.ContextDependentVersion] {
+          row { source_context: "hash0" always_process: true }
+        }
       }
     }
-  }
+    required_input {
+      v_name { path: "kythe/cxx/extractor/testdata/metadata.cc.meta" }
+      info {
+        path: "./kythe/cxx/extractor/testdata/metadata.cc.meta"
+        digest: "1d6faa9e1a76d13f3ab8558a3640158b1f0a54f624a4e37ddc3ef41ed4191058"
+      }
+    }
+    argument: "/dummy/bin/g++"
+    argument: "-target"
+    argument: "dummy-target"
+    argument: "-DKYTHE_IS_RUNNING=1"
+    argument: "-resource-dir"
+    argument: "/kythe_builtins"
+    argument: "--driver-mode=g++"
+    argument: "-I./kythe/cxx/extractor"
+    argument: "./kythe/cxx/extractor/testdata/metadata.cc"
+    argument: "-fsyntax-only"
+    source_file: "./kythe/cxx/extractor/testdata/metadata.cc"
+    working_directory: "/root"
+    entry_context: "hash0"
+  )pb");
 }
-required_input {
-  v_name {
-    path: "kythe/cxx/extractor/testdata/metadata.cc.meta"
-  }
-  info {
-    path: "./kythe/cxx/extractor/testdata/metadata.cc.meta"
-    digest: "1d6faa9e1a76d13f3ab8558a3640158b1f0a54f624a4e37ddc3ef41ed4191058"
-  }
-}
-argument: "/dummy/bin/g++"
-argument: "-target"
-argument: "dummy-target"
-argument: "-DKYTHE_IS_RUNNING=1"
-argument: "-resource-dir"
-argument: "/kythe_builtins"
-argument: "--driver-mode=g++"
-argument: "-I./kythe/cxx/extractor"
-argument: "./kythe/cxx/extractor/testdata/metadata.cc"
-argument: "-fsyntax-only"
-source_file: "./kythe/cxx/extractor/testdata/metadata.cc"
-working_directory: "/root"
-entry_context: "hash0"
-)";
 
 TEST(CxxExtractorTest, TextMetadataExtraction) {
   kythe::proto::CompilationUnit unit = ExtractSingleCompilationOrDie({{
@@ -79,7 +74,7 @@ TEST(CxxExtractorTest, TextMetadataExtraction) {
   unit.clear_details();
   unit.set_argument(2, "dummy-target");
 
-  EXPECT_THAT(unit, EquivToCompilation(kExpectedCompilation));
+  EXPECT_THAT(unit, EquivToProto(ExpectedCompilation()));
 }
 }  // namespace
 }  // namespace kythe

--- a/kythe/cxx/extractor/testdata/modules_test.cc
+++ b/kythe/cxx/extractor/testdata/modules_test.cc
@@ -21,65 +21,58 @@
 #include "gtest/gtest.h"
 #include "kythe/cxx/extractor/testlib.h"
 #include "kythe/proto/analysis.pb.h"
+#include "protobuf-matchers/protocol-buffer-matchers.h"
 
 namespace kythe {
 namespace {
+using ::protobuf_matchers::EquivToProto;
 
-constexpr absl::string_view kExpectedCompilation = R"(
-v_name {
-  language: "c++"
-}
-required_input {
-  v_name {
-    path: "kythe/cxx/extractor/testdata/modules.cc"
-  }
-  info {
-    path: "./kythe/cxx/extractor/testdata/modules.cc"
-    digest: "65f89e233c735e33c51ab2445b0586b102d03430d3ed177e021a33b1fffeac9f"
-  }
-  details {
-    [type.googleapis.com/kythe.proto.ContextDependentVersion] {
-      row {
-        source_context: "hash0"
-        always_process: true
+proto::CompilationUnit ExpectedCompilation() {
+  return ParseTextCompilationUnitOrDie(R"pb(
+    v_name { language: "c++" }
+    required_input {
+      v_name { path: "kythe/cxx/extractor/testdata/modules.cc" }
+      info {
+        path: "./kythe/cxx/extractor/testdata/modules.cc"
+        digest: "65f89e233c735e33c51ab2445b0586b102d03430d3ed177e021a33b1fffeac9f"
+      }
+      details {
+        [type.googleapis.com/kythe.proto.ContextDependentVersion] {
+          row { source_context: "hash0" always_process: true }
+        }
       }
     }
-  }
+    required_input {
+      v_name { path: "kythe/cxx/extractor/testdata/modfoo.h" }
+      info {
+        path: "./kythe/cxx/extractor/testdata/modfoo.h"
+        digest: "cd8c82152d321ecfa60a7ab3ccec78ad7168abf22dd93150ccee7fea420ad432"
+      }
+    }
+    required_input {
+      v_name { path: "kythe/cxx/extractor/testdata/modfoo.modulemap" }
+      info {
+        path: "kythe/cxx/extractor/testdata/modfoo.modulemap"
+        digest: "94416d419ecab4bce80084ef89587c4ca31a3cabad12498bd98aa213b1dd5189"
+      }
+    }
+    argument: "/dummy/bin/g++"
+    argument: "-target"
+    argument: "dummy-target"
+    argument: "-DKYTHE_IS_RUNNING=1"
+    argument: "-resource-dir"
+    argument: "/kythe_builtins"
+    argument: "--driver-mode=g++"
+    argument: "-fmodules"
+    argument: "-fmodule-map-file=kythe/cxx/extractor/testdata/modfoo.modulemap"
+    argument: "-I./kythe/cxx/extractor"
+    argument: "./kythe/cxx/extractor/testdata/modules.cc"
+    argument: "-fsyntax-only"
+    source_file: "./kythe/cxx/extractor/testdata/modules.cc"
+    working_directory: "/root"
+    entry_context: "hash0"
+  )pb");
 }
-required_input {
-  v_name {
-    path: "kythe/cxx/extractor/testdata/modfoo.h"
-  }
-  info {
-    path: "./kythe/cxx/extractor/testdata/modfoo.h"
-    digest: "cd8c82152d321ecfa60a7ab3ccec78ad7168abf22dd93150ccee7fea420ad432"
-  }
-}
-required_input {
-  v_name {
-    path: "kythe/cxx/extractor/testdata/modfoo.modulemap"
-  }
-  info {
-    path: "kythe/cxx/extractor/testdata/modfoo.modulemap"
-    digest: "94416d419ecab4bce80084ef89587c4ca31a3cabad12498bd98aa213b1dd5189"
-  }
-}
-argument: "/dummy/bin/g++"
-argument: "-target"
-argument: "dummy-target"
-argument: "-DKYTHE_IS_RUNNING=1"
-argument: "-resource-dir"
-argument: "/kythe_builtins"
-argument: "--driver-mode=g++"
-argument: "-fmodules"
-argument: "-fmodule-map-file=kythe/cxx/extractor/testdata/modfoo.modulemap"
-argument: "-I./kythe/cxx/extractor"
-argument: "./kythe/cxx/extractor/testdata/modules.cc"
-argument: "-fsyntax-only"
-source_file: "./kythe/cxx/extractor/testdata/modules.cc"
-working_directory: "/root"
-entry_context: "hash0"
-)";
 
 TEST(CxxExtractorTest, TestModulesExtraction) {
   kythe::proto::CompilationUnit unit = ExtractSingleCompilationOrDie({{
@@ -100,7 +93,7 @@ TEST(CxxExtractorTest, TestModulesExtraction) {
         return absl::StartsWith(arg, "-fmodules-cache-path=");
       }));
 
-  EXPECT_THAT(unit, EquivToCompilation(kExpectedCompilation));
+  EXPECT_THAT(unit, EquivToProto(ExpectedCompilation()));
 }
 
 }  // namespace

--- a/kythe/cxx/extractor/testdata/root_directory_test.cc
+++ b/kythe/cxx/extractor/testdata/root_directory_test.cc
@@ -23,48 +23,45 @@
 #include "kythe/cxx/common/path_utils.h"
 #include "kythe/cxx/extractor/testlib.h"
 #include "kythe/proto/analysis.pb.h"
+#include "protobuf-matchers/protocol-buffer-matchers.h"
 
 namespace kythe {
 namespace {
 using ::kythe::proto::CompilationUnit;
+using ::protobuf_matchers::EquivToProto;
 using ::testing::SizeIs;
 
 constexpr absl::string_view kFilePath =
     "kythe/cxx/extractor/testdata/altroot/altpath/file.cc";
 
-constexpr absl::string_view kExpectedCompilation = R"(
-v_name {
-  language: "c++"
-}
-required_input {
-  v_name {
-    path: "altpath/file.cc"
-  }
-  info {
-    path: "file.cc"
-    digest: "a24091884bc15b53e380fe5b874d1bb52d89269fdf2592808ac70ba189204730"
-  }
-  details {
-    [type.googleapis.com/kythe.proto.ContextDependentVersion] {
-      row {
-        source_context: "hash0"
-        always_process: true
+CompilationUnit ExpectedCompilation() {
+  return ParseTextCompilationUnitOrDie(R"pb(
+    v_name { language: "c++" }
+    required_input {
+      v_name { path: "altpath/file.cc" }
+      info {
+        path: "file.cc"
+        digest: "a24091884bc15b53e380fe5b874d1bb52d89269fdf2592808ac70ba189204730"
+      }
+      details {
+        [type.googleapis.com/kythe.proto.ContextDependentVersion] {
+          row { source_context: "hash0" always_process: true }
+        }
       }
     }
-  }
+    argument: "/dummy/bin/g++"
+    argument: "-target"
+    argument: "dummy-target"
+    argument: "-DKYTHE_IS_RUNNING=1"
+    argument: "-resource-dir"
+    argument: "/kythe_builtins"
+    argument: "--driver-mode=g++"
+    argument: "file.cc"
+    argument: "-fsyntax-only"
+    source_file: "file.cc"
+    working_directory: "/root"
+    entry_context: "hash0")pb");
 }
-argument: "/dummy/bin/g++"
-argument: "-target"
-argument: "dummy-target"
-argument: "-DKYTHE_IS_RUNNING=1"
-argument: "-resource-dir"
-argument: "/kythe_builtins"
-argument: "--driver-mode=g++"
-argument: "file.cc"
-argument: "-fsyntax-only"
-source_file: "file.cc"
-working_directory: "/root"
-entry_context: "hash0")";
 
 // Verifies that the extractor properly handles KYTHE_ROOT_DIRECTORY
 // other than the working directory.
@@ -92,7 +89,7 @@ TEST(RootDirectoryTest, AlternateRootDirectoryExtracts) {
   unit.set_argument(2, "dummy-target");
   unit.clear_details();
 
-  EXPECT_THAT(unit, EquivToCompilation(kExpectedCompilation));
+  EXPECT_THAT(unit, EquivToProto(ExpectedCompilation()));
 }
 
 // Verifies that the extractor properly picks a stable
@@ -126,7 +123,7 @@ TEST(RootDirectoryTest, WorkingDirectoryAvoidsConflict) {
   unit.set_argument(2, "dummy-target");
   unit.clear_details();
 
-  auto expected = ParseTextCompilationUnitOrDie(kExpectedCompilation);
+  auto expected = ExpectedCompilation();
   expected.add_argument(absl::StrCat("-DUNUSED=", working_directory));
   // RepeatedPtrField lacks an "insert" method, so we have to use rotate
   // to position it correctly.
@@ -135,7 +132,7 @@ TEST(RootDirectoryTest, WorkingDirectoryAvoidsConflict) {
               expected.mutable_argument()->pointer_end());
   expected.set_working_directory(working_directory);
 
-  EXPECT_THAT(unit, EquivToCompilation(expected));
+  EXPECT_THAT(unit, EquivToProto(expected));
 }
 
 }  // namespace

--- a/kythe/cxx/extractor/testlib.cc
+++ b/kythe/cxx/extractor/testlib.cc
@@ -30,7 +30,6 @@
 #include "gmock/gmock.h"
 #include "google/protobuf/message.h"
 #include "google/protobuf/text_format.h"
-#include "google/protobuf/util/message_differencer.h"
 #include "gtest/gtest.h"
 #include "kythe/cxx/common/kzip_reader.h"
 #include "kythe/cxx/common/path_utils.h"
@@ -57,31 +56,6 @@ void CanonicalizeHash(HashMap* hashes, std::string* hash) {
   auto inserted = hashes->insert({*hash, hashes->size()});
   *hash = absl::StrCat("hash", inserted.first->second);
 }
-
-class EquivToCompilationImpl
-    : public ::testing::MatcherInterface<const kpb::CompilationUnit&> {
- public:
-  explicit EquivToCompilationImpl(kpb::CompilationUnit expected)
-      : expected_(std::move(expected)) {}
-
-  bool MatchAndExplain(
-      const kpb::CompilationUnit& actual,
-      ::testing::MatchResultListener* listener) const override {
-    std::string delta;
-    if (!EquivalentCompilations(expected_, actual, &delta)) {
-      *listener << "\n" << delta;
-      return false;
-    }
-    return true;
-  }
-
-  void DescribeTo(std::ostream* os) const override {
-    *os << "kythe::proto::CompilationUnit differs";
-  }
-
- private:
-  kpb::CompilationUnit expected_;
-};
 
 /// \brief Range wrapper around ContextDependentVersion, if any.
 class MutableContextRows {
@@ -304,30 +278,9 @@ kpb::CompilationUnit ExtractSingleCompilationOrDie(ExtractorOptions options) {
   }
 }
 
-bool EquivalentCompilations(const kpb::CompilationUnit& lhs,
-                            const kpb::CompilationUnit& rhs,
-                            std::string* delta) {
-  gpb::util::MessageDifferencer diff;
-  diff.set_message_field_comparison(gpb::util::MessageDifferencer::EQUIVALENT);
-  diff.ReportDifferencesToString(delta);
-  return diff.Compare(lhs, rhs);
-}
-
 kpb::CompilationUnit ParseTextCompilationUnitOrDie(absl::string_view text) {
   kpb::CompilationUnit result;
   CHECK(gpb::TextFormat::ParseFromString(std::string(text), &result));
   return result;
 }
-
-::testing::Matcher<const kpb::CompilationUnit&> EquivToCompilation(
-    const kpb::CompilationUnit& unit) {
-  return ::testing::Matcher<const kpb::CompilationUnit&>(
-      new EquivToCompilationImpl(unit));
-}
-
-::testing::Matcher<const kpb::CompilationUnit&> EquivToCompilation(
-    absl::string_view expected) {
-  return EquivToCompilation(ParseTextCompilationUnitOrDie(expected));
-}
-
 }  // namespace kythe

--- a/kythe/cxx/indexer/cxx/BUILD
+++ b/kythe/cxx/indexer/cxx/BUILD
@@ -573,6 +573,7 @@ cc_test(
         "//kythe/cxx/common/indexing:output",
         "//kythe/cxx/common/indexing:testlib",
         "//third_party:gtest",
+        "@com_github_inazarenko_protobuf_matchers//protobuf-matchers",
         "@com_google_protobuf//:protobuf",
         "@llvm-project//clang:ast",
         "@llvm-project//clang:frontend",

--- a/kythe/cxx/indexer/cxx/KytheIndexerUnitTest.cc
+++ b/kythe/cxx/indexer/cxx/KytheIndexerUnitTest.cc
@@ -31,15 +31,18 @@
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/Frontend/FrontendAction.h"
 #include "clang/Tooling/Tooling.h"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "kythe/cxx/common/indexing/KytheGraphRecorder.h"
 #include "kythe/cxx/common/indexing/RecordingOutputStream.h"
 #include "kythe/cxx/indexer/cxx/IndexerASTHooks.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/Twine.h"
+#include "protobuf-matchers/protocol-buffer-matchers.h"
 
 namespace kythe {
 namespace {
+using ::protobuf_matchers::EqualsProto;
 
 using clang::SourceLocation;
 
@@ -184,7 +187,7 @@ TEST(KytheIndexerUnitTest, GraphRecorderNodeKind) {
   ASSERT_TRUE(entry.edge_kind().empty());
   ASSERT_FALSE(entry.has_target());
   ASSERT_TRUE(entry.has_source());
-  ASSERT_EQ(vname.DebugString(), entry.source().DebugString());
+  ASSERT_THAT(vname, EqualsProto(entry.source()));
 }
 
 TEST(KytheIndexerUnitTest, GraphRecorderNodeProperty) {
@@ -214,7 +217,7 @@ TEST(KytheIndexerUnitTest, GraphRecorderNodeProperty) {
     ASSERT_TRUE(entry.edge_kind().empty());
     ASSERT_FALSE(entry.has_target());
     ASSERT_TRUE(entry.has_source());
-    ASSERT_EQ(vname.DebugString(), entry.source().DebugString());
+    ASSERT_THAT(vname, EqualsProto(entry.source()));
   }
   ASSERT_TRUE(found_kind_fact);
   ASSERT_TRUE(found_property_fact);
@@ -244,8 +247,8 @@ TEST(KytheIndexerUnitTest, GraphRecorderEdge) {
   ASSERT_EQ("/kythe/edge/defines/binding", entry.edge_kind());
   ASSERT_TRUE(entry.has_target());
   ASSERT_TRUE(entry.has_source());
-  ASSERT_EQ(vname_source.DebugString(), entry.source().DebugString());
-  ASSERT_EQ(vname_target.DebugString(), entry.target().DebugString());
+  ASSERT_THAT(vname_source, EqualsProto(entry.source()));
+  ASSERT_THAT(vname_target, EqualsProto(entry.target()));
 }
 
 TEST(KytheIndexerUnitTest, GraphRecorderEdgeOrdinal) {
@@ -271,8 +274,8 @@ TEST(KytheIndexerUnitTest, GraphRecorderEdgeOrdinal) {
   EXPECT_EQ("/kythe/edge/defines/binding.42", entry.edge_kind());
   ASSERT_TRUE(entry.has_target());
   ASSERT_TRUE(entry.has_source());
-  EXPECT_EQ(vname_source.DebugString(), entry.source().DebugString());
-  EXPECT_EQ(vname_target.DebugString(), entry.target().DebugString());
+  EXPECT_THAT(vname_source, EqualsProto(entry.source()));
+  EXPECT_THAT(vname_target, EqualsProto(entry.target()));
 }
 
 static void WriteStringToStackAndBuffer(const std::string& value,


### PR DESCRIPTION
While we wait for an official release of them, use an unofficial port to clean up some uses of DebugString and ad-hoc partial re-implementations of the equivalent matchers.