### PR TITLE
fix(xrefs_filter): properly merge page lists that represent allPages

### DIFF
--- a/kythe/go/serving/xrefs/xrefs_filter.go
+++ b/kythe/go/serving/xrefs/xrefs_filter.go
@@ -261,6 +261,9 @@ func postingAnd(idx postings, list []uint32, trigram uint32) []uint32 {
 }
 
 func mergeOr(l1, l2 []uint32) []uint32 {
+	if isAllPages(l1) || isAllPages(l2) {
+		return allPages
+	}
 	var l []uint32
 	var i, j int
 	for i < len(l1) || j < len(l2) {


### PR DESCRIPTION
Previously, uint32max, which represents the set of all pages, was being merged into the list of page indices and later used as an array index, which was out of bounds.