### PR TITLE
fix(cxx_common): attempt to reduce memory usage of bazel artifact selector

### DIFF
--- a/kythe/cxx/extractor/BUILD
+++ b/kythe/cxx/extractor/BUILD
@@ -349,6 +349,7 @@ cc_library(
         "@com_github_google_glog//:glog",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/container:node_hash_map",
         "@com_google_absl//absl/hash",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",

--- a/kythe/cxx/extractor/BUILD
+++ b/kythe/cxx/extractor/BUILD
@@ -349,6 +349,7 @@ cc_library(
         "@com_github_google_glog//:glog",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/hash",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/types:optional",

--- a/kythe/cxx/extractor/bazel_artifact.h
+++ b/kythe/cxx/extractor/bazel_artifact.h
@@ -38,6 +38,11 @@ struct BazelArtifactFile {
   bool operator!=(const BazelArtifactFile& other) const {
     return !(*this == other);
   }
+
+  template <typename H>
+  friend H AbslHashValue(H h, const BazelArtifactFile& file) {
+    return H::combine(std::move(h), file.local_path, file.uri);
+  }
 };
 
 /// \brief A list of extracted compilation units and the target which owns them.

--- a/kythe/cxx/extractor/bazel_artifact_selector.h
+++ b/kythe/cxx/extractor/bazel_artifact_selector.h
@@ -168,13 +168,17 @@ class AspectArtifactSelector final : public BazelArtifactSelector {
   absl::Status DeserializeFrom(const google::protobuf::Any& state) final;
 
  private:
+  struct FileSet {
+    absl::flat_hash_set<BazelArtifactFile> files;
+    absl::flat_hash_set<std::string> children;
+  };
+
   struct State {
     // A record of all of the NamedSetOfFiles events which have been processed.
     absl::flat_hash_set<std::string> disposed;
-    // Mapping from fileset id to NamedSetOfFiles whose file names matched the
-    // allowlist, but have not yet been consumed by an event.
-    absl::flat_hash_map<std::string, build_event_stream::NamedSetOfFiles>
-        filesets;
+    // Mapping from fileset id to NamedSetOfFiles whose file names matched
+    // the allowlist, but have not yet been consumed by an event.
+    absl::flat_hash_map<std::string, FileSet> filesets;
     // Mapping from fileset id to target name which required that
     // file set when it had not yet been seen.
     absl::flat_hash_map<std::string, std::string> pending;
@@ -188,6 +192,8 @@ class AspectArtifactSelector final : public BazelArtifactSelector {
 
   void ReadFilesInto(absl::string_view id, absl::string_view target,
                      std::vector<BazelArtifactFile>& files);
+  bool InsertFileSet(absl::string_view id,
+                     const build_event_stream::NamedSetOfFiles& fileset);
 
   Options options_;
   State state_;

--- a/kythe/cxx/extractor/bazel_artifact_selector.h
+++ b/kythe/cxx/extractor/bazel_artifact_selector.h
@@ -22,6 +22,7 @@
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
+#include "absl/container/node_hash_map.h"
 #include "absl/meta/type_traits.h"
 #include "absl/status/status.h"
 #include "absl/types/optional.h"
@@ -153,6 +154,11 @@ class AspectArtifactSelector final : public BazelArtifactSelector {
   explicit AspectArtifactSelector(Options options)
       : options_(std::move(options)) {}
 
+  AspectArtifactSelector(const AspectArtifactSelector& other);
+  AspectArtifactSelector& operator=(const AspectArtifactSelector& other);
+  AspectArtifactSelector(AspectArtifactSelector&&) = default;
+  AspectArtifactSelector& operator=(AspectArtifactSelector&&) = default;
+
   /// \brief Selects an artifact if the event matches an expected
   /// aspect-produced compilation unit.
   absl::optional<BazelArtifact> Select(
@@ -169,13 +175,15 @@ class AspectArtifactSelector final : public BazelArtifactSelector {
 
  private:
   struct FileSet {
-    absl::flat_hash_set<BazelArtifactFile> files;
+    std::vector<const BazelArtifactFile*> files;
     absl::flat_hash_set<std::string> children;
   };
 
   struct State {
     // A record of all of the NamedSetOfFiles events which have been processed.
     absl::flat_hash_set<std::string> disposed;
+    // Map of active files to count of filesets which contain it.
+    absl::node_hash_map<BazelArtifactFile, int> files;
     // Mapping from fileset id to NamedSetOfFiles whose file names matched
     // the allowlist, but have not yet been consumed by an event.
     absl::flat_hash_map<std::string, FileSet> filesets;


### PR DESCRIPTION
This should reduce memory usage somewhat, although there are likely more gains to be had particularly during serialization.  This should incidentally reduce the size of the serialized state by removing the unused fields and using a slightly more compact format for the fields which *are* used.