### PR TITLE
fix(presubmit): omit manual targets from both input and output sets

### DIFF
--- a/tools/git/test-affected-targets.sh
+++ b/tools/git/test-affected-targets.sh
@@ -32,7 +32,7 @@ TAG_RE="\\b($(join_by '|' "${OMIT_TAGS[@]}"))\\b"
 readarray -t TARGETS < <(bazel query \
   --keep_going \
   --noshow_progress \
-  "rdeps(//..., set($*)) except attr('tags', '$TAG_RE', //...)")
+  "let exclude = attr('tags', '$TAG_RE', //...) in rdeps(//... except \$exclude, set($*)) except \$exclude")
 
 if [[ "${#TARGETS[@]}" -gt 0 ]]; then
   echo "Building targets"


### PR DESCRIPTION
This avoids considering the dependencies of `manual` and similar targets, which avoids issues with local-only dependencies of those targets, rather than just merely excluding them after the fact.