### PR TITLE
feat(java_indexer): try to handle unsupported -source flags

### DIFF
--- a/kythe/java/com/google/devtools/kythe/platform/java/BUILD
+++ b/kythe/java/com/google/devtools/kythe/platform/java/BUILD
@@ -33,6 +33,7 @@ java_library(
     srcs = ["JavacOptionsUtils.java"],
     javacopts = [
         "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+        "--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
         "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
         "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
         "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",

--- a/kythe/java/com/google/devtools/kythe/platform/java/BUILD
+++ b/kythe/java/com/google/devtools/kythe/platform/java/BUILD
@@ -38,6 +38,7 @@ java_library(
         "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
     ],
     deps = [
+        "//kythe/java/com/google/devtools/kythe/common:flogger",
         "//kythe/proto:analysis_java_proto",
         "//kythe/proto:java_java_proto",
         "//third_party/guava",

--- a/kythe/java/com/google/devtools/kythe/platform/java/JavaCompilationDetails.java
+++ b/kythe/java/com/google/devtools/kythe/platform/java/JavaCompilationDetails.java
@@ -208,7 +208,8 @@ public class JavaCompilationDetails implements AutoCloseable {
     ModifiableOptions arguments =
         ModifiableOptions.of(compilationUnit.getArgumentList())
             .ensureEncodingSet(DEFAULT_ENCODING)
-            .updateWithJavaOptions(compilationUnit);
+            .updateWithJavaOptions(compilationUnit)
+            .updateToMinimumSupportedSourceVersion();
 
     if (processors.isEmpty()) {
       arguments.add("-proc:none");

--- a/kythe/javatests/com/google/devtools/kythe/platform/java/BUILD
+++ b/kythe/javatests/com/google/devtools/kythe/platform/java/BUILD
@@ -7,6 +7,7 @@ java_test(
     size = "small",
     srcs = ["OptionsTest.java"],
     javacopts = [
+        "--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
         "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
     ],
     jvm_flags = [

--- a/kythe/javatests/com/google/devtools/kythe/platform/java/OptionsTest.java
+++ b/kythe/javatests/com/google/devtools/kythe/platform/java/OptionsTest.java
@@ -208,4 +208,53 @@ public class OptionsTest {
     assertThat(updatedArgs.get(updatedArgs.indexOf("--boot-class-path") + 1))
         .matches(".*(\\.jar|lib/modules)");
   }
+
+  @Test
+  public void updateToMinimumSupportedSourceVersion_updatesSource() {
+    // We can't test the --source format of the flag because it is only supported by recent versions
+    // of java.
+    ModifiableOptions args = ModifiableOptions.of(ImmutableList.of("-foo", "-source", "7"));
+
+    assertThat(args.updateToMinimumSupportedSourceVersion().build())
+        .containsExactly("-foo", "-source", "8")
+        .inOrder();
+  }
+
+  @Test
+  public void updateToMinimumSupportedSourceVersion_updatesSource1DotFormat() {
+    ModifiableOptions args = ModifiableOptions.of(ImmutableList.of("-foo", "-source", "1.7"));
+
+    assertThat(args.updateToMinimumSupportedSourceVersion().build())
+        .containsExactly("-foo", "-source", "8")
+        .inOrder();
+  }
+
+  @Test
+  public void updateToMinimumSupportedSourceVersion_removeTarget() {
+    ModifiableOptions args =
+        ModifiableOptions.of(ImmutableList.of("-foo", "-source", "7", "-target", "7"));
+
+    assertThat(args.updateToMinimumSupportedSourceVersion().build())
+        .containsExactly("-foo", "-source", "8")
+        .inOrder();
+  }
+
+  @Test
+  public void updateToMinimumSupportedSourceVersion_updatesMultipleSource() {
+    ModifiableOptions args =
+        ModifiableOptions.of(ImmutableList.of("-foo", "-source", "7", "-source", "6"));
+
+    assertThat(args.updateToMinimumSupportedSourceVersion().build())
+        .containsExactly("-foo", "-source", "8")
+        .inOrder();
+  }
+
+  @Test
+  public void updateToMinimumSupportedSourceVersion_doesNotUpdateSupportedVersion() {
+    ModifiableOptions args = ModifiableOptions.of(ImmutableList.of("-foo", "-source", "9"));
+
+    assertThat(args.updateToMinimumSupportedSourceVersion().build())
+        .containsExactly("-foo", "-source", "9")
+        .inOrder();
+  }
 }

--- a/kythe/javatests/com/google/devtools/kythe/platform/java/OptionsTest.java
+++ b/kythe/javatests/com/google/devtools/kythe/platform/java/OptionsTest.java
@@ -24,6 +24,7 @@ import com.google.devtools.kythe.platform.java.JavacOptionsUtils.ModifiableOptio
 import com.google.devtools.kythe.proto.Analysis.CompilationUnit;
 import com.google.devtools.kythe.proto.Java.JavaDetails;
 import com.google.protobuf.Any;
+import com.sun.tools.javac.code.Source;
 import com.sun.tools.javac.main.Option;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -213,48 +214,53 @@ public class OptionsTest {
   public void updateToMinimumSupportedSourceVersion_updatesSource() {
     // We can't test the --source format of the flag because it is only supported by recent versions
     // of java.
-    ModifiableOptions args = ModifiableOptions.of(ImmutableList.of("-foo", "-source", "7"));
+    ModifiableOptions args =
+        ModifiableOptions.of(ImmutableList.of("-foo", "-source", Source.JDK1_2.name));
 
     assertThat(args.updateToMinimumSupportedSourceVersion().build())
-        .containsExactly("-foo", "-source", "8")
+        .containsExactly("-foo", "-source", Source.MIN.name)
         .inOrder();
   }
 
   @Test
   public void updateToMinimumSupportedSourceVersion_updatesSource1DotFormat() {
-    ModifiableOptions args = ModifiableOptions.of(ImmutableList.of("-foo", "-source", "1.7"));
+    ModifiableOptions args =
+        ModifiableOptions.of(ImmutableList.of("-foo", "-source", Source.JDK1_2.name));
 
     assertThat(args.updateToMinimumSupportedSourceVersion().build())
-        .containsExactly("-foo", "-source", "8")
+        .containsExactly("-foo", "-source", Source.MIN.name)
         .inOrder();
   }
 
   @Test
   public void updateToMinimumSupportedSourceVersion_removeTarget() {
     ModifiableOptions args =
-        ModifiableOptions.of(ImmutableList.of("-foo", "-source", "7", "-target", "7"));
+        ModifiableOptions.of(
+            ImmutableList.of("-foo", "-source", Source.JDK1_2.name, "-target", Source.JDK1_2.name));
 
     assertThat(args.updateToMinimumSupportedSourceVersion().build())
-        .containsExactly("-foo", "-source", "8")
+        .containsExactly("-foo", "-source", Source.MIN.name)
         .inOrder();
   }
 
   @Test
   public void updateToMinimumSupportedSourceVersion_updatesMultipleSource() {
     ModifiableOptions args =
-        ModifiableOptions.of(ImmutableList.of("-foo", "-source", "7", "-source", "6"));
+        ModifiableOptions.of(
+            ImmutableList.of("-foo", "-source", Source.JDK1_2.name, "-source", Source.JDK1_3.name));
 
     assertThat(args.updateToMinimumSupportedSourceVersion().build())
-        .containsExactly("-foo", "-source", "8")
+        .containsExactly("-foo", "-source", Source.MIN.name)
         .inOrder();
   }
 
   @Test
   public void updateToMinimumSupportedSourceVersion_doesNotUpdateSupportedVersion() {
-    ModifiableOptions args = ModifiableOptions.of(ImmutableList.of("-foo", "-source", "9"));
+    ModifiableOptions args =
+        ModifiableOptions.of(ImmutableList.of("-foo", "-source", Source.DEFAULT.name));
 
     assertThat(args.updateToMinimumSupportedSourceVersion().build())
-        .containsExactly("-foo", "-source", "9")
+        .containsExactly("-foo", "-source", Source.DEFAULT.name)
         .inOrder();
   }
 }


### PR DESCRIPTION
If the -source flag is set to a version below our minimum supported version, change the flag to our minimum supported version and try to index the CU. java flag behavior may have changed between the source version requested and the one we replace it with, but the alternative is to immediately fail indexing when the Java APIs throw an exception or return an error when they are aware of the unsupported -source version.