### PR TITLE
feat(proto_verifier_test): add cc_deps and cc_indexer parameters

### DIFF
--- a/kythe/cxx/indexer/cxx/testdata/proto/cc_proto_verifier_test.bzl
+++ b/kythe/cxx/indexer/cxx/testdata/proto/cc_proto_verifier_test.bzl
@@ -24,6 +24,8 @@ def cc_proto_verifier_test(
         name,
         srcs,
         proto_libs,
+        cc_deps = [],
+        cc_indexer = "//kythe/cxx/indexer/cxx:indexer",
         verifier_opts = [
             "--ignore_dups",
             # Else the verifier chokes on the inconsistent marked source from the protobuf headers.
@@ -39,6 +41,8 @@ def cc_proto_verifier_test(
       name: Name of the test.
       srcs: The compilation's C++ source files; each file's verifier goals will be checked
       proto_libs: A list of proto_library targets
+      cc_deps: Additional cc deps needed by the cc test file
+      cc_indexer: The cc indexer to use
       verifier_opts: List of options passed to the verifier tool
       size: Size of the test.
       experimental_guess_proto_semantics: guess proto semantics?
@@ -74,7 +78,7 @@ def cc_proto_verifier_test(
         cc_extract_kzip,
         name = name + "_cc_kzip",
         srcs = srcs,
-        deps = cc_proto_libs,
+        deps = cc_proto_libs + cc_deps,
     )
 
     claim_file = None
@@ -125,6 +129,8 @@ def cc_proto_verifier_test(
             "--experimental_drop_instantiation_independent_data",
             "--noemit_anchors_on_builtins",
         ] + guess_opt + df_opt + claim_opt,
+        indexer = cc_indexer,
+        test_indexer = cc_indexer,
     )
 
     return _invoke(

--- a/tools/build_rules/verifier_test/cc_indexer_test.bzl
+++ b/tools/build_rules/verifier_test/cc_indexer_test.bzl
@@ -371,12 +371,7 @@ cc_extract_kzip = rule(
             may be used for dependencies which are required for an eventual
             Kythe index, but should not be extracted here.
             """,
-            allow_files = [
-                ".cc",
-                ".c",
-                ".h",
-                ".meta",  # Cross language metadata files.
-            ],
+            allow_files = True,
             providers = [
                 [CcInfo],
                 [CxxCompilationUnits],


### PR DESCRIPTION
cc_indexer allows passing a different indexer binary, which we'll use internally for testing proto static reflection
cc_deps allows additional c++ deps to the file being tested, which we'll also be using for testing proto static reflection

Note that there may be a better way to make the changes to cc_indexer_test.bzl. It seems when `allow_files` is set to a list of allowed extensions, the `providers` list is ignored and cc_library targets are not allowed to be passed. Setting `allow_files = True` works around this.