### PR TITLE
feat(typescript): merge constructor nodes

### DIFF
--- a/kythe/typescript/indexer.ts
+++ b/kythe/typescript/indexer.ts
@@ -2355,7 +2355,6 @@ class Visitor {
       // If the class has an explicit constructor method - use it as an anchor.
       const ctorSymbol = this.getCtorSymbol(decl);
       if (ctorSymbol && ctorSymbol.declarations) {
-        console.error('Hey ho!');
         const ctorDecl = ctorSymbol.declarations[0];
         const span = this.getTextSpan(ctorDecl, 'constructor');
         ctorAnchor = this.newAnchor(ctorDecl, span.start, span.end);

--- a/kythe/typescript/testdata/class.ts
+++ b/kythe/typescript/testdata/class.ts
@@ -26,8 +26,6 @@ interface IExtended extends IFace {
 
 //- @Class defines/binding Class=vname("Class#type", _, _, _, _)
 //- Class.node/kind record
-//- @Class defines/binding ClassValue=vname("Class", _, _, _, _)
-//- ClassValue.node/kind function
 //- @IFace ref IFace
 //- Class extends IFace
 class Class implements IFace {
@@ -45,7 +43,7 @@ class Class implements IFace {
     // This ctor declares a new member var named 'otherMember', and also
     // declares an ordinary parameter named 'member' (to ensure we don't get
     // confused about params to the ctor vs true member variables).
-    //- @constructor defines/binding ClassCtor=vname("Class#type.constructor", _, _, _, _)
+    //- @constructor defines/binding ClassCtor=vname("Class", _, _, _, _)
     //- ClassCtor.node/kind function
     //- ClassCtor.subkind constructor
     //- @otherMember defines/binding OtherMember
@@ -53,8 +51,8 @@ class Class implements IFace {
     //- @member defines/binding FakeMember
     //- FakeMember.node/kind variable
     constructor(public otherMember: number, member: string) {
-      //- @Class ref ClassValue
-      //- @"new Class(0, 'a')" ref/call ClassValue
+      //- @Class ref ClassCtor
+      //- @"new Class(0, 'a')" ref/call ClassCtor
       new Class(0, 'a');
     }
 
@@ -75,7 +73,12 @@ class Class implements IFace {
     ifaceMethod(): void {}
 }
 
-//- @Class ref ClassValue
+
+//- @Subclass defines/binding Subclass=vname("Subclass#type", _, _, _, _)
+//- Subclass.node/kind record
+//- @Subclass defines/binding SubclassCtor=vname("Subclass", _, _, _, _)
+//- SubclassCtor.node/kind function
+//- @Class ref Class
 class Subclass extends Class {
     //- @method defines/binding OverridenMethod
     //- OverridenMethod overrides Method
@@ -93,7 +96,7 @@ class SubSubclass extends Class implements IExtended {
     ifaceMethod() {}
 }
 
-//- @Class ref ClassValue
+//- @Class ref ClassCtor
 //- @Class ref/id Class
 let instance = new Class(3, 'a');
 //- @otherMember ref OtherMember
@@ -103,6 +106,5 @@ instance.otherMember;
 //- @Class ref Class
 let useAsType: Class = instance;
 
-//- @Class ref ClassValue
-//- @Class ref/id Class
+//- @Class ref Class
 Class;

--- a/kythe/typescript/testdata/schema.ts
+++ b/kythe/typescript/testdata/schema.ts
@@ -17,7 +17,6 @@ export default NspI;
 
 // ClassDeclaration
 //- @C defines/binding VName("C#type", _, _, "testdata/schema", "typescript")
-//- @C defines/binding VName("C", _, _, "testdata/schema", "typescript")
 class C {
   // PropertyDeclaration instance member
   //- @property defines/binding VName("C#type.property", _, _, "testdata/schema", "typescript")
@@ -36,7 +35,7 @@ class C {
   method() {}
 
   // Constructor, ParameterPropertyDeclaration
-  //- @constructor defines/binding VName("C#type.constructor", _, _, "testdata/schema", "typescript")
+  //- @constructor defines/binding VName("C", _, _, "testdata/schema", "typescript")
   //- @cprop defines/binding VName("C#type.cprop", _, _, "testdata/schema", "typescript")
   constructor(private cprop: number) {}
 


### PR DESCRIPTION
This PR changes what nodes are emitted for TS classes. Before the change for the following class:

```
class Foo {
  constructor() {}
}
```
there were 3 nodes:

* `Foo#type` - node representing type of the class. 
* `Foo` - node representing value of the class.
* `Foo#type.constructor` - node representing constructor (if class an explicit constructor).

This PR merges the last two nodes into `Foo`. So after this change it will look like this:

* `Foo#type` - node representing class.
* `Foo` - node representing constructor.

Anchor for the constructor node is chosen based on whether class has an explicit constructor. 

With the new change clicking on `constructor` in the class declaration users will see all instantiations of the class. 