### PR TITLE
chore: rename class

### DIFF
--- a/kythe/java/com/google/devtools/kythe/extractors/java/standalone/BUILD
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/standalone/BUILD
@@ -8,7 +8,7 @@ exports_files(["javac-wrapper.sh"])
 
 java_binary(
     name = "javac_extractor",
-    srcs = ["Javac9Wrapper.java"],
+    srcs = ["JavacWrapper.java"],
     javacopts = [
         "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
         "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
@@ -22,7 +22,7 @@ java_binary(
         "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
         "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
     ],
-    main_class = "com.google.devtools.kythe.extractors.java.standalone.Javac9Wrapper",
+    main_class = "com.google.devtools.kythe.extractors.java.standalone.JavacWrapper",
     visibility = ["//visibility:public"],
     deps = [
         ":abstract_javac_wrapper",

--- a/kythe/java/com/google/devtools/kythe/extractors/java/standalone/JavacWrapper.java
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/standalone/JavacWrapper.java
@@ -36,8 +36,12 @@ import java.util.List;
 import javax.tools.JavaFileObject;
 import javax.tools.StandardLocation;
 
-/** A class that wraps javac to extract compilation information and write it to an index file. */
-public class Javac9Wrapper extends AbstractJavacWrapper {
+/**
+ * A class that wraps javac to extract compilation information and write it to an index file.
+ *
+ * <p>This class works for Java 9 and later.
+ */
+public class JavacWrapper extends AbstractJavacWrapper {
   @Override
   protected Collection<CompilationDescription> processCompilation(
       String[] arguments, JavaCompilationUnitExtractor javaCompilationUnitExtractor)
@@ -141,6 +145,6 @@ public class Javac9Wrapper extends AbstractJavacWrapper {
   }
 
   public static void main(String[] args) {
-    new Javac9Wrapper().process(args);
+    new JavacWrapper().process(args);
   }
 }


### PR DESCRIPTION
This class works for Java 9 and later. Seeing Javac9 in the class name can be misleading