### PR TITLE
feat(typescript_indexer): handle type nodes when emitting ref/id from object bindings

### DIFF
--- a/kythe/typescript/indexer.ts
+++ b/kythe/typescript/indexer.ts
@@ -2061,7 +2061,12 @@ class Visitor {
     if (propName == null) return;
     const propertyOnType = type.getProperty(propName);
     if (propertyOnType == null) return;
-    const vname = this.host.getSymbolName(propertyOnType, TSNamespace.VALUE);
+    const propFlags = propertyOnType.flags;
+    const isType = (propFlags &
+                    (ts.SymbolFlags.Class | ts.SymbolFlags.Interface |
+                     ts.SymbolFlags.RegularEnum | ts.SymbolFlags.TypeAlias)) > 0;
+    const vname = this.host.getSymbolName(
+        propertyOnType, isType ? TSNamespace.TYPE : TSNamespace.VALUE);
     if (vname == null) return;
     const anchor = this.newAnchor(prop);
     this.emitEdge(anchor, EdgeKind.REF_ID, vname);

--- a/kythe/typescript/testdata/dynamic_import_group/import.ts
+++ b/kythe/typescript/testdata/dynamic_import_group/import.ts
@@ -1,6 +1,7 @@
 
 function regularFunction() {
     //- @"'./module'" ref/imports Mod
+    //- @StuffDoer ref/id StuffDoer
     import('./module').then(({StuffDoer}) => {
         new StuffDoer().doStuff();
     })
@@ -13,8 +14,17 @@ function regularFunction() {
 }
 
 async function asyncFunction() {
+    const {
+        //- @StuffDoer ref/id StuffDoer
+        StuffDoer,
+        //- @CONSTANT ref/id Constant
+        CONSTANT,
+        //- @doStuff ref/id DoStuff
+        doStuff,
+        //- @Enum ref/id Enum
+        Enum,
     //- @"'./module'" ref/imports Mod
-    const {StuffDoer} = await import('./module');
+    } = await import('./module');
     new StuffDoer().doStuff();
 }
 

--- a/kythe/typescript/testdata/dynamic_import_group/module.ts
+++ b/kythe/typescript/testdata/dynamic_import_group/module.ts
@@ -1,5 +1,16 @@
 //- Mod=vname("module", _, _, "testdata/dynamic_import_group/module", _).node/kind record
 
+//- @StuffDoer defines/binding StuffDoer
+//- StuffDoer.node/kind record
 export class StuffDoer {
     doStuff() {}
 }
+
+//- @CONSTANT defines/binding Constant
+export const CONSTANT = 1;
+
+//- @doStuff defines/binding DoStuff
+export function doStuff() {}
+
+//- @Enum defines/binding Enum
+export enum Enum {}


### PR DESCRIPTION
This fixes indexing of dynamic imports where imported symbols such as classes and enums use TSNamespace.TYPE in their vnames. 