### PR TITLE
feat(typescript): add ref/id edges for shorthands

### DIFF
--- a/kythe/typescript/indexer.ts
+++ b/kythe/typescript/indexer.ts
@@ -1814,16 +1814,16 @@ class Visitor {
       todo(this.sourceRoot, decl, 'Emit variable delaration code');
     }
 
-    if (decl.kind === ts.SyntaxKind.PropertyDeclaration) {
+    if (ts.isPropertyDeclaration(decl)) {
       const declNode = decl as ts.PropertyDeclaration;
       if (isStaticMember(declNode, declNode.parent)) {
         this.emitFact(vname, FactName.TAG_STATIC, '');
       }
     }
-    if (decl.kind === ts.SyntaxKind.PropertySignature ||
-        decl.kind === ts.SyntaxKind.PropertyDeclaration ||
-        decl.kind === ts.SyntaxKind.PropertyAssignment ||
-        decl.kind === ts.SyntaxKind.ShorthandPropertyAssignment) {
+    if (ts.isPropertySignature(decl) ||
+        ts.isPropertyDeclaration(decl) ||
+        ts.isPropertyAssignment(decl) ||
+        ts.isShorthandPropertyAssignment(decl)) {
       this.emitSubkind(vname, Subkind.FIELD);
     }
     if (ts.isShorthandPropertyAssignment(decl)) {

--- a/kythe/typescript/testdata/object.ts
+++ b/kythe/typescript/testdata/object.ts
@@ -1,5 +1,6 @@
 export {}
 
+//- @shortProperty defines/binding ShortPropertyVariable
 const shortProperty = 0;
 
 //- @#0"computed" defines/binding Computed
@@ -14,6 +15,7 @@ const Object = {
   //- @shortProperty defines/binding ShortProperty
   //- ShortProperty.node/kind variable
   //- ShortProperty.subkind field
+  //- @shortProperty ref/id ShortPropertyVariable
   shortProperty,
 
   //- !{@"[computed]" defines/binding _}


### PR DESCRIPTION
Also refactors code a bit:
*  Exit early when vname is undefined as lot's of logic depends on vname being present. 
* Consistently use `ts.is*` functions. 