### PR TITLE
feat(typescript): emit code nodes for tsx attributes

### DIFF
--- a/kythe/typescript/indexer.ts
+++ b/kythe/typescript/indexer.ts
@@ -1752,7 +1752,7 @@ class Visitor {
       if (ts.isVariableDeclaration(decl) || ts.isPropertyAssignment(decl) ||
           ts.isPropertyDeclaration(decl) || ts.isBindingElement(decl) ||
           ts.isShorthandPropertyAssignment(decl) ||
-          ts.isPropertySignature(decl)) {
+          ts.isPropertySignature(decl) || ts.isJsxAttribute(decl)) {
         this.emitDeclarationCode(decl, vname);
       } else {
         todo(this.sourceRoot, decl, 'Emit variable delaration code');
@@ -1792,7 +1792,7 @@ class Visitor {
   emitDeclarationCode(
       decl: ts.VariableDeclaration|ts.PropertyAssignment|
       ts.PropertyDeclaration|ts.BindingElement|ts.ShorthandPropertyAssignment|
-      ts.PropertySignature,
+      ts.PropertySignature|ts.JsxAttribute,
       declVName: VName) {
     const codeParts: JSONMarkedSource[] = [];
     const initializerList = decl.parent;

--- a/kythe/typescript/testdata/tsx.tsx
+++ b/kythe/typescript/testdata/tsx.tsx
@@ -6,9 +6,22 @@ function render() {
   //- @#0"value" defines/binding Value
   const value = 'value';
   return (
-    //- @"attr" defines/binding _Attr
+    //- @"attr" defines/binding Attr
     //- @"value" ref Value
-    //- @+4"src" defines/binding _Src
+    //- Attr code AttrCode
+    //- AttrCode child.0 AttrContext
+    //- AttrContext.pre_text "(property)"
+    //- AttrCode child.1 AttrSpace
+    //- AttrSpace.pre_text " "
+    //- AttrCode child.2 AttrName
+    //- AttrName.pre_text "attr"
+    //- AttrCode child.3 AttrTy
+    //- AttrTy.post_text "string"
+    //- AttrCode child.4 AttrEq
+    //- AttrEq.pre_text " = "
+    //- AttrCode child.5 AttrInit
+    //- AttrInit.pre_text "{value}"
+    //- @+4"src" defines/binding _Src1
     //- @+3"value" ref Value
     //- @+3"src" defines/binding _Src2
     <div attr={value}>


### PR DESCRIPTION
This avoids noisy TODOs currently emitted for TSX files. Overall I'm not sure if there is value in outputting nodes for DOM attributes in tsx files. But given it was already implemented - I just fixed what already exists.