### PR TITLE
feat(build): add and use permissive wrapper for select.with_or

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -36,6 +36,31 @@ build --tool_java_language_version=11
 build --java_runtime_version=remotejdk_11
 build --tool_java_runtime_version=remotejdk_11
 
+build:java11 --java_language_version=11
+build:java11 --tool_java_language_version=11
+build:java11 --java_runtime_version=remotejdk_11
+build:java11 --tool_java_runtime_version=remotejdk_11
+
+build:java17 --java_language_version=17
+build:java17 --tool_java_language_version=17
+build:java17 --java_runtime_version=remotejdk_17
+build:java17 --tool_java_runtime_version=remotejdk_17
+
+build:java19 --java_language_version=19
+build:java19 --tool_java_language_version=19
+build:java19 --java_runtime_version=remotejdk_19
+build:java19 --tool_java_runtime_version=remotejdk_19
+
+build:java20 --java_language_version=20
+build:java20 --tool_java_language_version=20
+build:java20 --java_runtime_version=remotejdk_20
+build:java20 --tool_java_runtime_version=remotejdk_20
+
+# TODO(https://github.com/bazelbuild/bazel/issues/14502): remove this when
+# Bazel 6.2 is released and out .bazelminversion updated.
+test:java19 --jvmopt=-Djava.security.manager=allow
+test:java20 --jvmopt=-Djava.security.manager=allow
+
 # Import default javacopts
 import %workspace%/tools/javacopts.bazelrc
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -57,7 +57,7 @@ build:java20 --java_runtime_version=remotejdk_20
 build:java20 --tool_java_runtime_version=remotejdk_20
 
 # TODO(https://github.com/bazelbuild/bazel/issues/14502): remove this when
-# Bazel 6.2 is released and out .bazelminversion updated.
+# Bazel 6.2 is released and our .bazelminversion updated.
 test:java19 --jvmopt=-Djava.security.manager=allow
 test:java20 --jvmopt=-Djava.security.manager=allow
 

--- a/kythe/java/com/google/devtools/kythe/extractors/java/standalone/BUILD
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/standalone/BUILD
@@ -1,5 +1,6 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+load("//tools:build_rules/selects.bzl", select_with_or = "with_or")
 
 package(default_visibility = ["//kythe:default_visibility"])
 
@@ -40,11 +41,13 @@ java_library(
     ],
     runtime_deps = [
         ":reflective_jdk_compatibility_shims",
-    ] + select({
+    ] + select_with_or({
         "//buildenv/java:language_version_11": [":jdk9_compatibility_shims"],
-        "//buildenv/java:language_version_17": [":jdk15_compatibility_shims"],
-        "//buildenv/java:language_version_19": [":jdk15_compatibility_shims"],
-        "//buildenv/java:language_version_20": [":jdk15_compatibility_shims"],
+        (
+            "//buildenv/java:language_version_17",
+            "//buildenv/java:language_version_19",
+            "//buildenv/java:language_version_20",
+        ): [":jdk15_compatibility_shims"],
     }),
     deps = [
         ":jdk_compatibility_shims",
@@ -75,8 +78,8 @@ java_library(
     javacopts = [
         "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
     ],
-    target_compatible_with = select({
-        "//buildenv/java:language_version_11": [],
+    target_compatible_with = select_with_or({
+        ("//buildenv/java:language_version_11",): [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
     visibility = ["//visibility:private"],
@@ -97,10 +100,12 @@ java_library(
     # This is incompatible with the default test configuration and
     # bazel cquery doesn't work with objc_library targets.
     tags = ["manual"],
-    target_compatible_with = select({
-        "//buildenv/java:language_version_17": [],
-        "//buildenv/java:language_version_19": [],
-        "//buildenv/java:language_version_20": [],
+    target_compatible_with = select_with_or({
+        (
+            "//buildenv/java:language_version_17",
+            "//buildenv/java:language_version_19",
+            "//buildenv/java:language_version_20",
+        ): [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
     visibility = ["//visibility:private"],

--- a/kythe/java/com/google/devtools/kythe/platform/java/helpers/BUILD
+++ b/kythe/java/com/google/devtools/kythe/platform/java/helpers/BUILD
@@ -1,4 +1,5 @@
 load("@rules_java//java:defs.bzl", "java_library")
+load("//tools:build_rules/selects.bzl", select_with_or = "with_or")
 
 package(default_visibility = ["//kythe:default_visibility"])
 
@@ -21,10 +22,12 @@ java_library(
     ],
     runtime_deps = [
         ":reflective_jdk_compatibility_shims",
-    ] + select({
+    ] + select_with_or({
         "//buildenv/java:language_version_11": [":jdk9_compatibility_shims"],
-        "//buildenv/java:language_version_17": [":jdk15_compatibility_shims"],
-        "//buildenv/java:language_version_19": [":jdk15_compatibility_shims"],
+        (
+            "//buildenv/java:language_version_17",
+            "//buildenv/java:language_version_19",
+        ): [":jdk15_compatibility_shims"],
         "//buildenv/java:language_version_20": [":jdk20_compatibility_shims"],
     }),
     deps = [
@@ -56,7 +59,7 @@ java_library(
         "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
         "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
     ],
-    target_compatible_with = select({
+    target_compatible_with = select_with_or({
         "//buildenv/java:language_version_11": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
@@ -78,9 +81,11 @@ java_library(
     # This is incompatible with the default test configuration and
     # bazel cquery doesn't work with objc_library targets.
     tags = ["manual"],
-    target_compatible_with = select({
-        "//buildenv/java:language_version_17": [],
-        "//buildenv/java:language_version_19": [],
+    target_compatible_with = select_with_or({
+        (
+            "//buildenv/java:language_version_17",
+            "//buildenv/java:language_version_19",
+        ): [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
     visibility = ["//visibility:private"],
@@ -97,10 +102,8 @@ java_library(
     javacopts = [
         "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
     ],
-    # This is incompatible with the default test configuration and
-    # bazel cquery doesn't work with objc_library targets.
     tags = ["manual"],
-    target_compatible_with = select({
+    target_compatible_with = select_with_or({
         "//buildenv/java:language_version_20": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),

--- a/tools/build_rules/selects.bzl
+++ b/tools/build_rules/selects.bzl
@@ -1,0 +1,19 @@
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+def with_or(mapping, no_match_error = ""):
+    """Like selects.with_or, but allows duplicate conditions in the key tuples."""
+    return select(with_or_dict(mapping), no_match_error = no_match_error)
+
+def with_or_dict(mapping):
+    """Like selects.with_or_dict, but allows duplicate condtions in tuples."""
+    output_dict = {}
+    for key, value in mapping.items():
+        if type(key) == type(()):
+            # Keep only unique values from the tuple.
+            key = tuple({k: None for k in key if k})
+
+        # Omit empty-keyed values.
+        if key:
+            output_dict[key] = value
+
+    return selects.with_or_dict(output_dict)


### PR DESCRIPTION
When selecting on JDK version compatibility, use a more permissive version of selects.with_or which only keeps unique values in tuple-valued keys and omits falsy keys entirely.  This should allow simplifying the import to replace unsupported JDK versions with an empty string without breaking all the things.