### PR TITLE
feat(typescript_indexer): add flag to emit zero-width spans for module nodes

### DIFF
--- a/kythe/typescript/indexer.ts
+++ b/kythe/typescript/indexer.ts
@@ -81,6 +81,11 @@ export interface IndexingOptions {
    */
   readFile?: (path: string) => Buffer;
 
+  /**
+   * When enabled emits 0-0 spans at the beginning of each file that represent current module.
+   * By default 0-1 spans are emitted. Also this flag changes it to emit `defines/implicit`
+   * edtes instead of `defines/binding`.
+   */
   emitZeroWidthSpansForModuleNodes?: boolean;
 }
 

--- a/kythe/typescript/indexer.ts
+++ b/kythe/typescript/indexer.ts
@@ -80,6 +80,8 @@ export interface IndexingOptions {
    * is used.
    */
   readFile?: (path: string) => Buffer;
+
+  emitZeroWidthSpansForModuleNodes?: boolean;
 }
 
 /**
@@ -1571,8 +1573,14 @@ class Visitor {
     this.emitEdge(this.kFile, EdgeKind.CHILD_OF, kMod);
 
     // Emit the anchor, bound to the beginning of the file.
-    const anchor = this.newAnchor(this.file, 0, 1);
-    this.emitEdge(anchor, EdgeKind.DEFINES_BINDING, kMod);
+    const anchor = this.newAnchor(
+        this.file, 0, this.host.options.emitZeroWidthSpansForModuleNodes ? 0 : 1);
+    this.emitEdge(
+        anchor,
+        this.host.options.emitZeroWidthSpansForModuleNodes ?
+            EdgeKind.DEFINES_IMPLICIT :
+            EdgeKind.DEFINES_BINDING,
+        kMod);
   }
 
   /**

--- a/kythe/typescript/indexer.ts
+++ b/kythe/typescript/indexer.ts
@@ -84,7 +84,7 @@ export interface IndexingOptions {
   /**
    * When enabled emits 0-0 spans at the beginning of each file that represent current module.
    * By default 0-1 spans are emitted. Also this flag changes it to emit `defines/implicit`
-   * edtes instead of `defines/binding`.
+   * edges instead of `defines/binding`.
    */
   emitZeroWidthSpansForModuleNodes?: boolean;
 }

--- a/kythe/typescript/kythe.ts
+++ b/kythe/typescript/kythe.ts
@@ -51,6 +51,7 @@ export enum EdgeKind {
   COMPLETES_UNIQUELY = '/kythe/edge/completes/uniquely',
   DEFINES = '/kythe/edge/defines',
   DEFINES_BINDING = '/kythe/edge/defines/binding',
+  DEFINES_IMPLICIT = '/kythe/edge/defines/implicit',
   DEPENDS = '/kythe/edge/depends',
   DOCUMENTS = '/kythe/edge/documents',
   EXPORTS = '/kythe/edge/exports',


### PR DESCRIPTION
At the moment TS emits 1-width spans at the beginning of the file that `defines/binding` semantic node that represents module. The new flag changes it to:

1. Emit zero-width spans so that that span is not treated as something clickable in UIs.
2. Use `defines/implicit` instead of `defines/binding`.