### PR TITLE
feat(java): add semantic/generated=set facts for annotated proto accessors

### DIFF
--- a/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
@@ -46,6 +46,7 @@ import com.google.devtools.kythe.proto.Diagnostic;
 import com.google.devtools.kythe.proto.MarkedSource;
 import com.google.devtools.kythe.proto.Storage.VName;
 import com.google.devtools.kythe.util.Span;
+import com.google.protobuf.DescriptorProtos.GeneratedCodeInfo.Annotation.Semantic;
 import com.sun.source.tree.MemberReferenceTree.ReferenceMode;
 import com.sun.source.tree.Scope;
 import com.sun.source.tree.Tree.Kind;
@@ -1423,7 +1424,7 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
             entrySets.emitEdge(node, rule.edgeOut, rule.vname);
           }
 
-          if (rule.semantic == Metadata.Semantic.WRITE) {
+          if (rule.semantic == Semantic.WRITE) {
             VName genFuncVName = rule.reverseEdge ? node : rule.vname;
             entrySets.getEmitter().emitFact(genFuncVName, "/kythe/semantic/generated", "set");
           }

--- a/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
@@ -1424,7 +1424,7 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
             entrySets.emitEdge(node, rule.edgeOut, rule.vname);
           }
 
-          if (rule.semantic == Semantic.WRITE) {
+          if (rule.semantic == Semantic.SET) {
             VName genFuncVName = rule.reverseEdge ? node : rule.vname;
             entrySets.getEmitter().emitFact(genFuncVName, "/kythe/semantic/generated", "set");
           }

--- a/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
@@ -1422,6 +1422,13 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
           } else {
             entrySets.emitEdge(node, rule.edgeOut, rule.vname);
           }
+
+          if (rule.semantic != Metadata.Semantic.NONE) {
+            if (rule.semantic == Metadata.Semantic.WRITE) {
+              VName genFuncVName = rule.reverseEdge ? node : rule.vname;
+              entrySets.getEmitter().emitFact(genFuncVName, "/kythe/semantic/generated", "set");
+            }
+          }
         }
       }
     }

--- a/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
@@ -1423,11 +1423,9 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
             entrySets.emitEdge(node, rule.edgeOut, rule.vname);
           }
 
-          if (rule.semantic != Metadata.Semantic.NONE) {
-            if (rule.semantic == Metadata.Semantic.WRITE) {
-              VName genFuncVName = rule.reverseEdge ? node : rule.vname;
-              entrySets.getEmitter().emitFact(genFuncVName, "/kythe/semantic/generated", "set");
-            }
+          if (rule.semantic == Metadata.Semantic.WRITE) {
+            VName genFuncVName = rule.reverseEdge ? node : rule.vname;
+            entrySets.getEmitter().emitFact(genFuncVName, "/kythe/semantic/generated", "set");
           }
         }
       }

--- a/kythe/java/com/google/devtools/kythe/platform/shared/Metadata.java
+++ b/kythe/java/com/google/devtools/kythe/platform/shared/Metadata.java
@@ -34,8 +34,10 @@ import java.util.List;
 public class Metadata {
   /** An additional semantic to apply to the given (java) node. */
   public enum Semantic {
-    NONE, /// < No special semantics.
-    WRITE, /// < Write semantics.
+    /** No special semantics. */
+    NONE,
+    /** Write semantics */
+    WRITE,
   };
 
   /**

--- a/kythe/java/com/google/devtools/kythe/platform/shared/Metadata.java
+++ b/kythe/java/com/google/devtools/kythe/platform/shared/Metadata.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ListMultimap;
 import com.google.common.collect.MultimapBuilder;
 import com.google.devtools.kythe.analyzers.base.EdgeKind;
 import com.google.devtools.kythe.proto.Storage.VName;
+import com.google.protobuf.DescriptorProtos.GeneratedCodeInfo.Annotation.Semantic;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -32,14 +33,6 @@ import java.util.List;
  * path to a loadable metadata file.
  */
 public class Metadata {
-  /** An additional semantic to apply to the given (java) node. */
-  public enum Semantic {
-    /** No special semantics. */
-    NONE,
-    /** Write semantics */
-    WRITE,
-  };
-
   /**
    * A Rule can generate one additional edge based on input conditions.
    *
@@ -62,7 +55,7 @@ public class Metadata {
      */
     public boolean reverseEdge;
 
-    public Semantic semantic = Semantic.NONE;
+    public Semantic semantic;
   }
 
   /** Applies a new {@link Rule} to the file to which this metadata pertains. */

--- a/kythe/java/com/google/devtools/kythe/platform/shared/Metadata.java
+++ b/kythe/java/com/google/devtools/kythe/platform/shared/Metadata.java
@@ -32,6 +32,12 @@ import java.util.List;
  * path to a loadable metadata file.
  */
 public class Metadata {
+  /** An additional semantic to apply to the given (java) node. */
+  public enum Semantic {
+    NONE, /// < No special semantics.
+    WRITE, /// < Write semantics.
+  };
+
   /**
    * A Rule can generate one additional edge based on input conditions.
    *
@@ -53,6 +59,8 @@ public class Metadata {
      * we will emit {@code Node edgeOut vname}.
      */
     public boolean reverseEdge;
+
+    public Semantic semantic = Semantic.NONE;
   }
 
   /** Applies a new {@link Rule} to the file to which this metadata pertains. */

--- a/kythe/java/com/google/devtools/kythe/platform/shared/ProtobufMetadataLoader.java
+++ b/kythe/java/com/google/devtools/kythe/platform/shared/ProtobufMetadataLoader.java
@@ -145,6 +145,19 @@ public class ProtobufMetadataLoader implements MetadataLoader {
               .build();
       rule.edgeOut = EdgeKind.GENERATES;
       rule.reverseEdge = true;
+
+      switch (annotation.getSemantic()) {
+        case NONE:
+          break;
+        case SET:
+          rule.semantic = Metadata.Semantic.WRITE;
+          break;
+        case ALIAS:
+          logger.atWarning().log(
+              "Metadata contains annotation with semantic=ALIAS, which shouldn't be used in java");
+          break;
+      }
+
       metadata.addRule(rule);
     }
     for (VName vname : fileVNames) {

--- a/kythe/java/com/google/devtools/kythe/platform/shared/ProtobufMetadataLoader.java
+++ b/kythe/java/com/google/devtools/kythe/platform/shared/ProtobufMetadataLoader.java
@@ -145,19 +145,7 @@ public class ProtobufMetadataLoader implements MetadataLoader {
               .build();
       rule.edgeOut = EdgeKind.GENERATES;
       rule.reverseEdge = true;
-
-      switch (annotation.getSemantic()) {
-        case NONE:
-          break;
-        case SET:
-          rule.semantic = Metadata.Semantic.WRITE;
-          break;
-        case ALIAS:
-          logger.atWarning().log(
-              "Metadata contains annotation with semantic=ALIAS, which shouldn't be used in java");
-          break;
-      }
-
+      rule.semantic = annotation.getSemantic();
       metadata.addRule(rule);
     }
     for (VName vname : fileVNames) {


### PR DESCRIPTION
I have some proto verifier tests to exercise this, but they require the internal changes to `protoc` to be pushed to github, then included in a release, then updated in our dependencies. Merging this earlier will allow us to try this out in internally sooner.