### PR TITLE
chore(typescript_indexer): extract plugin API to a separate file

### DIFF
--- a/kythe/typescript/BUILD
+++ b/kythe/typescript/BUILD
@@ -27,6 +27,7 @@ ts_project(
     name = "indexer",
     srcs = [
         "indexer.ts",
+        "plugin_api.ts",
         "utf8.ts",
     ],
     declaration = True,

--- a/kythe/typescript/README.md
+++ b/kythe/typescript/README.md
@@ -54,6 +54,17 @@ TypeScript projects this doesn't come up because all files are modules.
 
 ## Design notes
 
+### Plugin system
+
+Indexer is based on plugin system. Each plugin takes an `IndexerHost` instance
+and emits Kythe nodes, facts and edges. Plugin usually iterates through a set of
+srcs files and processes them resulting in Kythe data.
+
+There is one default plugin that always included - `TypescriptIndexer`. This
+plugin does the main indexing work: go through all symbols in file and emit
+nodes and edges for them. Other plugins live outside of this repo and are can
+be passed as optional array.
+
 ### Separate compilation
 
 The Google TypeScript build relies heavily on TypeScript's `--declaration` flag

--- a/kythe/typescript/indexer.ts
+++ b/kythe/typescript/indexer.ts
@@ -22,6 +22,7 @@ import * as ts from 'typescript';
 
 import {EdgeKind, FactName, JSONEdge, JSONFact, JSONMarkedSource, makeOrdinalEdge, MarkedSourceKind, NodeKind, OrdinalEdge, Subkind, VName} from './kythe';
 import * as utf8 from './utf8';
+import { CompilationUnit, Context, IndexerHost, IndexingOptions, Plugin, TSNamespace } from './plugin_api';
 
 const LANGUAGE = 'typescript';
 
@@ -29,150 +30,6 @@ enum RefType {
   READ,
   WRITE,
   READ_WRITE
-}
-
-/** A unit of code that can be indexed. It resembles Kythe's CompilationUnit proto. */
-export interface CompilationUnit {
-  /** A VName for the entire compilation, containing e.g. corpus name. Used as basis for all vnames emitted by indexer. */
-  rootVName: VName;
-
-  /** A map of file path to file-specific VName. */
-  fileVNames: Map<string, VName>;
-
-  /** Files to index. */
-  srcs: string[];
-
-  /**
-   * List of files from which TS compiler will start type checking. It should include srcs files + file that provide
-   * global types, that are not imported from srcs files. All other dep files must be loaded following imports
-   * and by IndexingOptions.readFile function.
-   */
-  rootFiles: string[];
-}
-
-/**
- * Various options that are required in order to perform indexing.
- */
-export interface IndexingOptions {
-
-  /** Compiler options to use for indexing. */
-  compilerOptions: ts.CompilerOptions;
-
-  /**
-   * Compiler host to use for indexing. Simplest approach is to create
-   * ts.createCompilerHost(options). In more advanced cases callers
-   * might augment host to cache commonly used libraries for example.
-   */
-  compilerHost: ts.CompilerHost;
-
-  /** Function that receives final kythe indexing data. */
-  emit: (obj: JSONFact|JSONEdge) => void;
-
-  /**
-   * If provided, a list of plugin indexers to run after the TypeScript program has been indexed.
-   */
-  plugins?: Plugin[];
-
-  /**
-   * If provided, a function that reads a file as bytes to a Node Buffer. It'd be nice to just
-   * reuse program.getSourceFile but unfortunately that returns a (Unicode) string and we need
-   * to get at each file's raw bytes for UTF-8<->UTF-16 conversions. If omitted - fs.readFileSync
-   * is used.
-   */
-  readFile?: (path: string) => Buffer;
-
-  /**
-   * When enabled emits 0-0 spans at the beginning of each file that represent current module.
-   * By default 0-1 spans are emitted. Also this flag changes it to emit `defines/implicit`
-   * edges instead of `defines/binding`.
-   */
-  emitZeroWidthSpansForModuleNodes?: boolean;
-}
-
-/**
- * An indexer host holds information about the program indexing and methods
- * used by the TypeScript indexer that may also be useful to plugins, reducing
- * code duplication.
- */
-export interface IndexerHost {
-  /** Compilation unit being indexed. */
-  compilationUnit: CompilationUnit;
-
-  options: IndexingOptions;
-
-  /**
-   * Gets the offset table for a file path.
-   * These are used to lookup UTF-8 offsets (used by Kythe) from UTF-16 offsets
-   * (used by TypeScript), and vice versa.
-   */
-  getOffsetTable(path: string): Readonly<utf8.OffsetTable>;
-  /**
-   * getSymbolAtLocation is the same as ts.TypeChecker.getSymbolAtLocation,
-   * except that it has a return type that properly captures that
-   * getSymbolAtLocation can return undefined.  (The TypeScript API itself is
-   * not yet null-safe, so it hasn't been annotated with full types.)
-   */
-  getSymbolAtLocation(node: ts.Node): ts.Symbol|undefined;
-
-  /**
-   * Similar to getSymbolAtLocation() if returned symbol is an alias. One
-   * example is imports:
-   *
-   * // a.ts
-   * export value = 42;  // #1
-   *
-   * // b.ts
-   * import {value} from './a'; // #2
-   * console.log(value);  // #3
-   *
-   * getSymbolAtLocationFollowingAliases for #3 will return #1 while regular
-   * getSymbolAtLocation returns #2.
-   */
-  getSymbolAtLocationFollowingAliases(node: ts.Node): ts.Symbol|undefined;
-
-  /**
-   * Computes the VName (and signature) of a ts.Symbol. A Context can be
-   * optionally specified to help disambiguate nodes with multiple declarations.
-   * See the documentation of Context for more information.
-   */
-  getSymbolName(sym: ts.Symbol, ns: TSNamespace, context?: Context): VName
-      |undefined;
-  /**
-   * scopedSignature computes a scoped name for a ts.Node.
-   * E.g. if you have a function `foo` containing a block containing a variable
-   * `bar`, it might return a VName like
-   *   signature: "foo.block0.bar""
-   *   path: <appropriate path to module>
-   */
-  scopedSignature(startNode: ts.Node): VName;
-  /**
-   * Converts a file path into a file VName.
-   */
-  pathToVName(path: string): VName;
-  /**
-   * Returns the module name of a TypeScript source file.
-   * See moduleName() for more details.
-   */
-  moduleName(path: string): string;
-  /**
-   * TypeScript program.
-   */
-  program: ts.Program;
-}
-
-/**
- * A indexer plugin adds extra functionality with the same inputs as the base
- * indexer.
- */
-export interface Plugin {
-  /** Name of the plugin. It will be printed to stderr when running plugin. */
-  name: string;
-  /**
-   * Indexes a TypeScript program with extra functionality.
-   * Takes a indexer host, which provides useful properties and methods that
-   * the plugin can defer to rather than reimplementing.
-   */
-  index(context: IndexerHost): void;
 }
 
 /**
@@ -194,41 +51,6 @@ function toArray<T>(it: Iterator<T>): T[] {
  */
 function stripExtension(path: string): string {
   return path.replace(/\.(d\.)?tsx?$/, '');
-}
-
-/**
- * TSNamespace represents the three declaration namespaces of TypeScript: types,
- * values, and (confusingly) namespaces. A given symbol may be a type, and/or a
- * value, and/or a namespace.
- *
- * See the table at
- *   https://www.typescriptlang.org/docs/handbook/declaration-merging.html
- * for a listing of namespace groups for various declaration types and further
- * discussion.
- *
- * TYPE_MIGRATION is a temporary namespace to be used during the tvar migration.
- */
-export enum TSNamespace {
-  TYPE,
-  VALUE,
-  NAMESPACE,
-  TYPE_MIGRATION,
-}
-
-/**
- * Context represents the environment a node is declared in, and may be used for
- * disambiguating a node's declarations if it has multiple.
- */
-export enum Context {
-  /**
-   * No disambiguation about a node's declarations. May be lazily generated
-   * from other contexts; see SymbolVNameStore documentation.
-   */
-  Any,
-  /** The node is declared as a getter. */
-  Getter,
-  /** The node is declared as a setter. */
-  Setter,
 }
 
 /**
@@ -2810,6 +2632,21 @@ class Visitor {
   }
 }
 
+class TypescriptIndexer implements Plugin {
+  name = 'TypescriptIndexerPlugin';
+
+  index(context: IndexerHost) {
+    for (const path of context.compilationUnit.srcs) {
+      const sourceFile = context.program.getSourceFile(path);
+      if (!sourceFile) {
+        throw new Error(`requested indexing ${path} not found in program`);
+      }
+      const visitor = new Visitor(context, sourceFile);
+      visitor.index();
+    }
+  }
+}
+
 /**
  * index indexes a TypeScript program, producing Kythe JSON objects for the
  * source files in the specified paths.
@@ -2841,20 +2678,8 @@ export function index(compilationUnit: CompilationUnit, options: IndexingOptions
   // so the caller can act on them if it wants.
 
   const indexingContext =  new StandardIndexerContext(program, compilationUnit, options);
-
-  for (const path of compilationUnit.srcs) {
-    const sourceFile = program.getSourceFile(path);
-    if (!sourceFile) {
-      throw new Error(`requested indexing ${path} not found in program`);
-    }
-    const visitor = new Visitor(
-        indexingContext,
-        sourceFile,
-    );
-    visitor.index();
-  }
-
-  for (const plugin of options.plugins ?? []) {
+  const plugins = [new TypescriptIndexer(), ...(options.plugins ?? [])];
+  for (const plugin of plugins) {
     try {
       plugin.index(indexingContext);
     } catch (err) {

--- a/kythe/typescript/indexer.ts
+++ b/kythe/typescript/indexer.ts
@@ -2632,6 +2632,10 @@ class Visitor {
   }
 }
 
+/**
+ * Main plugin that runs over all srcs files in a compilation unit and emits
+ * Kythe data for all symbols in those files.
+ */
 class TypescriptIndexer implements Plugin {
   name = 'TypescriptIndexerPlugin';
 

--- a/kythe/typescript/plugin_api.ts
+++ b/kythe/typescript/plugin_api.ts
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2023 The Kythe Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview This file contains interfaces and constants necessary to
+ * implement a plugin for TS indexing.
+ */
+
+import * as ts from 'typescript';
+
+import {JSONEdge, JSONFact, VName} from './kythe';
+import * as utf8 from './utf8';
+
+/**
+ * A unit of code that can be indexed. It resembles Kythe's CompilationUnit
+ * proto.
+ */
+export interface CompilationUnit {
+  /**
+   * A VName for the entire compilation, containing e.g. corpus name. Used as
+   * basis for all vnames emitted by indexer.
+   */
+  rootVName: VName;
+
+  /** A map of file path to file-specific VName. */
+  fileVNames: Map<string, VName>;
+
+  /** Files to index. */
+  srcs: string[];
+
+  /**
+   * List of files from which TS compiler will start type checking. It should
+   * include srcs files + file that provide global types, that are not imported
+   * from srcs files. All other dep files must be loaded following imports and
+   * by IndexingOptions.readFile function.
+   */
+  rootFiles: string[];
+}
+
+/**
+ * Various options that are required in order to perform indexing.
+ */
+export interface IndexingOptions {
+  /** Compiler options to use for indexing. */
+  compilerOptions: ts.CompilerOptions;
+
+  /**
+   * Compiler host to use for indexing. Simplest approach is to create
+   * ts.createCompilerHost(options). In more advanced cases callers
+   * might augment host to cache commonly used libraries for example.
+   */
+  compilerHost: ts.CompilerHost;
+
+  /** Function that receives final kythe indexing data. */
+  emit: (obj: JSONFact|JSONEdge) => void;
+
+  /**
+   * If provided, a list of plugin indexers to run after the TypeScript program
+   * has been indexed.
+   */
+  plugins?: Plugin[];
+
+  /**
+   * If provided, a function that reads a file as bytes to a Node Buffer. It'd
+   * be nice to just reuse program.getSourceFile but unfortunately that returns
+   * a (Unicode) string and we need to get at each file's raw bytes for
+   * UTF-8<->UTF-16 conversions. If omitted - fs.readFileSync is used.
+   */
+  readFile?: (path: string) => Buffer;
+
+  /**
+   * When enabled emits 0-0 spans at the beginning of each file that represent
+   * current module. By default 0-1 spans are emitted. Also this flag changes it
+   * to emit `defines/implicit` edges instead of `defines/binding`.
+   */
+  emitZeroWidthSpansForModuleNodes?: boolean;
+}
+
+
+
+/**
+ * TSNamespace represents the three declaration namespaces of TypeScript: types,
+ * values, and (confusingly) namespaces. A given symbol may be a type, and/or a
+ * value, and/or a namespace.
+ *
+ * See the table at
+ *   https://www.typescriptlang.org/docs/handbook/declaration-merging.html
+ * for a listing of namespace groups for various declaration types and further
+ * discussion.
+ *
+ * TYPE_MIGRATION is a temporary namespace to be used during the tvar migration.
+ */
+export enum TSNamespace {
+  TYPE,
+  VALUE,
+  NAMESPACE,
+  TYPE_MIGRATION,
+}
+
+/**
+ * Context represents the environment a node is declared in, and may be used for
+ * disambiguating a node's declarations if it has multiple.
+ */
+export enum Context {
+  /**
+   * No disambiguation about a node's declarations. May be lazily generated
+   * from other contexts; see SymbolVNameStore documentation.
+   */
+  Any,
+  /** The node is declared as a getter. */
+  Getter,
+  /** The node is declared as a setter. */
+  Setter,
+}
+
+/**
+ * An indexer host holds information about the program indexing and methods
+ * used by the TypeScript indexer that may also be useful to plugins, reducing
+ * code duplication.
+ */
+export interface IndexerHost {
+  /** Compilation unit being indexed. */
+  compilationUnit: CompilationUnit;
+
+  options: IndexingOptions;
+
+  /**
+   * Gets the offset table for a file path.
+   * These are used to lookup UTF-8 offsets (used by Kythe) from UTF-16 offsets
+   * (used by TypeScript), and vice versa.
+   */
+  getOffsetTable(path: string): Readonly<utf8.OffsetTable>;
+  /**
+   * getSymbolAtLocation is the same as ts.TypeChecker.getSymbolAtLocation,
+   * except that it has a return type that properly captures that
+   * getSymbolAtLocation can return undefined.  (The TypeScript API itself is
+   * not yet null-safe, so it hasn't been annotated with full types.)
+   */
+  getSymbolAtLocation(node: ts.Node): ts.Symbol|undefined;
+
+  /**
+   * Similar to getSymbolAtLocation() if returned symbol is an alias. One
+   * example is imports:
+   *
+   * // a.ts
+   * export value = 42;  // #1
+   *
+   * // b.ts
+   * import {value} from './a'; // #2
+   * console.log(value);  // #3
+   *
+   * getSymbolAtLocationFollowingAliases for #3 will return #1 while regular
+   * getSymbolAtLocation returns #2.
+   */
+  getSymbolAtLocationFollowingAliases(node: ts.Node): ts.Symbol|undefined;
+
+  /**
+   * Computes the VName (and signature) of a ts.Symbol. A Context can be
+   * optionally specified to help disambiguate nodes with multiple declarations.
+   * See the documentation of Context for more information.
+   */
+  getSymbolName(sym: ts.Symbol, ns: TSNamespace, context?: Context): VName
+      |undefined;
+  /**
+   * scopedSignature computes a scoped name for a ts.Node.
+   * E.g. if you have a function `foo` containing a block containing a variable
+   * `bar`, it might return a VName like
+   *   signature: "foo.block0.bar""
+   *   path: <appropriate path to module>
+   */
+  scopedSignature(startNode: ts.Node): VName;
+  /**
+   * Converts a file path into a file VName.
+   */
+  pathToVName(path: string): VName;
+  /**
+   * Returns the module name of a TypeScript source file.
+   * See moduleName() for more details.
+   */
+  moduleName(path: string): string;
+  /**
+   * TypeScript program.
+   */
+  program: ts.Program;
+}
+
+/**
+ * A indexer plugin adds extra functionality with the same inputs as the base
+ * indexer.
+ */
+export interface Plugin {
+  /** Name of the plugin. It will be printed to stderr when running plugin. */
+  name: string;
+  /**
+   * Indexes a TypeScript program with extra functionality.
+   * Takes a indexer host, which provides useful properties and methods that
+   * the plugin can defer to rather than reimplementing.
+   */
+  index(context: IndexerHost): void;
+}

--- a/kythe/typescript/test.ts
+++ b/kythe/typescript/test.ts
@@ -31,6 +31,7 @@ import * as ts from 'typescript';
 
 import * as indexer from './indexer';
 import * as kythe from './kythe';
+import { CompilationUnit, IndexerHost, Plugin } from './plugin_api';
 
 const KYTHE_PATH = process.env['KYTHE'] || '/opt/kythe';
 const RUNFILES = process.env['TEST_SRCDIR'];
@@ -92,7 +93,7 @@ function isTsFile(filename: string): boolean {
  */
 function verify(
     host: ts.CompilerHost, options: ts.CompilerOptions, testCase: TestCase,
-    plugins?: indexer.Plugin[]): Promise<void> {
+    plugins?: Plugin[]): Promise<void> {
   const rootVName: kythe.VName = {
     corpus: 'testcorpus',
     root: '',
@@ -115,7 +116,7 @@ function verify(
   }
 
   try {
-    const compilationUnit: indexer.CompilationUnit = {
+    const compilationUnit: CompilationUnit = {
       rootVName,
       fileVNames,
       srcs: testFiles,
@@ -216,7 +217,7 @@ function filterTestCases(testCases: TestCase[], filters: string[]): TestCase[] {
   });
 }
 
-async function testIndexer(filters: string[], plugins?: indexer.Plugin[]) {
+async function testIndexer(filters: string[], plugins?: Plugin[]) {
   const config =
       indexer.loadTsConfig('testdata/tsconfig.for.tests.json', 'testdata');
   let testCases = getTestCases(config.options, 'testdata');
@@ -245,9 +246,9 @@ async function testIndexer(filters: string[], plugins?: indexer.Plugin[]) {
 }
 
 async function testPlugin() {
-  const plugin: indexer.Plugin = {
+  const plugin: Plugin = {
     name: 'TestPlugin',
-    index(context: indexer.IndexerHost) {
+    index(context: IndexerHost) {
       for (const testPath of context.compilationUnit.srcs) {
         const pluginMod = {
           ...context.pathToVName(context.moduleName(testPath)),


### PR DESCRIPTION
Inputs such as CompilationUnit, IndexerHost and others as well as Plugin interface are moved to `plugin_api.ts`. 

This way it's easier for plugin developers to see what API is and what they have access to. Additionally it allows for further splitting `indexer.ts` into sub files as currently that file is almost 3k lines.

Additionally reworks `indexer.ts` to introduce TypescriptIndexer plugin which is a main plugin that indexes TS files. By doing  that we make sure that Plugin interface provides enough capabilities for proper indexing.

This PR will require a bunch of changes in google3 as other TS plugins import interfaces that were moved to `plugin_api.ts`. But it should be trivial to update imports to point at the new file.