### PR TITLE
fix(typescript_indexer): emit `overrides` edges for methods that are 2+ levels away

### DIFF
--- a/kythe/typescript/indexer.ts
+++ b/kythe/typescript/indexer.ts
@@ -2020,15 +2020,20 @@ class Visitor {
         const overriddenCondition = (sym: ts.Symbol) =>
             Boolean(sym.flags & funcFlags) && sym.name === funcName;
 
-        // TODO(b/181591179): Remove this alias and casts
-        type AnyDuringTs42Migration = any;
-        const overridden: AnyDuringTs42Migration =
-            toArray(type.symbol.members.values() as AnyDuringTs42Migration)
-                .find(overriddenCondition as AnyDuringTs42Migration);
+        const overridden = toArray<ts.Symbol>(type.symbol.members.values())
+            .find(overriddenCondition);
         if (overridden) {
           const base = this.host.getSymbolName(overridden, TSNamespace.VALUE);
           if (base) {
             this.emitEdge(funcVName, EdgeKind.OVERRIDES, base);
+          }
+        } else {
+          // If parent class or interface doesn't have this method - it's possible
+          // that parent's parent might. To check for that recurse to the parent's parent
+          // classes/interfaces.
+          const decl = type.symbol.declarations?.[0];
+          if (decl && (ts.isClassLike(decl) || ts.isInterfaceDeclaration(decl))) {
+            this.emitOverridesEdgeForFunction(funcSym, funcVName, decl);
           }
         }
       }

--- a/kythe/typescript/testdata/class.ts
+++ b/kythe/typescript/testdata/class.ts
@@ -82,18 +82,18 @@ class Class implements IFace {
 class Subclass extends Class {
     //- @method defines/binding OverridenMethod
     //- OverridenMethod overrides Method
-    method() {
+    override method() {
         //- @member ref Member
         this.member;
     }
 }
 
-class SubSubclass extends Class implements IExtended {
+class SubSubclass extends Subclass implements IExtended {
     //- @ifaceMethod defines/binding OverridenIFaceMethod
     //- OverridenIFaceMethod overrides ClassIFaceMethod
     //- OverridenIFaceMethod overrides ExtendedIFaceMethod
     //- !{ OverridenIFaceMethod overrides IFaceMethod }
-    ifaceMethod() {}
+    override ifaceMethod() {}
 }
 
 //- @Class ref ClassCtor


### PR DESCRIPTION
This fixes the following scenario:

```typescript
class One { 
  doStuff() {}
}

class Two extends One {}

class Three extends Two {
  override doStuff() {}
}
```

Previously TS indexer didn't emit `overrides` edge between `doStuff` methods. Now TS indexer traverses all parent class chain until it finds a class/interface that contains method in question or until it reaches base class/interface.