### PR TITLE
Revert "fix(cxx_indexer): find vnames for pch/pcm files"

### DIFF
--- a/kythe/cxx/indexer/cxx/GraphObserver.h
+++ b/kythe/cxx/indexer/cxx/GraphObserver.h
@@ -351,14 +351,15 @@ class GraphObserver {
 
   /// \brief Returns a claim token for namespaces declared at `Loc`.
   /// \param Loc The declaration site of the namespace.
-  virtual const ClaimToken* getNamespaceClaimToken(clang::SourceLocation Loc) {
+  virtual const ClaimToken* getNamespaceClaimToken(
+      clang::SourceLocation Loc) const {
     return getDefaultClaimToken();
   }
 
   /// \brief Returns a claim token for anonymous namespaces declared at `Loc`.
   /// \param Loc The declaration site of the anonymous namespace.
   virtual const ClaimToken* getAnonymousNamespaceClaimToken(
-      clang::SourceLocation Loc) {
+      clang::SourceLocation Loc) const {
     return getDefaultClaimToken();
   }
 
@@ -1075,13 +1076,13 @@ class GraphObserver {
   /// map from the FileId inside a SourceLocation to a (file, transcript)
   /// pair.
   virtual const ClaimToken* getClaimTokenForLocation(
-      const clang::SourceLocation L) {
+      const clang::SourceLocation L) const {
     return getDefaultClaimToken();
   }
 
   /// \brief Returns a `ClaimToken` covering a given source range.
   virtual const ClaimToken* getClaimTokenForRange(
-      const clang::SourceRange& SR) {
+      const clang::SourceRange& SR) const {
     return getDefaultClaimToken();
   }
 

--- a/kythe/cxx/indexer/cxx/KytheGraphObserver.cc
+++ b/kythe/cxx/indexer/cxx/KytheGraphObserver.cc
@@ -1519,7 +1519,7 @@ void KytheGraphObserver::AddContextInformation(
 }
 
 const KytheClaimToken* KytheGraphObserver::getClaimTokenForLocation(
-    clang::SourceLocation source_location) {
+    clang::SourceLocation source_location) const {
   if (!source_location.isValid()) {
     return &default_token_;
   }
@@ -1532,28 +1532,16 @@ const KytheClaimToken* KytheGraphObserver::getClaimTokenForLocation(
     return &default_token_;
   }
   auto token = claim_checked_files_.find(file);
-  if (token == claim_checked_files_.end()) {
-    if (SourceManager->isLoadedFileID(file)) {
-      // This is the first time we've encountered a file loaded from a pch/pcm.
-      if (auto* entry = SourceManager->getFileEntryForID(file)) {
-        auto vname = VNameFromFileEntry(entry);
-        KytheClaimToken new_token;
-        new_token.set_vname(VNameFromFileEntry(entry));
-        new_token.set_rough_claimed(false);
-        token = claim_checked_files_.emplace(file, new_token).first;
-      }
-    }
-  }
   return token != claim_checked_files_.end() ? &token->second : &default_token_;
 }
 
 const KytheClaimToken* KytheGraphObserver::getClaimTokenForRange(
-    const clang::SourceRange& range) {
+    const clang::SourceRange& range) const {
   return getClaimTokenForLocation(range.getBegin());
 }
 
 const KytheClaimToken* KytheGraphObserver::getAnonymousNamespaceClaimToken(
-    clang::SourceLocation loc) {
+    clang::SourceLocation loc) const {
   if (isMainSourceFileRelatedLocation(loc)) {
     CHECK(main_source_file_token_ != nullptr);
     return main_source_file_token_;
@@ -1562,12 +1550,12 @@ const KytheClaimToken* KytheGraphObserver::getAnonymousNamespaceClaimToken(
 }
 
 const KytheClaimToken* KytheGraphObserver::getNamespaceClaimToken(
-    clang::SourceLocation loc) {
+    clang::SourceLocation loc) const {
   return &getNamespaceTokens(loc).named;
 }
 
 const KytheGraphObserver::NamespaceTokens&
-KytheGraphObserver::getNamespaceTokens(clang::SourceLocation loc) {
+KytheGraphObserver::getNamespaceTokens(clang::SourceLocation loc) const {
   auto* file_token = getClaimTokenForLocation(loc);
   auto [iter, inserted] =
       namespace_tokens_.emplace(file_token, NamespaceTokens{});

--- a/kythe/cxx/indexer/cxx/KytheGraphObserver.h
+++ b/kythe/cxx/indexer/cxx/KytheGraphObserver.h
@@ -428,16 +428,16 @@ class KytheGraphObserver : public GraphObserver {
   }
 
   const KytheClaimToken* getClaimTokenForLocation(
-      const clang::SourceLocation source_location) override;
+      const clang::SourceLocation source_location) const override;
 
   const KytheClaimToken* getClaimTokenForRange(
-      const clang::SourceRange& source_range) override;
+      const clang::SourceRange& source_range) const override;
 
   const KytheClaimToken* getNamespaceClaimToken(
-      clang::SourceLocation loc) override;
+      clang::SourceLocation loc) const override;
 
   const KytheClaimToken* getAnonymousNamespaceClaimToken(
-      clang::SourceLocation loc) override;
+      clang::SourceLocation loc) const override;
 
   /// \brief Appends a representation of `Range` to `Ostream`.
   void AppendRangeToStream(llvm::raw_ostream& ostream,
@@ -470,7 +470,7 @@ class KytheGraphObserver : public GraphObserver {
     KytheClaimToken anonymous;  ///< Token to use for anonymous namespaces.
   };
 
-  const NamespaceTokens& getNamespaceTokens(clang::SourceLocation loc);
+  const NamespaceTokens& getNamespaceTokens(clang::SourceLocation loc) const;
 
   void AddMarkedSource(const VNameRef& vname,
                        const absl::optional<MarkedSource>& signature) {


### PR DESCRIPTION
Reverts kythe/kythe#5612


Is there not some other preprocessor callback that gets invoked for PCH/PCM files?