### PR TITLE
chore(cxx): s/absl::string_view/std::string_view/g

### DIFF
--- a/kythe/cxx/common/file_vname_generator.cc
+++ b/kythe/cxx/common/file_vname_generator.cc
@@ -34,7 +34,7 @@ std::string EscapeBackslashes(std::string_view value) {
 }
 
 absl::optional<std::string_view> FindMatch(std::string_view text,
-                                            const RE2& pattern) {
+                                           const RE2& pattern) {
   re2::StringPiece match;
   if (pattern.Match(text, 0, text.size(), RE2::UNANCHORED, &match, 1)) {
     return std::string_view(match.data(), match.size());

--- a/kythe/cxx/common/file_vname_generator.cc
+++ b/kythe/cxx/common/file_vname_generator.cc
@@ -29,25 +29,25 @@ namespace {
 
 const LazyRE2 kSubstitutionsPattern = {R"(@\w+@)"};
 
-std::string EscapeBackslashes(absl::string_view value) {
+std::string EscapeBackslashes(std::string_view value) {
   return absl::StrReplaceAll(value, {{R"(\)", R"(\\)"}});
 }
 
-absl::optional<absl::string_view> FindMatch(absl::string_view text,
+absl::optional<std::string_view> FindMatch(std::string_view text,
                                             const RE2& pattern) {
   re2::StringPiece match;
   if (pattern.Match(text, 0, text.size(), RE2::UNANCHORED, &match, 1)) {
-    return absl::string_view(match.data(), match.size());
+    return std::string_view(match.data(), match.size());
   }
   return absl::nullopt;
 }
 
 absl::StatusOr<std::string> ParseTemplate(const RE2& pattern,
-                                          absl::string_view input) {
+                                          std::string_view input) {
   std::string result;
-  while (absl::optional<absl::string_view> match =
+  while (absl::optional<std::string_view> match =
              FindMatch(input, *kSubstitutionsPattern)) {
-    absl::string_view group = match->substr(1, match->size() - 2);
+    std::string_view group = match->substr(1, match->size() - 2);
 
     int index = 0;
     if (!absl::SimpleAtoi(group, &index)) {
@@ -62,7 +62,7 @@ absl::StatusOr<std::string> ParseTemplate(const RE2& pattern,
       return absl::InvalidArgumentError(
           absl::StrCat("Capture index out of range: ", index));
     }
-    absl::string_view prefix = input.substr(0, match->begin() - input.begin());
+    std::string_view prefix = input.substr(0, match->begin() - input.begin());
     absl::StrAppend(&result, EscapeBackslashes(prefix), "\\", index);
     input.remove_prefix(prefix.size() + match->size());
   }
@@ -73,7 +73,7 @@ absl::StatusOr<std::string> ParseTemplate(const RE2& pattern,
 
 absl::StatusOr<std::string> ParseTemplateMember(const RE2& pattern,
                                                 const rapidjson::Value& parent,
-                                                absl::string_view name) {
+                                                std::string_view name) {
   const auto member =
       parent.FindMember(rapidjson::Value(name.data(), name.size()));
   if (member == parent.MemberEnd()) {
@@ -89,7 +89,7 @@ absl::StatusOr<std::string> ParseTemplateMember(const RE2& pattern,
 }  // namespace
 
 kythe::proto::VName FileVNameGenerator::LookupBaseVName(
-    absl::string_view path) const {
+    std::string_view path) const {
   for (const auto& rule : rules_) {
     std::vector<re2::StringPiece> captures(
         1 +
@@ -117,7 +117,7 @@ kythe::proto::VName FileVNameGenerator::LookupBaseVName(
 }
 
 kythe::proto::VName FileVNameGenerator::LookupVName(
-    absl::string_view path) const {
+    std::string_view path) const {
   kythe::proto::VName vname = LookupBaseVName(path);
   if (vname.path().empty()) {
     vname.set_path(path.data(), path.size());
@@ -125,7 +125,7 @@ kythe::proto::VName FileVNameGenerator::LookupVName(
   return vname;
 }
 
-bool FileVNameGenerator::LoadJsonString(absl::string_view data,
+bool FileVNameGenerator::LoadJsonString(std::string_view data,
                                         std::string* error_text) {
   absl::Status status = LoadJsonString(data);
   if (!status.ok() && error_text != nullptr) {
@@ -134,7 +134,7 @@ bool FileVNameGenerator::LoadJsonString(absl::string_view data,
   return status.ok();
 }
 
-absl::Status FileVNameGenerator::LoadJsonString(absl::string_view data) {
+absl::Status FileVNameGenerator::LoadJsonString(std::string_view data) {
   using Value = rapidjson::Value;
   rapidjson::Document document;
   document.Parse(data.data(), data.size());

--- a/kythe/cxx/common/file_vname_generator.h
+++ b/kythe/cxx/common/file_vname_generator.h
@@ -19,11 +19,11 @@
 
 #include <memory>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
-#include <string_view>
 #include "kythe/proto/storage.pb.h"
 #include "re2/re2.h"
 

--- a/kythe/cxx/common/file_vname_generator.h
+++ b/kythe/cxx/common/file_vname_generator.h
@@ -23,7 +23,7 @@
 
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "kythe/proto/storage.pb.h"
 #include "re2/re2.h"
 

--- a/kythe/cxx/common/file_vname_generator.h
+++ b/kythe/cxx/common/file_vname_generator.h
@@ -38,15 +38,15 @@ class FileVNameGenerator {
   /// \param json_string The string containing the configuration to add.
   /// \param error_text Non-null. Will be set to text describing any errors.
   /// \return false if the string could not be parsed.
-  bool LoadJsonString(absl::string_view data, std::string* error_text);
-  absl::Status LoadJsonString(absl::string_view data);
+  bool LoadJsonString(std::string_view data, std::string* error_text);
+  absl::Status LoadJsonString(std::string_view data);
 
   /// \brief Returns a base VName for a given file path (or an empty VName if
   /// no configuration rule matches the path).
-  kythe::proto::VName LookupBaseVName(absl::string_view path) const;
+  kythe::proto::VName LookupBaseVName(std::string_view path) const;
 
   /// \brief Returns a VName for the given file path.
-  kythe::proto::VName LookupVName(absl::string_view path) const;
+  kythe::proto::VName LookupVName(std::string_view path) const;
 
   /// \brief Sets the default base VName to use when no rules match.
   void set_default_base_vname(const kythe::proto::VName& default_vname) {

--- a/kythe/cxx/common/index_reader.h
+++ b/kythe/cxx/common/index_reader.h
@@ -32,7 +32,7 @@ namespace kythe {
 class IndexReaderInterface {
  public:
   /// \brief Callback invoked for each available unit digest.
-  using ScanCallback = std::function<bool(absl::string_view)>;
+  using ScanCallback = std::function<bool(std::string_view)>;
 
   IndexReaderInterface() = default;
   // IndexReaderInterface is neither copyable nor movable.
@@ -47,11 +47,11 @@ class IndexReaderInterface {
   /// \brief Reads and returns requested IndexCompilation.
   ///  Returns kNotFound if the digest isn't present.
   virtual absl::StatusOr<kythe::proto::IndexedCompilation> ReadUnit(
-      absl::string_view digest) = 0;
+      std::string_view digest) = 0;
 
   /// \brief Reads and returns the requested file data.
   ///  Returns kNotFound if the digest isn't present.
-  virtual absl::StatusOr<std::string> ReadFile(absl::string_view digest) = 0;
+  virtual absl::StatusOr<std::string> ReadFile(std::string_view digest) = 0;
 };
 
 /// \brief Pimpl wrapper around IndexReaderInterface.
@@ -74,13 +74,13 @@ class IndexReader {
   /// \brief Reads and returns requested IndexCompilation.
   ///  Returns kNotFound if the digest isn't present.
   absl::StatusOr<kythe::proto::IndexedCompilation> ReadUnit(
-      absl::string_view digest) {
+      std::string_view digest) {
     return impl_->ReadUnit(digest);
   }
 
   /// \brief Reads and returns the requested file data.
   ///  Returns kNotFound if the digest isn't present.
-  absl::StatusOr<std::string> ReadFile(absl::string_view digest) {
+  absl::StatusOr<std::string> ReadFile(std::string_view digest) {
     return impl_->ReadFile(digest);
   }
 

--- a/kythe/cxx/common/index_reader.h
+++ b/kythe/cxx/common/index_reader.h
@@ -19,10 +19,10 @@
 
 #include <functional>
 #include <string>
+#include <string_view>
 
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
-#include <string_view>
 #include "kythe/proto/analysis.pb.h"
 
 namespace kythe {

--- a/kythe/cxx/common/index_reader.h
+++ b/kythe/cxx/common/index_reader.h
@@ -22,7 +22,7 @@
 
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "kythe/proto/analysis.pb.h"
 
 namespace kythe {

--- a/kythe/cxx/common/index_writer.h
+++ b/kythe/cxx/common/index_writer.h
@@ -17,9 +17,10 @@
 #ifndef KYTHE_CXX_COMMON_INDEX_WRITER_H_
 #define KYTHE_CXX_COMMON_INDEX_WRITER_H_
 
+#include <string_view>
+
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
-#include <string_view>
 #include "kythe/proto/analysis.pb.h"
 
 namespace kythe {

--- a/kythe/cxx/common/index_writer.h
+++ b/kythe/cxx/common/index_writer.h
@@ -41,7 +41,7 @@ class IndexWriterInterface {
 
   /// \brief Write the file data to the index. Returns the hex-encoded
   /// SHA256 digest of the file's contents.
-  virtual absl::StatusOr<std::string> WriteFile(absl::string_view content) = 0;
+  virtual absl::StatusOr<std::string> WriteFile(std::string_view content) = 0;
 
   /// \brief Flush and finalize any outstanding writes.
   virtual absl::Status Close() = 0;
@@ -65,7 +65,7 @@ class IndexWriter final {
   }
 
   /// \brief Write the file data to the index.
-  absl::StatusOr<std::string> WriteFile(absl::string_view content) {
+  absl::StatusOr<std::string> WriteFile(std::string_view content) {
     return impl_->WriteFile(content);
   }
 

--- a/kythe/cxx/common/index_writer.h
+++ b/kythe/cxx/common/index_writer.h
@@ -19,7 +19,7 @@
 
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "kythe/proto/analysis.pb.h"
 
 namespace kythe {

--- a/kythe/cxx/common/indexing/KytheCachingOutput.h
+++ b/kythe/cxx/common/indexing/KytheCachingOutput.h
@@ -24,7 +24,7 @@
 
 #include "absl/log/die_if_null.h"
 #include "absl/log/log.h"
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "google/protobuf/io/coded_stream.h"
 #include "google/protobuf/io/zero_copy_stream_impl.h"
 #include "kythe/cxx/common/indexing/KytheOutputStream.h"

--- a/kythe/cxx/common/indexing/KytheCachingOutput.h
+++ b/kythe/cxx/common/indexing/KytheCachingOutput.h
@@ -20,11 +20,11 @@
 #include <openssl/sha.h>
 
 #include <memory>
+#include <string_view>
 #include <vector>
 
 #include "absl/log/die_if_null.h"
 #include "absl/log/log.h"
-#include <string_view>
 #include "google/protobuf/io/coded_stream.h"
 #include "google/protobuf/io/zero_copy_stream_impl.h"
 #include "kythe/cxx/common/indexing/KytheOutputStream.h"

--- a/kythe/cxx/common/indexing/KytheGraphRecorder.cc
+++ b/kythe/cxx/common/indexing/KytheGraphRecorder.cc
@@ -88,7 +88,7 @@ static const std::string* kEdgeKindSpellings[] = {
     new std::string("/kythe/edge/ref/call/direct"),
     new std::string("/kythe/edge/ref/call/direct/implicit")};
 
-bool of_spelling(absl::string_view str, EdgeKindID* edge_id) {
+bool of_spelling(std::string_view str, EdgeKindID* edge_id) {
   size_t edge_index = 0;
   for (auto* edge : kEdgeKindSpellings) {
     if (*edge == str) {
@@ -130,24 +130,24 @@ static const std::string* const kEmptyStringSpelling = new std::string("");
 
 static const std::string* const kRootPropertySpelling = new std::string("/");
 
-absl::string_view spelling_of(PropertyID property_id) {
+std::string_view spelling_of(PropertyID property_id) {
   const auto* str = kPropertySpellings[static_cast<ptrdiff_t>(property_id)];
-  return absl::string_view(str->data(), str->size());
+  return std::string_view(str->data(), str->size());
 }
 
-absl::string_view spelling_of(NodeKindID node_kind_id) {
+std::string_view spelling_of(NodeKindID node_kind_id) {
   const auto* str = kNodeKindSpellings[static_cast<ptrdiff_t>(node_kind_id)];
-  return absl::string_view(str->data(), str->size());
+  return std::string_view(str->data(), str->size());
 }
 
-absl::string_view spelling_of(EdgeKindID edge_kind_id) {
+std::string_view spelling_of(EdgeKindID edge_kind_id) {
   const auto* str = kEdgeKindSpellings[static_cast<ptrdiff_t>(edge_kind_id)];
-  return absl::string_view(str->data(), str->size());
+  return std::string_view(str->data(), str->size());
 }
 
 void KytheGraphRecorder::AddProperty(const VNameRef& node_vname,
                                      PropertyID property_id,
-                                     absl::string_view property_value) {
+                                     std::string_view property_value) {
   stream_->Emit(FactRef{&node_vname, spelling_of(property_id), property_value});
 }
 
@@ -163,7 +163,7 @@ void KytheGraphRecorder::AddMarkedSource(const VNameRef& node_vname,
   std::vector<char> buffer(size);
   marked_source.SerializeToArray(buffer.data(), size);
   stream_->Emit(FactRef{&node_vname, spelling_of(PropertyID::kCode),
-                        absl::string_view(buffer.data(), buffer.size())});
+                        std::string_view(buffer.data(), buffer.size())});
 }
 
 void KytheGraphRecorder::AddEdge(const VNameRef& edge_from,
@@ -180,7 +180,7 @@ void KytheGraphRecorder::AddEdge(const VNameRef& edge_from,
 }
 
 void KytheGraphRecorder::AddFileContent(const VNameRef& file_vname,
-                                        absl::string_view file_content) {
+                                        std::string_view file_content) {
   AddProperty(file_vname, PropertyID::kNodeKind,
               spelling_of(NodeKindID::kFile));
   AddProperty(file_vname, PropertyID::kText, file_content);

--- a/kythe/cxx/common/indexing/KytheGraphRecorder.h
+++ b/kythe/cxx/common/indexing/KytheGraphRecorder.h
@@ -136,25 +136,25 @@ enum class EdgeKindID {
 /// ~~~
 /// spelling_of(kAnchor) == "/kythe/anchor"
 /// ~~~
-absl::string_view spelling_of(NodeKindID node_kind_id);
+std::string_view spelling_of(NodeKindID node_kind_id);
 
 /// \brief Returns the Kythe spelling of `property_id`
 ///
 /// ~~~
 /// spelling_of(kLocationUri) == "/kythe/loc/uri"
 /// ~~~
-absl::string_view spelling_of(PropertyID property_id);
+std::string_view spelling_of(PropertyID property_id);
 
 /// \brief Returns the Kythe spelling of `edge_kind_id`
 ///
 /// ~~~
 /// spelling_of(kDefines) == "/kythe/defines"
 /// ~~~
-absl::string_view spelling_of(EdgeKindID edge_kind_id);
+std::string_view spelling_of(EdgeKindID edge_kind_id);
 
 /// Returns true and sets `out_edge` to the enumerator corresponding to
 /// `spelling` (or returns false if there is no such correspondence).
-bool of_spelling(absl::string_view str, EdgeKindID* edge_id);
+bool of_spelling(std::string_view str, EdgeKindID* edge_id);
 
 /// \brief Records Kythe nodes and edges to a provided `KytheOutputStream`.
 class KytheGraphRecorder {
@@ -171,7 +171,7 @@ class KytheGraphRecorder {
   /// \param property_id The `PropertyID` of the property to record.
   /// \param property_value The value of the property to set.
   void AddProperty(const VNameRef& node_vname, PropertyID property_id,
-                   absl::string_view property_value);
+                   std::string_view property_value);
 
   /// \brief Record a node's marked source.
   ///
@@ -213,7 +213,7 @@ class KytheGraphRecorder {
   /// \param file_vname The file's vname.
   /// \param file_content The buffer of this file's content.
   void AddFileContent(const VNameRef& file_vname,
-                      absl::string_view file_content);
+                      std::string_view file_content);
 
   /// \brief Stop using the last entry group pushed to the stack.
   void PopEntryGroup() { stream_->PopBuffer(); }

--- a/kythe/cxx/common/indexing/KytheGraphRecorder.h
+++ b/kythe/cxx/common/indexing/KytheGraphRecorder.h
@@ -18,7 +18,7 @@
 #define KYTHE_CXX_COMMON_INDEXING_KYTHE_GRAPH_RECORDER_H_
 
 #include "KytheOutputStream.h"
-#include "absl/strings/string_view.h"
+#include <string_view>
 
 namespace kythe {
 

--- a/kythe/cxx/common/indexing/KytheGraphRecorder.h
+++ b/kythe/cxx/common/indexing/KytheGraphRecorder.h
@@ -17,8 +17,9 @@
 #ifndef KYTHE_CXX_COMMON_INDEXING_KYTHE_GRAPH_RECORDER_H_
 #define KYTHE_CXX_COMMON_INDEXING_KYTHE_GRAPH_RECORDER_H_
 
-#include "KytheOutputStream.h"
 #include <string_view>
+
+#include "KytheOutputStream.h"
 
 namespace kythe {
 

--- a/kythe/cxx/common/indexing/KytheOutputStream.h
+++ b/kythe/cxx/common/indexing/KytheOutputStream.h
@@ -17,9 +17,10 @@
 #ifndef KYTHE_CXX_COMMON_INDEXING_KYTHE_OUTPUT_STREAM_H_
 #define KYTHE_CXX_COMMON_INDEXING_KYTHE_OUTPUT_STREAM_H_
 
+#include <string_view>
+
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
-#include <string_view>
 #include "kythe/proto/common.pb.h"
 #include "kythe/proto/storage.pb.h"
 

--- a/kythe/cxx/common/indexing/KytheOutputStream.h
+++ b/kythe/cxx/common/indexing/KytheOutputStream.h
@@ -19,7 +19,7 @@
 
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "kythe/proto/common.pb.h"
 #include "kythe/proto/storage.pb.h"
 

--- a/kythe/cxx/common/indexing/KytheOutputStream.h
+++ b/kythe/cxx/common/indexing/KytheOutputStream.h
@@ -30,16 +30,16 @@ using MarkedSource = kythe::proto::common::MarkedSource;
 /// A collection of references to the components of a VName.
 class VNameRef {
  public:
-  absl::string_view signature() const { return signature_; }
-  absl::string_view corpus() const { return corpus_; }
-  absl::string_view root() const { return root_; }
-  absl::string_view path() const { return path_; }
-  absl::string_view language() const { return language_; }
-  void set_signature(absl::string_view s) { signature_ = s; }
-  void set_corpus(absl::string_view s) { corpus_ = s; }
-  void set_root(absl::string_view s) { root_ = s; }
-  void set_path(absl::string_view s) { path_ = s; }
-  void set_language(absl::string_view s) { language_ = s; }
+  std::string_view signature() const { return signature_; }
+  std::string_view corpus() const { return corpus_; }
+  std::string_view root() const { return root_; }
+  std::string_view path() const { return path_; }
+  std::string_view language() const { return language_; }
+  void set_signature(std::string_view s) { signature_ = s; }
+  void set_corpus(std::string_view s) { corpus_ = s; }
+  void set_root(std::string_view s) { root_ = s; }
+  void set_path(std::string_view s) { path_ = s; }
+  void set_language(std::string_view s) { language_ = s; }
 
   explicit VNameRef(const proto::VName& vname)
       : signature_(vname.signature().data(), vname.signature().size()),
@@ -61,17 +61,17 @@ class VNameRef {
   }
 
  private:
-  absl::string_view signature_;
-  absl::string_view corpus_;
-  absl::string_view root_;
-  absl::string_view path_;
-  absl::string_view language_;
+  std::string_view signature_;
+  std::string_view corpus_;
+  std::string_view root_;
+  std::string_view path_;
+  std::string_view language_;
 };
 /// A collection of references to the components of a single Kythe fact.
 struct FactRef {
   const VNameRef* source;
-  absl::string_view fact_name;
-  absl::string_view fact_value;
+  std::string_view fact_name;
+  std::string_view fact_value;
   /// Overwrites all of the fields in `entry` that can differ between single
   /// facts.
   void Expand(proto::Entry* entry) const {
@@ -83,7 +83,7 @@ struct FactRef {
 /// A collection of references to the components of a single Kythe edge.
 struct EdgeRef {
   const VNameRef* source;
-  absl::string_view edge_kind;
+  std::string_view edge_kind;
   const VNameRef* target;
   /// Overwrites all of the fields in `entry` that can differ between edges
   /// without ordinals.
@@ -97,7 +97,7 @@ struct EdgeRef {
 /// ordinal.
 struct OrdinalEdgeRef {
   const VNameRef* source;
-  absl::string_view edge_kind;
+  std::string_view edge_kind;
   const VNameRef* target;
   uint32_t ordinal;
   /// Overwrites all of the fields in `entry` that can differ between edges with

--- a/kythe/cxx/common/json_proto.cc
+++ b/kythe/cxx/common/json_proto.cc
@@ -48,14 +48,14 @@ class PermissiveTypeResolver : public TypeResolver {
   absl::Status ResolveMessageType(
       const std::string& type_url,
       google::protobuf::Type* message_type) override {
-    absl::string_view adjusted = type_url;
+    std::string_view adjusted = type_url;
     adjusted.remove_prefix(type_url.rfind('/') + 1);
     return impl_->ResolveMessageType(absl::StrCat("/", adjusted), message_type);
   }
 
   absl::Status ResolveEnumType(const std::string& type_url,
                                google::protobuf::Enum* enum_type) override {
-    absl::string_view adjusted = type_url;
+    std::string_view adjusted = type_url;
     adjusted.remove_prefix(type_url.rfind('/') + 1);
     return impl_->ResolveEnumType(absl::StrCat("/", adjusted), enum_type);
   }
@@ -224,20 +224,20 @@ absl::Status ParseFromJsonStream(
   return ParseFromJsonStream(input, DefaultParseOptions(), message);
 }
 
-absl::Status ParseFromJsonString(absl::string_view input,
+absl::Status ParseFromJsonString(std::string_view input,
                                  const JsonParseOptions& options,
                                  google::protobuf::Message* message) {
   google::protobuf::io::ArrayInputStream stream(input.data(), input.size());
   return ParseFromJsonStream(&stream, options, message);
 }
 
-absl::Status ParseFromJsonString(absl::string_view input,
+absl::Status ParseFromJsonString(std::string_view input,
                                  google::protobuf::Message* message) {
   return ParseFromJsonString(input, DefaultParseOptions(), message);
 }
 
 void PackAny(const google::protobuf::Message& message,
-             absl::string_view type_uri, google::protobuf::Any* out) {
+             std::string_view type_uri, google::protobuf::Any* out) {
   out->set_type_url(type_uri.data(), type_uri.size());
   message.SerializeToString(out->mutable_value());
 }

--- a/kythe/cxx/common/json_proto.h
+++ b/kythe/cxx/common/json_proto.h
@@ -18,10 +18,10 @@
 #define KYTHE_CXX_COMMON_JSON_PROTO_H_
 
 #include <string>
+#include <string_view>
 
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
-#include <string_view>
 #include "google/protobuf/any.pb.h"
 #include "google/protobuf/io/zero_copy_stream.h"
 #include "google/protobuf/message.h"

--- a/kythe/cxx/common/json_proto.h
+++ b/kythe/cxx/common/json_proto.h
@@ -33,7 +33,7 @@ namespace kythe {
 /// \param input The input text to parse.
 /// \param message The message to parse.
 /// \return The status message result of parsing.
-absl::Status ParseFromJsonString(absl::string_view input,
+absl::Status ParseFromJsonString(std::string_view input,
                                  google::protobuf::Message* message);
 
 /// \brief Deserializes a protobuf from JSON text.
@@ -42,7 +42,7 @@ absl::Status ParseFromJsonString(absl::string_view input,
 /// \param message The message to parse.
 /// \return The status message result of parsing.
 absl::Status ParseFromJsonString(
-    absl::string_view input,
+    std::string_view input,
     const google::protobuf::util::JsonParseOptions& options,
     google::protobuf::Message* message);
 
@@ -100,7 +100,7 @@ absl::StatusOr<std::string> WriteMessageAsJsonToString(
 /// \param type_uri The URI of the message type.
 /// \param out The resulting Any.
 void PackAny(const google::protobuf::Message& message,
-             absl::string_view type_uri, google::protobuf::Any* out);
+             std::string_view type_uri, google::protobuf::Any* out);
 
 /// \brief Unpack a protobuf from an Any.
 /// \param any The Any to unpack.

--- a/kythe/cxx/common/json_proto.h
+++ b/kythe/cxx/common/json_proto.h
@@ -21,7 +21,7 @@
 
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "google/protobuf/any.pb.h"
 #include "google/protobuf/io/zero_copy_stream.h"
 #include "google/protobuf/message.h"

--- a/kythe/cxx/common/kythe_metadata_file.cc
+++ b/kythe/cxx/common/kythe_metadata_file.cc
@@ -43,7 +43,7 @@ bool CheckVName(const proto::VName& vname) {
 /// in buf_string
 /// \param data_start_pos the offset of the first byte of payload in
 /// buf_string
-absl::optional<std::string> LoadCommentMetadata(absl::string_view buf_string,
+absl::optional<std::string> LoadCommentMetadata(std::string_view buf_string,
                                                 size_t comment_slash_pos,
                                                 size_t data_start_pos) {
   std::string raw_data;
@@ -56,14 +56,14 @@ absl::optional<std::string> LoadCommentMetadata(absl::string_view buf_string,
   // file.
   bool single_line = buf_string[comment_slash_pos + 1] == '/';
   auto next_term =
-      single_line ? absl::string_view::npos : buf_string.find("*/", pos);
+      single_line ? std::string_view::npos : buf_string.find("*/", pos);
   for (; pos < buf_string.size();) {
     while (pos < buf_string.size() && isspace(buf_string[pos])) ++pos;
     auto next_newline = buf_string.find('\n', pos);
-    if (next_term != absl::string_view::npos &&
-        (next_newline == absl::string_view::npos || next_term < next_newline)) {
+    if (next_term != std::string_view::npos &&
+        (next_newline == std::string_view::npos || next_term < next_newline)) {
       raw_data.append(buf_string.data() + pos, next_term - pos);
-    } else if (next_newline != absl::string_view::npos) {
+    } else if (next_newline != std::string_view::npos) {
       raw_data.append(buf_string.data() + pos, next_newline - pos);
       pos = next_newline + 1;
       if (!single_line) {
@@ -83,7 +83,7 @@ absl::optional<std::string> LoadCommentMetadata(absl::string_view buf_string,
 /// \brief Attempts to load buffer as a header-style metadata file.
 /// \param buffer data to try and parse.
 /// \return the decoded metadata on success or absl::nullopt on failure.
-absl::optional<std::string> LoadHeaderMetadata(absl::string_view buffer) {
+absl::optional<std::string> LoadHeaderMetadata(std::string_view buffer) {
   if (buffer.size() < 2) {
     return absl::nullopt;
   }
@@ -100,11 +100,11 @@ absl::optional<std::string> LoadHeaderMetadata(absl::string_view buffer) {
 /// \param search_string the string identifying the data.
 /// \return the decoded metadata on success or absl::nullopt on failure.
 absl::optional<std::string> FindCommentMetadata(
-    absl::string_view buffer, const std::string& search_string) {
+    std::string_view buffer, const std::string& search_string) {
   auto comment_start = buffer.find("/* " + search_string);
-  if (comment_start == absl::string_view::npos) {
+  if (comment_start == std::string_view::npos) {
     comment_start = buffer.find("// " + search_string);
-    if (comment_start == absl::string_view::npos) {
+    if (comment_start == std::string_view::npos) {
       return absl::nullopt;
     }
   }
@@ -122,7 +122,7 @@ absl::optional<MetadataFile::Rule> MetadataFile::LoadMetaElement(
     return MetadataFile::Rule{};
   }
 
-  absl::string_view edge_string = mapping.edge();
+  std::string_view edge_string = mapping.edge();
   if (edge_string.empty() && !(mapping.type() == MappingRule::ANCHOR_DEFINES &&
                                mapping.semantic() != MappingRule::SEMA_NONE)) {
     LOG(WARNING) << "When loading metadata: empty edge.";
@@ -179,7 +179,7 @@ absl::optional<MetadataFile::Rule> MetadataFile::LoadMetaElement(
 }
 
 std::unique_ptr<MetadataFile> KytheMetadataSupport::LoadFromJSON(
-    absl::string_view id, absl::string_view json) {
+    std::string_view id, std::string_view json) {
   proto::metadata::GeneratedCodeInfo metadata;
   google::protobuf::util::JsonParseOptions options;
   // Existing implementations specify message types using lower-case enum names,
@@ -205,7 +205,7 @@ std::unique_ptr<MetadataFile> KytheMetadataSupport::LoadFromJSON(
 
 std::unique_ptr<kythe::MetadataFile> KytheMetadataSupport::ParseFile(
     const std::string& raw_filename, const std::string& filename,
-    absl::string_view buffer, absl::string_view target_buffer) {
+    std::string_view buffer, std::string_view target_buffer) {
   auto metadata = LoadFromJSON(raw_filename, buffer);
   if (!metadata) {
     LOG(WARNING) << "Failed loading " << raw_filename;
@@ -220,11 +220,11 @@ void MetadataSupports::UseVNameLookup(VNameLookup lookup) const {
 }
 
 std::unique_ptr<kythe::MetadataFile> MetadataSupports::ParseFile(
-    const std::string& filename, absl::string_view buffer,
-    const std::string& search_string, absl::string_view target_buffer) const {
+    const std::string& filename, std::string_view buffer,
+    const std::string& search_string, std::string_view target_buffer) const {
   std::string modified_filename = filename;
   absl::optional<std::string> decoded_buffer_storage;
-  absl::string_view decoded_buffer = buffer;
+  std::string_view decoded_buffer = buffer;
   if (!search_string.empty()) {
     decoded_buffer_storage = FindCommentMetadata(buffer, search_string);
     if (!decoded_buffer_storage) {

--- a/kythe/cxx/common/kythe_metadata_file.h
+++ b/kythe/cxx/common/kythe_metadata_file.h
@@ -19,8 +19,8 @@
 
 #include <map>
 #include <memory>
-
 #include <string_view>
+
 #include "absl/types/optional.h"
 #include "kythe/proto/metadata.pb.h"
 #include "kythe/proto/storage.pb.h"

--- a/kythe/cxx/common/kythe_metadata_file.h
+++ b/kythe/cxx/common/kythe_metadata_file.h
@@ -20,7 +20,7 @@
 #include <map>
 #include <memory>
 
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "absl/types/optional.h"
 #include "kythe/proto/metadata.pb.h"
 #include "kythe/proto/storage.pb.h"

--- a/kythe/cxx/common/kythe_metadata_file.h
+++ b/kythe/cxx/common/kythe_metadata_file.h
@@ -58,7 +58,7 @@ class MetadataFile {
   /// Creates a new MetadataFile from a list of rules ranging from `begin` to
   /// `end`.
   template <typename InputIterator>
-  static std::unique_ptr<MetadataFile> LoadFromRules(absl::string_view id,
+  static std::unique_ptr<MetadataFile> LoadFromRules(std::string_view id,
                                                      InputIterator begin,
                                                      InputIterator end) {
     std::unique_ptr<MetadataFile> meta_file = std::make_unique<MetadataFile>();
@@ -85,7 +85,7 @@ class MetadataFile {
     return file_scope_rules_;
   }
 
-  absl::string_view id() const { return id_; }
+  std::string_view id() const { return id_; }
 
  private:
   /// Rules to apply keyed on `begin`.
@@ -119,7 +119,7 @@ class MetadataSupport {
   /// \return A `MetadataFile` on success; otherwise, null.
   virtual std::unique_ptr<kythe::MetadataFile> ParseFile(
       const std::string& raw_filename, const std::string& filename,
-      absl::string_view buffer, absl::string_view target_buffer) {
+      std::string_view buffer, std::string_view target_buffer) {
     return nullptr;
   }
 
@@ -154,8 +154,8 @@ class MetadataSupports {
   }
 
   std::unique_ptr<kythe::MetadataFile> ParseFile(
-      const std::string& filename, absl::string_view buffer,
-      const std::string& search_string, absl::string_view target_buffer) const;
+      const std::string& filename, std::string_view buffer,
+      const std::string& search_string, std::string_view target_buffer) const;
 
   void UseVNameLookup(VNameLookup lookup) const;
 
@@ -168,13 +168,13 @@ class KytheMetadataSupport : public MetadataSupport {
  public:
   std::unique_ptr<kythe::MetadataFile> ParseFile(
       const std::string& raw_filename, const std::string& filename,
-      absl::string_view buffer, absl::string_view target_buffer) override;
+      std::string_view buffer, std::string_view target_buffer) override;
 
  private:
   /// \brief Load the JSON-encoded metadata from `json`.
   /// \return null on failure.
-  static std::unique_ptr<MetadataFile> LoadFromJSON(absl::string_view id,
-                                                    absl::string_view json);
+  static std::unique_ptr<MetadataFile> LoadFromJSON(std::string_view id,
+                                                    std::string_view json);
 };
 
 }  // namespace kythe

--- a/kythe/cxx/common/kythe_uri.cc
+++ b/kythe/cxx/common/kythe_uri.cc
@@ -52,14 +52,14 @@ int value_for_hex_digit(char c) {
   return -1;
 }
 
-std::pair<absl::string_view, absl::string_view> Split(absl::string_view input,
+std::pair<std::string_view, std::string_view> Split(std::string_view input,
                                                       char ch) {
   return absl::StrSplit(input, absl::MaxSplits(ch, 1));
 }
 
 }  // namespace
 
-std::string UriEscape(UriEscapeMode mode, absl::string_view uri) {
+std::string UriEscape(UriEscapeMode mode, std::string_view uri) {
   size_t num_escapes = 0;
   for (char c : uri) {
     if (should_escape(mode, c)) {
@@ -83,7 +83,7 @@ std::string UriEscape(UriEscapeMode mode, absl::string_view uri) {
 /// \brief URI-unescapes a string.
 /// \param string The string to unescape.
 /// \return A pair of (success, error-or-unescaped-string).
-std::pair<bool, std::string> UriUnescape(absl::string_view string) {
+std::pair<bool, std::string> UriUnescape(std::string_view string) {
   size_t num_escapes = 0;
   for (size_t i = 0, s = string.size(); i < s; ++i) {
     if (string[i] == '%') {
@@ -119,11 +119,11 @@ std::string URI::ToString() const {
       vname_.language().empty()) {
     return result;
   }
-  absl::string_view signature = vname_.signature();
-  absl::string_view path = vname_.path();
-  absl::string_view corpus = vname_.corpus();
-  absl::string_view language = vname_.language();
-  absl::string_view root = vname_.root();
+  std::string_view signature = vname_.signature();
+  std::string_view path = vname_.path();
+  std::string_view corpus = vname_.corpus();
+  std::string_view language = vname_.language();
+  std::string_view root = vname_.root();
   if (!corpus.empty()) {
     result.append("//");
     result.append(UriEscape(UriEscapeMode::kEscapePaths, corpus));
@@ -149,8 +149,8 @@ std::string URI::ToString() const {
 
 /// \brief Separate out the scheme component of `uri` if one exists.
 /// \return (scheme, tail) if there was a scheme; ("", uri) otherwise.
-static std::pair<absl::string_view, absl::string_view> SplitScheme(
-    absl::string_view uri) {
+static std::pair<std::string_view, std::string_view> SplitScheme(
+    std::string_view uri) {
   for (size_t i = 0, s = uri.size(); i != s; ++i) {
     char c = uri[i];
     if (c == ':') {
@@ -161,12 +161,12 @@ static std::pair<absl::string_view, absl::string_view> SplitScheme(
       break;
     }
   }
-  return std::make_pair(absl::string_view(), uri);
+  return std::make_pair(std::string_view(), uri);
 }
 
 URI::URI(const kythe::proto::VName& from_vname) : vname_(from_vname) {}
 
-bool URI::ParseString(absl::string_view uri) {
+bool URI::ParseString(std::string_view uri) {
   auto head_fragment = Split(uri, '#');
   auto head = head_fragment.first, fragment = head_fragment.second;
   auto scheme_head = SplitScheme(head);

--- a/kythe/cxx/common/kythe_uri.cc
+++ b/kythe/cxx/common/kythe_uri.cc
@@ -53,7 +53,7 @@ int value_for_hex_digit(char c) {
 }
 
 std::pair<std::string_view, std::string_view> Split(std::string_view input,
-                                                      char ch) {
+                                                    char ch) {
   return absl::StrSplit(input, absl::MaxSplits(ch, 1));
 }
 

--- a/kythe/cxx/common/kythe_uri.h
+++ b/kythe/cxx/common/kythe_uri.h
@@ -34,7 +34,7 @@ enum class UriEscapeMode {
 /// \brief URI-escapes a string.
 /// \param mode The escaping mode to use.
 /// \param string The string to escape.
-std::string UriEscape(UriEscapeMode mode, absl::string_view uri);
+std::string UriEscape(UriEscapeMode mode, std::string_view uri);
 
 /// \brief A Kythe URI.
 ///
@@ -55,7 +55,7 @@ class URI {
   /// \brief Constructs a URI from an encoded string.
   /// \param uri The string to construct from.
   /// \return (true, URI) on success; (false, empty URI) on failure.
-  static std::pair<bool, URI> FromString(absl::string_view uri) {
+  static std::pair<bool, URI> FromString(std::string_view uri) {
     URI result;
     bool is_ok = result.ParseString(uri);
     return std::make_pair(is_ok, result);
@@ -73,7 +73,7 @@ class URI {
   /// \brief Attempts to overwrite vname_ using the provided URI string.
   /// \param uri The URI to parse.
   /// \return true on success
-  bool ParseString(absl::string_view uri);
+  bool ParseString(std::string_view uri);
 
   /// The VName this URI represents.
   kythe::proto::VName vname_;

--- a/kythe/cxx/common/kythe_uri.h
+++ b/kythe/cxx/common/kythe_uri.h
@@ -19,7 +19,7 @@
 
 #include <string>
 
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "kythe/cxx/common/vname_ordering.h"
 #include "kythe/proto/storage.pb.h"
 

--- a/kythe/cxx/common/kythe_uri.h
+++ b/kythe/cxx/common/kythe_uri.h
@@ -18,8 +18,8 @@
 #define KYTHE_CXX_COMMON_KYTHE_URI_H_
 
 #include <string>
-
 #include <string_view>
+
 #include "kythe/cxx/common/vname_ordering.h"
 #include "kythe/proto/storage.pb.h"
 

--- a/kythe/cxx/common/kzip_reader.cc
+++ b/kythe/cxx/common/kzip_reader.cc
@@ -19,6 +19,7 @@
 #include <openssl/sha.h>
 
 #include <set>
+#include <string_view>
 
 #include "absl/log/check.h"
 #include "absl/log/log.h"
@@ -29,7 +30,6 @@
 #include "absl/strings/match.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_split.h"
-#include <string_view>
 #include "absl/strings/strip.h"
 #include "absl/types/optional.h"
 #include "google/protobuf/io/zero_copy_stream.h"
@@ -194,8 +194,7 @@ std::string_view DirNameForEncoding(KzipEncoding encoding) {
 
 }  // namespace
 
-absl::optional<std::string_view> KzipReader::UnitDigest(
-    std::string_view path) {
+absl::optional<std::string_view> KzipReader::UnitDigest(std::string_view path) {
   if (!absl::ConsumePrefix(&path, unit_prefix_) || path.empty()) {
     return absl::nullopt;
   }

--- a/kythe/cxx/common/kzip_reader.cc
+++ b/kythe/cxx/common/kzip_reader.cc
@@ -29,7 +29,7 @@
 #include "absl/strings/match.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_split.h"
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "absl/strings/strip.h"
 #include "absl/types/optional.h"
 #include "google/protobuf/io/zero_copy_stream.h"

--- a/kythe/cxx/common/kzip_reader.cc
+++ b/kythe/cxx/common/kzip_reader.cc
@@ -41,8 +41,8 @@
 namespace kythe {
 namespace {
 
-constexpr absl::string_view kJsonUnitsDir = "/units/";
-constexpr absl::string_view kProtoUnitsDir = "/pbunits/";
+constexpr std::string_view kJsonUnitsDir = "/units/";
+constexpr std::string_view kProtoUnitsDir = "/pbunits/";
 
 struct ZipFileClose {
   void operator()(zip_file_t* file) {
@@ -99,7 +99,7 @@ class ZipFileInputStream : public google::protobuf::io::ZeroCopyInputStream {
 };
 
 struct KzipOptions {
-  absl::string_view root;
+  std::string_view root;
   KzipEncoding encoding;
 };
 
@@ -109,18 +109,18 @@ absl::StatusOr<KzipOptions> Validate(zip_t* archive) {
   }
 
   // Pull the root directory from an arbitrary entry.
-  absl::string_view root = zip_get_name(archive, 0, 0);
+  std::string_view root = zip_get_name(archive, 0, 0);
   auto slashpos = root.find('/');
-  if (slashpos == 0 || slashpos == absl::string_view::npos) {
+  if (slashpos == 0 || slashpos == std::string_view::npos) {
     return absl::InvalidArgumentError(
         absl::StrCat("Malformed kzip: invalid root: ", root));
   }
   root.remove_suffix(root.size() - slashpos);
   DLOG(LEVEL(-1)) << "Using archive root: " << root;
-  std::set<absl::string_view> proto_units;
-  std::set<absl::string_view> json_units;
+  std::set<std::string_view> proto_units;
+  std::set<std::string_view> json_units;
   for (int i = 0; i < zip_get_num_entries(archive, 0); ++i) {
-    absl::string_view name = zip_get_name(archive, i, 0);
+    std::string_view name = zip_get_name(archive, i, 0);
     if (!absl::ConsumePrefix(&name, root)) {
       return absl::InvalidArgumentError(
           absl::StrCat("Malformed kzip: invalid entry: ", name));
@@ -135,7 +135,7 @@ absl::StatusOr<KzipOptions> Validate(zip_t* archive) {
   if (json_units.empty()) {
     encoding = KzipEncoding::kProto;
   } else if (!proto_units.empty()) {
-    std::vector<absl::string_view> diff;
+    std::vector<std::string_view> diff;
     std::set_symmetric_difference(json_units.begin(), json_units.end(),
                                   proto_units.begin(), proto_units.end(),
                                   std::inserter(diff, diff.end()));
@@ -180,7 +180,7 @@ absl::StatusOr<std::string> ReadTextFile(zip_t* archive,
   return absl::UnknownError(absl::StrCat("Unable to read: ", path));
 }
 
-absl::string_view DirNameForEncoding(KzipEncoding encoding) {
+std::string_view DirNameForEncoding(KzipEncoding encoding) {
   switch (encoding) {
     case KzipEncoding::kJson:
       return kJsonUnitsDir;
@@ -194,8 +194,8 @@ absl::string_view DirNameForEncoding(KzipEncoding encoding) {
 
 }  // namespace
 
-absl::optional<absl::string_view> KzipReader::UnitDigest(
-    absl::string_view path) {
+absl::optional<std::string_view> KzipReader::UnitDigest(
+    std::string_view path) {
   if (!absl::ConsumePrefix(&path, unit_prefix_) || path.empty()) {
     return absl::nullopt;
   }
@@ -203,7 +203,7 @@ absl::optional<absl::string_view> KzipReader::UnitDigest(
 }
 
 /* static */
-absl::StatusOr<IndexReader> KzipReader::Open(absl::string_view path) {
+absl::StatusOr<IndexReader> KzipReader::Open(std::string_view path) {
   int error;
   if (auto archive =
           ZipHandle(zip_open(std::string(path).c_str(), ZIP_RDONLY, &error))) {
@@ -235,7 +235,7 @@ absl::StatusOr<IndexReader> KzipReader::FromSource(zip_source_t* source) {
   return error.ToStatus();
 }
 
-KzipReader::KzipReader(ZipHandle archive, absl::string_view root,
+KzipReader::KzipReader(ZipHandle archive, std::string_view root,
                        KzipEncoding encoding)
     : archive_(std::move(archive)),
       encoding_(encoding),
@@ -243,7 +243,7 @@ KzipReader::KzipReader(ZipHandle archive, absl::string_view root,
       unit_prefix_(absl::StrCat(root, DirNameForEncoding(encoding))) {}
 
 absl::StatusOr<proto::IndexedCompilation> KzipReader::ReadUnit(
-    absl::string_view digest) {
+    std::string_view digest) {
   std::string path = absl::StrCat(unit_prefix_, digest);
 
   if (auto file = ZipFile(zip_fopen(archive(), path.c_str(), 0))) {
@@ -275,7 +275,7 @@ absl::StatusOr<proto::IndexedCompilation> KzipReader::ReadUnit(
   return absl::UnknownError(absl::StrCat("Unable to open unit ", digest));
 }
 
-absl::StatusOr<std::string> KzipReader::ReadFile(absl::string_view digest) {
+absl::StatusOr<std::string> KzipReader::ReadFile(std::string_view digest) {
   return ReadTextFile(archive(), absl::StrCat(files_prefix_, digest));
 }
 

--- a/kythe/cxx/common/kzip_reader.h
+++ b/kythe/cxx/common/kzip_reader.h
@@ -33,7 +33,7 @@ namespace kythe {
 
 class KzipReader : public IndexReaderInterface {
  public:
-  static absl::StatusOr<IndexReader> Open(absl::string_view path);
+  static absl::StatusOr<IndexReader> Open(std::string_view path);
 
   /// \brief Constructs an `IndexReader` from the provided source.
   /// `zip_source_t` is reference counted, see
@@ -46,9 +46,9 @@ class KzipReader : public IndexReaderInterface {
   absl::Status Scan(const ScanCallback& callback) override;
 
   absl::StatusOr<kythe::proto::IndexedCompilation> ReadUnit(
-      absl::string_view digest) override;
+      std::string_view digest) override;
 
-  absl::StatusOr<std::string> ReadFile(absl::string_view digest) override;
+  absl::StatusOr<std::string> ReadFile(std::string_view digest) override;
 
  private:
   struct Discard {
@@ -58,12 +58,12 @@ class KzipReader : public IndexReaderInterface {
   };
   using ZipHandle = std::unique_ptr<zip_t, Discard>;
 
-  explicit KzipReader(ZipHandle archive, absl::string_view basename,
+  explicit KzipReader(ZipHandle archive, std::string_view basename,
                       KzipEncoding encoding);
 
   zip_t* archive() { return archive_.get(); }
 
-  absl::optional<absl::string_view> UnitDigest(absl::string_view path);
+  absl::optional<std::string_view> UnitDigest(std::string_view path);
 
   ZipHandle archive_;
   KzipEncoding encoding_;

--- a/kythe/cxx/common/kzip_reader.h
+++ b/kythe/cxx/common/kzip_reader.h
@@ -21,10 +21,10 @@
 
 #include <functional>
 #include <string>
+#include <string_view>
 
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
-#include <string_view>
 #include "kythe/cxx/common/index_reader.h"
 #include "kythe/cxx/common/kzip_encoding.h"
 #include "kythe/proto/analysis.pb.h"

--- a/kythe/cxx/common/kzip_reader.h
+++ b/kythe/cxx/common/kzip_reader.h
@@ -24,7 +24,7 @@
 
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "kythe/cxx/common/index_reader.h"
 #include "kythe/cxx/common/kzip_encoding.h"
 #include "kythe/proto/analysis.pb.h"

--- a/kythe/cxx/common/kzip_reader_test.cc
+++ b/kythe/cxx/common/kzip_reader_test.cc
@@ -23,7 +23,7 @@
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_cat.h"
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "absl/strings/strip.h"
 #include "gtest/gtest.h"
 #include "kythe/cxx/common/libzip/error.h"

--- a/kythe/cxx/common/kzip_reader_test.cc
+++ b/kythe/cxx/common/kzip_reader_test.cc
@@ -18,12 +18,12 @@
 
 #include <functional>
 #include <string>
+#include <string_view>
 
 #include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_cat.h"
-#include <string_view>
 #include "absl/strings/strip.h"
 #include "gtest/gtest.h"
 #include "kythe/cxx/common/libzip/error.h"

--- a/kythe/cxx/common/kzip_reader_test.cc
+++ b/kythe/cxx/common/kzip_reader_test.cc
@@ -64,7 +64,7 @@ zip_source_t* ZipSourceFunctionCreate(ZipCallback* callback,
                                     static_cast<void*>(callback), error);
 }
 
-std::string TestFile(absl::string_view basename) {
+std::string TestFile(std::string_view basename) {
   return absl::StrCat(TestSourceRoot(), "kythe/testdata/platform/",
                       absl::StripPrefix(basename, "/"));
 }
@@ -104,7 +104,7 @@ TEST(KzipReaderTest, OpenAndReadSimpleKzip) {
       KzipReader::Open(TestFile("stringset.kzip"));
   ASSERT_TRUE(reader.ok()) << reader.status();
   EXPECT_TRUE(reader
-                  ->Scan([&](absl::string_view digest) {
+                  ->Scan([&](std::string_view digest) {
                     auto unit = reader->ReadUnit(digest);
                     if (unit.ok()) {
                       for (const auto& file : unit->unit().required_input()) {
@@ -184,7 +184,7 @@ TEST(KzipReaderTest, SourceFreedOnEmptyFile) {
 // file, the reference count is maintained correctly.
 TEST(KzipReaderTest, SourceFreedOnInvalidFile) {
   bool freed = false;
-  const absl::string_view buf = "this is not a valid zip file";
+  const std::string_view buf = "this is not a valid zip file";
   zip_source_t* buf_src =
       zip_source_buffer_create(buf.data(), buf.size(), false, nullptr);
   ASSERT_NE(buf_src, nullptr);
@@ -350,7 +350,7 @@ TEST(KzipReaderTest, FromSourceReadsSimpleKzip) {
 
   ASSERT_TRUE(reader.ok()) << reader.status();
   EXPECT_TRUE(reader
-                  ->Scan([&](absl::string_view digest) {
+                  ->Scan([&](std::string_view digest) {
                     auto unit = reader->ReadUnit(digest);
                     if (unit.ok()) {
                       for (const auto& file : unit->unit().required_input()) {

--- a/kythe/cxx/common/kzip_writer.cc
+++ b/kythe/cxx/common/kzip_writer.cc
@@ -38,24 +38,24 @@
 namespace kythe {
 namespace {
 
-constexpr absl::string_view kRoot = "root/";
-constexpr absl::string_view kJsonUnitRoot = "root/units/";
-constexpr absl::string_view kProtoUnitRoot = "root/pbunits/";
-constexpr absl::string_view kFileRoot = "root/files/";
+constexpr std::string_view kRoot = "root/";
+constexpr std::string_view kJsonUnitRoot = "root/units/";
+constexpr std::string_view kProtoUnitRoot = "root/pbunits/";
+constexpr std::string_view kFileRoot = "root/files/";
 // Set all file modified times to 0 so zip file diffs only show content diffs,
 // not zip creation time diffs.
 constexpr time_t kModTime = 0;
 
-std::string SHA256Digest(absl::string_view content) {
+std::string SHA256Digest(std::string_view content) {
   std::array<unsigned char, SHA256_DIGEST_LENGTH> buf;
   ::SHA256(reinterpret_cast<const unsigned char*>(content.data()),
            content.size(), buf.data());
   return absl::BytesToHexString(
-      absl::string_view(reinterpret_cast<const char*>(buf.data()), buf.size()));
+      std::string_view(reinterpret_cast<const char*>(buf.data()), buf.size()));
 }
 
 absl::Status WriteTextFile(zip_t* archive, const std::string& path,
-                           absl::string_view content) {
+                           std::string_view content) {
   if (auto source =
           zip_source_buffer(archive, content.data(), content.size(), 0)) {
     auto idx = zip_file_add(archive, path.c_str(), source, ZIP_FL_ENC_UTF_8);
@@ -70,9 +70,9 @@ absl::Status WriteTextFile(zip_t* archive, const std::string& path,
   return libzip::ToStatus(zip_get_error(archive));
 }
 
-absl::string_view Basename(absl::string_view path) {
+std::string_view Basename(std::string_view path) {
   auto pos = path.find_last_of('/');
-  if (pos == absl::string_view::npos) {
+  if (pos == std::string_view::npos) {
     return path;
   }
   return absl::ClippedSubstr(path, pos + 1);
@@ -86,7 +86,7 @@ bool HasEncoding(KzipEncoding lhs, KzipEncoding rhs) {
 }  // namespace
 
 /* static */
-absl::StatusOr<IndexWriter> KzipWriter::Create(absl::string_view path,
+absl::StatusOr<IndexWriter> KzipWriter::Create(std::string_view path,
                                                KzipEncoding encoding) {
   int error;
   if (auto archive =
@@ -116,7 +116,7 @@ KzipWriter::~KzipWriter() {
 
 // Creates entries for the three directories if not already present.
 absl::Status KzipWriter::InitializeArchive(zip_t* archive) {
-  std::vector<absl::string_view> dirs = {kRoot, kFileRoot};
+  std::vector<std::string_view> dirs = {kRoot, kFileRoot};
   if (HasEncoding(encoding_, KzipEncoding::kJson)) {
     dirs.push_back(kJsonUnitRoot);
   }
@@ -171,7 +171,7 @@ absl::StatusOr<std::string> KzipWriter::WriteUnit(
   return result;
 }
 
-absl::StatusOr<std::string> KzipWriter::WriteFile(absl::string_view content) {
+absl::StatusOr<std::string> KzipWriter::WriteFile(std::string_view content) {
   if (!initialized_) {
     auto status = InitializeArchive(archive_);
     if (!status.ok()) {
@@ -196,8 +196,8 @@ absl::Status KzipWriter::Close() {
   return result;
 }
 
-absl::StatusOr<std::string> KzipWriter::InsertFile(absl::string_view path,
-                                                   absl::string_view content) {
+absl::StatusOr<std::string> KzipWriter::InsertFile(std::string_view path,
+                                                   std::string_view content) {
   // Initially insert an empty string for the file content.
   auto insertion = contents_.emplace(std::string(path), "");
   if (insertion.second) {

--- a/kythe/cxx/common/kzip_writer.h
+++ b/kythe/cxx/common/kzip_writer.h
@@ -23,7 +23,7 @@
 
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "kythe/cxx/common/index_writer.h"
 #include "kythe/cxx/common/kzip_encoding.h"
 #include "kythe/proto/analysis.pb.h"

--- a/kythe/cxx/common/kzip_writer.h
+++ b/kythe/cxx/common/kzip_writer.h
@@ -19,11 +19,11 @@
 
 #include <zip.h>
 
+#include <string_view>
 #include <unordered_map>
 
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
-#include <string_view>
 #include "kythe/cxx/common/index_writer.h"
 #include "kythe/cxx/common/kzip_encoding.h"
 #include "kythe/proto/analysis.pb.h"

--- a/kythe/cxx/common/kzip_writer.h
+++ b/kythe/cxx/common/kzip_writer.h
@@ -38,7 +38,7 @@ class KzipWriter : public IndexWriterInterface {
   /// \param path Path to the file to create. Must not currently exist.
   /// \param encoding Encoding to use for compilation units.
   static absl::StatusOr<IndexWriter> Create(
-      absl::string_view path, KzipEncoding encoding = DefaultEncoding());
+      std::string_view path, KzipEncoding encoding = DefaultEncoding());
   /// \brief Constructs an IndexWriter from the libzip source pointer.
   /// \param source zip_source_t to use as backing store.
   /// See https://libzip.org/documentation/zip_source.html for ownership.
@@ -56,7 +56,7 @@ class KzipWriter : public IndexWriterInterface {
       const kythe::proto::IndexedCompilation& unit) override;
 
   /// \brief Writes the file contents to the kzip file, returning their digest.
-  absl::StatusOr<std::string> WriteFile(absl::string_view content) override;
+  absl::StatusOr<std::string> WriteFile(std::string_view content) override;
 
   /// \brief Flushes accumulated writes and closes the kzip file.
   /// Close must be called before the KzipWriter is destroyed!
@@ -69,8 +69,8 @@ class KzipWriter : public IndexWriterInterface {
 
   explicit KzipWriter(zip_t* archive, KzipEncoding encoding);
 
-  absl::StatusOr<std::string> InsertFile(absl::string_view path,
-                                         absl::string_view content);
+  absl::StatusOr<std::string> InsertFile(std::string_view path,
+                                         std::string_view content);
 
   absl::Status InitializeArchive(zip_t* archive);
 

--- a/kythe/cxx/common/kzip_writer_c_api.cc
+++ b/kythe/cxx/common/kzip_writer_c_api.cc
@@ -64,7 +64,7 @@ KzipWriter* KzipWriter_Create(const char* path, const size_t path_len,
   CHECK(path != nullptr);
   *create_status = 0;
   KzipEncoding kzip_encoding = ToKzipEncoding(encoding);
-  const absl::string_view path_view(path, path_len);
+  const std::string_view path_view(path, path_len);
 
   absl::StatusOr<IndexWriter> writer =
       kythe::KzipWriter::Create(path_view, kzip_encoding);

--- a/kythe/cxx/common/kzip_writer_c_api.cc
+++ b/kythe/cxx/common/kzip_writer_c_api.cc
@@ -23,7 +23,7 @@
 #include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "kythe/cxx/common/index_writer.h"
 #include "kythe/cxx/common/kzip_writer.h"
 #include "kythe/proto/analysis.pb.h"

--- a/kythe/cxx/common/kzip_writer_c_api.cc
+++ b/kythe/cxx/common/kzip_writer_c_api.cc
@@ -19,11 +19,12 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include <string_view>
+
 #include "absl/log/check.h"
 #include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
-#include <string_view>
 #include "kythe/cxx/common/index_writer.h"
 #include "kythe/cxx/common/kzip_writer.h"
 #include "kythe/proto/analysis.pb.h"

--- a/kythe/cxx/common/kzip_writer_c_api_test.cc
+++ b/kythe/cxx/common/kzip_writer_c_api_test.cc
@@ -39,11 +39,11 @@ namespace {
 using ::testing::ElementsAre;
 using ::testing::Values;
 
-absl::string_view TestTmpdir() {
+std::string_view TestTmpdir() {
   return absl::StripSuffix(std::getenv("TEST_TMPDIR"), "/");
 }
 
-std::string TestOutputFile(absl::string_view basename) {
+std::string TestOutputFile(std::string_view basename) {
   const auto* test_info = testing::UnitTest::GetInstance()->current_test_info();
   const auto filename =
       absl::StrReplaceAll(absl::StrCat(test_info->test_case_name(), "_",

--- a/kythe/cxx/common/kzip_writer_c_api_test.cc
+++ b/kythe/cxx/common/kzip_writer_c_api_test.cc
@@ -26,7 +26,7 @@
 #include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_replace.h"
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "absl/strings/strip.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"

--- a/kythe/cxx/common/kzip_writer_c_api_test.cc
+++ b/kythe/cxx/common/kzip_writer_c_api_test.cc
@@ -19,6 +19,7 @@
 #include <zip.h>
 
 #include <cstdlib>
+#include <string_view>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -26,7 +27,6 @@
 #include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_replace.h"
-#include <string_view>
 #include "absl/strings/strip.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"

--- a/kythe/cxx/common/kzip_writer_test.cc
+++ b/kythe/cxx/common/kzip_writer_test.cc
@@ -41,18 +41,18 @@ namespace {
 using ::testing::ElementsAre;
 using ::testing::Values;
 
-absl::string_view TestTmpdir() {
+std::string_view TestTmpdir() {
   return absl::StripSuffix(std::getenv("TEST_TMPDIR"), "/");
 }
 
-std::string TestFile(absl::string_view basename) {
+std::string TestFile(std::string_view basename) {
   return absl::StrCat(TestSourceRoot(), "kythe/testdata/platform/",
                       absl::StripPrefix(basename, "/"));
 }
 
 template <typename T>
 struct WithStatusFn {
-  bool operator()(absl::string_view digest) {
+  bool operator()(std::string_view digest) {
     *status = function(digest);
     return status->ok();
   }
@@ -66,7 +66,7 @@ WithStatusFn<T> WithStatus(absl::Status* status, T function) {
   return WithStatusFn<T>{status, std::move(function)};
 }
 
-std::string TestOutputFile(absl::string_view basename) {
+std::string TestOutputFile(std::string_view basename) {
   const auto* test_info = testing::UnitTest::GetInstance()->current_test_info();
   const auto filename =
       absl::StrReplaceAll(absl::StrCat(test_info->test_case_name(), "_",
@@ -80,7 +80,7 @@ CopyIndex(IndexReader* reader, IndexWriter* writer) {
   absl::Status error;
   std::unordered_map<std::string, std::unordered_set<std::string>> digests;
   absl::Status scan =
-      reader->Scan(WithStatus(&error, [&](absl::string_view digest) {
+      reader->Scan(WithStatus(&error, [&](std::string_view digest) {
         auto unit = reader->ReadUnit(digest);
         if (!unit.ok()) {
           return unit.status();
@@ -116,7 +116,7 @@ ReadDigests(IndexReader* reader) {
   absl::Status error;
   std::unordered_map<std::string, std::unordered_set<std::string>> digests;
   absl::Status scan =
-      reader->Scan(WithStatus(&error, [&](absl::string_view digest) {
+      reader->Scan(WithStatus(&error, [&](std::string_view digest) {
         auto unit = reader->ReadUnit(digest);
         if (!unit.ok()) {
           return unit.status();

--- a/kythe/cxx/common/kzip_writer_test.cc
+++ b/kythe/cxx/common/kzip_writer_test.cc
@@ -27,7 +27,7 @@
 #include "absl/status/statusor.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_replace.h"
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "absl/strings/strip.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"

--- a/kythe/cxx/common/kzip_writer_test.cc
+++ b/kythe/cxx/common/kzip_writer_test.cc
@@ -19,6 +19,7 @@
 #include <zip.h>
 
 #include <cstdlib>
+#include <string_view>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -27,7 +28,6 @@
 #include "absl/status/statusor.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_replace.h"
-#include <string_view>
 #include "absl/strings/strip.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"

--- a/kythe/cxx/common/path_utils.cc
+++ b/kythe/cxx/common/path_utils.cc
@@ -59,7 +59,7 @@ std::string_view PathPrefix(std::string_view path) {
 }
 
 std::string_view TrimPathPrefix(const std::string_view path,
-                                 std::string_view prefix) {
+                                std::string_view prefix) {
   std::string_view result = path;
   if (absl::ConsumePrefix(&result, prefix) &&
       (result.empty() || prefix == "/" || absl::ConsumePrefix(&result, "/"))) {
@@ -297,9 +297,7 @@ absl::StatusOr<std::string> MakeCleanAbsolutePath(std::string_view path) {
   }
 }
 
-std::string_view Dirname(std::string_view path) {
-  return SplitPath(path).dir;
-}
+std::string_view Dirname(std::string_view path) { return SplitPath(path).dir; }
 
 std::string_view Basename(std::string_view path) {
   return SplitPath(path).base;

--- a/kythe/cxx/common/path_utils.cc
+++ b/kythe/cxx/common/path_utils.cc
@@ -38,11 +38,11 @@ namespace {
 // Predicate used in CleanPath for skipping empty components
 // and components consistening of a single '.'.
 struct SkipEmptyDot {
-  bool operator()(absl::string_view sp) { return !(sp.empty() || sp == "."); }
+  bool operator()(std::string_view sp) { return !(sp.empty() || sp == "."); }
 };
 
 // Deal with relative paths as well as '/' and '//'.
-absl::string_view PathPrefix(absl::string_view path) {
+std::string_view PathPrefix(std::string_view path) {
   int slash_count = 0;
   for (char ch : path) {
     if (ch == '/' && ++slash_count <= 2) continue;
@@ -58,9 +58,9 @@ absl::string_view PathPrefix(absl::string_view path) {
   }
 }
 
-absl::string_view TrimPathPrefix(const absl::string_view path,
-                                 absl::string_view prefix) {
-  absl::string_view result = path;
+std::string_view TrimPathPrefix(const std::string_view path,
+                                 std::string_view prefix) {
+  std::string_view result = path;
   if (absl::ConsumePrefix(&result, prefix) &&
       (result.empty() || prefix == "/" || absl::ConsumePrefix(&result, "/"))) {
     return result;
@@ -69,7 +69,7 @@ absl::string_view TrimPathPrefix(const absl::string_view path,
 }
 
 absl::StatusOr<absl::optional<PathRealizer>> MaybeMakeRealizer(
-    PathCanonicalizer::Policy policy, absl::string_view root) {
+    PathCanonicalizer::Policy policy, std::string_view root) {
   switch (policy) {
     case PathCanonicalizer::Policy::kCleanOnly:
       return {absl::nullopt};
@@ -85,7 +85,7 @@ absl::StatusOr<absl::optional<PathRealizer>> MaybeMakeRealizer(
 }
 
 absl::optional<std::string> MaybeRealPath(
-    const absl::optional<PathRealizer>& realizer, absl::string_view root) {
+    const absl::optional<PathRealizer>& realizer, std::string_view root) {
   if (realizer.has_value()) {
     if (auto result = realizer->Relativize(root); result.ok()) {
       return *std::move(result);
@@ -97,14 +97,14 @@ absl::optional<std::string> MaybeRealPath(
 }
 
 struct PathParts {
-  absl::string_view dir, base;
+  std::string_view dir, base;
 };
 
-PathParts SplitPath(absl::string_view path) {
+PathParts SplitPath(std::string_view path) {
   std::string::difference_type pos = path.find_last_of('/');
 
   // Handle the case with no '/' in 'path'.
-  if (pos == absl::string_view::npos) return {path.substr(0, 0), path};
+  if (pos == std::string_view::npos) return {path.substr(0, 0), path};
 
   // Handle the case with a single leading '/' in 'path'.
   if (pos == 0) return {path.substr(0, 1), absl::ClippedSubstr(path, 1)};
@@ -114,7 +114,7 @@ PathParts SplitPath(absl::string_view path) {
 
 }  // namespace
 
-absl::StatusOr<PathCleaner> PathCleaner::Create(absl::string_view root) {
+absl::StatusOr<PathCleaner> PathCleaner::Create(std::string_view root) {
   if (absl::StatusOr<std::string> resolved = MakeCleanAbsolutePath(root);
       resolved.ok()) {
     return PathCleaner(*std::move(resolved));
@@ -124,7 +124,7 @@ absl::StatusOr<PathCleaner> PathCleaner::Create(absl::string_view root) {
 }
 
 absl::StatusOr<std::string> PathCleaner::Relativize(
-    absl::string_view path) const {
+    std::string_view path) const {
   if (absl::StatusOr<std::string> resolved = MakeCleanAbsolutePath(path);
       resolved.ok()) {
     return std::string(TrimPathPrefix(*std::move(resolved), root_));
@@ -133,7 +133,7 @@ absl::StatusOr<std::string> PathCleaner::Relativize(
   }
 }
 
-absl::StatusOr<PathRealizer> PathRealizer::Create(absl::string_view root) {
+absl::StatusOr<PathRealizer> PathRealizer::Create(std::string_view root) {
   if (absl::StatusOr<std::string> resolved = RealPath(root); resolved.ok()) {
     return PathRealizer(*std::move(resolved));
   } else {
@@ -161,7 +161,7 @@ absl::StatusOr<std::string> PathRealizer::PathCache::FindOrInsert(K&& key,
 }
 
 absl::StatusOr<std::string> PathRealizer::Relativize(
-    absl::string_view path) const {
+    std::string_view path) const {
   return cache_->FindOrInsert(
       CleanPath(path), [this, path]() -> absl::StatusOr<std::string> {
         if (absl::StatusOr<std::string> resolved = RealPath(path);
@@ -174,7 +174,7 @@ absl::StatusOr<std::string> PathRealizer::Relativize(
 }
 
 absl::StatusOr<PathCanonicalizer> PathCanonicalizer::Create(
-    absl::string_view root, Policy policy) {
+    std::string_view root, Policy policy) {
   absl::StatusOr<PathCleaner> cleaner = PathCleaner::Create(root);
   if (!cleaner.ok()) {
     return cleaner.status();
@@ -188,7 +188,7 @@ absl::StatusOr<PathCanonicalizer> PathCanonicalizer::Create(
 }
 
 absl::StatusOr<std::string> PathCanonicalizer::Relativize(
-    absl::string_view path) const {
+    std::string_view path) const {
   switch (policy_) {
     case Policy::kPreferRelative:
       if (auto resolved = MaybeRealPath(realizer_, path)) {
@@ -210,7 +210,7 @@ absl::StatusOr<std::string> PathCanonicalizer::Relativize(
 }
 
 absl::optional<PathCanonicalizer::Policy> ParseCanonicalizationPolicy(
-    absl::string_view policy) {
+    std::string_view policy) {
   using Policy = PathCanonicalizer::Policy;
   if (policy == "0" || policy == "clean-only") {
     return Policy::kCleanOnly;
@@ -224,7 +224,7 @@ absl::optional<PathCanonicalizer::Policy> ParseCanonicalizationPolicy(
   return absl::nullopt;
 }
 
-bool AbslParseFlag(absl::string_view text, PathCanonicalizer::Policy* policy,
+bool AbslParseFlag(std::string_view text, PathCanonicalizer::Policy* policy,
                    std::string* error) {
   if (auto parsed = ParseCanonicalizationPolicy(text)) {
     *policy = *parsed;
@@ -248,15 +248,15 @@ std::string AbslUnparseFlag(PathCanonicalizer::Policy policy) {
   return "(unknown)";
 }
 
-std::string JoinPath(absl::string_view a, absl::string_view b) {
+std::string JoinPath(std::string_view a, std::string_view b) {
   return absl::StrCat(absl::StripSuffix(a, "/"), "/",
                       absl::StripPrefix(b, "/"));
 }
 
-std::string CleanPath(absl::string_view input) {
+std::string CleanPath(std::string_view input) {
   const bool is_absolute_path = absl::StartsWith(input, "/");
-  std::vector<absl::string_view> parts;
-  for (absl::string_view comp : absl::StrSplit(input, '/', SkipEmptyDot{})) {
+  std::vector<std::string_view> parts;
+  for (std::string_view comp : absl::StrSplit(input, '/', SkipEmptyDot{})) {
     if (comp == "..") {
       if (!parts.empty() && parts.back() != "..") {
         parts.pop_back();
@@ -270,7 +270,7 @@ std::string CleanPath(absl::string_view input) {
   return absl::StrCat(PathPrefix(input), absl::StrJoin(parts, "/"));
 }
 
-bool IsAbsolutePath(absl::string_view path) {
+bool IsAbsolutePath(std::string_view path) {
   return absl::StartsWith(path, "/");
 }
 
@@ -286,7 +286,7 @@ absl::StatusOr<std::string> GetCurrentDirectory() {
   return result;
 }
 
-absl::StatusOr<std::string> MakeCleanAbsolutePath(absl::string_view path) {
+absl::StatusOr<std::string> MakeCleanAbsolutePath(std::string_view path) {
   if (IsAbsolutePath(path)) {
     return CleanPath(path);
   }
@@ -297,16 +297,16 @@ absl::StatusOr<std::string> MakeCleanAbsolutePath(absl::string_view path) {
   }
 }
 
-absl::string_view Dirname(absl::string_view path) {
+std::string_view Dirname(std::string_view path) {
   return SplitPath(path).dir;
 }
 
-absl::string_view Basename(absl::string_view path) {
+std::string_view Basename(std::string_view path) {
   return SplitPath(path).base;
 }
 
-std::string RelativizePath(absl::string_view to_relativize,
-                           absl::string_view relativize_against) {
+std::string RelativizePath(std::string_view to_relativize,
+                           std::string_view relativize_against) {
   absl::StatusOr<PathCleaner> cleaner = PathCleaner::Create(relativize_against);
   if (!cleaner.ok()) {
     return "";
@@ -314,7 +314,7 @@ std::string RelativizePath(absl::string_view to_relativize,
   return cleaner->Relativize(to_relativize).value_or("");
 }
 
-absl::StatusOr<std::string> RealPath(absl::string_view path) {
+absl::StatusOr<std::string> RealPath(std::string_view path) {
   // realpath requires a null-terminated cstring, but string_view may not be.
   // checking whether or not it is null-terminated is potentially UB.
   std::string zpath(path);

--- a/kythe/cxx/common/path_utils.h
+++ b/kythe/cxx/common/path_utils.h
@@ -23,7 +23,7 @@
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/status/statusor.h"
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "absl/synchronization/mutex.h"
 #include "absl/types/optional.h"
 

--- a/kythe/cxx/common/path_utils.h
+++ b/kythe/cxx/common/path_utils.h
@@ -35,13 +35,13 @@ class PathCleaner {
   /// \brief Creates a PathCleaner using the given root.
   /// \param root The root against which to relativize.
   ///             Will be cleaned and made an absolute path.
-  static absl::StatusOr<PathCleaner> Create(absl::string_view root);
+  static absl::StatusOr<PathCleaner> Create(std::string_view root);
 
   /// \brief Transforms the cleaned, absolute version of `path` into a path
   ///        relative to the configured root.
   /// \return A path relative to root, if `path` is, else a cleaned `path` or an
   ///         error if the current directory cannot be determined.
-  absl::StatusOr<std::string> Relativize(absl::string_view path) const;
+  absl::StatusOr<std::string> Relativize(std::string_view path) const;
 
  private:
   explicit PathCleaner(std::string root) : root_(std::move(root)) {}
@@ -55,7 +55,7 @@ class PathRealizer {
   /// \brief Creates a PathCleaner using the given root.
   /// \param root The root against which to relativize.
   ///             Will be resolved and made an absolute path.
-  static absl::StatusOr<PathRealizer> Create(absl::string_view root);
+  static absl::StatusOr<PathRealizer> Create(std::string_view root);
 
   /// PathRealizer is copyable and movable.
   PathRealizer(const PathRealizer& other);
@@ -67,7 +67,7 @@ class PathRealizer {
   ///        relative to the configured root.
   /// \return A path relative to root, if `path` is, else a resolved `path` or
   ///         an error if the path cannot be resolved.
-  absl::StatusOr<std::string> Relativize(absl::string_view path) const;
+  absl::StatusOr<std::string> Relativize(std::string_view path) const;
 
  private:
   class PathCache {
@@ -99,11 +99,11 @@ class PathCanonicalizer {
 
   /// \brief Creates a new PathCanonicalizer with the given root and policy.
   static absl::StatusOr<PathCanonicalizer> Create(
-      absl::string_view root, Policy policy = Policy::kCleanOnly);
+      std::string_view root, Policy policy = Policy::kCleanOnly);
 
   /// \brief Transforms the provided path into a relative path depending on
   ///        configured policy.
-  absl::StatusOr<std::string> Relativize(absl::string_view path) const;
+  absl::StatusOr<std::string> Relativize(std::string_view path) const;
 
  private:
   explicit PathCanonicalizer(Policy policy, PathCleaner cleaner,
@@ -119,7 +119,7 @@ class PathCanonicalizer {
 ///
 /// This is an extension point for the Abseil Flags library to allow
 /// using PathCanonicalizer directly as a flag.
-bool AbslParseFlag(absl::string_view text, PathCanonicalizer::Policy* policy,
+bool AbslParseFlag(std::string_view text, PathCanonicalizer::Policy* policy,
                    std::string* error);
 
 /// \brief Returns the flag string representation of PathCanonicalizer::Policy.
@@ -133,23 +133,23 @@ std::string AbslUnparseFlag(PathCanonicalizer::Policy policy);
 /// Parses either integeral values of enumerators or lower-case,
 /// dash-separated names: "clean-only", "prefer-relative", "prefer-real".
 absl::optional<PathCanonicalizer::Policy> ParseCanonicalizationPolicy(
-    absl::string_view policy);
+    std::string_view policy);
 
 /// \brief Append path `b` to path `a`, cleaning and returning the result.
-std::string JoinPath(absl::string_view a, absl::string_view b);
+std::string JoinPath(std::string_view a, std::string_view b);
 
 /// \brief Returns the part of the path before the final '/'.
-absl::string_view Dirname(absl::string_view path);
+std::string_view Dirname(std::string_view path);
 
 /// \brief Returns the part of the path after the final '/'.
-absl::string_view Basename(absl::string_view path);
+std::string_view Basename(std::string_view path);
 
 /// \brief Collapse duplicate "/"s, resolve ".." and "." path elements, remove
 /// trailing "/".
-std::string CleanPath(absl::string_view input);
+std::string CleanPath(std::string_view input);
 
 // \brief Returns true if path is absolute.
-bool IsAbsolutePath(absl::string_view path);
+bool IsAbsolutePath(std::string_view path);
 
 /// \brief Relativize `to_relativize` with respect to `relativize_against`.
 ///
@@ -161,18 +161,18 @@ bool IsAbsolutePath(absl::string_view path);
 ///
 /// \param to_relativize Relative or absolute path to a file.
 /// \param relativize_against Relative or absolute path to a directory.
-std::string RelativizePath(absl::string_view to_relativize,
-                           absl::string_view relativize_against);
+std::string RelativizePath(std::string_view to_relativize,
+                           std::string_view relativize_against);
 
 /// \brief Convert `path` to an absolute path, eliminating `.` and `..`.
 /// \param path The path to convert.
-absl::StatusOr<std::string> MakeCleanAbsolutePath(absl::string_view path);
+absl::StatusOr<std::string> MakeCleanAbsolutePath(std::string_view path);
 
 /// \brief Returns the process's current working directory or an error.
 absl::StatusOr<std::string> GetCurrentDirectory();
 
 /// \brief Returns the result of resolving symbolic links.
-absl::StatusOr<std::string> RealPath(absl::string_view path);
+absl::StatusOr<std::string> RealPath(std::string_view path);
 
 }  // namespace kythe
 

--- a/kythe/cxx/common/path_utils.h
+++ b/kythe/cxx/common/path_utils.h
@@ -19,11 +19,11 @@
 
 #include <memory>
 #include <string>
+#include <string_view>
 #include <utility>
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/status/statusor.h"
-#include <string_view>
 #include "absl/synchronization/mutex.h"
 #include "absl/types/optional.h"
 

--- a/kythe/cxx/common/protobuf_metadata_file.cc
+++ b/kythe/cxx/common/protobuf_metadata_file.cc
@@ -43,8 +43,8 @@ proto::VName ProtobufMetadataSupport::VNameForAnnotation(
 
 std::unique_ptr<kythe::MetadataFile> ProtobufMetadataSupport::ParseFile(
     const std::string& raw_filename, const std::string& filename,
-    absl::string_view buffer, absl::string_view target_buffer) {
-  absl::string_view file_ref(filename);
+    std::string_view buffer, std::string_view target_buffer) {
+  std::string_view file_ref(filename);
   if (!(absl::EndsWith(filename, ".pb.h.meta") ||
         absl::EndsWith(filename, ".pb.h") ||
         absl::EndsWith(filename, ".proto.h.meta") ||

--- a/kythe/cxx/common/protobuf_metadata_file.h
+++ b/kythe/cxx/common/protobuf_metadata_file.h
@@ -56,7 +56,7 @@ class ProtobufMetadataSupport : public MetadataSupport {
   /// a warning.
   std::unique_ptr<kythe::MetadataFile> ParseFile(
       const std::string& raw_filename, const std::string& filename,
-      absl::string_view buffer, absl::string_view target_buffer) override;
+      std::string_view buffer, std::string_view target_buffer) override;
 
   void UseVNameLookup(VNameLookup lookup) override { vname_lookup_ = lookup; }
 

--- a/kythe/cxx/common/re2_flag.cc
+++ b/kythe/cxx/common/re2_flag.cc
@@ -17,7 +17,7 @@
 #include "kythe/cxx/common/re2_flag.h"
 
 namespace kythe {
-bool AbslParseFlag(absl::string_view text, RE2Flag* value, std::string* error) {
+bool AbslParseFlag(std::string_view text, RE2Flag* value, std::string* error) {
   if (text.empty()) {
     return true;
   }

--- a/kythe/cxx/common/re2_flag.h
+++ b/kythe/cxx/common/re2_flag.h
@@ -19,8 +19,8 @@
 
 #include <memory>
 #include <string>
-
 #include <string_view>
+
 #include "re2/re2.h"
 
 namespace kythe {

--- a/kythe/cxx/common/re2_flag.h
+++ b/kythe/cxx/common/re2_flag.h
@@ -27,7 +27,7 @@ namespace kythe {
 struct RE2Flag {
   std::shared_ptr<re2::RE2> value;
 };
-bool AbslParseFlag(absl::string_view text, RE2Flag* value, std::string* error);
+bool AbslParseFlag(std::string_view text, RE2Flag* value, std::string* error);
 std::string AbslUnparseFlag(const RE2Flag& value);
 }  // namespace kythe
 

--- a/kythe/cxx/common/re2_flag.h
+++ b/kythe/cxx/common/re2_flag.h
@@ -20,7 +20,7 @@
 #include <memory>
 #include <string>
 
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "re2/re2.h"
 
 namespace kythe {

--- a/kythe/cxx/common/regex.cc
+++ b/kythe/cxx/common/regex.cc
@@ -17,12 +17,12 @@
 #include "kythe/cxx/common/regex.h"
 
 #include <memory>
+#include <string_view>
 
 #include "absl/log/check.h"
 #include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
-#include <string_view>
 #include "re2/re2.h"
 
 namespace kythe {

--- a/kythe/cxx/common/regex.cc
+++ b/kythe/cxx/common/regex.cc
@@ -22,7 +22,7 @@
 #include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "re2/re2.h"
 
 namespace kythe {

--- a/kythe/cxx/common/regex.cc
+++ b/kythe/cxx/common/regex.cc
@@ -61,7 +61,7 @@ RE2::Set CheckCompiled(RE2::Set set) {
 }
 }  // namespace
 
-absl::StatusOr<Regex> Regex::Compile(absl::string_view pattern,
+absl::StatusOr<Regex> Regex::Compile(std::string_view pattern,
                                      const RE2::Options& options) {
   std::shared_ptr<const RE2> re = std::make_shared<RE2>(pattern, options);
   if (!re->ok()) {
@@ -103,7 +103,7 @@ RegexSet& RegexSet::operator=(RegexSet&& other) noexcept {
 }
 
 absl::StatusOr<std::vector<int>> RegexSet::ExplainMatch(
-    absl::string_view value) const {
+    std::string_view value) const {
   RE2::Set::ErrorInfo error;
   std::vector<int> matches;
   if (set_->Match(value, &matches, &error)) {

--- a/kythe/cxx/common/regex.h
+++ b/kythe/cxx/common/regex.h
@@ -32,7 +32,7 @@ class Regex {
  public:
   /// \brief Compiles the pattern into a Regex with the provided options.
   static absl::StatusOr<Regex> Compile(
-      absl::string_view pattern,
+      std::string_view pattern,
       const RE2::Options& options = RE2::DefaultOptions);
 
   /// \brief Constructs a Regex from an already-compiled RE2 object.
@@ -65,7 +65,7 @@ class Regex {
 class RegexSet {
  public:
   /// \brief Builds a RegexSet from the list of patterns and options.
-  template <typename Range = absl::Span<const absl::string_view>>
+  template <typename Range = absl::Span<const std::string_view>>
   static absl::StatusOr<RegexSet> Build(
       const Range& patterns, const RE2::Options& = RE2::DefaultOptions,
       RE2::Anchor = RE2::UNANCHORED);
@@ -88,14 +88,14 @@ class RegexSet {
 
   /// \brief Returns true if the provided value matches one of the contained
   /// regular expressions.
-  bool Match(absl::string_view value) const {
+  bool Match(std::string_view value) const {
     return set_->Match(value, nullptr);
   }
 
   /// \brief Matches the input against the contained regular expressions,
   /// returning the indices at which the value matched or an empty vector if it
   /// did not.
-  absl::StatusOr<std::vector<int>> ExplainMatch(absl::string_view value) const;
+  absl::StatusOr<std::vector<int>> ExplainMatch(std::string_view value) const;
 
  private:
   std::shared_ptr<const RE2::Set> set_;  // non-null.

--- a/kythe/cxx/common/regex.h
+++ b/kythe/cxx/common/regex.h
@@ -15,9 +15,9 @@
  */
 
 #include <memory>
+#include <string_view>
 
 #include "absl/status/statusor.h"
-#include <string_view>
 #include "absl/types/span.h"
 #include "re2/re2.h"
 #include "re2/set.h"

--- a/kythe/cxx/common/regex.h
+++ b/kythe/cxx/common/regex.h
@@ -17,7 +17,7 @@
 #include <memory>
 
 #include "absl/status/statusor.h"
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "absl/types/span.h"
 #include "re2/re2.h"
 #include "re2/set.h"

--- a/kythe/cxx/common/sha256_hasher.cc
+++ b/kythe/cxx/common/sha256_hasher.cc
@@ -23,7 +23,7 @@
 #include <string>
 
 #include "absl/strings/escaping.h"
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "absl/types/span.h"
 
 namespace kythe {

--- a/kythe/cxx/common/sha256_hasher.cc
+++ b/kythe/cxx/common/sha256_hasher.cc
@@ -21,9 +21,9 @@
 #include <array>
 #include <cstddef>
 #include <string>
+#include <string_view>
 
 #include "absl/strings/escaping.h"
-#include <string_view>
 #include "absl/types/span.h"
 
 namespace kythe {

--- a/kythe/cxx/common/sha256_hasher.h
+++ b/kythe/cxx/common/sha256_hasher.h
@@ -45,13 +45,13 @@ class Sha256Hasher {
 
    public:
     template <typename T, typename Dest = first_convertible<
-                              absl::string_view, absl::Span<const std::byte>,
+                              std::string_view, absl::Span<const std::byte>,
                               absl::Span<const unsigned char>,
                               absl::Span<const char>>::from<T>>
     ByteView(T&& data)  // NOLINT
         : ByteView(Dest(data)) {}
 
-    ByteView(absl::string_view data)  // NOLINT
+    ByteView(std::string_view data)  // NOLINT
         : ByteView(data.data(), data.size()) {}
     ByteView(absl::Span<const std::byte> data)  // NOLINT
         : ByteView(data.data(), data.size()) {}

--- a/kythe/cxx/common/sha256_hasher.h
+++ b/kythe/cxx/common/sha256_hasher.h
@@ -22,8 +22,8 @@
 #include <array>
 #include <cstddef>
 #include <string>
-
 #include <string_view>
+
 #include "absl/types/span.h"
 
 namespace kythe {

--- a/kythe/cxx/common/sha256_hasher.h
+++ b/kythe/cxx/common/sha256_hasher.h
@@ -23,7 +23,7 @@
 #include <cstddef>
 #include <string>
 
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "absl/types/span.h"
 
 namespace kythe {

--- a/kythe/cxx/common/testutil.cc
+++ b/kythe/cxx/common/testutil.cc
@@ -18,10 +18,10 @@
 #include <unistd.h>
 
 #include <cstdlib>
+#include <string_view>
 
 #include "absl/log/die_if_null.h"
 #include "absl/strings/str_cat.h"
-#include <string_view>
 #include "absl/strings/strip.h"
 
 namespace kythe {

--- a/kythe/cxx/common/testutil.cc
+++ b/kythe/cxx/common/testutil.cc
@@ -21,7 +21,7 @@
 
 #include "absl/log/die_if_null.h"
 #include "absl/strings/str_cat.h"
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "absl/strings/strip.h"
 
 namespace kythe {

--- a/kythe/cxx/common/utf8_line_index.cc
+++ b/kythe/cxx/common/utf8_line_index.cc
@@ -17,11 +17,11 @@
 #include "kythe/cxx/common/utf8_line_index.h"
 
 #include <ostream>
+#include <string_view>
 
 #include "absl/algorithm/container.h"
 #include "absl/log/check.h"
 #include "absl/log/log.h"
-#include <string_view>
 
 namespace kythe {
 

--- a/kythe/cxx/common/utf8_line_index.cc
+++ b/kythe/cxx/common/utf8_line_index.cc
@@ -35,7 +35,7 @@ std::ostream& operator<<(std::ostream& dest,
 
 bool IsUTF8ContinuationByte(int byte) { return ((byte & 0xC0) == 0x80); }
 
-bool IsUTF8EndOfLineByte(int byte_offset, absl::string_view content) {
+bool IsUTF8EndOfLineByte(int byte_offset, std::string_view content) {
   // If/when we were using a string, checking for the past-the-end byte
   // was safe.  Now that we use string_view we have to avoid that.
   return (content[byte_offset] == '\n' ||
@@ -43,7 +43,7 @@ bool IsUTF8EndOfLineByte(int byte_offset, absl::string_view content) {
                                             content[byte_offset + 1] != '\n')));
 }
 
-UTF8LineIndex::UTF8LineIndex(absl::string_view content) : content_(content) {
+UTF8LineIndex::UTF8LineIndex(std::string_view content) : content_(content) {
   IndexContent();
 }
 
@@ -148,7 +148,7 @@ int UTF8LineIndex::ComputeByteOffset(int line, int column) const {
   return byte_offset;
 }
 
-absl::string_view UTF8LineIndex::GetLine(int line_number) const {
+std::string_view UTF8LineIndex::GetLine(int line_number) const {
   const int start_byte_offset = ComputeByteOffset(line_number, 0);
   if (line_number == line_begin_byte_offsets_.size()) {
     // The last line is a special case, as it might be unterminated.
@@ -157,19 +157,19 @@ absl::string_view UTF8LineIndex::GetLine(int line_number) const {
   const int end_byte_offset = ComputeByteOffset(line_number + 1, 0);
   if (start_byte_offset == -1 || end_byte_offset == -1) {
     // Error case.
-    return absl::string_view();
+    return std::string_view();
   }
   return absl::ClippedSubstr(content_, start_byte_offset,
                              end_byte_offset - start_byte_offset);
 }
 
-absl::string_view UTF8LineIndex::GetSubstrFromLine(
+std::string_view UTF8LineIndex::GetSubstrFromLine(
     int line_number, int start_position_in_code_points,
     int length_in_code_points) const {
   CHECK_GE(start_position_in_code_points, 0);
   CHECK_GE(length_in_code_points, 0);
 
-  absl::string_view line = GetLine(line_number);
+  std::string_view line = GetLine(line_number);
 
   int start_byte_offset = -1;  // a negative number means not being set yet
   int code_point_number = 0;
@@ -196,7 +196,7 @@ absl::string_view UTF8LineIndex::GetSubstrFromLine(
   } else {
     LOG(ERROR) << "Substring index " << start_position_in_code_points
                << " not found in " << line;
-    return absl::string_view();
+    return std::string_view();
   }
 }
 

--- a/kythe/cxx/common/utf8_line_index.cc
+++ b/kythe/cxx/common/utf8_line_index.cc
@@ -21,7 +21,7 @@
 #include "absl/algorithm/container.h"
 #include "absl/log/check.h"
 #include "absl/log/log.h"
-#include "absl/strings/string_view.h"
+#include <string_view>
 
 namespace kythe {
 

--- a/kythe/cxx/common/utf8_line_index.h
+++ b/kythe/cxx/common/utf8_line_index.h
@@ -19,9 +19,8 @@
 
 #include <iosfwd>
 #include <string>
-#include <vector>
-
 #include <string_view>
+#include <vector>
 
 namespace kythe {
 
@@ -122,8 +121,8 @@ class UTF8LineIndex {
   //
   // TODO: Optimize this function for the case of ASCII.
   std::string_view GetSubstrFromLine(int line_number,
-                                      int start_position_in_code_points,
-                                      int length_in_code_points) const;
+                                     int start_position_in_code_points,
+                                     int length_in_code_points) const;
 
   // Returns the number of lines in the indexed file, including the last line
   // even if it was not terminated.

--- a/kythe/cxx/common/utf8_line_index.h
+++ b/kythe/cxx/common/utf8_line_index.h
@@ -31,7 +31,7 @@ bool IsUTF8ContinuationByte(int byte);
 
 // Returns whether a UTF-8 byte from the |content| is the end of a line,
 // i.e., a '\n', or a '\r' not immediately followed by a '\n'.
-bool IsUTF8EndOfLineByte(int byte_offset, absl::string_view content);
+bool IsUTF8EndOfLineByte(int byte_offset, std::string_view content);
 
 // Describes the position of a character in a file, in an encoding-independent
 // way.  By encoding-independent, we mean that if the file were re-encoded in
@@ -77,7 +77,7 @@ class UTF8LineIndex {
   // The content must be less than 2GB long.
   //
   // Complexity: O(content.size())
-  explicit UTF8LineIndex(absl::string_view content);
+  explicit UTF8LineIndex(std::string_view content);
 
   // Given a (0-based) byte offset into the file, returns character-based
   // information on the position of that offset.
@@ -111,7 +111,7 @@ class UTF8LineIndex {
   //
   // The first line is line 1. This returned string_view is a view into the
   // buffer indexed by this UTF8LineIndex.
-  absl::string_view GetLine(int line_number) const;
+  std::string_view GetLine(int line_number) const;
 
   // Returns a substring from the line at a given line number, starting from
   // a given |start_position_in_code_points| and with a length of
@@ -121,7 +121,7 @@ class UTF8LineIndex {
   // the rest of the line including the end-of-line marker.
   //
   // TODO: Optimize this function for the case of ASCII.
-  absl::string_view GetSubstrFromLine(int line_number,
+  std::string_view GetSubstrFromLine(int line_number,
                                       int start_position_in_code_points,
                                       int length_in_code_points) const;
 
@@ -142,7 +142,7 @@ class UTF8LineIndex {
   }
 
   // Returns (a reference to) the content of the indexed file.
-  absl::string_view str() const { return content_; }
+  std::string_view str() const { return content_; }
 
  private:
   // Populates the index vectors based on content_.
@@ -157,7 +157,7 @@ class UTF8LineIndex {
   }
 
   // The content covered by this UTF8LineIndex.
-  absl::string_view content_;
+  std::string_view content_;
 
   // line_ends_byte_offsets_[n] stores the byte offset of the start of line n-1.
   std::vector<int> line_begin_byte_offsets_;

--- a/kythe/cxx/common/utf8_line_index.h
+++ b/kythe/cxx/common/utf8_line_index.h
@@ -21,7 +21,7 @@
 #include <string>
 #include <vector>
 
-#include "absl/strings/string_view.h"
+#include <string_view>
 
 namespace kythe {
 

--- a/kythe/cxx/common/utf8_line_index_test.cc
+++ b/kythe/cxx/common/utf8_line_index_test.cc
@@ -21,7 +21,7 @@
 #include "absl/log/check.h"
 #include "absl/log/log.h"
 #include "absl/strings/str_cat.h"
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "gtest/gtest.h"
 
 namespace {

--- a/kythe/cxx/common/utf8_line_index_test.cc
+++ b/kythe/cxx/common/utf8_line_index_test.cc
@@ -17,11 +17,11 @@
 #include "kythe/cxx/common/utf8_line_index.h"
 
 #include <algorithm>
+#include <string_view>
 
 #include "absl/log/check.h"
 #include "absl/log/log.h"
 #include "absl/strings/str_cat.h"
-#include <string_view>
 #include "gtest/gtest.h"
 
 namespace {

--- a/kythe/cxx/common/utf8_line_index_test.cc
+++ b/kythe/cxx/common/utf8_line_index_test.cc
@@ -37,7 +37,7 @@ static bool IsUTF8ContinuationByte(int byte) { return ((byte & 0xC0) == 0x80); }
 // covered by a UTF8LineIndex, and also for breaking the file up into lines
 // and then concatenating those lines.
 void CheckRoundTrips(const UTF8LineIndex& index) {
-  absl::string_view content(index.str());
+  std::string_view content(index.str());
   for (int byte_offset = 0; byte_offset < content.size(); ++byte_offset) {
     if (IsUTF8ContinuationByte(content[byte_offset])) continue;
     CharacterPosition position(index.ComputePositionForByteOffset(byte_offset));

--- a/kythe/cxx/extractor/bazel_artifact_reader.cc
+++ b/kythe/cxx/extractor/bazel_artifact_reader.cc
@@ -20,7 +20,7 @@
 #include "absl/strings/escaping.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_join.h"
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.pb.h"
 
 namespace kythe {

--- a/kythe/cxx/extractor/bazel_artifact_reader.cc
+++ b/kythe/cxx/extractor/bazel_artifact_reader.cc
@@ -16,11 +16,11 @@
 #include "kythe/cxx/extractor/bazel_artifact_reader.h"
 
 #include <string>
+#include <string_view>
 
 #include "absl/strings/escaping.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_join.h"
-#include <string_view>
 #include "src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.pb.h"
 
 namespace kythe {

--- a/kythe/cxx/extractor/bazel_artifact_selector.cc
+++ b/kythe/cxx/extractor/bazel_artifact_selector.cc
@@ -132,7 +132,7 @@ absl::Status DeserializeInternal(T& selector, const U& container) {
                     : absl::NotFoundError(
                           absl::StrCat("No state found: ", error.ToString()));
 }
-bool StrictAtoI(absl::string_view value, int64_t* out) {
+bool StrictAtoI(std::string_view value, int64_t* out) {
   if (value == "0") {
     *out = 0;
     return true;
@@ -275,7 +275,7 @@ class AspectArtifactSelectorSerializationHelper {
       result_.add_disposed(SerializeFileSetId(id));
     }
 
-    void SerializePending(FileSetId id, absl::string_view target) {
+    void SerializePending(FileSetId id, std::string_view target) {
       (*result_.mutable_pending())[SerializeFileSetId(id)] = target;
     }
 
@@ -405,7 +405,7 @@ class AspectArtifactSelectorSerializationHelper {
       });
     }
 
-    absl::Status DeserializePending(int64_t id, absl::string_view target) {
+    absl::Status DeserializePending(int64_t id, std::string_view target) {
       absl::StatusOr<FileSetId> real_id = DeserializeFileSetId(id);
       if (!real_id.ok()) return real_id.status();
 
@@ -580,7 +580,7 @@ const BazelArtifactFile* AspectArtifactSelector::FileTable::Find(
 
 std::optional<AspectArtifactSelector::FileSetId>
 AspectArtifactSelector::FileSetTable::InternUnlessDisposed(
-    absl::string_view id) {
+    std::string_view id) {
   auto [result, inserted] = InternOrCreate(id);
   if (!inserted && disposed_.contains(result)) {
     return std::nullopt;
@@ -589,7 +589,7 @@ AspectArtifactSelector::FileSetTable::InternUnlessDisposed(
 }
 
 std::pair<AspectArtifactSelector::FileSetId, bool>
-AspectArtifactSelector::FileSetTable::InternOrCreate(absl::string_view id) {
+AspectArtifactSelector::FileSetTable::InternOrCreate(std::string_view id) {
   int64_t token;
   if (StrictAtoI(id, &token)) {
     return {{token}, false};
@@ -637,7 +637,7 @@ std::string AspectArtifactSelector::FileSetTable::ToString(FileSetId id) const {
 }
 
 absl::optional<BazelArtifact> AspectArtifactSelector::SelectFileSet(
-    absl::string_view id, const build_event_stream::NamedSetOfFiles& fileset) {
+    std::string_view id, const build_event_stream::NamedSetOfFiles& fileset) {
   std::optional<FileSetId> file_set_id = InternUnlessDisposed(id);
   if (!file_set_id.has_value()) {
     // Already disposed, skip.
@@ -709,7 +709,7 @@ AspectArtifactSelector::PartitionFileSets(
 }
 
 void AspectArtifactSelector::ExtractFilesInto(
-    FileSetId id, absl::string_view target,
+    FileSetId id, std::string_view target,
     std::vector<BazelArtifactFile>* files) {
   if (state_.file_sets.Disposed(id)) {
     return;
@@ -768,12 +768,12 @@ void AspectArtifactSelector::InsertFileSet(
 ExtraActionSelector::ExtraActionSelector(
     absl::flat_hash_set<std::string> action_types)
     : action_matches_([action_types = std::move(action_types)](
-                          absl::string_view action_type) {
+                          std::string_view action_type) {
         return action_types.empty() || action_types.contains(action_type);
       }) {}
 
 ExtraActionSelector::ExtraActionSelector(const RE2* action_pattern)
-    : action_matches_([action_pattern](absl::string_view action_type) {
+    : action_matches_([action_pattern](std::string_view action_type) {
         if (action_pattern == nullptr || action_pattern->pattern().empty()) {
           return false;
         }

--- a/kythe/cxx/extractor/bazel_artifact_selector.h
+++ b/kythe/cxx/extractor/bazel_artifact_selector.h
@@ -237,7 +237,7 @@ class AspectArtifactSelector final : public BazelArtifactSelector {
 
   class FileSetTable {
    public:
-    std::optional<FileSetId> InternUnlessDisposed(absl::string_view id);
+    std::optional<FileSetId> InternUnlessDisposed(std::string_view id);
     bool InsertUnlessDisposed(FileSetId id, FileSet file_set);
     // Extracts the FileSet and, if previously present, marks it disposed.
     std::optional<FileSet> ExtractAndDispose(FileSetId id);
@@ -254,7 +254,7 @@ class AspectArtifactSelector final : public BazelArtifactSelector {
     const absl::flat_hash_set<FileSetId>& disposed() const { return disposed_; }
 
    private:
-    std::pair<FileSetId, bool> InternOrCreate(absl::string_view id);
+    std::pair<FileSetId, bool> InternOrCreate(std::string_view id);
 
     // A record of all pending FileSets.
     absl::flat_hash_map<FileSetId, FileSet> file_sets_;
@@ -279,7 +279,7 @@ class AspectArtifactSelector final : public BazelArtifactSelector {
     absl::flat_hash_map<FileSetId, std::string> pending;
   };
   absl::optional<BazelArtifact> SelectFileSet(
-      absl::string_view id, const build_event_stream::NamedSetOfFiles& fileset);
+      std::string_view id, const build_event_stream::NamedSetOfFiles& fileset);
 
   absl::optional<BazelArtifact> SelectTargetCompleted(
       const build_event_stream::BuildEventId::TargetCompletedId& id,
@@ -295,12 +295,12 @@ class AspectArtifactSelector final : public BazelArtifactSelector {
 
   // Extracts the selected files into the (optional) `files` output.
   // If `files` is nullptr, extracted files will be dropped.
-  void ExtractFilesInto(FileSetId id, absl::string_view target,
+  void ExtractFilesInto(FileSetId id, std::string_view target,
                         std::vector<BazelArtifactFile>* files);
   void InsertFileSet(FileSetId id,
                      const build_event_stream::NamedSetOfFiles& fileset);
 
-  std::optional<FileSetId> InternUnlessDisposed(absl::string_view id) {
+  std::optional<FileSetId> InternUnlessDisposed(std::string_view id) {
     return state_.file_sets.InternUnlessDisposed(id);
   }
 
@@ -330,7 +330,7 @@ class ExtraActionSelector final : public BazelArtifactSelector {
       const build_event_stream::BuildEvent& event) final;
 
  private:
-  std::function<bool(absl::string_view)> action_matches_;
+  std::function<bool(std::string_view)> action_matches_;
 };
 
 }  // namespace kythe

--- a/kythe/cxx/extractor/bazel_artifact_selector_test.cc
+++ b/kythe/cxx/extractor/bazel_artifact_selector_test.cc
@@ -115,7 +115,7 @@ std::vector<build_event_stream::BuildEvent> ToNamedSetOfFilesEvents(
 
 // The TargetCompleted event will always come after the NamedSetOfFiles events.
 void ToTargetCompletedBuildEvents(
-    absl::string_view label,
+    std::string_view label,
     const absl::flat_hash_map<std::string, FileSet>& file_sets,
     std::vector<build_event_stream::BuildEvent>& result) {
   ToNamedSetOfFilesEvents(file_sets, result);
@@ -165,7 +165,7 @@ AspectArtifactSelector::Options DefaultOptions() {
   };
 }
 
-build_event_stream::BuildEvent ParseEventOrDie(absl::string_view text) {
+build_event_stream::BuildEvent ParseEventOrDie(std::string_view text) {
   build_event_stream::BuildEvent result;
 
   google::protobuf::io::ArrayInputStream input(text.data(), text.size());

--- a/kythe/cxx/extractor/bazel_artifact_selector_test.cc
+++ b/kythe/cxx/extractor/bazel_artifact_selector_test.cc
@@ -16,6 +16,7 @@
 #include "kythe/cxx/extractor/bazel_artifact_selector.h"
 
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "absl/container/flat_hash_map.h"
@@ -23,7 +24,6 @@
 #include "absl/log/check.h"
 #include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
-#include <string_view>
 #include "absl/types/optional.h"
 #include "absl/types/span.h"
 #include "gmock/gmock.h"

--- a/kythe/cxx/extractor/bazel_artifact_selector_test.cc
+++ b/kythe/cxx/extractor/bazel_artifact_selector_test.cc
@@ -23,7 +23,7 @@
 #include "absl/log/check.h"
 #include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "absl/types/optional.h"
 #include "absl/types/span.h"
 #include "gmock/gmock.h"

--- a/kythe/cxx/extractor/cxx_extractor.cc
+++ b/kythe/cxx/extractor/cxx_extractor.cc
@@ -83,7 +83,7 @@ constexpr char kBuiltinResourceDirectory[] = "/kythe_builtins";
 
 /// A list of directory names to try when finding a suitable stable working
 /// directory.
-constexpr absl::string_view kStableRootDirectories[] = {
+constexpr std::string_view kStableRootDirectories[] = {
     "/root",
     "/build",
     "/kythe_cxx_extractor_root",
@@ -98,22 +98,22 @@ bool IsStdinPath(llvm::StringRef path) {
   return path == "-" || path == "<stdin>" || path.starts_with("<stdin:");
 }
 
-absl::string_view GetPathForProto(
+std::string_view GetPathForProto(
     const proto::CxxCompilationUnitDetails::SystemHeaderPrefix& prefix) {
   return prefix.prefix();
 }
 
-absl::string_view GetPathForProto(
+std::string_view GetPathForProto(
     const proto::CxxCompilationUnitDetails::StatPath& path) {
   return path.path();
 }
 
-absl::string_view GetPathForProto(
+std::string_view GetPathForProto(
     const proto::CompilationUnit::FileInput& input) {
   return input.info().path();
 }
 
-absl::string_view GetPathForProto(
+std::string_view GetPathForProto(
     const proto::CxxCompilationUnitDetails::HeaderSearchDir& dir) {
   return dir.path();
 }
@@ -145,13 +145,13 @@ std::string NormalizePath(llvm::StringRef path) { return RelativizePath(path); }
 
 class RequiredRoots {
  public:
-  explicit RequiredRoots(absl::string_view working_directory)
+  explicit RequiredRoots(std::string_view working_directory)
       : working_directory_(absl::StripSuffix(working_directory, "/")) {}
 
   template <typename T>
-  bool Update(absl::string_view name, const T& container) {
+  bool Update(std::string_view name, const T& container) {
     for (const auto& item : container) {
-      absl::string_view path = GetPathForProto(item);
+      std::string_view path = GetPathForProto(item);
       // Check if the working directory is a path prefix.
       if (absl::ConsumePrefix(&path, working_directory_) &&
           (path.empty() || absl::ConsumePrefix(&path, "/"))) {
@@ -171,7 +171,7 @@ class RequiredRoots {
       return working_directory_;
     }
 
-    for (absl::string_view root : kStableRootDirectories) {
+    for (std::string_view root : kStableRootDirectories) {
       if (!roots_.contains(root)) {
         return std::string(root);
       }
@@ -182,7 +182,7 @@ class RequiredRoots {
   }
 
  private:
-  absl::flat_hash_set<absl::string_view> roots_;
+  absl::flat_hash_set<std::string_view> roots_;
   std::string working_directory_;
   bool success_ = true;
 };
@@ -190,12 +190,12 @@ class RequiredRoots {
 /// \brief Finds a suitable stable root directory, if possible.
 /// Otherwise falls back to using the provided root.
 std::string FindStableRoot(
-    absl::string_view working_directory,
+    std::string_view working_directory,
     const RepeatedPtrField<std::string>& arguments,
     const RepeatedPtrField<proto::CompilationUnit::FileInput>& required_input,
     const proto::CxxCompilationUnitDetails& details) {
   absl::ConsumeSuffix(&working_directory, "/");
-  for (absl::string_view arg : arguments) {
+  for (std::string_view arg : arguments) {
     if (arg.find(working_directory) != arg.npos) {
       LOG(WARNING) << "Using real working directory (" << working_directory
                    << ") due to its inclusion in compiler argument: " << arg;
@@ -261,7 +261,7 @@ void AddFileContext(const SourceFile& source_file,
 /// \brief Comparator for CompilationUnit::FileInput, ordering by VName.
 class OrderFileInputByVName {
  public:
-  explicit OrderFileInputByVName(absl::string_view main_source_file)
+  explicit OrderFileInputByVName(std::string_view main_source_file)
       : main_source_file_(main_source_file) {}
 
   bool operator()(const kythe::proto::CompilationUnit::FileInput& lhs,
@@ -271,8 +271,8 @@ class OrderFileInputByVName {
 
  private:
   using FileInputTuple =
-      std::tuple<int, absl::string_view, absl::string_view, absl::string_view,
-                 absl::string_view, absl::string_view>;
+      std::tuple<int, std::string_view, std::string_view, std::string_view,
+                 std::string_view, std::string_view>;
   FileInputTuple AsTuple(
       const kythe::proto::CompilationUnit::FileInput& file_input) const {
     const auto& vname = file_input.v_name();
@@ -286,7 +286,7 @@ class OrderFileInputByVName {
                           vname.path(), vname.language());
   }
 
-  absl::string_view main_source_file_;
+  std::string_view main_source_file_;
 };
 
 /// \brief A SHA-256 hash accumulator.
@@ -1110,12 +1110,12 @@ kythe::proto::VName CompilationWriter::VNameForPath(const RootPath& path) {
   return out;
 }
 
-kythe::proto::VName CompilationWriter::VNameForPath(absl::string_view path) {
+kythe::proto::VName CompilationWriter::VNameForPath(std::string_view path) {
   return VNameForPath(RootRelativePath(path));
 }
 
 CompilationWriter::RootPath CompilationWriter::RootRelativePath(
-    absl::string_view path) {
+    std::string_view path) {
   // Don't attempt to relativize builtin resource paths.
   if (absl::StartsWith(path, kBuiltinResourceDirectory)) {
     return RootPath{std::string(path)};

--- a/kythe/cxx/extractor/cxx_extractor.cc
+++ b/kythe/cxx/extractor/cxx_extractor.cc
@@ -36,7 +36,6 @@
 #include "absl/strings/match.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
-#include <string_view>
 #include "absl/strings/strip.h"
 #include "absl/types/optional.h"
 #include "clang/Basic/Module.h"

--- a/kythe/cxx/extractor/cxx_extractor.cc
+++ b/kythe/cxx/extractor/cxx_extractor.cc
@@ -36,7 +36,7 @@
 #include "absl/strings/match.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "absl/strings/strip.h"
 #include "absl/types/optional.h"
 #include "clang/Basic/Module.h"

--- a/kythe/cxx/extractor/cxx_extractor.h
+++ b/kythe/cxx/extractor/cxx_extractor.h
@@ -230,11 +230,11 @@ class CompilationWriter {
   /// \brief Attempts to generate a root-relative path.
   /// This is a path relative to KYTHE_ROOT_DIRECTORY, not the working directory
   /// and should only be used for doing VName mapping a lookups.
-  RootPath RootRelativePath(absl::string_view path);
+  RootPath RootRelativePath(std::string_view path);
 
   /// \brief Attempts to generate a VName for the file at some path.
   /// \param path The path (likely from Clang) to the file.
-  kythe::proto::VName VNameForPath(absl::string_view path);
+  kythe::proto::VName VNameForPath(std::string_view path);
   kythe::proto::VName VNameForPath(const RootPath& path);
 
  private:

--- a/kythe/cxx/extractor/dump_bazel_artifacts.cc
+++ b/kythe/cxx/extractor/dump_bazel_artifacts.cc
@@ -32,7 +32,7 @@ ABSL_FLAG(std::string, build_event_binary_file, "",
 namespace kythe {
 namespace {
 
-absl::string_view Basename(absl::string_view path) {
+std::string_view Basename(std::string_view path) {
   if (auto pos = path.rfind('/'); pos != path.npos) {
     return path.substr(pos + 1);
   }

--- a/kythe/cxx/extractor/dump_bazel_artifacts.cc
+++ b/kythe/cxx/extractor/dump_bazel_artifacts.cc
@@ -21,7 +21,7 @@
 #include "absl/flags/flag.h"
 #include "absl/flags/parse.h"
 #include "absl/log/log.h"
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "google/protobuf/io/zero_copy_stream_impl.h"
 #include "kythe/cxx/common/init.h"
 #include "kythe/cxx/extractor/bazel_artifact_reader.h"

--- a/kythe/cxx/extractor/dump_bazel_artifacts.cc
+++ b/kythe/cxx/extractor/dump_bazel_artifacts.cc
@@ -16,12 +16,12 @@
 #include <fstream>
 #include <iostream>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "absl/flags/flag.h"
 #include "absl/flags/parse.h"
 #include "absl/log/log.h"
-#include <string_view>
 #include "google/protobuf/io/zero_copy_stream_impl.h"
 #include "kythe/cxx/common/init.h"
 #include "kythe/cxx/extractor/bazel_artifact_reader.h"

--- a/kythe/cxx/extractor/proto/proto_extractor.cc
+++ b/kythe/cxx/extractor/proto/proto_extractor.cc
@@ -55,7 +55,7 @@ class LoggingMultiFileErrorCollector
 class RecordingDiskSourceTree : public DiskSourceTree {
  public:
   google::protobuf::io::ZeroCopyInputStream* Open(
-      absl::string_view filename) override {
+      std::string_view filename) override {
     // Record resolved/canonical path because the same proto may be Open()'d via
     // multiple relative paths and we only want to record it once.
     std::string canonical_path;

--- a/kythe/cxx/extractor/proto/proto_extractor.h
+++ b/kythe/cxx/extractor/proto/proto_extractor.h
@@ -17,7 +17,7 @@
 #ifndef KYTHE_CXX_EXTRACTOR_PROTO_PROTO_EXTRACTOR_H_
 #define KYTHE_CXX_EXTRACTOR_PROTO_PROTO_EXTRACTOR_H_
 
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "kythe/cxx/common/file_vname_generator.h"
 #include "kythe/cxx/common/index_writer.h"
 #include "kythe/proto/analysis.pb.h"

--- a/kythe/cxx/extractor/proto/proto_extractor.h
+++ b/kythe/cxx/extractor/proto/proto_extractor.h
@@ -18,6 +18,7 @@
 #define KYTHE_CXX_EXTRACTOR_PROTO_PROTO_EXTRACTOR_H_
 
 #include <string_view>
+
 #include "kythe/cxx/common/file_vname_generator.h"
 #include "kythe/cxx/common/index_writer.h"
 #include "kythe/proto/analysis.pb.h"

--- a/kythe/cxx/extractor/proto/proto_extractor_main.cc
+++ b/kythe/cxx/extractor/proto/proto_extractor_main.cc
@@ -40,7 +40,7 @@ namespace kythe {
 namespace lang_proto {
 namespace {
 /// \brief Returns a kzip-based IndexWriter or dies.
-IndexWriter OpenKzipWriterOrDie(absl::string_view path) {
+IndexWriter OpenKzipWriterOrDie(std::string_view path) {
   auto writer = KzipWriter::Create(path);
   CHECK(writer.ok()) << "Failed to open KzipWriter: " << writer.status();
   return std::move(*writer);

--- a/kythe/cxx/extractor/testdata/alternate_platform_test.cc
+++ b/kythe/cxx/extractor/testdata/alternate_platform_test.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "kythe/cxx/extractor/testlib.h"

--- a/kythe/cxx/extractor/testdata/alternate_platform_test.cc
+++ b/kythe/cxx/extractor/testdata/alternate_platform_test.cc
@@ -15,6 +15,7 @@
  */
 
 #include <string_view>
+
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "kythe/cxx/extractor/testlib.h"

--- a/kythe/cxx/extractor/testdata/build_config_test.cc
+++ b/kythe/cxx/extractor/testdata/build_config_test.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "absl/log/log.h"
 #include "gmock/gmock.h"
 #include "google/protobuf/message.h"

--- a/kythe/cxx/extractor/testdata/build_config_test.cc
+++ b/kythe/cxx/extractor/testdata/build_config_test.cc
@@ -15,6 +15,7 @@
  */
 
 #include <string_view>
+
 #include "absl/log/log.h"
 #include "gmock/gmock.h"
 #include "google/protobuf/message.h"

--- a/kythe/cxx/extractor/testdata/extract_transcript_test.cc
+++ b/kythe/cxx/extractor/testdata/extract_transcript_test.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "kythe/cxx/extractor/testlib.h"

--- a/kythe/cxx/extractor/testdata/extract_transcript_test.cc
+++ b/kythe/cxx/extractor/testdata/extract_transcript_test.cc
@@ -15,6 +15,7 @@
  */
 
 #include <string_view>
+
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "kythe/cxx/extractor/testlib.h"

--- a/kythe/cxx/extractor/testdata/has_include_test.cc
+++ b/kythe/cxx/extractor/testdata/has_include_test.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "kythe/cxx/extractor/testlib.h"

--- a/kythe/cxx/extractor/testdata/has_include_test.cc
+++ b/kythe/cxx/extractor/testdata/has_include_test.cc
@@ -15,6 +15,7 @@
  */
 
 #include <string_view>
+
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "kythe/cxx/extractor/testlib.h"

--- a/kythe/cxx/extractor/testdata/header_only_module_test.cc
+++ b/kythe/cxx/extractor/testdata/header_only_module_test.cc
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-#include "absl/algorithm/container.h"
 #include <string_view>
+
+#include "absl/algorithm/container.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "kythe/cxx/extractor/testlib.h"

--- a/kythe/cxx/extractor/testdata/header_only_module_test.cc
+++ b/kythe/cxx/extractor/testdata/header_only_module_test.cc
@@ -15,7 +15,7 @@
  */
 
 #include "absl/algorithm/container.h"
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "kythe/cxx/extractor/testlib.h"

--- a/kythe/cxx/extractor/testdata/indirect_has_include_test.cc
+++ b/kythe/cxx/extractor/testdata/indirect_has_include_test.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "kythe/cxx/extractor/testlib.h"

--- a/kythe/cxx/extractor/testdata/indirect_has_include_test.cc
+++ b/kythe/cxx/extractor/testdata/indirect_has_include_test.cc
@@ -15,6 +15,7 @@
  */
 
 #include <string_view>
+
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "kythe/cxx/extractor/testlib.h"

--- a/kythe/cxx/extractor/testdata/installed_dir_test.cc
+++ b/kythe/cxx/extractor/testdata/installed_dir_test.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "kythe/cxx/extractor/testlib.h"

--- a/kythe/cxx/extractor/testdata/installed_dir_test.cc
+++ b/kythe/cxx/extractor/testdata/installed_dir_test.cc
@@ -15,6 +15,7 @@
  */
 
 #include <string_view>
+
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "kythe/cxx/extractor/testlib.h"

--- a/kythe/cxx/extractor/testdata/main_source_file_env_dep_test.cc
+++ b/kythe/cxx/extractor/testdata/main_source_file_env_dep_test.cc
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-#include "absl/algorithm/container.h"
 #include <string_view>
+
+#include "absl/algorithm/container.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "kythe/cxx/extractor/testlib.h"

--- a/kythe/cxx/extractor/testdata/main_source_file_env_dep_test.cc
+++ b/kythe/cxx/extractor/testdata/main_source_file_env_dep_test.cc
@@ -15,7 +15,7 @@
  */
 
 #include "absl/algorithm/container.h"
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "kythe/cxx/extractor/testlib.h"

--- a/kythe/cxx/extractor/testdata/main_source_file_no_env_dep_test.cc
+++ b/kythe/cxx/extractor/testdata/main_source_file_no_env_dep_test.cc
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-#include "absl/algorithm/container.h"
 #include <string_view>
+
+#include "absl/algorithm/container.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "kythe/cxx/extractor/testlib.h"

--- a/kythe/cxx/extractor/testdata/main_source_file_no_env_dep_test.cc
+++ b/kythe/cxx/extractor/testdata/main_source_file_no_env_dep_test.cc
@@ -15,7 +15,7 @@
  */
 
 #include "absl/algorithm/container.h"
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "kythe/cxx/extractor/testlib.h"

--- a/kythe/cxx/extractor/testdata/metadata_test.cc
+++ b/kythe/cxx/extractor/testdata/metadata_test.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "kythe/cxx/extractor/testlib.h"

--- a/kythe/cxx/extractor/testdata/metadata_test.cc
+++ b/kythe/cxx/extractor/testdata/metadata_test.cc
@@ -15,6 +15,7 @@
  */
 
 #include <string_view>
+
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "kythe/cxx/extractor/testlib.h"

--- a/kythe/cxx/extractor/testdata/modules_test.cc
+++ b/kythe/cxx/extractor/testdata/modules_test.cc
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
+#include <string_view>
+
 #include "absl/algorithm/container.h"
 #include "absl/strings/match.h"
-#include <string_view>
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "kythe/cxx/extractor/testlib.h"

--- a/kythe/cxx/extractor/testdata/modules_test.cc
+++ b/kythe/cxx/extractor/testdata/modules_test.cc
@@ -89,7 +89,7 @@ TEST(CxxExtractorTest, TestModulesExtraction) {
   unit.set_argument(2, "dummy-target");
   unit.clear_details();
   unit.mutable_argument()->erase(
-      absl::c_find_if(unit.argument(), [](absl::string_view arg) {
+      absl::c_find_if(unit.argument(), [](std::string_view arg) {
         return absl::StartsWith(arg, "-fmodules-cache-path=");
       }));
 

--- a/kythe/cxx/extractor/testdata/modules_test.cc
+++ b/kythe/cxx/extractor/testdata/modules_test.cc
@@ -16,7 +16,7 @@
 
 #include "absl/algorithm/container.h"
 #include "absl/strings/match.h"
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "kythe/cxx/extractor/testlib.h"

--- a/kythe/cxx/extractor/testdata/root_directory_test.cc
+++ b/kythe/cxx/extractor/testdata/root_directory_test.cc
@@ -31,7 +31,7 @@ using ::kythe::proto::CompilationUnit;
 using ::protobuf_matchers::EquivToProto;
 using ::testing::SizeIs;
 
-constexpr absl::string_view kFilePath =
+constexpr std::string_view kFilePath =
     "kythe/cxx/extractor/testdata/altroot/altpath/file.cc";
 
 CompilationUnit ExpectedCompilation() {

--- a/kythe/cxx/extractor/testdata/root_directory_test.cc
+++ b/kythe/cxx/extractor/testdata/root_directory_test.cc
@@ -16,7 +16,7 @@
 
 #include <string>
 
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "absl/types/optional.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"

--- a/kythe/cxx/extractor/testdata/root_directory_test.cc
+++ b/kythe/cxx/extractor/testdata/root_directory_test.cc
@@ -15,8 +15,8 @@
  */
 
 #include <string>
-
 #include <string_view>
+
 #include "absl/types/optional.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"

--- a/kythe/cxx/extractor/testlib.cc
+++ b/kythe/cxx/extractor/testlib.cc
@@ -27,7 +27,7 @@
 #include "absl/log/check.h"
 #include "absl/log/log.h"
 #include "absl/strings/str_cat.h"
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "gmock/gmock.h"
 #include "google/protobuf/message.h"
 #include "google/protobuf/text_format.h"

--- a/kythe/cxx/extractor/testlib.cc
+++ b/kythe/cxx/extractor/testlib.cc
@@ -48,9 +48,9 @@ using HashMap = ::absl::flat_hash_map<std::string, std::size_t>;
 using ::bazel::tools::cpp::runfiles::Runfiles;
 
 // Path prefix joined to runfiles to form the workspace-relative path.
-constexpr absl::string_view kWorkspaceRoot = "io_kythe";
+constexpr std::string_view kWorkspaceRoot = "io_kythe";
 
-constexpr absl::string_view kExtractorPath =
+constexpr std::string_view kExtractorPath =
     "kythe/cxx/extractor/cxx_extractor";
 
 void CanonicalizeHash(HashMap* hashes, std::string* hash) {
@@ -225,7 +225,7 @@ absl::optional<std::vector<kpb::CompilationUnit>> ExtractCompilations(
         absl::optional<std::vector<kpb::CompilationUnit>> result(
             absl::in_place);  // Default construct a result vector.
 
-        auto status = reader->Scan([&](absl::string_view digest) {
+        auto status = reader->Scan([&](std::string_view digest) {
           if (auto unit = reader->ReadUnit(digest); unit.ok()) {
             result->push_back(std::move(*unit->mutable_unit()));
             return true;
@@ -254,7 +254,7 @@ absl::optional<std::vector<kpb::CompilationUnit>> ExtractCompilations(
   return absl::nullopt;
 }
 
-absl::optional<std::string> ResolveRunfiles(absl::string_view path) {
+absl::optional<std::string> ResolveRunfiles(std::string_view path) {
   std::string error;
   std::unique_ptr<Runfiles> runfiles(Runfiles::CreateForTest(&error));
   if (runfiles == nullptr) {
@@ -279,7 +279,7 @@ kpb::CompilationUnit ExtractSingleCompilationOrDie(ExtractorOptions options) {
   }
 }
 
-kpb::CompilationUnit ParseTextCompilationUnitOrDie(absl::string_view text) {
+kpb::CompilationUnit ParseTextCompilationUnitOrDie(std::string_view text) {
   kpb::CompilationUnit result;
   CHECK(gpb::TextFormat::ParseFromString(std::string(text), &result));
   return result;

--- a/kythe/cxx/extractor/testlib.cc
+++ b/kythe/cxx/extractor/testlib.cc
@@ -21,13 +21,13 @@
 
 #include <iostream>
 #include <optional>
+#include <string_view>
 #include <utility>
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/log/check.h"
 #include "absl/log/log.h"
 #include "absl/strings/str_cat.h"
-#include <string_view>
 #include "gmock/gmock.h"
 #include "google/protobuf/message.h"
 #include "google/protobuf/text_format.h"
@@ -50,8 +50,7 @@ using ::bazel::tools::cpp::runfiles::Runfiles;
 // Path prefix joined to runfiles to form the workspace-relative path.
 constexpr std::string_view kWorkspaceRoot = "io_kythe";
 
-constexpr std::string_view kExtractorPath =
-    "kythe/cxx/extractor/cxx_extractor";
+constexpr std::string_view kExtractorPath = "kythe/cxx/extractor/cxx_extractor";
 
 void CanonicalizeHash(HashMap* hashes, std::string* hash) {
   auto inserted = hashes->insert({*hash, hashes->size()});
@@ -61,8 +60,9 @@ void CanonicalizeHash(HashMap* hashes, std::string* hash) {
 /// \brief Range wrapper around ContextDependentVersion, if any.
 class MutableContextRows {
  public:
-  using iterator = decltype(
-      std::declval<kpb::ContextDependentVersion>().mutable_row()->begin());
+  using iterator = decltype(std::declval<kpb::ContextDependentVersion>()
+                                .mutable_row()
+                                ->begin());
   explicit MutableContextRows(kpb::CompilationUnit::FileInput* file_input) {
     for (gpb::Any& detail : *file_input->mutable_details()) {
       if (detail.UnpackTo(&context_)) {

--- a/kythe/cxx/extractor/testlib.h
+++ b/kythe/cxx/extractor/testlib.h
@@ -50,7 +50,7 @@ kythe::proto::CompilationUnit ExtractSingleCompilationOrDie(
 
 /// \brief Resolves the provided workspace-relative path to find the absolute
 /// runfiles path of the given file.
-absl::optional<std::string> ResolveRunfiles(absl::string_view path);
+absl::optional<std::string> ResolveRunfiles(std::string_view path);
 
 /// \brief Compares the two protobuf messages with MessageDifferencer and
 /// reports the delta.
@@ -66,11 +66,11 @@ bool EquivalentCompilations(const kythe::proto::CompilationUnit& lhs,
 /// \brief Returns a gMock matcher which compares its argument aginst the
 /// provided compilation unit and returns the result.
 ::testing::Matcher<const kythe::proto::CompilationUnit&> EquivToCompilation(
-    absl::string_view expected);
+    std::string_view expected);
 
 /// \brief Parses a TextFormat CompilationUnit protocol buffer or aborts.
 kythe::proto::CompilationUnit ParseTextCompilationUnitOrDie(
-    absl::string_view text);
+    std::string_view text);
 
 }  // namespace kythe
 #endif  // KYTHE_CXX_EXTRACTOR_TESTLIB_H_

--- a/kythe/cxx/extractor/textproto/textproto_extractor.cc
+++ b/kythe/cxx/extractor/textproto/textproto_extractor.cc
@@ -57,7 +57,7 @@ namespace lang_textproto {
 namespace {
 
 /// \brief Returns a kzip-based IndexWriter or dies.
-IndexWriter OpenKzipWriterOrDie(absl::string_view path) {
+IndexWriter OpenKzipWriterOrDie(std::string_view path) {
   auto writer = KzipWriter::Create(path);
   CHECK(writer.ok()) << "Failed to open KzipWriter: " << writer.status();
   return std::move(*writer);

--- a/kythe/cxx/extractor/textproto/textproto_schema.cc
+++ b/kythe/cxx/extractor/textproto/textproto_schema.cc
@@ -23,10 +23,10 @@
 namespace kythe {
 namespace lang_textproto {
 
-TextprotoSchema ParseTextprotoSchemaComments(absl::string_view textproto) {
+TextprotoSchema ParseTextprotoSchemaComments(std::string_view textproto) {
   TextprotoSchema schema;
 
-  for (absl::string_view line : absl::StrSplit(textproto, '\n')) {
+  for (std::string_view line : absl::StrSplit(textproto, '\n')) {
     if (absl::ConsumePrefix(&line, "#")) {
       line = absl::StripLeadingAsciiWhitespace(line);
       if (absl::ConsumePrefix(&line, "proto-file:")) {

--- a/kythe/cxx/extractor/textproto/textproto_schema.h
+++ b/kythe/cxx/extractor/textproto/textproto_schema.h
@@ -26,8 +26,8 @@ namespace kythe {
 namespace lang_textproto {
 
 struct TextprotoSchema {
-  absl::string_view proto_message, proto_file;
-  std::vector<absl::string_view> proto_imports;
+  std::string_view proto_message, proto_file;
+  std::vector<std::string_view> proto_imports;
 };
 
 /// Parses comments at the top of textproto files that specify the corresponding
@@ -46,7 +46,7 @@ struct TextprotoSchema {
 /// incomplete.
 /// WARNING: The return value is made up of string_views that reference the
 /// input. Therefore the input string_view must outlive any use of the output.
-TextprotoSchema ParseTextprotoSchemaComments(absl::string_view textproto);
+TextprotoSchema ParseTextprotoSchemaComments(std::string_view textproto);
 
 }  // namespace lang_textproto
 }  // namespace kythe

--- a/kythe/cxx/extractor/textproto/textproto_schema.h
+++ b/kythe/cxx/extractor/textproto/textproto_schema.h
@@ -18,9 +18,8 @@
 #define KYTHE_CXX_EXTRACTOR_TEXTPROTO_SCHEMA_H_
 
 #include <string>
-#include <vector>
-
 #include <string_view>
+#include <vector>
 
 namespace kythe {
 namespace lang_textproto {

--- a/kythe/cxx/extractor/textproto/textproto_schema.h
+++ b/kythe/cxx/extractor/textproto/textproto_schema.h
@@ -20,7 +20,7 @@
 #include <string>
 #include <vector>
 
-#include "absl/strings/string_view.h"
+#include <string_view>
 
 namespace kythe {
 namespace lang_textproto {

--- a/kythe/cxx/indexer/cxx/GraphObserver.cc
+++ b/kythe/cxx/indexer/cxx/GraphObserver.cc
@@ -35,16 +35,16 @@ struct MintedVNameHeader {
 };
 }  // anonymous namespace
 
-FileHashRecorder::FileHashRecorder(absl::string_view path)
+FileHashRecorder::FileHashRecorder(std::string_view path)
     : out_file_(::fopen(std::string(path).c_str(), "w")) {
   if (out_file_ == nullptr) ::perror("Error in fopen");
   CHECK(out_file_ != nullptr)
       << "Couldn't open file " << path << " for hash recording.";
 }
 
-void FileHashRecorder::RecordHash(absl::string_view hash,
-                                  absl::string_view web64hash,
-                                  absl::string_view original) {
+void FileHashRecorder::RecordHash(std::string_view hash,
+                                  std::string_view web64hash,
+                                  std::string_view original) {
   auto result = hashes_.insert(std::string(hash));
   if (!result.second) return;
   absl::FPrintF(out_file_, "%s\t%s\n", web64hash, original);
@@ -53,7 +53,7 @@ FileHashRecorder::~FileHashRecorder() {
   CHECK(::fclose(out_file_) == 0) << "Couldn't close file for hash recording.";
 }
 
-std::string GraphObserver::ForceEncodeString(absl::string_view InString) const {
+std::string GraphObserver::ForceEncodeString(std::string_view InString) const {
   auto hash = Sha256Hasher(InString).FinishBinString();
   std::string result;
   // Use web-safe escaping because vnames are frequently URI-encoded. This
@@ -67,14 +67,14 @@ std::string GraphObserver::ForceEncodeString(absl::string_view InString) const {
 }
 
 std::string GraphObserver::CompressAnchorSignature(
-    absl::string_view InSignature) const {
+    std::string_view InSignature) const {
   if (InSignature.size() <= kSha256DigestBase64MaxEncodingLength) {
     return std::string(InSignature);
   }
   return absl::WebSafeBase64Escape(Sha256Hasher(InSignature).FinishBinString());
 }
 
-std::string GraphObserver::CompressString(absl::string_view InString) const {
+std::string GraphObserver::CompressString(std::string_view InString) const {
   if (InString.size() <= kSha256DigestBase64MaxEncodingLength) {
     return std::string(InString);
   }

--- a/kythe/cxx/indexer/cxx/GraphObserver.h
+++ b/kythe/cxx/indexer/cxx/GraphObserver.h
@@ -24,7 +24,7 @@
 
 #include "absl/container/flat_hash_set.h"
 #include "absl/log/check.h"
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "absl/types/optional.h"
 #include "absl/types/span.h"
 #include "clang/Basic/SourceLocation.h"

--- a/kythe/cxx/indexer/cxx/GraphObserver.h
+++ b/kythe/cxx/indexer/cxx/GraphObserver.h
@@ -21,10 +21,10 @@
 /// \brief Defines the class kythe::GraphObserver
 
 #include <string>
+#include <string_view>
 
 #include "absl/container/flat_hash_set.h"
 #include "absl/log/check.h"
-#include <string_view>
 #include "absl/types/optional.h"
 #include "absl/types/span.h"
 #include "clang/Basic/SourceLocation.h"

--- a/kythe/cxx/indexer/cxx/GraphObserver.h
+++ b/kythe/cxx/indexer/cxx/GraphObserver.h
@@ -72,16 +72,16 @@ class ProfileBlock {
 
 class HashRecorder {
  public:
-  virtual void RecordHash(absl::string_view hash, absl::string_view web64hash,
-                          absl::string_view original) {}
+  virtual void RecordHash(std::string_view hash, std::string_view web64hash,
+                          std::string_view original) {}
   virtual ~HashRecorder() = default;
 };
 
 class FileHashRecorder : public HashRecorder {
  public:
-  explicit FileHashRecorder(absl::string_view path);
-  void RecordHash(absl::string_view hash, absl::string_view web64hash,
-                  absl::string_view original) override;
+  explicit FileHashRecorder(std::string_view path);
+  void RecordHash(std::string_view hash, std::string_view web64hash,
+                  std::string_view original) override;
   ~FileHashRecorder() override;
 
  private:
@@ -131,16 +131,16 @@ class GraphObserver {
 
   /// \brief Uses a one-way function to encode `InString`. Guaranteed to return
   /// only websafe base64 characters.
-  std::string ForceEncodeString(absl::string_view InString) const;
+  std::string ForceEncodeString(std::string_view InString) const;
 
   /// \brief Uses a one-way function to compress `InString` if it's longer than
   /// the result of using that function would be.
-  std::string CompressString(absl::string_view InString) const;
+  std::string CompressString(std::string_view InString) const;
 
   /// \brief Uses a one-way function to compress the anchor signature
   /// `InSignature` if it's longer than the result of using that function would
   /// be.
-  std::string CompressAnchorSignature(absl::string_view InSignature) const;
+  std::string CompressAnchorSignature(std::string_view InSignature) const;
 
   /// \brief Push another group onto the group stack, assigning
   /// any observations that follow to it.
@@ -1135,7 +1135,7 @@ class GraphObserver {
       std::function<bool(clang::FileID, const NodeId&)> iter) const {}
 
   /// Name of the platform or build configuration to emit on anchors.
-  virtual absl::string_view getBuildConfig() const { return ""; }
+  virtual std::string_view getBuildConfig() const { return ""; }
 
  protected:
   clang::SourceManager* SourceManager = nullptr;

--- a/kythe/cxx/indexer/cxx/ImputedConstructorSupport.cc
+++ b/kythe/cxx/indexer/cxx/ImputedConstructorSupport.cc
@@ -122,18 +122,18 @@ clang::SourceRange FindNamedCalleeRange(const clang::Expr* expr) {
   return clang::SourceRange();
 }
 
-std::function<bool(absl::string_view)> CompilePatterns(
+std::function<bool(std::string_view)> CompilePatterns(
     const std::unordered_set<std::string>& patterns) {
   re2::RE2::Options options;
   options.set_never_capture(true);
   // TODO(shahms): A mechanism for reporting compile errors.
   std::shared_ptr<re2::RE2> regex = std::make_shared<re2::RE2>(
       absl::StrJoin(patterns, "|",
-                    [](std::string* out, absl::string_view value) {
+                    [](std::string* out, std::string_view value) {
                       absl::StrAppend(out, "(", value, ")");
                     }),
       options);
-  return [regex](absl::string_view name) {
+  return [regex](std::string_view name) {
     return re2::RE2::FullMatch({name.data(), name.size()}, *regex);
   };
 }
@@ -146,7 +146,7 @@ ImputedConstructorSupport::ImputedConstructorSupport(
 }
 
 ImputedConstructorSupport::ImputedConstructorSupport(
-    std::function<bool(absl::string_view)> allow_constructor_name)
+    std::function<bool(std::string_view)> allow_constructor_name)
     : allow_constructor_name_(std::move(allow_constructor_name)) {}
 
 void ImputedConstructorSupport::InspectCallExpr(

--- a/kythe/cxx/indexer/cxx/ImputedConstructorSupport.h
+++ b/kythe/cxx/indexer/cxx/ImputedConstructorSupport.h
@@ -22,7 +22,7 @@
 #include <unordered_set>
 
 #include "IndexerLibrarySupport.h"
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "clang/AST/Expr.h"
 
 namespace kythe {

--- a/kythe/cxx/indexer/cxx/ImputedConstructorSupport.h
+++ b/kythe/cxx/indexer/cxx/ImputedConstructorSupport.h
@@ -37,7 +37,7 @@ class ImputedConstructorSupport : public LibrarySupport {
           "llvm::make_unique"});
 
   explicit ImputedConstructorSupport(
-      std::function<bool(absl::string_view)> allow_constructor_name);
+      std::function<bool(std::string_view)> allow_constructor_name);
 
   void InspectCallExpr(IndexerASTVisitor& visitor,
                        const clang::CallExpr* call_expr,
@@ -45,7 +45,7 @@ class ImputedConstructorSupport : public LibrarySupport {
                        GraphObserver::NodeId& callee_id) override;
 
  private:
-  const std::function<bool(absl::string_view)> allow_constructor_name_;
+  const std::function<bool(std::string_view)> allow_constructor_name_;
 };
 
 }  // namespace kythe

--- a/kythe/cxx/indexer/cxx/ImputedConstructorSupport.h
+++ b/kythe/cxx/indexer/cxx/ImputedConstructorSupport.h
@@ -19,10 +19,10 @@
 
 #include <functional>
 #include <string>
+#include <string_view>
 #include <unordered_set>
 
 #include "IndexerLibrarySupport.h"
-#include <string_view>
 #include "clang/AST/Expr.h"
 
 namespace kythe {

--- a/kythe/cxx/indexer/cxx/IndexerASTHooks.cc
+++ b/kythe/cxx/indexer/cxx/IndexerASTHooks.cc
@@ -26,7 +26,7 @@
 #include "absl/log/log.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_join.h"
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "absl/types/optional.h"
 #include "clang/AST/Attr.h"
 #include "clang/AST/AttrVisitor.h"

--- a/kythe/cxx/indexer/cxx/IndexerASTHooks.cc
+++ b/kythe/cxx/indexer/cxx/IndexerASTHooks.cc
@@ -17,6 +17,7 @@
 #include "IndexerASTHooks.h"
 
 #include <algorithm>
+#include <string_view>
 #include <tuple>
 
 #include "GraphObserver.h"
@@ -26,7 +27,6 @@
 #include "absl/log/log.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_join.h"
-#include <string_view>
 #include "absl/types/optional.h"
 #include "clang/AST/Attr.h"
 #include "clang/AST/AttrVisitor.h"

--- a/kythe/cxx/indexer/cxx/IndexerASTHooks.cc
+++ b/kythe/cxx/indexer/cxx/IndexerASTHooks.cc
@@ -5876,27 +5876,27 @@ IndexerASTVisitor::CreateObjCMethodTypeNode(const clang::ObjCMethodDecl* MD) {
                                  NodeIds);
 }
 
-void IndexerASTVisitor::LogErrorWithASTDump(absl::string_view msg,
+void IndexerASTVisitor::LogErrorWithASTDump(std::string_view msg,
                                             const clang::Decl* Decl) const {
   LOG(ERROR) << msg << " :" << std::endl << StreamAdapter::Dump(*Decl);
 }
 
-void IndexerASTVisitor::LogErrorWithASTDump(absl::string_view msg,
+void IndexerASTVisitor::LogErrorWithASTDump(std::string_view msg,
                                             const clang::Expr* Expr) const {
   LOG(ERROR) << msg << " :" << std::endl << StreamAdapter::Dump(*Expr, Context);
 }
 
-void IndexerASTVisitor::LogErrorWithASTDump(absl::string_view msg,
+void IndexerASTVisitor::LogErrorWithASTDump(std::string_view msg,
                                             const clang::Type* Type) const {
   LOG(ERROR) << msg << " :" << std::endl << StreamAdapter::Dump(*Type, Context);
 }
 
-void IndexerASTVisitor::LogErrorWithASTDump(absl::string_view msg,
+void IndexerASTVisitor::LogErrorWithASTDump(std::string_view msg,
                                             clang::QualType Type) const {
   LOG(ERROR) << msg << " :" << std::endl << StreamAdapter::Dump(Type, Context);
 }
 
-void IndexerASTVisitor::LogErrorWithASTDump(absl::string_view msg,
+void IndexerASTVisitor::LogErrorWithASTDump(std::string_view msg,
                                             clang::TypeLoc Type) const {
   LOG(ERROR) << msg << " :" << std::endl
              << "@"

--- a/kythe/cxx/indexer/cxx/IndexerASTHooks.h
+++ b/kythe/cxx/indexer/cxx/IndexerASTHooks.h
@@ -965,14 +965,14 @@ class IndexerASTVisitor : public RecursiveTypeVisitor<IndexerASTVisitor> {
   void ConnectCategoryToBaseClass(const GraphObserver::NodeId& DeclNode,
                                   const clang::ObjCInterfaceDecl* IFace);
 
-  void LogErrorWithASTDump(absl::string_view msg,
+  void LogErrorWithASTDump(std::string_view msg,
                            const clang::Decl* Decl) const;
-  void LogErrorWithASTDump(absl::string_view msg,
+  void LogErrorWithASTDump(std::string_view msg,
                            const clang::Expr* Expr) const;
-  void LogErrorWithASTDump(absl::string_view msg,
+  void LogErrorWithASTDump(std::string_view msg,
                            const clang::Type* Type) const;
-  void LogErrorWithASTDump(absl::string_view msg, clang::TypeLoc Type) const;
-  void LogErrorWithASTDump(absl::string_view msg, clang::QualType Type) const;
+  void LogErrorWithASTDump(std::string_view msg, clang::TypeLoc Type) const;
+  void LogErrorWithASTDump(std::string_view msg, clang::QualType Type) const;
 
   /// \brief This is used to handle the visitation of a clang::TypedefDecl
   /// or a clang::TypeAliasDecl.

--- a/kythe/cxx/indexer/cxx/IndexerASTHooks.h
+++ b/kythe/cxx/indexer/cxx/IndexerASTHooks.h
@@ -30,7 +30,7 @@
 #include "absl/container/flat_hash_map.h"
 #include "absl/log/check.h"
 #include "absl/memory/memory.h"
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "absl/types/optional.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/ASTTypeTraits.h"

--- a/kythe/cxx/indexer/cxx/IndexerASTHooks.h
+++ b/kythe/cxx/indexer/cxx/IndexerASTHooks.h
@@ -20,6 +20,7 @@
 #define KYTHE_CXX_INDEXER_CXX_INDEXER_AST_HOOKS_H_
 
 #include <memory>
+#include <string_view>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -30,7 +31,6 @@
 #include "absl/container/flat_hash_map.h"
 #include "absl/log/check.h"
 #include "absl/memory/memory.h"
-#include <string_view>
 #include "absl/types/optional.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/ASTTypeTraits.h"
@@ -965,12 +965,9 @@ class IndexerASTVisitor : public RecursiveTypeVisitor<IndexerASTVisitor> {
   void ConnectCategoryToBaseClass(const GraphObserver::NodeId& DeclNode,
                                   const clang::ObjCInterfaceDecl* IFace);
 
-  void LogErrorWithASTDump(std::string_view msg,
-                           const clang::Decl* Decl) const;
-  void LogErrorWithASTDump(std::string_view msg,
-                           const clang::Expr* Expr) const;
-  void LogErrorWithASTDump(std::string_view msg,
-                           const clang::Type* Type) const;
+  void LogErrorWithASTDump(std::string_view msg, const clang::Decl* Decl) const;
+  void LogErrorWithASTDump(std::string_view msg, const clang::Expr* Expr) const;
+  void LogErrorWithASTDump(std::string_view msg, const clang::Type* Type) const;
   void LogErrorWithASTDump(std::string_view msg, clang::TypeLoc Type) const;
   void LogErrorWithASTDump(std::string_view msg, clang::QualType Type) const;
 

--- a/kythe/cxx/indexer/cxx/IndexerFrontendAction.cc
+++ b/kythe/cxx/indexer/cxx/IndexerFrontendAction.cc
@@ -58,8 +58,10 @@ constexpr std::string_view kBuildDetailsURI =
 /// \brief Range wrapper around unpacked ContextDependentVersion rows.
 class FileContextRows {
  public:
-  using iterator = decltype(
-      std::declval<kythe::proto::ContextDependentVersion>().row().begin());
+  using iterator =
+      decltype(std::declval<kythe::proto::ContextDependentVersion>()
+                   .row()
+                   .begin());
 
   explicit FileContextRows(
       const kythe::proto::CompilationUnit::FileInput& file_input) {

--- a/kythe/cxx/indexer/cxx/IndexerFrontendAction.cc
+++ b/kythe/cxx/indexer/cxx/IndexerFrontendAction.cc
@@ -52,7 +52,7 @@ bool RunToolOnCode(std::unique_ptr<clang::FrontendAction> tool_action,
 namespace {
 
 // Message type URI for the build details message.
-constexpr absl::string_view kBuildDetailsURI =
+constexpr std::string_view kBuildDetailsURI =
     "kythe.io/proto/kythe.proto.BuildDetails";
 
 /// \brief Range wrapper around unpacked ContextDependentVersion rows.

--- a/kythe/cxx/indexer/cxx/KytheGraphObserver.cc
+++ b/kythe/cxx/indexer/cxx/KytheGraphObserver.cc
@@ -26,7 +26,7 @@
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_join.h"
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "clang/AST/Attr.h"
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclCXX.h"

--- a/kythe/cxx/indexer/cxx/KytheGraphObserver.cc
+++ b/kythe/cxx/indexer/cxx/KytheGraphObserver.cc
@@ -18,6 +18,7 @@
 
 #include <optional>
 #include <string>
+#include <string_view>
 
 #include "IndexerASTHooks.h"
 #include "absl/flags/flag.h"
@@ -26,7 +27,6 @@
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_join.h"
-#include <string_view>
 #include "clang/AST/Attr.h"
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclCXX.h"
@@ -1321,11 +1321,10 @@ void KytheGraphObserver::applyMetadataFile(
   }
   if (auto metadata = meta_supports_->ParseFile(
           std::string(file->getName()),
-          std::string_view(buffer->getBuffer().data(),
-                            buffer->getBufferSize()),
+          std::string_view(buffer->getBuffer().data(), buffer->getBufferSize()),
           search_string,
           std::string_view(target_buffer->getBuffer().data(),
-                            target_buffer->getBufferSize()))) {
+                           target_buffer->getBufferSize()))) {
     meta_.emplace(id, std::move(metadata));
   }
 }

--- a/kythe/cxx/indexer/cxx/KytheGraphObserver.cc
+++ b/kythe/cxx/indexer/cxx/KytheGraphObserver.cc
@@ -62,7 +62,7 @@ namespace kythe {
 namespace {
 
 /// \brief Clang builtins whose name and token match.
-constexpr absl::string_view kUniformClangBuiltins[] = {
+constexpr std::string_view kUniformClangBuiltins[] = {
     "void",
     "bool",
     "_Bool",
@@ -151,8 +151,8 @@ struct ClaimedStringFormatter {
   }
 };
 
-absl::string_view ConvertRef(llvm::StringRef ref) {
-  return absl::string_view(ref.data(), ref.size());
+std::string_view ConvertRef(llvm::StringRef ref) {
+  return std::string_view(ref.data(), ref.size());
 }
 
 const char* VisibilityPropertyValue(clang::AccessSpecifier access) {
@@ -723,12 +723,12 @@ VNameRef KytheGraphObserver::VNameRefFromNodeId(
     return DecodeMintedVName(node_id);
   }
   VNameRef out_ref;
-  out_ref.set_language(absl::string_view(supported_language::kIndexerLang));
+  out_ref.set_language(std::string_view(supported_language::kIndexerLang));
   if (const auto* token =
           clang::dyn_cast<KytheClaimToken>(node_id.getToken())) {
     token->DecorateVName(&out_ref);
     if (token->language_independent()) {
-      out_ref.set_language(absl::string_view());
+      out_ref.set_language(std::string_view());
     }
   }
   out_ref.set_signature(ConvertRef(node_id.IdentityRef()));
@@ -1058,7 +1058,7 @@ void KytheGraphObserver::assignUsr(const NodeId& node, llvm::StringRef usr,
   VNameRef node_vname = VNameRefFromNodeId(node);
   VNameRef usr_vname;
   usr_vname.set_corpus(usr_default_corpus_
-                           ? absl::string_view(default_token_.vname().corpus())
+                           ? std::string_view(default_token_.vname().corpus())
                            : "");
   usr_vname.set_signature(hex);
   usr_vname.set_language("usr");
@@ -1321,10 +1321,10 @@ void KytheGraphObserver::applyMetadataFile(
   }
   if (auto metadata = meta_supports_->ParseFile(
           std::string(file->getName()),
-          absl::string_view(buffer->getBuffer().data(),
+          std::string_view(buffer->getBuffer().data(),
                             buffer->getBufferSize()),
           search_string,
-          absl::string_view(target_buffer->getBuffer().data(),
+          std::string_view(target_buffer->getBuffer().data(),
                             target_buffer->getBufferSize()))) {
     meta_.emplace(id, std::move(metadata));
   }
@@ -1615,22 +1615,22 @@ KytheGraphObserver::getNamespaceTokens(clang::SourceLocation loc) const {
 }
 
 void KytheGraphObserver::RegisterBuiltins() {
-  auto RegisterBuiltin = [&](absl::string_view name,
+  auto RegisterBuiltin = [&](std::string_view name,
                              const MarkedSource& marked_source) {
     builtins_.emplace(name, Builtin{NodeId::CreateUncompressed(
                                         getDefaultClaimToken(),
                                         absl::StrCat(name, "#builtin")),
                                     marked_source, false});
   };
-  auto RegisterTokenBuiltin = [&](absl::string_view name,
-                                  absl::string_view token) {
+  auto RegisterTokenBuiltin = [&](std::string_view name,
+                                  std::string_view token) {
     MarkedSource sig;
     sig.set_kind(MarkedSource::IDENTIFIER);
     sig.set_pre_text(token);
     RegisterBuiltin(name, sig);
   };
 
-  for (absl::string_view token : kUniformClangBuiltins) {
+  for (std::string_view token : kUniformClangBuiltins) {
     RegisterTokenBuiltin(token, token);
   }
 

--- a/kythe/cxx/indexer/cxx/KytheGraphObserver.h
+++ b/kythe/cxx/indexer/cxx/KytheGraphObserver.h
@@ -397,7 +397,7 @@ class KytheGraphObserver : public GraphObserver {
   /// \brief Configures the claimant that will be used to make claims.
   void set_claimant(const kythe::proto::VName& vname) { claimant_ = vname; }
 
-  void set_default_corpus(absl::string_view corpus) {
+  void set_default_corpus(std::string_view corpus) {
     default_token_.mutable_vname()->set_corpus(std::string(corpus));
     type_token_.mutable_vname()->set_corpus(std::string(corpus));
   }
@@ -458,7 +458,7 @@ class KytheGraphObserver : public GraphObserver {
   void iterateOverClaimedFiles(
       std::function<bool(clang::FileID, const NodeId&)> iter) const override;
 
-  absl::string_view getBuildConfig() const override { return build_config_; }
+  std::string_view getBuildConfig() const override { return build_config_; }
 
   std::vector<std::pair<clang::FileID, const MetadataFile*>> GetMetadataFiles()
       const override {

--- a/kythe/cxx/indexer/cxx/KytheVFS.cc
+++ b/kythe/cxx/indexer/cxx/KytheVFS.cc
@@ -58,7 +58,7 @@ std::string FixupPath(llvm::StringRef path, llvm::sys::path::Style style) {
 }
 }  // anonymous namespace
 
-IndexVFS::IndexVFS(absl::string_view working_directory,
+IndexVFS::IndexVFS(std::string_view working_directory,
                    const std::vector<proto::FileData>& virtual_files,
                    const std::vector<llvm::StringRef>& virtual_dirs,
                    llvm::sys::path::Style style)

--- a/kythe/cxx/indexer/cxx/KytheVFS.h
+++ b/kythe/cxx/indexer/cxx/KytheVFS.h
@@ -18,10 +18,10 @@
 #define KYTHE_CXX_COMMON_INDEXING_KYTHE_VFS_H_
 
 #include <memory>
+#include <string_view>
 
 #include "absl/base/attributes.h"
 #include "absl/container/flat_hash_map.h"
-#include <string_view>
 #include "absl/types/optional.h"
 #include "clang/Basic/FileManager.h"
 #include "kythe/proto/analysis.pb.h"

--- a/kythe/cxx/indexer/cxx/KytheVFS.h
+++ b/kythe/cxx/indexer/cxx/KytheVFS.h
@@ -42,7 +42,7 @@ class IndexVFS : public llvm::vfs::FileSystem {
   /// \param virtual_dirs Directories to map.
   /// \param style Style used to parse incoming paths. Paths are normalized
   /// to POSIX-style.
-  explicit IndexVFS(absl::string_view working_directory,
+  explicit IndexVFS(std::string_view working_directory,
                     const std::vector<proto::FileData>& virtual_files
                         ABSL_ATTRIBUTE_LIFETIME_BOUND,
                     const std::vector<llvm::StringRef>& virtual_dirs,

--- a/kythe/cxx/indexer/cxx/KytheVFS.h
+++ b/kythe/cxx/indexer/cxx/KytheVFS.h
@@ -21,7 +21,7 @@
 
 #include "absl/base/attributes.h"
 #include "absl/container/flat_hash_map.h"
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "absl/types/optional.h"
 #include "clang/Basic/FileManager.h"
 #include "kythe/proto/analysis.pb.h"

--- a/kythe/cxx/indexer/cxx/clang_range_finder_test.cc
+++ b/kythe/cxx/indexer/cxx/clang_range_finder_test.cc
@@ -17,13 +17,13 @@
 
 #include <functional>
 #include <memory>
+#include <string_view>
 
 #include "absl/log/check.h"
 #include "absl/log/die_if_null.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_join.h"
-#include <string_view>
 #include "clang/AST/Decl.h"
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/Frontend/ASTUnit.h"

--- a/kythe/cxx/indexer/cxx/clang_range_finder_test.cc
+++ b/kythe/cxx/indexer/cxx/clang_range_finder_test.cc
@@ -23,7 +23,7 @@
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_join.h"
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "clang/AST/Decl.h"
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/Frontend/ASTUnit.h"

--- a/kythe/cxx/indexer/cxx/clang_range_finder_test.cc
+++ b/kythe/cxx/indexer/cxx/clang_range_finder_test.cc
@@ -47,17 +47,17 @@ class ClangRangeFinderTest : public ::testing::Test {
     return *ABSL_DIE_IF_NULL(ast_);
   }
 
-  absl::string_view GetSourceText(clang::SourceRange range) {
+  std::string_view GetSourceText(clang::SourceRange range) {
     return GetSourceText(clang::CharSourceRange::getCharRange(range));
   }
 
-  absl::string_view GetSourceText(clang::CharSourceRange range) {
+  std::string_view GetSourceText(clang::CharSourceRange range) {
     CHECK(range.isValid());
     bool invalid = false;
     auto text = clang::Lexer::getSourceText(range, source_manager(),
                                             lang_options(), &invalid);
     CHECK(!invalid);
-    return absl::string_view(text.data(), text.size());
+    return std::string_view(text.data(), text.size());
   }
 
   const clang::Decl* top_level_back() { return *(ast_->top_level_end() - 1); }
@@ -74,10 +74,10 @@ class ClangRangeFinderTest : public ::testing::Test {
   std::unique_ptr<clang::ASTUnit> ast_;
 };
 
-// Returns a matcher checking for an empty absl::string_view starting at data.
+// Returns a matcher checking for an empty std::string_view starting at data.
 auto EmptyAt(const char* data) {
   return ::testing::AllOf(
-      ::testing::Property(&absl::string_view::data, ::testing::Eq(data)),
+      ::testing::Property(&std::string_view::data, ::testing::Eq(data)),
       ::testing::IsEmpty());
 }
 
@@ -125,12 +125,12 @@ std::vector<const clang::NamedDecl*> FindAllNamedDecls(clang::ASTUnit& ast) {
 class NamedDeclTestCase {
  public:
   using DeclFinder = std::function<const clang::NamedDecl*(clang::ASTUnit&)>;
-  NamedDeclTestCase(absl::string_view format, absl::string_view name = "entity",
+  NamedDeclTestCase(std::string_view format, std::string_view name = "entity",
                     DeclFinder find_decl = &FindLastDecl)
       : format_(ABSL_DIE_IF_NULL(absl::ParsedFormat<'s'>::New(format))),
         name_(name),
         find_decl_(std::move(find_decl)) {}
-  NamedDeclTestCase(absl::string_view format, DeclFinder find_decl)
+  NamedDeclTestCase(std::string_view format, DeclFinder find_decl)
       : NamedDeclTestCase(format, "entity", std::move(find_decl)) {}
 
   std::string SourceText() const { return absl::StrFormat(*format_, name_); }
@@ -139,7 +139,7 @@ class NamedDeclTestCase {
     return ABSL_DIE_IF_NULL(find_decl_(ast));
   }
 
-  absl::string_view name() const { return name_; }
+  std::string_view name() const { return name_; }
 
  private:
   std::shared_ptr<absl::ParsedFormat<'s'>> format_;
@@ -242,7 +242,7 @@ TEST_F(ClangRangeFinderTest, TerribleMacrosAreZeroWidth) {
   // macro arguments.  We want to ensure that only ranges originating from
   // explicit macro arguments are expanded and all others are zero-width from
   // the front of the macro expansion.
-  absl::string_view macro = R"(
+  std::string_view macro = R"(
 #define ASSIGN_OR_RETURN(...)                                            \
   IMPL_GET_VARIADIC_(                                                    \
       (__VA_ARGS__, IMPL_ASSIGN_OR_RETURN_3_, IMPL_ASSIGN_OR_RETURN_2_)) \
@@ -269,7 +269,7 @@ TEST_F(ClangRangeFinderTest, TerribleMacrosAreZeroWidth) {
                             "ASSIGN_OR_RETURN(int r, get(a, b));",
                             "return nullptr;", "}"},
                            "\n"));
-  std::vector<std::pair<std::string, absl::string_view>> ranges;
+  std::vector<std::pair<std::string, std::string_view>> ranges;
   for (const auto* decl : FindAllNamedDecls(Parse(source))) {
     if (decl->getName().empty()) continue;
     ranges.push_back({decl->getNameAsString(),

--- a/kythe/cxx/indexer/cxx/frontend.cc
+++ b/kythe/cxx/indexer/cxx/frontend.cc
@@ -142,7 +142,7 @@ void DecodeKZipFile(const std::string& path, bool silent,
   CHECK(reader.ok()) << "Couldn't open kzip from " << path << ": "
                      << reader.status();
   bool compilation_read = false;
-  auto status = reader->Scan([&](absl::string_view digest) {
+  auto status = reader->Scan([&](std::string_view digest) {
     IndexerJob job;
     job.silent = silent;
 

--- a/kythe/cxx/indexer/cxx/marked_source.cc
+++ b/kythe/cxx/indexer/cxx/marked_source.cc
@@ -146,7 +146,7 @@ class NodeStack {
   /// \brief Copy data from `annotations` and `formatted_range` to
   /// `dest_source`.
   /// \return the MarkedSource node covering an identifier, or null.
-  MarkedSource* ProcessAnnotations(absl::string_view formatted_range,
+  MarkedSource* ProcessAnnotations(std::string_view formatted_range,
                                    const std::vector<Annotation>& annotations,
                                    MarkedSource* dest_source) {
     /// For certain kinds of annotations, we'll substitute our own special
@@ -231,9 +231,9 @@ class NodeStack {
   /// \param at_end whether the span on the top of the stack is about to be
   /// popped because there are no other spans that get opened before the
   /// current span closes.
-  void AppendToTop(absl::string_view formatted_range, size_t cancel_count,
+  void AppendToTop(std::string_view formatted_range, size_t cancel_count,
                    size_t start, size_t end, bool at_end) {
-    absl::string_view text = formatted_range.substr(start, end - start);
+    std::string_view text = formatted_range.substr(start, end - start);
     CHECK(!nodes_.empty());
     if (cancel_count != 0) {
       return;

--- a/kythe/cxx/indexer/proto/comments.cc
+++ b/kythe/cxx/indexer/proto/comments.cc
@@ -25,12 +25,12 @@
 namespace kythe {
 
 std::string StripCommentMarkers(const std::string& source) {
-  absl::string_view stripped = absl::StripAsciiWhitespace(source);
+  std::string_view stripped = absl::StripAsciiWhitespace(source);
 
   // Handle block comments, of the form "/* ... */".
   if (absl::ConsumePrefix(&stripped, "/*")) {
     absl::ConsumeSuffix(&stripped, "*/");
-    std::vector<absl::string_view> lines = absl::StrSplit(stripped, '\n');
+    std::vector<std::string_view> lines = absl::StrSplit(stripped, '\n');
     for (auto& line : lines) {
       line = absl::StripAsciiWhitespace(line);
       if (!absl::ConsumePrefix(&line, "* ")) {
@@ -41,7 +41,7 @@ std::string StripCommentMarkers(const std::string& source) {
   }
 
   // Handle line-ending comments, of the form "// ...".
-  std::vector<absl::string_view> lines = absl::StrSplit(stripped, '\n');
+  std::vector<std::string_view> lines = absl::StrSplit(stripped, '\n');
   for (auto& line : lines) {
     line = absl::StripAsciiWhitespace(line);
     if (!absl::ConsumePrefix(&line, "// ")) {

--- a/kythe/cxx/indexer/proto/file_descriptor_walker.cc
+++ b/kythe/cxx/indexer/proto/file_descriptor_walker.cc
@@ -16,13 +16,14 @@
 
 #include "kythe/cxx/indexer/proto/file_descriptor_walker.h"
 
+#include <string_view>
+
 #include "absl/log/check.h"
 #include "absl/log/log.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_join.h"
 #include "absl/strings/str_split.h"
-#include <string_view>
 #include "absl/types/optional.h"
 #include "google/protobuf/descriptor.h"
 #include "google/protobuf/repeated_field.h"

--- a/kythe/cxx/indexer/proto/file_descriptor_walker.cc
+++ b/kythe/cxx/indexer/proto/file_descriptor_walker.cc
@@ -22,7 +22,7 @@
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_join.h"
 #include "absl/strings/str_split.h"
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "absl/types/optional.h"
 #include "google/protobuf/descriptor.h"
 #include "google/protobuf/repeated_field.h"

--- a/kythe/cxx/indexer/proto/file_descriptor_walker.cc
+++ b/kythe/cxx/indexer/proto/file_descriptor_walker.cc
@@ -58,8 +58,8 @@ using ::kythe::proto::VName;
 namespace {
 
 // TODO(justbuchanan): remove all re2::StringPiece code once re2 is compatible
-// with absl::string_view.
-re2::StringPiece ToStringPiece(absl::string_view v) {
+// with std::string_view.
+re2::StringPiece ToStringPiece(std::string_view v) {
   return {v.data(), v.size()};
 }
 
@@ -86,15 +86,15 @@ class ScopedLookup {
   const int component_;
 };
 
-absl::optional<absl::string_view> TypeName(const EnumDescriptor& desc) {
+absl::optional<std::string_view> TypeName(const EnumDescriptor& desc) {
   return desc.name();
 }
 
-absl::optional<absl::string_view> TypeName(const Descriptor& desc) {
+absl::optional<std::string_view> TypeName(const Descriptor& desc) {
   return desc.name();
 }
 
-absl::optional<absl::string_view> TypeName(const FieldDescriptor& field) {
+absl::optional<std::string_view> TypeName(const FieldDescriptor& field) {
   if (field.is_map()) {
     return absl::nullopt;
   }
@@ -110,7 +110,7 @@ absl::optional<absl::string_view> TypeName(const FieldDescriptor& field) {
 template <typename DescriptorType>
 void TruncateLocationToTypeName(Location& location,
                                 const DescriptorType& desc) {
-  absl::optional<absl::string_view> type_name = TypeName(desc);
+  absl::optional<std::string_view> type_name = TypeName(desc);
   if (!type_name.has_value() || location.end <= location.begin ||
       (location.end - location.begin) <= type_name->size()) {
     return;
@@ -124,7 +124,7 @@ int FileDescriptorWalker::ComputeByteOffset(int line_number,
                                             int column_number) const {
   int byte_offset_of_start_of_line =
       line_index_.ComputeByteOffset(line_number, 0);
-  absl::string_view line_text = line_index_.GetLine(line_number);
+  std::string_view line_text = line_index_.GetLine(line_number);
   int byte_offset_into_line =
       ByteOffsetOfTabularColumn(line_text, column_number);
   if (byte_offset_into_line < 0) {
@@ -146,7 +146,7 @@ Location FileDescriptorWalker::LocationOfLeadingComments(
   comment_location.begin = entity_location.begin - line_offset_of_entity;
   comment_location.end = entity_location.begin - line_offset_of_entity - 1;
   int next_line_number = entity_start_line - 1;
-  absl::string_view bottom_line = line_index_.GetLine(next_line_number);
+  std::string_view bottom_line = line_index_.GetLine(next_line_number);
   while (
       RE2::FullMatch(ToStringPiece(bottom_line), R"((\s*\*/?\s*)|(\s*//\n))")) {
     comment_location.begin -= bottom_line.size();
@@ -159,7 +159,7 @@ Location FileDescriptorWalker::LocationOfLeadingComments(
   }
   while (!comment_lines.empty()) {
     const std::string& comment_line = comment_lines.back();
-    absl::string_view actual_line = line_index_.GetLine(next_line_number);
+    std::string_view actual_line = line_index_.GetLine(next_line_number);
     std::string comment_re =
         absl::StrCat(R"(\s*(?://|/?\*\s*))", RE2::QuoteMeta(comment_line),
                      R"(\s*(?:\*/)?\s*)");
@@ -193,7 +193,7 @@ Location FileDescriptorWalker::LocationOfTrailingComments(
       R"(\s*(?:/\*|//)\s*)", RE2::QuoteMeta(comment_lines.front()));
   int line_number = entity_start_line;
   for (; line_number <= line_index_.line_count(); ++line_number) {
-    absl::string_view entity_line = line_index_.GetLine(line_number);
+    std::string_view entity_line = line_index_.GetLine(line_number);
     re2::StringPiece comment_start;
     if (RE2::PartialMatch(ToStringPiece(entity_line), R"((\s*(?:/\*|//)))",
                           &comment_start)) {
@@ -213,7 +213,7 @@ Location FileDescriptorWalker::LocationOfTrailingComments(
   }
   ++line_number;
   for (const std::string& comment_line : comment_lines) {
-    absl::string_view actual_line = line_index_.GetLine(line_number);
+    std::string_view actual_line = line_index_.GetLine(line_number);
     std::string comment_re =
         absl::StrCat(R"(\s*(?://|/?\*\s*))", RE2::QuoteMeta(comment_line),
                      R"(\s*(?:\*/)?\s*)");
@@ -227,7 +227,7 @@ Location FileDescriptorWalker::LocationOfTrailingComments(
     ++line_number;
   }
 
-  absl::string_view bottom_line = line_index_.GetLine(line_number);
+  std::string_view bottom_line = line_index_.GetLine(line_number);
   while (RE2::FullMatch(ToStringPiece(bottom_line), R"(\s*\*/?\s*)")) {
     comment_location.end += bottom_line.size();
     ++line_number;
@@ -483,8 +483,8 @@ void FileDescriptorWalker::VisitField(const std::string* parent_name,
   if (field->is_map()) {
     // Map key/value types do not have SourceCodeInfo locations; we have to
     // find them within the outer "map<...>" type location.
-    absl::string_view content = absl::string_view(content_);
-    absl::string_view type_name = content.substr(
+    std::string_view content = std::string_view(content_);
+    std::string_view type_name = content.substr(
         type_location.begin, type_location.end - type_location.begin);
     re2::StringPiece key, val;
     if (RE2::FullMatch(ToStringPiece(type_name),

--- a/kythe/cxx/indexer/proto/file_descriptor_walker.h
+++ b/kythe/cxx/indexer/proto/file_descriptor_walker.h
@@ -21,11 +21,11 @@
 #include <memory>
 #include <set>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "absl/log/log.h"
 #include "absl/status/statusor.h"
-#include <string_view>
 #include "absl/types/optional.h"
 #include "kythe/cxx/common/file_vname_generator.h"
 #include "kythe/cxx/common/indexing/KytheOutputStream.h"

--- a/kythe/cxx/indexer/proto/file_descriptor_walker.h
+++ b/kythe/cxx/indexer/proto/file_descriptor_walker.h
@@ -25,7 +25,7 @@
 
 #include "absl/log/log.h"
 #include "absl/status/statusor.h"
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "absl/types/optional.h"
 #include "kythe/cxx/common/file_vname_generator.h"
 #include "kythe/cxx/common/indexing/KytheOutputStream.h"

--- a/kythe/cxx/indexer/proto/kythe_indexer_main.cc
+++ b/kythe/cxx/indexer/proto/kythe_indexer_main.cc
@@ -28,6 +28,7 @@
 #include <unistd.h>
 
 #include <string>
+#include <string_view>
 
 #include "absl/flags/flag.h"
 #include "absl/flags/parse.h"
@@ -37,7 +38,6 @@
 #include "absl/status/statusor.h"
 #include "absl/strings/match.h"
 #include "absl/strings/str_cat.h"
-#include <string_view>
 #include "google/protobuf/io/coded_stream.h"
 #include "google/protobuf/io/gzip_stream.h"
 #include "google/protobuf/io/zero_copy_stream.h"

--- a/kythe/cxx/indexer/proto/kythe_indexer_main.cc
+++ b/kythe/cxx/indexer/proto/kythe_indexer_main.cc
@@ -37,7 +37,7 @@
 #include "absl/status/statusor.h"
 #include "absl/strings/match.h"
 #include "absl/strings/str_cat.h"
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "google/protobuf/io/coded_stream.h"
 #include "google/protobuf/io/gzip_stream.h"
 #include "google/protobuf/io/zero_copy_stream.h"

--- a/kythe/cxx/indexer/proto/kythe_indexer_main.cc
+++ b/kythe/cxx/indexer/proto/kythe_indexer_main.cc
@@ -84,7 +84,7 @@ void DecodeKzipFile(const std::string& path,
   CHECK(reader.ok()) << "Couldn't open kzip from " << path << ": "
                      << reader.status();
   bool compilation_read = false;
-  auto status = reader->Scan([&](absl::string_view digest) {
+  auto status = reader->Scan([&](std::string_view digest) {
     std::vector<proto::FileData> virtual_files;
     auto compilation = reader->ReadUnit(digest);
     CHECK(compilation.ok()) << compilation.status();
@@ -116,7 +116,7 @@ bool ReadProtoFile(int fd, const std::string& relative_path,
   std::string source_data;
   ssize_t amount_read;
   while ((amount_read = ::read(fd, buf, sizeof buf)) > 0) {
-    absl::StrAppend(&source_data, absl::string_view(buf, amount_read));
+    absl::StrAppend(&source_data, std::string_view(buf, amount_read));
   }
   if (amount_read < 0) {
     LOG(ERROR) << "Error reading input file";

--- a/kythe/cxx/indexer/proto/marked_source.cc
+++ b/kythe/cxx/indexer/proto/marked_source.cc
@@ -19,9 +19,9 @@
 #include "absl/strings/str_split.h"
 
 namespace kythe {
-bool GenerateMarkedSourceForDottedName(absl::string_view name,
+bool GenerateMarkedSourceForDottedName(std::string_view name,
                                        MarkedSource* root) {
-  std::vector<absl::string_view> tokens = absl::StrSplit(name, '.');
+  std::vector<std::string_view> tokens = absl::StrSplit(name, '.');
   if (tokens.empty()) {
     return false;
   }

--- a/kythe/cxx/indexer/proto/marked_source.h
+++ b/kythe/cxx/indexer/proto/marked_source.h
@@ -27,7 +27,7 @@ namespace kythe {
 // `root` is the node to turn into a (box (context) (identifier)) or an
 // identifier, depending on the structure of `name`.
 // Returns true if at least one token was found.
-bool GenerateMarkedSourceForDottedName(absl::string_view name,
+bool GenerateMarkedSourceForDottedName(std::string_view name,
                                        MarkedSource* root);
 
 // Given a proto descriptor, generates an appropriate code fact. Returns

--- a/kythe/cxx/indexer/proto/offset_util.cc
+++ b/kythe/cxx/indexer/proto/offset_util.cc
@@ -21,7 +21,7 @@
 namespace kythe {
 namespace lang_proto {
 
-int ByteOffsetOfTabularColumn(absl::string_view line_text, int column_number) {
+int ByteOffsetOfTabularColumn(std::string_view line_text, int column_number) {
   int computed_column = 0;
   int offset = 0;
   while (computed_column < column_number && offset < line_text.size()) {

--- a/kythe/cxx/indexer/proto/offset_util.h
+++ b/kythe/cxx/indexer/proto/offset_util.h
@@ -24,7 +24,7 @@ namespace lang_proto {
 
 // Figures out just how many bytes one needs to go into `line_text` to reach
 // what the proto compiler calls column `column_number`.
-int ByteOffsetOfTabularColumn(absl::string_view line_text, int column_number);
+int ByteOffsetOfTabularColumn(std::string_view line_text, int column_number);
 
 }  // namespace lang_proto
 }  // namespace kythe

--- a/kythe/cxx/indexer/proto/offset_util.h
+++ b/kythe/cxx/indexer/proto/offset_util.h
@@ -17,7 +17,7 @@
 #ifndef KYTHE_CXX_INDEXER_PROTO_OFFSET_UTIL_H_
 #define KYTHE_CXX_INDEXER_PROTO_OFFSET_UTIL_H_
 
-#include "absl/strings/string_view.h"
+#include <string_view>
 
 namespace kythe {
 namespace lang_proto {

--- a/kythe/cxx/indexer/proto/proto_analyzer.cc
+++ b/kythe/cxx/indexer/proto/proto_analyzer.cc
@@ -18,7 +18,7 @@
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/log/log.h"
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "kythe/cxx/indexer/proto/file_descriptor_walker.h"
 
 namespace kythe {

--- a/kythe/cxx/indexer/proto/proto_analyzer.cc
+++ b/kythe/cxx/indexer/proto/proto_analyzer.cc
@@ -16,9 +16,10 @@
 
 #include "kythe/cxx/indexer/proto/proto_analyzer.h"
 
+#include <string_view>
+
 #include "absl/container/flat_hash_map.h"
 #include "absl/log/log.h"
-#include <string_view>
 #include "kythe/cxx/indexer/proto/file_descriptor_walker.h"
 
 namespace kythe {

--- a/kythe/cxx/indexer/proto/search_path.cc
+++ b/kythe/cxx/indexer/proto/search_path.cc
@@ -27,7 +27,7 @@ namespace lang_proto {
 namespace {
 
 void AddPathSubstitutions(
-    absl::string_view path_argument,
+    std::string_view path_argument,
     std::vector<std::pair<std::string, std::string>>* substitutions) {
   std::vector<std::string> parts =
       absl::StrSplit(path_argument, ':', absl::SkipEmpty());
@@ -56,7 +56,7 @@ void _ParsePathSubstitutions(
     } else if (argument == "-I" || argument == "--proto_path") {
       expecting_path_arg = true;
     } else {
-      absl::string_view argument_value = argument;
+      std::string_view argument_value = argument;
       if (absl::ConsumePrefix(&argument_value, "-I")) {
         AddPathSubstitutions(argument_value, substitutions);
       } else if (absl::ConsumePrefix(&argument_value, "--proto_path=")) {

--- a/kythe/cxx/indexer/proto/source_tree.cc
+++ b/kythe/cxx/indexer/proto/source_tree.cc
@@ -33,8 +33,8 @@ namespace {
 // StrReplace() in open-source abseil?
 /// Finds the first occurrence of @oldsub in @s and replaces it with @newsub. If
 /// @oldsub is not present, just returns @s.
-std::string StringReplaceFirst(absl::string_view s, absl::string_view oldsub,
-                               absl::string_view newsub) {
+std::string StringReplaceFirst(std::string_view s, std::string_view oldsub,
+                               std::string_view newsub) {
   return absl::StrJoin(absl::StrSplit(s, absl::MaxSplits(oldsub, 1)), newsub);
 }
 
@@ -47,7 +47,7 @@ bool PreloadedProtoFileTree::AddFile(const std::string& filename,
 }
 
 google::protobuf::io::ZeroCopyInputStream* PreloadedProtoFileTree::Open(
-    absl::string_view filename) {
+    std::string_view filename) {
   last_error_ = "";
 
   if (auto iter = file_mapping_cache_->find(filename);
@@ -102,7 +102,7 @@ google::protobuf::io::ZeroCopyInputStream* PreloadedProtoFileTree::Open(
   return nullptr;
 }
 
-bool PreloadedProtoFileTree::Read(absl::string_view file_path,
+bool PreloadedProtoFileTree::Read(std::string_view file_path,
                                   std::string* out) {
   std::unique_ptr<google::protobuf::io::ZeroCopyInputStream> in_stream(
       Open({file_path.data(), file_path.size()}));

--- a/kythe/cxx/indexer/proto/source_tree.h
+++ b/kythe/cxx/indexer/proto/source_tree.h
@@ -69,14 +69,14 @@ class PreloadedProtoFileTree : public google::protobuf::compiler::SourceTree {
   // as `filename`, leaving FileReaders to do any elaboration (e.g., in this
   // case, applying path substitutions).
   google::protobuf::io::ZeroCopyInputStream* Open(
-      absl::string_view filename) override;
+      std::string_view filename) override;
 
   // If Open() returns nullptr, calling this method immediately will return a
   // description of the error.
   std::string GetLastErrorMessage() override { return last_error_; }
 
   // A wrapper around Open(), that reads the proto file contents into a buffer.
-  bool Read(absl::string_view file_path, std::string* out);
+  bool Read(std::string_view file_path, std::string* out);
 
  private:
   // All path prefix substitutions to consider.

--- a/kythe/cxx/indexer/textproto/analyzer.cc
+++ b/kythe/cxx/indexer/textproto/analyzer.cc
@@ -18,6 +18,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <string_view>
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
@@ -28,7 +29,6 @@
 #include "absl/strings/numbers.h"
 #include "absl/strings/str_join.h"
 #include "absl/strings/str_split.h"
-#include <string_view>
 #include "absl/strings/strip.h"
 #include "absl/types/optional.h"
 #include "google/protobuf/descriptor.h"
@@ -171,8 +171,7 @@ class TextprotoAnalyzer : public PluginApi {
   proto::VName CreateAndAddAnchorNode(const proto::VName& file_vname,
                                       std::string_view sp) override;
 
-  proto::VName VNameForRelPath(
-      std::string_view simplified_path) const override;
+  proto::VName VNameForRelPath(std::string_view simplified_path) const override;
 
   void SetPlugins(std::vector<std::unique_ptr<Plugin>> p) {
     plugins_ = std::move(p);

--- a/kythe/cxx/indexer/textproto/analyzer.cc
+++ b/kythe/cxx/indexer/textproto/analyzer.cc
@@ -28,7 +28,7 @@
 #include "absl/strings/numbers.h"
 #include "absl/strings/str_join.h"
 #include "absl/strings/str_split.h"
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "absl/strings/strip.h"
 #include "absl/types/optional.h"
 #include "google/protobuf/descriptor.h"

--- a/kythe/cxx/indexer/textproto/analyzer.h
+++ b/kythe/cxx/indexer/textproto/analyzer.h
@@ -30,7 +30,7 @@ namespace kythe {
 namespace lang_textproto {
 
 // The canonical name for the textproto language in Kythe.
-extern const absl::string_view kLanguageName;
+extern const std::string_view kLanguageName;
 
 /// Analyzes the textproto file(s) described by @unit and emits graph facts to
 /// @recorder.

--- a/kythe/cxx/indexer/textproto/plugin.h
+++ b/kythe/cxx/indexer/textproto/plugin.h
@@ -41,19 +41,19 @@ class PluginApi {
 
   // Adds an anchor for the text span and returns its VName.
   virtual proto::VName CreateAndAddAnchorNode(const proto::VName& file_vname,
-                                              absl::string_view sp) = 0;
+                                              std::string_view sp) = 0;
 
   virtual KytheGraphRecorder* recorder() = 0;
 
   virtual void EmitDiagnostic(const proto::VName& file_vname,
-                              absl::string_view signature,
-                              absl::string_view msg) = 0;
+                              std::string_view signature,
+                              std::string_view msg) = 0;
 
   // Returns a VName for the given relative path by resolving it to its full
   // path and matching it against a file in the CompilationUnit's
   // required_inputs.
   virtual proto::VName VNameForRelPath(
-      absl::string_view simplified_path) const = 0;
+      std::string_view simplified_path) const = 0;
 
   // Returns a pointer to the descriptor pool built from the .proto files
   // included as dependencies in the textproto's compilation unit.
@@ -66,7 +66,7 @@ struct StringToken {
   std::string parsed_value;
   // The span of source text in the input. The underlying string that the view
   // references is owned by the `PluginApi`.
-  absl::string_view source_text;
+  std::string_view source_text;
 };
 
 // Superclass for all plugins. A new plugin is instantiated for each textproto
@@ -99,7 +99,7 @@ class Plugin {
   virtual absl::Status AnalyzeIntegerField(
       PluginApi* api, const proto::VName& file_vname,
       const google::protobuf::FieldDescriptor& field,
-      absl::string_view field_value) {
+      std::string_view field_value) {
     return absl::OkStatus();
   }
 

--- a/kythe/cxx/indexer/textproto/plugin_registry.h
+++ b/kythe/cxx/indexer/textproto/plugin_registry.h
@@ -18,6 +18,7 @@
 #define KYTHE_CXX_INDEXER_TEXTPROTO_PLUGIN_REGISTRY_H_
 
 #include <string_view>
+
 #include "google/protobuf/descriptor.h"
 #include "kythe/cxx/indexer/textproto/plugin.h"
 

--- a/kythe/cxx/indexer/textproto/plugin_registry.h
+++ b/kythe/cxx/indexer/textproto/plugin_registry.h
@@ -17,7 +17,7 @@
 #ifndef KYTHE_CXX_INDEXER_TEXTPROTO_PLUGIN_REGISTRY_H_
 #define KYTHE_CXX_INDEXER_TEXTPROTO_PLUGIN_REGISTRY_H_
 
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "google/protobuf/descriptor.h"
 #include "kythe/cxx/indexer/textproto/plugin.h"
 

--- a/kythe/cxx/indexer/textproto/plugins/example/plugin.cc
+++ b/kythe/cxx/indexer/textproto/plugins/example/plugin.cc
@@ -28,7 +28,7 @@ absl::Status ExamplePlugin::AnalyzeStringField(
   // Create an anchor spanning the full range of the string value.
   const char* begin = tokens.front().source_text.data();
   const char* end = tokens.back().source_text.end();
-  const absl::string_view full_span = absl::string_view(begin, end - begin);
+  const std::string_view full_span = std::string_view(begin, end - begin);
   const proto::VName anchor_vname =
       api->CreateAndAddAnchorNode(file_vname, full_span);
 

--- a/kythe/cxx/indexer/textproto/recordio_textparser.cc
+++ b/kythe/cxx/indexer/textproto/recordio_textparser.cc
@@ -23,7 +23,7 @@
 #include "absl/strings/ascii.h"
 #include "absl/strings/match.h"
 #include "absl/strings/str_split.h"
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "absl/strings/strip.h"
 #include "absl/types/optional.h"
 

--- a/kythe/cxx/indexer/textproto/recordio_textparser.cc
+++ b/kythe/cxx/indexer/textproto/recordio_textparser.cc
@@ -17,13 +17,13 @@
 #include "kythe/cxx/indexer/textproto/recordio_textparser.h"
 
 #include <sstream>
+#include <string_view>
 
 #include "absl/functional/function_ref.h"
 #include "absl/log/log.h"
 #include "absl/strings/ascii.h"
 #include "absl/strings/match.h"
 #include "absl/strings/str_split.h"
-#include <string_view>
 #include "absl/strings/strip.h"
 #include "absl/types/optional.h"
 

--- a/kythe/cxx/indexer/textproto/recordio_textparser.cc
+++ b/kythe/cxx/indexer/textproto/recordio_textparser.cc
@@ -36,8 +36,8 @@ namespace {
 // also includes the delimiter char.
 struct WithChar {
   explicit WithChar(char ch) : delimiter_(ch) {}
-  absl::string_view Find(absl::string_view text, size_t pos) const {
-    absl::string_view sep = delimiter_.Find(text, pos);
+  std::string_view Find(std::string_view text, size_t pos) const {
+    std::string_view sep = delimiter_.Find(text, pos);
     // Always return a zero-width span after the delimiter, so that it's
     // included if present.
     sep.remove_prefix(sep.size());
@@ -50,18 +50,18 @@ struct WithChar {
 
 class ProtoLineDelimiter {
  public:
-  explicit ProtoLineDelimiter(absl::string_view delimiter,
+  explicit ProtoLineDelimiter(std::string_view delimiter,
                               int* line_count = nullptr)
       : delimiter_(delimiter), line_count_(line_count), current_line_(0) {}
 
   /// \brief Finds the next occurrence of the configured delimiter
   /// on a line by itself, after the first non-comment, non-empty line.
-  absl::string_view Find(absl::string_view text, size_t pos) {
+  std::string_view Find(std::string_view text, size_t pos) {
     // Store the start line of chunk.
     if (line_count_) {
       *line_count_ = current_line_;
     }
-    for (absl::string_view line :
+    for (std::string_view line :
          absl::StrSplit(text.substr(pos), WithChar('\n'))) {
       current_line_++;
       // Don't look for the delimiter until we've seen our first non-empty,
@@ -92,11 +92,11 @@ class ProtoLineDelimiter {
 }  // namespace
 
 void ParseRecordTextChunks(
-    absl::string_view content, absl::string_view record_delimiter,
-    absl::FunctionRef<void(absl::string_view chunk, int chunk_start_line)>
+    std::string_view content, std::string_view record_delimiter,
+    absl::FunctionRef<void(std::string_view chunk, int chunk_start_line)>
         callback) {
   int line_count = 0;
-  for (absl::string_view chunk : absl::StrSplit(
+  for (std::string_view chunk : absl::StrSplit(
            content, ProtoLineDelimiter(record_delimiter, &line_count))) {
     callback(chunk, line_count);
   }

--- a/kythe/cxx/indexer/textproto/recordio_textparser.h
+++ b/kythe/cxx/indexer/textproto/recordio_textparser.h
@@ -17,8 +17,9 @@
 #ifndef KYTHE_CXX_INDEXER_TEXTPROTO_RECORDIO_TEXTPARSER_H_
 #define KYTHE_CXX_INDEXER_TEXTPROTO_RECORDIO_TEXTPARSER_H_
 
-#include "absl/functional/function_ref.h"
 #include <string_view>
+
+#include "absl/functional/function_ref.h"
 #include "absl/types/optional.h"
 #include "google/protobuf/descriptor.h"
 #include "google/protobuf/dynamic_message.h"

--- a/kythe/cxx/indexer/textproto/recordio_textparser.h
+++ b/kythe/cxx/indexer/textproto/recordio_textparser.h
@@ -18,7 +18,7 @@
 #define KYTHE_CXX_INDEXER_TEXTPROTO_RECORDIO_TEXTPARSER_H_
 
 #include "absl/functional/function_ref.h"
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "absl/types/optional.h"
 #include "google/protobuf/descriptor.h"
 #include "google/protobuf/dynamic_message.h"

--- a/kythe/cxx/indexer/textproto/recordio_textparser.h
+++ b/kythe/cxx/indexer/textproto/recordio_textparser.h
@@ -46,8 +46,8 @@ namespace lang_textproto {
 // Also, note that delimiter could start with '#' which is also for the
 // comment.
 void ParseRecordTextChunks(
-    absl::string_view content, absl::string_view record_delimiter,
-    absl::FunctionRef<void(absl::string_view chunk, int chunk_start_line)>
+    std::string_view content, std::string_view record_delimiter,
+    absl::FunctionRef<void(std::string_view chunk, int chunk_start_line)>
         callback);
 
 }  // namespace lang_textproto

--- a/kythe/cxx/indexer/textproto/recordio_textparser_test.cc
+++ b/kythe/cxx/indexer/textproto/recordio_textparser_test.cc
@@ -29,7 +29,7 @@ std::vector<std::pair<int, std::string>> ParsedChunks(std::string content,
                                                       std::string separator) {
   std::vector<std::pair<int, std::string>> chunks;
   lang_textproto::ParseRecordTextChunks(
-      content, separator, [&](absl::string_view chunk, int chunk_start_line) {
+      content, separator, [&](std::string_view chunk, int chunk_start_line) {
         chunks.emplace_back(chunk_start_line, std::string(chunk));
       });
   return chunks;

--- a/kythe/cxx/indexer/textproto/recordio_textparser_test.cc
+++ b/kythe/cxx/indexer/textproto/recordio_textparser_test.cc
@@ -15,8 +15,9 @@
  */
 #include "kythe/cxx/indexer/textproto/recordio_textparser.h"
 
-#include "absl/strings/str_join.h"
 #include <string_view>
+
+#include "absl/strings/str_join.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 

--- a/kythe/cxx/indexer/textproto/recordio_textparser_test.cc
+++ b/kythe/cxx/indexer/textproto/recordio_textparser_test.cc
@@ -16,7 +16,7 @@
 #include "kythe/cxx/indexer/textproto/recordio_textparser.h"
 
 #include "absl/strings/str_join.h"
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 

--- a/kythe/cxx/indexer/textproto/textproto_indexer_main.cc
+++ b/kythe/cxx/indexer/textproto/textproto_indexer_main.cc
@@ -65,7 +65,7 @@ void DecodeKzipFile(const std::string& path,
   CHECK(reader.ok()) << "Couldn't open kzip from " << path << ": "
                      << reader.status();
   bool compilation_read = false;
-  auto status = reader->Scan([&](absl::string_view digest) {
+  auto status = reader->Scan([&](std::string_view digest) {
     std::vector<proto::FileData> virtual_files;
     auto compilation = reader->ReadUnit(digest);
     CHECK(compilation.ok()) << compilation.status();

--- a/kythe/cxx/tools/proto_metadata_plugin.cc
+++ b/kythe/cxx/tools/proto_metadata_plugin.cc
@@ -24,7 +24,7 @@
 #include "absl/strings/match.h"
 #include "absl/strings/str_join.h"
 #include "absl/strings/str_split.h"
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "absl/strings/strip.h"
 #include "google/protobuf/compiler/code_generator.h"
 #include "google/protobuf/compiler/cpp/generator.h"

--- a/kythe/cxx/tools/proto_metadata_plugin.cc
+++ b/kythe/cxx/tools/proto_metadata_plugin.cc
@@ -15,6 +15,7 @@
  */
 #include <cstdlib>
 #include <string>
+#include <string_view>
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/node_hash_map.h"
@@ -24,7 +25,6 @@
 #include "absl/strings/match.h"
 #include "absl/strings/str_join.h"
 #include "absl/strings/str_split.h"
-#include <string_view>
 #include "absl/strings/strip.h"
 #include "google/protobuf/compiler/code_generator.h"
 #include "google/protobuf/compiler/cpp/generator.h"
@@ -74,8 +74,7 @@ void WriteLines(std::string_view metadata, Printer* printer) {
   }
 }
 
-std::string WriteMetadata(std::string_view metafile,
-                          std::string_view contents,
+std::string WriteMetadata(std::string_view metafile, std::string_view contents,
                           ZeroCopyOutputStream* stream) {
   if (!absl::EndsWith(metafile, kMetadataFileSuffix)) {
     return "Not a metadata file";

--- a/kythe/cxx/tools/proto_metadata_plugin.cc
+++ b/kythe/cxx/tools/proto_metadata_plugin.cc
@@ -45,37 +45,37 @@ using ::google::protobuf::io::Printer;
 using ::google::protobuf::io::StringOutputStream;
 using ::google::protobuf::io::ZeroCopyOutputStream;
 
-constexpr absl::string_view kMetadataFileSuffix = ".meta";
-constexpr absl::string_view kHeaderFileSuffix = ".h";
-constexpr absl::string_view kCompressMetadataParam = "compress_metadata";
-constexpr absl::string_view kAnnotateHeaderParam = "annotate_headers";
-constexpr absl::string_view kAnnotationGuardParam = "annotation_guard_name";
-constexpr absl::string_view kAnnotationGuardDefault = "KYTHE_IS_RUNNING";
-constexpr absl::string_view kAnnotationPragmaParam = "annotation_pragma_name";
-constexpr absl::string_view kAnnotationPragmaInline = "kythe_inline_metadata";
-constexpr absl::string_view kAnnotationPragmaCompress =
+constexpr std::string_view kMetadataFileSuffix = ".meta";
+constexpr std::string_view kHeaderFileSuffix = ".h";
+constexpr std::string_view kCompressMetadataParam = "compress_metadata";
+constexpr std::string_view kAnnotateHeaderParam = "annotate_headers";
+constexpr std::string_view kAnnotationGuardParam = "annotation_guard_name";
+constexpr std::string_view kAnnotationGuardDefault = "KYTHE_IS_RUNNING";
+constexpr std::string_view kAnnotationPragmaParam = "annotation_pragma_name";
+constexpr std::string_view kAnnotationPragmaInline = "kythe_inline_metadata";
+constexpr std::string_view kAnnotationPragmaCompress =
     "kythe_inline_gzip_metadata";
 constexpr int kMetadataLineLength = 76;
 
-absl::string_view NextChunk(absl::string_view* data, int size) {
+std::string_view NextChunk(std::string_view* data, int size) {
   if (data->empty()) {
     return {};
   }
-  absl::string_view result = data->substr(0, size);
+  std::string_view result = data->substr(0, size);
   data->remove_prefix(result.size());
   return result;
 }
 
-void WriteLines(absl::string_view metadata, Printer* printer) {
+void WriteLines(std::string_view metadata, Printer* printer) {
   while (!metadata.empty()) {
-    absl::string_view chunk = NextChunk(&metadata, kMetadataLineLength);
+    std::string_view chunk = NextChunk(&metadata, kMetadataLineLength);
     printer->WriteRaw(chunk.data(), chunk.size());
     printer->PrintRaw("\n");
   }
 }
 
-std::string WriteMetadata(absl::string_view metafile,
-                          absl::string_view contents,
+std::string WriteMetadata(std::string_view metafile,
+                          std::string_view contents,
                           ZeroCopyOutputStream* stream) {
   if (!absl::EndsWith(metafile, kMetadataFileSuffix)) {
     return "Not a metadata file";
@@ -210,8 +210,8 @@ class WrappedContext : public GeneratorContext {
 bool CompressMetadata(std::string* parameter) {
   bool has_guard_name = false;
   bool compress_metadata = false;
-  std::vector<absl::string_view> parts = {kAnnotateHeaderParam};
-  for (absl::string_view param : absl::StrSplit(*parameter, ',')) {
+  std::vector<std::string_view> parts = {kAnnotateHeaderParam};
+  for (std::string_view param : absl::StrSplit(*parameter, ',')) {
     if (absl::StartsWith(param, kAnnotationPragmaParam) ||
         param == kAnnotateHeaderParam) {
       continue;

--- a/kythe/cxx/verifier/assertion_ast.h
+++ b/kythe/cxx/verifier/assertion_ast.h
@@ -45,14 +45,14 @@ class SymbolTable {
   explicit SymbolTable() : id_regex_("[%#]?[_a-zA-Z/][a-zA-Z_0-9/]*") {}
 
   /// \brief Returns the `Symbol` associated with `string` or `nullopt`.
-  absl::optional<Symbol> FindInterned(absl::string_view string) const {
+  absl::optional<Symbol> FindInterned(std::string_view string) const {
     const auto old = symbols_.find(std::string(string));
     if (old == symbols_.end()) return absl::nullopt;
     return old->second;
   }
 
   /// \brief Returns the `Symbol` associated with `string`, or aborts.
-  Symbol MustIntern(absl::string_view string) const {
+  Symbol MustIntern(std::string_view string) const {
     auto sym = FindInterned(string);
     CHECK(sym) << "no symbol for " << string;
     return *sym;

--- a/kythe/cxx/verifier/assertions_to_souffle.cc
+++ b/kythe/cxx/verifier/assertions_to_souffle.cc
@@ -20,7 +20,7 @@
 
 namespace kythe::verifier {
 namespace {
-constexpr absl::string_view kGlobalDecls = R"(
+constexpr std::string_view kGlobalDecls = R"(
 .type vname = [
   signature:number,
   corpus:number,

--- a/kythe/cxx/verifier/assertions_to_souffle.h
+++ b/kythe/cxx/verifier/assertions_to_souffle.h
@@ -18,9 +18,9 @@
 #define KYTHE_CXX_VERIFIER_ASSERTIONS_TO_SOUFFLE_
 
 #include <string>
+#include <string_view>
 
 #include "absl/container/flat_hash_map.h"
-#include <string_view>
 #include "kythe/cxx/verifier/assertion_ast.h"
 
 namespace kythe::verifier {

--- a/kythe/cxx/verifier/assertions_to_souffle.h
+++ b/kythe/cxx/verifier/assertions_to_souffle.h
@@ -34,7 +34,7 @@ class SouffleProgram {
              const std::vector<GoalGroup>& goal_groups);
 
   /// \return the lowered Souffle code.
-  absl::string_view code() { return code_; }
+  std::string_view code() { return code_; }
 
   /// \brief Configures whether to emit initial definitions.
   void set_emit_prelude(bool emit_prelude) { emit_prelude_ = emit_prelude; }

--- a/kythe/cxx/verifier/assertions_to_souffle.h
+++ b/kythe/cxx/verifier/assertions_to_souffle.h
@@ -20,7 +20,7 @@
 #include <string>
 
 #include "absl/container/flat_hash_map.h"
-#include "absl/strings/string_view.h"
+#include <string_view>
 #include "kythe/cxx/verifier/assertion_ast.h"
 
 namespace kythe::verifier {

--- a/kythe/cxx/verifier/assertions_to_souffle_test.cc
+++ b/kythe/cxx/verifier/assertions_to_souffle_test.cc
@@ -65,7 +65,7 @@ class AstTest : public ::testing::Test {
   }
 
   /// \return the generated program without boilerplate
-  absl::string_view MustGenerateProgram() {
+  std::string_view MustGenerateProgram() {
     CHECK(p_.Lower(symbol_table_, {}));
     auto code = p_.code();
     CHECK(absl::ConsumeSuffix(&code, ".\n"));

--- a/kythe/cxx/verifier/pretty_printer.cc
+++ b/kythe/cxx/verifier/pretty_printer.cc
@@ -26,7 +26,7 @@ namespace verifier {
 
 PrettyPrinter::~PrettyPrinter() {}
 
-void StringPrettyPrinter::Print(absl::string_view string) { data_ << string; }
+void StringPrettyPrinter::Print(std::string_view string) { data_ << string; }
 void StringPrettyPrinter::Print(const char* string) { data_ << string; }
 
 void StringPrettyPrinter::Print(const void* ptr) {
@@ -37,7 +37,7 @@ void StringPrettyPrinter::Print(const void* ptr) {
   }
 }
 
-void FileHandlePrettyPrinter::Print(absl::string_view string) {
+void FileHandlePrettyPrinter::Print(std::string_view string) {
   absl::FPrintF(file_, "%s", string);
 }
 
@@ -49,7 +49,7 @@ void FileHandlePrettyPrinter::Print(const void* ptr) {
   absl::FPrintF(file_, "0x%016llx", reinterpret_cast<unsigned long long>(ptr));
 }
 
-void QuoteEscapingPrettyPrinter::Print(absl::string_view string) {
+void QuoteEscapingPrettyPrinter::Print(std::string_view string) {
   for (char ch : string) {
     if (ch == '\"') {
       wrapped_.Print("\\\"");
@@ -64,12 +64,12 @@ void QuoteEscapingPrettyPrinter::Print(absl::string_view string) {
 }
 
 void QuoteEscapingPrettyPrinter::Print(const char* string) {
-  Print(absl::string_view(string));
+  Print(std::string_view(string));
 }
 
 void QuoteEscapingPrettyPrinter::Print(const void* ptr) { wrapped_.Print(ptr); }
 
-void HtmlEscapingPrettyPrinter::Print(absl::string_view string) {
+void HtmlEscapingPrettyPrinter::Print(std::string_view string) {
   for (char ch : string) {
     if (ch == '\"') {
       wrapped_.Print("&quot;");
@@ -86,7 +86,7 @@ void HtmlEscapingPrettyPrinter::Print(absl::string_view string) {
 }
 
 void HtmlEscapingPrettyPrinter::Print(const char* string) {
-  Print(absl::string_view(string));
+  Print(std::string_view(string));
 }
 
 void HtmlEscapingPrettyPrinter::Print(const void* ptr) { wrapped_.Print(ptr); }

--- a/kythe/cxx/verifier/pretty_printer.cc
+++ b/kythe/cxx/verifier/pretty_printer.cc
@@ -17,9 +17,9 @@
 #include "pretty_printer.h"
 
 #include <bitset>
+#include <string_view>
 
 #include "absl/strings/str_format.h"
-#include <string_view>
 
 namespace kythe {
 namespace verifier {

--- a/kythe/cxx/verifier/pretty_printer.cc
+++ b/kythe/cxx/verifier/pretty_printer.cc
@@ -19,7 +19,7 @@
 #include <bitset>
 
 #include "absl/strings/str_format.h"
-#include "absl/strings/string_view.h"
+#include <string_view>
 
 namespace kythe {
 namespace verifier {

--- a/kythe/cxx/verifier/pretty_printer.h
+++ b/kythe/cxx/verifier/pretty_printer.h
@@ -28,7 +28,7 @@ namespace verifier {
 class PrettyPrinter {
  public:
   /// \brief Prints `string`.
-  virtual void Print(absl::string_view string) = 0;
+  virtual void Print(std::string_view string) = 0;
 
   /// \brief Prints `string`.
   virtual void Print(const char* string) = 0;
@@ -42,8 +42,8 @@ class PrettyPrinter {
 /// \brief A `PrettyPrinter` using a `string` as its backing store.
 class StringPrettyPrinter : public PrettyPrinter {
  public:
-  /// \copydoc PrettyPrinter::Print(absl::string_view)
-  void Print(absl::string_view string) override;
+  /// \copydoc PrettyPrinter::Print(std::string_view)
+  void Print(std::string_view string) override;
   /// \copydoc PrettyPrinter::Print(const char*)
   void Print(const char* string) override;
   /// \copydoc PrettyPrinter::Print(const void *)
@@ -61,8 +61,8 @@ class FileHandlePrettyPrinter : public PrettyPrinter {
  public:
   /// \param file The file handle to print to.
   explicit FileHandlePrettyPrinter(FILE* file) : file_(file) {}
-  /// \copydoc PrettyPrinter::Print(absl::string_view)
-  void Print(absl::string_view string) override;
+  /// \copydoc PrettyPrinter::Print(std::string_view)
+  void Print(std::string_view string) override;
   /// \copydoc PrettyPrinter::Print(const char*)
   void Print(const char* string) override;
   /// \copydoc PrettyPrinter::Print(const void *)
@@ -80,8 +80,8 @@ class QuoteEscapingPrettyPrinter : public PrettyPrinter {
   /// sent.
   explicit QuoteEscapingPrettyPrinter(PrettyPrinter& wrapped)
       : wrapped_(wrapped) {}
-  /// \copydoc PrettyPrinter::Print(absl::string_view)
-  void Print(absl::string_view string) override;
+  /// \copydoc PrettyPrinter::Print(std::string_view)
+  void Print(std::string_view string) override;
   /// \copydoc PrettyPrinter::Print(const char*)
   void Print(const char* string) override;
   /// \copydoc PrettyPrinter::Print(const void *)
@@ -99,8 +99,8 @@ class HtmlEscapingPrettyPrinter : public PrettyPrinter {
   /// sent.
   explicit HtmlEscapingPrettyPrinter(PrettyPrinter& wrapped)
       : wrapped_(wrapped) {}
-  /// \copydoc PrettyPrinter::Print(absl::string_view)
-  void Print(absl::string_view string) override;
+  /// \copydoc PrettyPrinter::Print(std::string_view)
+  void Print(std::string_view string) override;
   /// \copydoc PrettyPrinter::Print(const char*)
   void Print(const char* string) override;
   /// \copydoc PrettyPrinter::Print(const void *)

--- a/kythe/cxx/verifier/pretty_printer.h
+++ b/kythe/cxx/verifier/pretty_printer.h
@@ -18,7 +18,6 @@
 #define KYTHE_CXX_VERIFIER_PRETTY_PRINTER_H_
 
 #include <sstream>
-
 #include <string_view>
 
 namespace kythe {

--- a/kythe/cxx/verifier/pretty_printer.h
+++ b/kythe/cxx/verifier/pretty_printer.h
@@ -19,7 +19,7 @@
 
 #include <sstream>
 
-#include "absl/strings/string_view.h"
+#include <string_view>
 
 namespace kythe {
 namespace verifier {

--- a/kythe/cxx/verifier/verifier.cc
+++ b/kythe/cxx/verifier/verifier.cc
@@ -718,9 +718,9 @@ bool Verifier::SetGoalCommentRegex(const std::string& regex,
 }
 
 bool Verifier::LoadInlineProtoFile(const std::string& file_data,
-                                   absl::string_view path,
-                                   absl::string_view root,
-                                   absl::string_view corpus) {
+                                   std::string_view path,
+                                   std::string_view root,
+                                   std::string_view corpus) {
   kythe::proto::Entries entries;
   bool ok = google::protobuf::TextFormat::ParseFromString(file_data, &entries);
   if (!ok) {

--- a/kythe/cxx/verifier/verifier.cc
+++ b/kythe/cxx/verifier/verifier.cc
@@ -718,8 +718,7 @@ bool Verifier::SetGoalCommentRegex(const std::string& regex,
 }
 
 bool Verifier::LoadInlineProtoFile(const std::string& file_data,
-                                   std::string_view path,
-                                   std::string_view root,
+                                   std::string_view path, std::string_view root,
                                    std::string_view corpus) {
   kythe::proto::Entries entries;
   bool ok = google::protobuf::TextFormat::ParseFromString(file_data, &entries);

--- a/kythe/cxx/verifier/verifier.h
+++ b/kythe/cxx/verifier/verifier.h
@@ -62,9 +62,9 @@ class Verifier {
   /// \param corpus the corpus to use for anchors
   /// \return false if we failed
   bool LoadInlineProtoFile(const std::string& file_data,
-                           absl::string_view path = "",
-                           absl::string_view root = "",
-                           absl::string_view corpus = "");
+                           std::string_view path = "",
+                           std::string_view root = "",
+                           std::string_view corpus = "");
 
   /// \brief During verification, ignore duplicate facts.
   void IgnoreDuplicateFacts();


### PR DESCRIPTION
The only change I reverted was in parsetextproto.h, which defines its own mock of absl::string_view