### PR TITLE
chore: count file references to select duplicate files in some cases

### DIFF
--- a/kythe/cxx/extractor/bazel_artifact_selector.h
+++ b/kythe/cxx/extractor/bazel_artifact_selector.h
@@ -211,9 +211,19 @@ class AspectArtifactSelector final : public BazelArtifactSelector {
     auto end() const { return id_map_.end(); }
 
    private:
+    struct Entry {
+      FileId id;
+      int count = 0;
+    };
+    using FileMap = absl::node_hash_map<BazelArtifactFile, Entry>;
+    using IdMap = absl::flat_hash_map<FileId, const BazelArtifactFile*>;
+
+    BazelArtifactFile ExtractIterators(IdMap::iterator id_iter,
+                                       FileMap::iterator file_iter);
+
     uint64_t next_id_ = 0;
-    absl::node_hash_map<BazelArtifactFile, FileId> file_map_;
-    absl::flat_hash_map<FileId, const BazelArtifactFile*> id_map_;
+    FileMap file_map_;
+    IdMap id_map_;
   };
 
   struct FileSet {


### PR DESCRIPTION
Not exactly a bug fix, but there are some internal tests which care about this.

Specifically, the contract of this API is that each file will be selected for at least one target which contains it, not every target, so either behavior is correct.