### PR TITLE
chore(pre-commit): update docker image so that it builds

### DIFF
--- a/kythe/release/cloudbuild/pre-commit/Dockerfile
+++ b/kythe/release/cloudbuild/pre-commit/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update \
                 # pre-commit dependencies
                 python3 python3-dev python3-pip \
                 # Linter dependencies
-                golang-1.18-go shellcheck clang-format-14 openjdk-11-jre-headless git \
+                golang-1.19-go shellcheck clang-format-14 openjdk-11-jre-headless git \
         && apt-get clean \
         && rm -rf /var/lib/apt/lists/*
 
@@ -30,11 +30,11 @@ RUN apt-get update \
 RUN update-alternatives \
       --install /usr/bin/clang-format clang-format /usr/bin/clang-format-14    100
 
-# Make go-1.18 the default
+# Make go-1.19 the default
 RUN update-alternatives \
-      --install /usr/bin/go go /usr/lib/go-1.18/bin/go  100
+      --install /usr/bin/go go /usr/lib/go-1.19/bin/go  100
 RUN update-alternatives \
-      --install /usr/bin/gofmt gofmt /usr/lib/go-1.18/bin/gofmt  100
+      --install /usr/bin/gofmt gofmt /usr/lib/go-1.19/bin/gofmt  100
 
 # Install pip-packages
 COPY requirements.txt pre-commit-requirements.txt

--- a/kythe/release/cloudbuild/pre-commit/Dockerfile
+++ b/kythe/release/cloudbuild/pre-commit/Dockerfile
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 # docker build -t gcr.io/kythe-repo/pre-commit .
-FROM ubuntu:22.04
+FROM ubuntu:23.04
 
 RUN apt-get update \
         && apt-get upgrade -y \
         && apt-get install -y --no-install-recommends \
                 curl ca-certificates \
                 # pre-commit dependencies
-                python3 python3-dev python3-pip \
+                python3 python3-dev python3-pip python3-venv \
                 # Linter dependencies
                 golang-1.19-go shellcheck clang-format-14 openjdk-11-jre-headless git \
         && apt-get clean \
@@ -38,7 +38,8 @@ RUN update-alternatives \
 
 # Install pip-packages
 COPY requirements.txt pre-commit-requirements.txt
-RUN pip3 install --require-hashes -r pre-commit-requirements.txt \
+RUN python3 -m venv /tmp/venv
+RUN /tmp/venv/bin/pip3 install --require-hashes -r pre-commit-requirements.txt \
  && rm pre-commit-requirements.txt
 
 # Install extra linters
@@ -66,4 +67,4 @@ RUN curl -o /tmp/rustup.sh --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs 
 # Install go wrapper script
 ADD go /usr/local/bin/go
 ENV PATH=$PATH:/root/go/bin:$CARGO_HOME/bin
-ENTRYPOINT ["pre-commit"]
+ENTRYPOINT ["/tmp/venv/bin/pre-commit"]


### PR DESCRIPTION
`honnef.co/go/tools/cmd/staticcheck@latest` requires go 1.19, so I updated that...
ubuntu 22.04 doesn't have go 1.19, so I updated that to 23.04...
ubuntu 23.04's python setup doesn't allow globally installing packages with pip, so I setup a virtual environment...

I think everything is working now