### PR TITLE
feat(typescript_indexer): improve marked source CONTEXT nodes

### DIFF
--- a/kythe/typescript/testdata/marked_source/class.ts
+++ b/kythe/typescript/testdata/marked_source/class.ts
@@ -12,16 +12,18 @@ class MyClass {
     //-
     //- ConstructorCode child.0 ConstructorContext
     //- ConstructorContext.kind "CONTEXT"
-    //- ConstructorContext.pre_text "MyClass"
+    //- ConstructorContext.post_child_text "."
+    //- ConstructorContext.add_final_list_token true
     //-
-    //- ConstructorCode child.1 ConstructorSpace
-    //- ConstructorSpace.pre_text " "
+    //- ConstructorContext child.0 ConstructorContextId
+    //- ConstructorContextId.kind "IDENTIFIER"
+    //- ConstructorContextId.pre_text "MyClass"
     //-
-    //- ConstructorCode child.2 ConstructorId
+    //- ConstructorCode child.1 ConstructorId
     //- ConstructorId.kind "IDENTIFIER"
     //- ConstructorId.pre_text "constructor"
     //-
-    //- ConstructorCode child.3 ConstructorParams
+    //- ConstructorCode child.2 ConstructorParams
     //- ConstructorParams.kind "PARAMETER_LOOKUP_BY_PARAM"
     //- ConstructorParams.pre_text "("
     //- ConstructorParams.post_text ")"
@@ -35,22 +37,24 @@ class MyClass {
     //-
     //- MyMethodCode child.0 MyMethodContext
     //- MyMethodContext.kind "CONTEXT"
-    //- MyMethodContext.pre_text "MyClass"
+    //- MyMethodContext.post_child_text "."
+    //- MyMethodContext.add_final_list_token true
     //-
-    //- MyMethodCode child.1 MyMethodSpace
-    //- MyMethodSpace.pre_text " "
-    //- 
-    //- MyMethodCode child.2 MyMethodCodeId
+    //- MyMethodContext child.0 MyMethodContextId
+    //- MyMethodContextId.kind "IDENTIFIER"
+    //- MyMethodContextId.pre_text "MyClass"
+    //-
+    //- MyMethodCode child.1 MyMethodCodeId
     //- MyMethodCodeId.kind "IDENTIFIER"
     //- MyMethodCodeId.pre_text "myMethod"
     //- 
-    //- MyMethodCode child.3 MyMethodParams
+    //- MyMethodCode child.2 MyMethodParams
     //- MyMethodParams.kind "PARAMETER_LOOKUP_BY_PARAM"
     //- MyMethodParams.pre_text "("
     //- MyMethodParams.post_text ")"
     //- MyMethodParams.post_child_text ", "
     //-
-    //- MyMethodCode child.4 MyMethodReturnType
+    //- MyMethodCode child.3 MyMethodReturnType
     //- MyMethodReturnType.kind "TYPE"
     //- MyMethodReturnType.pre_text ": "
     //- MyMethodReturnType.post_text "MyClass"
@@ -61,16 +65,22 @@ class MyClass {
     //- 
     //- ArgCode child.0 ArgCodeContext
     //- ArgCodeContext.kind "CONTEXT"
-    //- ArgCodeContext.pre_text "MyClass.myMethod"
+    //- ArgCodeContext.post_child_text "."
+    //- ArgCodeContext.add_final_list_token true
+    //-
+    //- ArgCodeContext child.0 ArgCodeContextClassId
+    //- ArgCodeContextClassId.kind "IDENTIFIER"
+    //- ArgCodeContextClassId.pre_text "MyClass"
+    //-
+    //- ArgCodeContext child.1 ArgCodeContextMethodId
+    //- ArgCodeContextMethodId.kind "IDENTIFIER"
+    //- ArgCodeContextMethodId.pre_text "myMethod"
     //- 
-    //- ArgCode child.1 ArgCodeSpace
-    //- ArgCodeSpace.pre_text " "
-    //- 
-    //- ArgCode child.2 ArgCodeId
+    //- ArgCode child.1 ArgCodeId
     //- ArgCodeId.kind "IDENTIFIER"
     //- ArgCodeId.pre_text "arg"
     //-
-    //- ArgCode child.3 ArgCodeType
+    //- ArgCode child.2 ArgCodeType
     //- ArgCodeType.kind "TYPE"
     //- ArgCodeType.pre_text ": "
     //- ArgCodeType.post_text "number"
@@ -81,7 +91,7 @@ class MyClass {
     // Test that return type is inferred.
     //- @returnNumber defines/binding ReturnNumber
     //- ReturnNumber code ReturnNumberCode
-    //- ReturnNumberCode child.4 ReturnNumberType
+    //- ReturnNumberCode child.3 ReturnNumberType
     //- ReturnNumberType.kind "TYPE"
     //- ReturnNumberType.pre_text ": "
     //- ReturnNumberType.post_text "number"

--- a/kythe/typescript/testdata/marked_source/enum.ts
+++ b/kythe/typescript/testdata/marked_source/enum.ts
@@ -13,20 +13,22 @@ enum MyEnum {
     //- 
     //- MyValueCode child.0 MyValueContext
     //- MyValueContext.kind "CONTEXT"
-    //- MyValueContext.pre_text "MyEnum"
+    //- MyValueContext.post_child_text "."
+    //- MyValueContext.add_final_list_token true
     //-
-    //- MyValueCode child.1 MyValueSpace
-    //- MyValueSpace.pre_text " "
+    //- MyValueContext child.0 MyValueContextId
+    //- MyValueContextId.kind "IDENTIFIER"
+    //- MyValueContextId.pre_text "MyEnum"
     //-
-    //- MyValueCode child.2 MyValueId
+    //- MyValueCode child.1 MyValueId
     //- MyValueId.kind "IDENTIFIER"
     //- MyValueId.pre_text "MY_VALUE"
     //- 
-    //- MyValueCode child.3 MyValueEqual
+    //- MyValueCode child.2 MyValueEqual
     //- MyValueEqual.kind "BOX"
     //- MyValueEqual.pre_text " = "
     //-
-    //- MyValueCode child.4 MyValueInitializer
+    //- MyValueCode child.3 MyValueInitializer
     //- MyValueInitializer.kind "INITIALIZER"
     //- MyValueInitializer.pre_text "123"
     MY_VALUE = 123,

--- a/kythe/typescript/testdata/marked_source/function.ts
+++ b/kythe/typescript/testdata/marked_source/function.ts
@@ -23,25 +23,27 @@
 //- 
 //- ArgCode child.0 ArgCodeContext
 //- ArgCodeContext.kind "CONTEXT"
-//- ArgCodeContext.pre_text "myFunction"
+//- ArgCodeContext.post_child_text "."
+//- ArgCodeContext.add_final_list_token true
 //-
-//- ArgCode child.1 ArgCodeSpace
-//- ArgCodeSpace.pre_text " "
+//- ArgCodeContext child.0 ArgCodeContextId
+//- ArgCodeContextId.kind "IDENTIFIER"
+//- ArgCodeContextId.pre_text "myFunction"
 //-
-//- ArgCode child.2 ArgCodeId
+//- ArgCode child.1 ArgCodeId
 //- ArgCodeId.kind "IDENTIFIER"
 //- ArgCodeId.pre_text "arg"
 //-
-//- ArgCode child.3 ArgCodeType
+//- ArgCode child.2 ArgCodeType
 //- ArgCodeType.kind "TYPE"
 //- ArgCodeType.pre_text ": "
 //- ArgCodeType.post_text "string"
 //-
-//- ArgCode child.4 ArgCodeEqual
+//- ArgCode child.3 ArgCodeEqual
 //- ArgCodeEqual.kind "BOX"
 //- ArgCodeEqual.pre_text " = "
 //-
-//- ArgCode child.5 ArgCodeDefaultValue
+//- ArgCode child.4 ArgCodeDefaultValue
 //- ArgCodeDefaultValue.kind "INITIALIZER"
 //- ArgCodeDefaultValue.pre_text "'0'"
 function myFunction(arg: string = '0'): number {

--- a/kythe/typescript/testdata/marked_source/property.ts
+++ b/kythe/typescript/testdata/marked_source/property.ts
@@ -1,33 +1,41 @@
 class A {
   //- @#0member defines/binding Member
   //- Member code MemberCode
+  //-
   //- MemberCode child.0 MemberContext
-  //- MemberContext.pre_text "A"
-  //- MemberCode child.1 MemberSpace
-  //- MemberSpace.pre_text " "
-  //- MemberCode child.2 MemberName
+  //- MemberContext.post_child_text "."
+  //- MemberContext.add_final_list_token true
+  //-
+  //- MemberContext child.0 MemberContextId
+  //- MemberContextId.pre_text "A"
+  //-
+  //- MemberCode child.1 MemberName
   //- MemberName.pre_text "member"
-  //- MemberCode child.3 MemberTy
+  //- MemberCode child.2 MemberTy
   //- MemberTy.post_text "string"
-  //- MemberCode child.4 MemberEq
+  //- MemberCode child.3 MemberEq
   //- MemberEq.pre_text " = "
-  //- MemberCode child.5 MemberInit
+  //- MemberCode child.4 MemberInit
   //- MemberInit.pre_text "'member'"
   member = 'member';
 
   //- @#0staticmember defines/binding StaticMember
   //- StaticMember code StaticMemberCode
+  //-
   //- StaticMemberCode child.0 StaticMemberContext
-  //- StaticMemberContext.pre_text "A"
-  //- StaticMemberCode child.1 StaticMemberSpace
-  //- StaticMemberSpace.pre_text " "
-  //- StaticMemberCode child.2 StaticMemberName
+  //- StaticMemberContext.post_child_text "."
+  //- StaticMemberContext.add_final_list_token true
+  //-
+  //- StaticMemberContext child.0 StaticMemberContextId
+  //- StaticMemberContextId.pre_text "A"
+  //-
+  //- StaticMemberCode child.1 StaticMemberName
   //- StaticMemberName.pre_text "staticmember"
-  //- StaticMemberCode child.3 StaticMemberTy
+  //- StaticMemberCode child.2 StaticMemberTy
   //- StaticMemberTy.post_text "string"
-  //- StaticMemberCode child.4 StaticMemberEq
+  //- StaticMemberCode child.3 StaticMemberEq
   //- StaticMemberEq.pre_text " = "
-  //- StaticMemberCode child.5 StaticMemberInit
+  //- StaticMemberCode child.4 StaticMemberInit
   //- StaticMemberInit.pre_text "'staticmember'"
   static staticmember = 'staticmember';
 }
@@ -49,13 +57,17 @@ let b = {
 interface C {
   //- @cprop defines/binding CProp
   //- CProp code CPropCode
+  //-
   //- CPropCode child.0 CPropContext
-  //- CPropContext.pre_text "C"
-  //- CPropCode child.1 CPropSpace
-  //- CPropSpace.pre_text " "
-  //- CPropCode child.2 CPropName
+  //- CPropContext.post_child_text "."
+  //- CPropContext.add_final_list_token true
+  //-
+  //- CPropContext child.0 CPropContextId
+  //- CPropContextId.pre_text "C"
+  //-
+  //- CPropCode child.1 CPropName
   //- CPropName.pre_text "cprop"
-  //- CPropCode child.3 CPropTy
+  //- CPropCode child.2 CPropTy
   //- CPropTy.post_text "string"
   cprop: string;
 }


### PR DESCRIPTION
Given the following class

```ts
class Person {
  getName(): string;
}
```

Previously marked source for the `getName` method was:

```json
{
    "kind": "BOX",
    "child": [
        {
            "kind": "CONTEXT",
            "pre_text": "Person"
        },
        {
            "kind": "BOX",
            "pre_text": " "
        },
        {
            "kind": "IDENTIFIER",
            "pre_text": "getName"
        }
    ]
}
```

After this change:

```json
{
    "kind": "BOX",
    "child": [
        {
            "kind": "CONTEXT",
            "post_child_text": ".",
            "add_final_list_token": true,
            "child": [
                {
                    "kind": "IDENTIFIER",
                    "pre_text": "Person"
                }
            ]
        },
        {
            "kind": "IDENTIFIER",
            "pre_text": "getName"
        }
    ]
}
```

This is closer to how it is represented in other languages (java, c++).
  