### PR TITLE
chore(typescript_indexer): stop re-exporting symbols from index.ts

### DIFF
--- a/kythe/typescript/indexer.ts
+++ b/kythe/typescript/indexer.ts
@@ -24,9 +24,6 @@ import {EdgeKind, FactName, JSONEdge, JSONFact, JSONMarkedSource, makeOrdinalEdg
 import * as utf8 from './utf8';
 import {CompilationUnit, Context, IndexerHost, IndexingOptions, Plugin, TSNamespace} from './plugin_api';
 
-// Temporarily re-export the plugin API from this file so that users can be migrated individually.
-export {CompilationUnit, Context, IndexerHost, IndexingOptions, Plugin, TSNamespace};
-
 const LANGUAGE = 'typescript';
 
 enum RefType {


### PR DESCRIPTION
All usages in google3 were migrated to import symbols from `plugin_api.ts`