### PR TITLE
chore: rename io_bazel repository to avoid conflicts

### DIFF
--- a/external.bzl
+++ b/external.bzl
@@ -305,7 +305,7 @@ def _cc_dependencies():
 def _java_dependencies():
     maybe(
         bazel_repository_files,
-        name = "io_bazel",
+        name = "io_bazel_files",
         commit = "20c4596365d6e198ce9e4559a372190ceedff3f5",
         files = [
             "src/java_tools/buildjar/java/com/google/devtools/build/buildjar/javac/JavacOptions.java",

--- a/kythe/java/com/google/devtools/kythe/extractors/java/bazel/BUILD
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/bazel/BUILD
@@ -26,7 +26,7 @@ java_binary(
         "//third_party/guava",
         "@com_google_protobuf//:protobuf_java",
         "@com_google_protobuf//:protobuf_java_util",
-        "@io_bazel//src/java_tools/buildjar/java/com/google/devtools/build/buildjar:javac_options",
+        "@io_bazel_files//src/java_tools/buildjar/java/com/google/devtools/build/buildjar:javac_options",
     ],
 )
 

--- a/kythe/web/site/site_docs.bzl
+++ b/kythe/web/site/site_docs.bzl
@@ -116,7 +116,8 @@ def _jekyll_impl(ctx):
     input_root = ctx.label.name + ".staging.d"
     symlinks = []
     for src in ctx.files.srcs:
-        symlink = ctx.actions.declare_file(paths.join(input_root, _package_path(src)))
+        declare_output = ctx.actions.declare_directory if src.is_directory else ctx.actions.declare_file
+        symlink = declare_output(paths.join(input_root, _package_path(src)))
         ctx.actions.symlink(output = symlink, target_file = src)
         symlinks.append(symlink)
     input_dir = paths.join(symlinks[0].root.path, symlinks[0].owner.package, input_root)


### PR DESCRIPTION
As we only import a modified part of the Bazel repository, rename it to avoid conflicts with the real one.

Also, fix website generation (although it still interacts poorly with bazel query).