### PR TITLE
chore(typescript_indexer): cleanup emitZeroWidthSpansForModuleNodes flag

### DIFF
--- a/kythe/typescript/indexer.ts
+++ b/kythe/typescript/indexer.ts
@@ -1423,14 +1423,8 @@ class Visitor {
     this.emitEdge(this.kFile, EdgeKind.CHILD_OF, kMod);
 
     // Emit the anchor, bound to the beginning of the file.
-    const anchor = this.newAnchor(
-        this.file, 0, this.host.options.emitZeroWidthSpansForModuleNodes ? 0 : 1);
-    this.emitEdge(
-        anchor,
-        this.host.options.emitZeroWidthSpansForModuleNodes ?
-            EdgeKind.DEFINES_IMPLICIT :
-            EdgeKind.DEFINES_BINDING,
-        kMod);
+    const anchor = this.newAnchor(this.file, 0, 0);
+    this.emitEdge(anchor, EdgeKind.DEFINES_IMPLICIT, kMod);
   }
 
   /**

--- a/kythe/typescript/testdata/imports_group/module.ts
+++ b/kythe/typescript/testdata/imports_group/module.ts
@@ -8,8 +8,8 @@
 // See discussion in emitModuleAnchor().
 //- ModAnchor.node/kind anchor
 //- ModAnchor./kythe/loc/start 0
-//- ModAnchor./kythe/loc/end 1
-//- ModAnchor defines/binding Mod
+//- ModAnchor./kythe/loc/end 0
+//- ModAnchor defines/implicit Mod
 
 //- @value defines/binding Val
 export const value = 3;

--- a/kythe/typescript/testdata/schema.ts
+++ b/kythe/typescript/testdata/schema.ts
@@ -4,8 +4,8 @@
 //- FileModule=VName("module", _, _, "testdata/schema", "typescript").node/kind record
 //- FileModuleAnchor.node/kind anchor
 //- FileModuleAnchor./kythe/loc/start 0
-//- FileModuleAnchor./kythe/loc/end 1
-//- FileModuleAnchor defines/binding FileModule
+//- FileModuleAnchor./kythe/loc/end 0
+//- FileModuleAnchor defines/implicit FileModule
 
 // NamespaceImport
 //- @NspI defines/binding VName("NspI", _, _, "testdata/schema", "typescript")


### PR DESCRIPTION
The flag has been launched in google3 for a few months now.