### PR TITLE
chore(java_indexer): prep for multijar

### DIFF
--- a/kythe/java/com/google/devtools/kythe/platform/java/helpers/15/JdkCompatibilityShimsImpl.java
+++ b/kythe/java/com/google/devtools/kythe/platform/java/helpers/15/JdkCompatibilityShimsImpl.java
@@ -17,56 +17,33 @@
 package com.google.devtools.kythe.platform.java.helpers;
 
 import com.google.auto.service.AutoService;
-import com.google.common.collect.ImmutableList;
 import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.tree.JCTree.JCCase;
 import com.sun.tools.javac.tree.JCTree.JCEnhancedForLoop;
 import com.sun.tools.javac.tree.JCTree.JCExpression;
-import java.lang.reflect.InvocationTargetException;
 import java.util.List;
-import java.util.Optional;
 
 /** Shims for providing source-level compatibility between JDK versions. */
 @AutoService(JdkCompatibilityShims.class)
-public final class ReflectiveJdkCompatibilityShims implements JdkCompatibilityShims {
-  private static final Runtime.Version minVersion = Runtime.Version.parse("9");
+public final class JdkCompatibilityShimsImpl implements JdkCompatibilityShims {
+  private static final Runtime.Version minVersion = Runtime.Version.parse("15");
+  private static final Runtime.Version maxVersion = Runtime.Version.parse("20");
 
-  public ReflectiveJdkCompatibilityShims() {}
+  public JdkCompatibilityShimsImpl() {}
 
   @Override
   public CompatibilityRange getCompatibileRange() {
-    return new CompatibilityRange(minVersion, Optional.empty(), CompatibilityLevel.FALLBACK);
+    return new CompatibilityRange(minVersion, maxVersion);
   }
 
   /** Return the list of expressions from a JCCase object */
   @Override
-  @SuppressWarnings("unchecked") // Safe by specification.
   public List<JCExpression> getCaseExpressions(JCCase tree) {
-    try {
-      try {
-        return (List<JCExpression>) tree.getClass().getMethod("getExpressions").invoke(tree);
-      } catch (NoSuchMethodException nsme) {
-        return ImmutableList.of(
-            (JCExpression) tree.getClass().getMethod("getExpression").invoke(tree));
-      }
-    } catch (InvocationTargetException
-        | IllegalAccessException
-        | NoSuchMethodException
-        | ClassCastException ex) {
-      throw new LinkageError(ex.getMessage(), ex);
-    }
+    return tree.getExpressions();
   }
 
   @Override
   public JCTree getForLoopVar(JCEnhancedForLoop tree) {
-    try {
-      try {
-        return (JCTree) tree.getClass().getField("varOrRecordPattern").get(tree);
-      } catch (NoSuchFieldException e) {
-        return (JCTree) tree.getClass().getField("var").get(tree);
-      }
-    } catch (IllegalAccessException | NoSuchFieldException | ClassCastException ex) {
-      throw new LinkageError(ex.getMessage(), ex);
-    }
+    return tree.var;
   }
 }

--- a/kythe/java/com/google/devtools/kythe/platform/java/helpers/20/JdkCompatibilityShimsImpl.java
+++ b/kythe/java/com/google/devtools/kythe/platform/java/helpers/20/JdkCompatibilityShimsImpl.java
@@ -25,10 +25,10 @@ import java.util.List;
 
 /** Shims for providing source-level compatibility between JDK versions. */
 @AutoService(JdkCompatibilityShims.class)
-public final class Jdk20CompatibilityShims implements JdkCompatibilityShims {
+public final class JdkCompatibilityShimsImpl implements JdkCompatibilityShims {
   private static final Runtime.Version minVersion = Runtime.Version.parse("20");
 
-  public Jdk20CompatibilityShims() {}
+  public JdkCompatibilityShimsImpl() {}
 
   @Override
   public CompatibilityRange getCompatibileRange() {

--- a/kythe/java/com/google/devtools/kythe/platform/java/helpers/9/JdkCompatibilityShimsImpl.java
+++ b/kythe/java/com/google/devtools/kythe/platform/java/helpers/9/JdkCompatibilityShimsImpl.java
@@ -26,11 +26,11 @@ import java.util.List;
 
 /** Shims for providing source-level compatibility between JDK versions. */
 @AutoService(JdkCompatibilityShims.class)
-public final class Jdk9CompatibilityShims implements JdkCompatibilityShims {
+public final class JdkCompatibilityShimsImpl implements JdkCompatibilityShims {
   private static final Runtime.Version minVersion = Runtime.Version.parse("9");
   private static final Runtime.Version maxVersion = Runtime.Version.parse("15");
 
-  public Jdk9CompatibilityShims() {}
+  public JdkCompatibilityShimsImpl() {}
 
   @Override
   public CompatibilityRange getCompatibileRange() {

--- a/kythe/java/com/google/devtools/kythe/platform/java/helpers/BUILD
+++ b/kythe/java/com/google/devtools/kythe/platform/java/helpers/BUILD
@@ -49,15 +49,18 @@ java_library(
         "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
     ],
     visibility = ["//visibility:private"],
-    deps = ["//kythe/java/com/google/devtools/kythe/util:ordered_compatibility_service"],
+    deps = [
+        "//kythe/java/com/google/devtools/kythe/util:ordered_compatibility_service",
+    ],
 )
 
 java_library(
     name = "jdk9_compatibility_shims",
-    srcs = ["Jdk9CompatibilityShims.java"],
+    srcs = ["9/JdkCompatibilityShimsImpl.java"],
     javacopts = [
         "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
         "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
+        "-Xep:PackageLocation:OFF",
     ],
     target_compatible_with = select_with_or({
         "//buildenv/java:language_version_11": [],
@@ -74,9 +77,10 @@ java_library(
 
 java_library(
     name = "jdk15_compatibility_shims",
-    srcs = ["Jdk15CompatibilityShims.java"],
+    srcs = ["15/JdkCompatibilityShimsImpl.java"],
     javacopts = [
         "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+        "-Xep:PackageLocation:OFF",
     ],
     # This is incompatible with the default test configuration and
     # bazel cquery doesn't work with objc_library targets.
@@ -98,9 +102,10 @@ java_library(
 
 java_library(
     name = "jdk20_compatibility_shims",
-    srcs = ["Jdk20CompatibilityShims.java"],
+    srcs = ["20/JdkCompatibilityShimsImpl.java"],
     javacopts = [
         "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+        "-Xep:PackageLocation:OFF",
     ],
     tags = ["manual"],
     target_compatible_with = select_with_or({
@@ -117,7 +122,7 @@ java_library(
 
 java_library(
     name = "reflective_jdk_compatibility_shims",
-    srcs = ["ReflectiveJdkCompatibilityShims.java"],
+    srcs = ["ReflectiveJdkCompatibilityShimsImpl.java"],
     javacopts = [
         "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
         "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",


### PR DESCRIPTION
Put shim implementations in different directories under the same class name so they can be included in a multijar.