### PR TITLE
fix(typescript_indexer): fix context in marked sources

### DIFF
--- a/kythe/typescript/testdata/marked_source/class.ts
+++ b/kythe/typescript/testdata/marked_source/class.ts
@@ -5,6 +5,27 @@
 //- MyClassCode.kind "IDENTIFIER"
 //- MyClassCode.pre_text "MyClass"
 class MyClass {
+    //- @constructor defines/binding Constructor
+    //-
+    //- Constructor code ConstructorCode
+    //- ConstructorCode.kind "BOX"
+    //-
+    //- ConstructorCode child.0 ConstructorContext
+    //- ConstructorContext.kind "CONTEXT"
+    //- ConstructorContext.pre_text "MyClass"
+    //-
+    //- ConstructorCode child.1 ConstructorSpace
+    //- ConstructorSpace.pre_text " "
+    //-
+    //- ConstructorCode child.2 ConstructorId
+    //- ConstructorId.kind "IDENTIFIER"
+    //- ConstructorId.pre_text "constructor"
+    //-
+    //- ConstructorCode child.3 ConstructorParams
+    //- ConstructorParams.kind "PARAMETER_LOOKUP_BY_PARAM"
+    //- ConstructorParams.pre_text "("
+    //- ConstructorParams.post_text ")"
+    //- ConstructorParams.post_child_text ", "
     constructor(arg: string) {}
 
     //- @myMethod defines/binding MyMethod
@@ -14,7 +35,7 @@ class MyClass {
     //-
     //- MyMethodCode child.0 MyMethodContext
     //- MyMethodContext.kind "CONTEXT"
-    //- MyMethodContext.pre_text "(method)"
+    //- MyMethodContext.pre_text "MyClass"
     //-
     //- MyMethodCode child.1 MyMethodSpace
     //- MyMethodSpace.pre_text " "
@@ -40,7 +61,7 @@ class MyClass {
     //- 
     //- ArgCode child.0 ArgCodeContext
     //- ArgCodeContext.kind "CONTEXT"
-    //- ArgCodeContext.pre_text "(parameter)"
+    //- ArgCodeContext.pre_text "MyClass.myMethod"
     //- 
     //- ArgCode child.1 ArgCodeSpace
     //- ArgCodeSpace.pre_text " "

--- a/kythe/typescript/testdata/marked_source/enum.ts
+++ b/kythe/typescript/testdata/marked_source/enum.ts
@@ -13,7 +13,7 @@ enum MyEnum {
     //- 
     //- MyValueCode child.0 MyValueContext
     //- MyValueContext.kind "CONTEXT"
-    //- MyValueContext.pre_text "(enum member)"
+    //- MyValueContext.pre_text "MyEnum"
     //-
     //- MyValueCode child.1 MyValueSpace
     //- MyValueSpace.pre_text " "

--- a/kythe/typescript/testdata/marked_source/function.ts
+++ b/kythe/typescript/testdata/marked_source/function.ts
@@ -2,24 +2,17 @@
 //- @myFunction defines/binding MyFunction
 //- MyFunction code MyFunctionCode
 //- 
-//- MyFunctionCode child.0 MyFunctionContext
-//- MyFunctionContext.kind "CONTEXT"
-//- MyFunctionContext.pre_text "function"
-//-
-//- MyFunctionCode child.1 MyFunctionSpace
-//- MyFunctionSpace.pre_text " "
-//- 
-//- MyFunctionCode child.2 MyFunctionName
+//- MyFunctionCode child.0 MyFunctionName
 //- MyFunctionName.kind "IDENTIFIER"
 //- MyFunctionName.pre_text "myFunction"
 //-
-//- MyFunctionCode child.3 MyFunctionParams
+//- MyFunctionCode child.1 MyFunctionParams
 //- MyFunctionParams.kind "PARAMETER_LOOKUP_BY_PARAM"
 //- MyFunctionParams.pre_text "("
 //- MyFunctionParams.post_text ")"
 //- MyFunctionParams.post_child_text ", "
 //- 
-//- MyFunctionCode child.4 MyFunctionReturnType
+//- MyFunctionCode child.2 MyFunctionReturnType
 //- MyFunctionReturnType.kind "TYPE"
 //- MyFunctionReturnType.pre_text ": "
 //- MyFunctionReturnType.post_text "number"
@@ -30,7 +23,7 @@
 //- 
 //- ArgCode child.0 ArgCodeContext
 //- ArgCodeContext.kind "CONTEXT"
-//- ArgCodeContext.pre_text "(parameter)"
+//- ArgCodeContext.pre_text "myFunction"
 //-
 //- ArgCode child.1 ArgCodeSpace
 //- ArgCodeSpace.pre_text " "

--- a/kythe/typescript/testdata/marked_source/property.ts
+++ b/kythe/typescript/testdata/marked_source/property.ts
@@ -2,7 +2,7 @@ class A {
   //- @#0member defines/binding Member
   //- Member code MemberCode
   //- MemberCode child.0 MemberContext
-  //- MemberContext.pre_text "(property)"
+  //- MemberContext.pre_text "A"
   //- MemberCode child.1 MemberSpace
   //- MemberSpace.pre_text " "
   //- MemberCode child.2 MemberName
@@ -18,7 +18,7 @@ class A {
   //- @#0staticmember defines/binding StaticMember
   //- StaticMember code StaticMemberCode
   //- StaticMemberCode child.0 StaticMemberContext
-  //- StaticMemberContext.pre_text "(property)"
+  //- StaticMemberContext.pre_text "A"
   //- StaticMemberCode child.1 StaticMemberSpace
   //- StaticMemberSpace.pre_text " "
   //- StaticMemberCode child.2 StaticMemberName
@@ -35,17 +35,13 @@ class A {
 let b = {
   //- @bprop defines/binding BProp
   //- BProp code BPropCode
-  //- BPropCode child.0 BPropContext
-  //- BPropContext.pre_text "(property)"
-  //- BPropCode child.1 BPropSpace
-  //- BPropSpace.pre_text " "
-  //- BPropCode child.2 BPropName
+  //- BPropCode child.0 BPropName
   //- BPropName.pre_text "bprop"
-  //- BPropCode child.3 BPropTy
+  //- BPropCode child.1 BPropTy
   //- BPropTy.post_text "number"
-  //- BPropCode child.4 BPropEq
+  //- BPropCode child.2 BPropEq
   //- BPropEq.pre_text " = "
-  //- BPropCode child.5 BPropInit
+  //- BPropCode child.3 BPropInit
   //- BPropInit.pre_text "1"
   bprop: 1,
 };
@@ -54,7 +50,7 @@ interface C {
   //- @cprop defines/binding CProp
   //- CProp code CPropCode
   //- CPropCode child.0 CPropContext
-  //- CPropContext.pre_text "(property)"
+  //- CPropContext.pre_text "C"
   //- CPropCode child.1 CPropSpace
   //- CPropSpace.pre_text " "
   //- CPropCode child.2 CPropName

--- a/kythe/typescript/testdata/marked_source/variable.ts
+++ b/kythe/typescript/testdata/marked_source/variable.ts
@@ -2,144 +2,106 @@ export {}
 
 //- @a defines/binding A
 //- A code ACode
-//- ACode child.0 AContext
-//- AContext.kind "CONTEXT"
-//- AContext.pre_text "const"
-//- ACode child.1 ASpace
-//- ASpace.kind "BOX"
-//- ASpace.pre_text " "
-//- ACode child.2 AName
+//- ACode child.0 AName
 //- AName.kind "IDENTIFIER"
 //- AName.pre_text "a"
-//- ACode child.3 ATy
+//- ACode child.1 ATy
 //- ATy.kind "TYPE"
 //- ATy.pre_text ": "
 //- ATy.post_text "string"
-//- ACode child.4 AEq
+//- ACode child.2 AEq
 //- AEq.kind "BOX"
 //- AEq.pre_text " = "
-//- ACode child.5 AInit
+//- ACode child.3 AInit
 //- AInit.kind "INITIALIZER"
 //- AInit.pre_text "'text'"
 const a: string = 'text';
 
 //- @b defines/binding B
 //- B code BCode
-//- BCode child.0 BContext
-//- BContext.pre_text "const"
-//- BCode child.1 BSpace
-//- BSpace.pre_text " "
-//- BCode child.2 BName
+//- BCode child.0 BName
 //- BName.pre_text "b"
-//- BCode child.3 BTy
+//- BCode child.1 BTy
 //- BTy.post_text "\"text\""
-//- BCode child.4 BEq
+//- BCode child.2 BEq
 //- BEq.pre_text " = "
-//- BCode child.5 BInit
+//- BCode child.3 BInit
 //- BInit.pre_text "'text'"
 const b = 'text';
 
 //- @c defines/binding C
 //- C code CCode
-//- CCode child.0 CContext
-//- CContext.pre_text "let"
-//- CCode child.1 CSpace
-//- CSpace.pre_text " "
-//- CCode child.2 CName
+//- CCode child.0 CName
 //- CName.pre_text "c"
-//- CCode child.3 CTy
+//- CCode child.1 CTy
 //- CTy.post_text "string"
-//- CCode child.4 CEq
+//- CCode child.2 CEq
 //- CEq.pre_text " = "
-//- CCode child.5 CInit
+//- CCode child.3 CInit
 //- CInit.pre_text "'text'"
 let c = 'text';
 
 //- @#0d defines/binding D
 //- D code DCode
-//- DCode child.0 DContext
-//- DContext.pre_text "let"
-//- DCode child.1 DSpace
-//- DSpace.pre_text " "
-//- DCode child.2 DName
+//- DCode child.0 DName
 //- DName.pre_text "d"
-//- DCode child.3 DTy
+//- DCode child.1 DTy
 //- DTy.post_text "string" // not string|undefined b/c tests have strictNullChecks=false
-//- !{DCode child.4 _DTy}
+//- !{DCode child.2 _DTy}
 let d: string|undefined;
 
 try {
   //- @e defines/binding E
   //- E code ECode
-  //- ECode child.0 EContext
-  //- EContext.pre_text "(local var)"
-  //- ECode child.1 ESpace
-  //- ESpace.pre_text " "
-  //- ECode child.2 EName
+  //- ECode child.0 EName
   //- EName.pre_text "e"
-  //- ECode child.3 ETy
+  //- ECode child.1 ETy
   //- ETy.post_text "any"
-  //- !{ECode child.4 _ETy}
+  //- !{ECode child.2 _ETy}
 } catch (e) {
 }
 
 //- @#0f defines/binding F
 //- F code FCode
-//- FCode child.0 FContext
-//- FContext.pre_text "let"
-//- FCode child.1 FSpace
-//- FSpace.pre_text " "
-//- FCode child.2 FName
+//- FCode child.0 FName
 //- FName.pre_text "f"
-//- FCode child.3 FTy
+//- FCode child.1 FTy
 //- FTy.post_text "number"
-//- FCode child.4 FEq
+//- FCode child.2 FEq
 //- FEq.pre_text " = "
-//- FCode child.5 FInit
+//- FCode child.3 FInit
 //- FInit.pre_text "0"
 //- @halias defines/binding H
 //- H code HCode
-//- HCode child.0 HContext
-//- HContext.pre_text "let"
-//- HCode child.1 HSpace
-//- HSpace.pre_text " "
-//- HCode child.2 HName
+//- HCode child.0 HName
 //- HName.pre_text "halias"
-//- HCode child.3 HTy
+//- HCode child.1 HTy
 //- HTy.post_text "number"
-//- HCode child.4 HEq
+//- HCode child.2 HEq
 //- HEq.pre_text " = "
-//- HCode child.5 HInit
+//- HCode child.3 HInit
 //- HInit.pre_text "1"
 //- @#0redcat defines/binding Redcat
 //- Redcat code RedcatCode
-//- RedcatCode child.0 RedcatContext
-//- RedcatContext.pre_text "let"
-//- RedcatCode child.1 RedcatSpace
-//- RedcatSpace.pre_text " "
-//- RedcatCode child.2 RedcatName
+//- RedcatCode child.0 RedcatName
 //- RedcatName.pre_text "redcat"
-//- RedcatCode child.3 RedcatTy
+//- RedcatCode child.1 RedcatTy
 //- RedcatTy.post_text "number"
-//- RedcatCode child.4 RedcatEq
+//- RedcatCode child.2 RedcatEq
 //- RedcatEq.pre_text " = "
-//- RedcatCode child.5 RedcatInit
+//- RedcatCode child.3 RedcatInit
 //- RedcatInit.pre_text "2"
 let {f, g: {h: halias}, redcat} = {f: 0, g: {h: 1}, ['redcat']: 2};
 
 //- @i defines/binding I
 //- I code ICode
-//- ICode child.0 IContext
-//- IContext.pre_text "let"
-//- ICode child.1 ISpace
-//- ISpace.pre_text " "
-//- ICode child.2 IName
+//- ICode child.0 IName
 //- IName.pre_text "i"
-//- ICode child.3 ITy
+//- ICode child.1 ITy
 //- ITy.post_text "number"
-//- ICode child.4 IEq
+//- ICode child.2 IEq
 //- IEq.pre_text " = "
-//- ICode child.5 IInit
+//- ICode child.3 IInit
 //- IInit.pre_text "3"
 let [_, [i]] = [2, [3]];
 
@@ -147,7 +109,7 @@ let [_, [i]] = [2, [3]];
 // whole RHS of the variable declaration.
 //- @#0j defines/binding J
 //- J code JCode
-//- JCode child.5 JInit
+//- JCode child.3 JInit
 //- JInit.pre_text "(() => {\n  return {j: 1};\n})()"
 let {j} = (() => {
   return {j: 1};

--- a/kythe/typescript/testdata/tsx.tsx
+++ b/kythe/typescript/testdata/tsx.tsx
@@ -9,17 +9,13 @@ function render() {
     //- @"attr" defines/binding Attr
     //- @"value" ref Value
     //- Attr code AttrCode
-    //- AttrCode child.0 AttrContext
-    //- AttrContext.pre_text "(property)"
-    //- AttrCode child.1 AttrSpace
-    //- AttrSpace.pre_text " "
-    //- AttrCode child.2 AttrName
+    //- AttrCode child.0 AttrName
     //- AttrName.pre_text "attr"
-    //- AttrCode child.3 AttrTy
+    //- AttrCode child.1 AttrTy
     //- AttrTy.post_text "string"
-    //- AttrCode child.4 AttrEq
+    //- AttrCode child.2 AttrEq
     //- AttrEq.pre_text " = "
-    //- AttrCode child.5 AttrInit
+    //- AttrCode child.3 AttrInit
     //- AttrInit.pre_text "{value}"
     //- @+4"src" defines/binding _Src1
     //- @+3"value" ref Value


### PR DESCRIPTION
Instead of using `parameter`, `function`, `method` as context for marked sources we now use name of containing class/interface/enum/method. 