### PR TITLE
fix(cxx_extractor): don't validate pchs

### DIFF
--- a/kythe/cxx/extractor/cxx_extractor.cc
+++ b/kythe/cxx/extractor/cxx_extractor.cc
@@ -41,6 +41,7 @@
 #include "clang/Lex/MacroArgs.h"
 #include "clang/Lex/PPCallbacks.h"
 #include "clang/Lex/Preprocessor.h"
+#include "clang/Lex/PreprocessorOptions.h"
 #include "clang/Tooling/Tooling.h"
 #include "glog/logging.h"
 #include "kythe/cxx/common/file_utils.h"

--- a/kythe/cxx/extractor/cxx_extractor.cc
+++ b/kythe/cxx/extractor/cxx_extractor.cc
@@ -994,6 +994,13 @@ class ExtractorAction : public clang::PreprocessorFrontendAction {
               getCompilerInstance().getDiagnostics().hasErrorOccurred());
   }
 
+ protected:
+  bool PrepareToExecuteAction(clang::CompilerInstance& CI) override {
+    CI.getPreprocessorOpts().DisablePCHOrModuleValidation =
+        clang::DisableValidationForModuleKind::All;
+    return clang::PreprocessorFrontendAction::PrepareToExecuteAction(CI);
+  }
+
  private:
   ExtractorCallback callback_;
   /// The main source file for the compilation (assuming only one).


### PR DESCRIPTION
The extractor will refuse to load pch/modules if they are built from a different libclang than the extractor binary. This is not ideal. Of course, there may be breaking changes in the pch format, but it's not unreasonable to assume that these changes happen less than daily. (Initial impressions hold that we still need to get around this problem to read even simple file content from a pch.)

This PR disables pch validation. Since we don't officially support builds that require pch/modules yet, the danger here is that we crash on a bad or incompatible (or actually corrupt) pch instead of quitting nicely with a diagnostic.

In service of #5543.