### PR TITLE
feat(java_indexer): add Semantic field to protobuf Metadata

### DIFF
--- a/kythe/java/com/google/devtools/kythe/platform/shared/Metadata.java
+++ b/kythe/java/com/google/devtools/kythe/platform/shared/Metadata.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ListMultimap;
 import com.google.common.collect.MultimapBuilder;
 import com.google.devtools.kythe.analyzers.base.EdgeKind;
 import com.google.devtools.kythe.proto.Storage.VName;
+import com.google.protobuf.DescriptorProtos.GeneratedCodeInfo.Annotation.Semantic;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -53,6 +54,9 @@ public class Metadata {
      * we will emit {@code Node edgeOut vname}.
      */
     public boolean reverseEdge;
+
+    /** Represents the identified object's effect on the element in the original .proto file. */
+    public Semantic semantic;
   }
 
   /** Applies a new {@link Rule} to the file to which this metadata pertains. */

--- a/kythe/java/com/google/devtools/kythe/platform/shared/ProtobufMetadataLoader.java
+++ b/kythe/java/com/google/devtools/kythe/platform/shared/ProtobufMetadataLoader.java
@@ -145,6 +145,7 @@ public class ProtobufMetadataLoader implements MetadataLoader {
               .build();
       rule.edgeOut = EdgeKind.GENERATES;
       rule.reverseEdge = true;
+      rule.semantic = annotation.getSemantic();
       metadata.addRule(rule);
     }
     for (VName vname : fileVNames) {


### PR DESCRIPTION
The field will be used by java-based indexers to emit `semantic/generated` facts when processing proto-generated code.