### PR TITLE
feat(typescript): add flag follow aliases when emitting refs

### DIFF
--- a/kythe/typescript/test.ts
+++ b/kythe/typescript/test.ts
@@ -128,6 +128,7 @@ function verify(
         verifier.stdin.write(JSON.stringify(obj) + '\n');
       },
       plugins,
+      enableAliasFollowing: true,
     });
   } finally {
     // Ensure we close stdin on the verifier even on crashes, or otherwise

--- a/kythe/typescript/testdata/imports_group/import.ts
+++ b/kythe/typescript/testdata/imports_group/import.ts
@@ -30,7 +30,7 @@ value;
 //- @value ref Val
 mod_imp.value;
 
-//- @renamedValue ref RenamedValue
+//- @renamedValue ref Val
 renamedValue;
 
 //- @value ref/imports Val
@@ -39,6 +39,11 @@ import {value as exportedValue} from './export';
 import {local} from './export';
 //- @aliasedLocal ref/imports Local
 import {aliasedLocal} from './export';
+
+import * as allExport from './export';
+
+// - @value ref Val
+allExport.value;
 
 // Importing a type from another module.
 //- @MyType ref/imports MyType


### PR DESCRIPTION
This PR adds flag that allows follow aliases when retrieving TS symbols for nodes in AST. It relies on TS API and should work well and support multiple levels of aliases.

This fixes bug where today xref is not produced for the following case:

```ts
// a.ts
export const value = 42;

// b.ts
export {value} from './a';

// c.ts
import * as b from './b';
b.value;
```

Previously there were no xref from `b.value` to `value` definition. Now there is. 

Also it will help to get rid of our custom alias collapsing that uses `localSymbolToRemoteReassignMap` once launched. I didn't know that I could achieve the same result using TS API when I implemented it originally.
