### PR TITLE
chore(typescript_indexer): temporarily re-export plugin API from indexer.ts

### DIFF
--- a/kythe/typescript/indexer.ts
+++ b/kythe/typescript/indexer.ts
@@ -22,7 +22,10 @@ import * as ts from 'typescript';
 
 import {EdgeKind, FactName, JSONEdge, JSONFact, JSONMarkedSource, makeOrdinalEdge, MarkedSourceKind, NodeKind, OrdinalEdge, Subkind, VName} from './kythe';
 import * as utf8 from './utf8';
-import { CompilationUnit, Context, IndexerHost, IndexingOptions, Plugin, TSNamespace } from './plugin_api';
+import {CompilationUnit, Context, IndexerHost, IndexingOptions, Plugin, TSNamespace} from './plugin_api';
+
+// Temporarily re-export the plugin API from this file so that users can be migrated individually.
+export {CompilationUnit, Context, IndexerHost, IndexingOptions, Plugin, TSNamespace};
 
 const LANGUAGE = 'typescript';
 

--- a/kythe/typescript/test.ts
+++ b/kythe/typescript/test.ts
@@ -31,7 +31,7 @@ import * as ts from 'typescript';
 
 import * as indexer from './indexer';
 import * as kythe from './kythe';
-import { CompilationUnit, IndexerHost, Plugin } from './plugin_api';
+import {CompilationUnit, IndexerHost, Plugin} from './plugin_api';
 
 const KYTHE_PATH = process.env['KYTHE'] || '/opt/kythe';
 const RUNFILES = process.env['TEST_SRCDIR'];


### PR DESCRIPTION
This will allow to sync refactoring #5684 to google3 without the need to update all in the same change. I'll update users once this is in. 