### PR TITLE
fix(extraction): fix Dockerfile and extraction script

### DIFF
--- a/kythe/extractors/bazel/Dockerfile
+++ b/kythe/extractors/bazel/Dockerfile
@@ -17,6 +17,8 @@ FROM debian:stable-slim
 # Install C++ compilers and other deps
 # note that openjdk-11-jdk-headless is a dependency of the java extractor
 RUN apt-get update -y && \
+    # This is temporary until Debian starts shipping merged /usr directories in their images
+    apt-mark hold usrmerge usr-is-merged && \
     apt-get upgrade -y && \
     apt-get install -y git clang-15 build-essential zip python3 openjdk-17-jdk-headless && \
     apt-get clean

--- a/kythe/extractors/bazel/extract.sh
+++ b/kythe/extractors/bazel/extract.sh
@@ -55,6 +55,7 @@ if [[ -n "$KYTHE_SYSTEM_DEPS" ]]; then
   # TODO(jaysachs): unclear if we should bail if any packages fail to install
   apt-get update && \
   apt-get upgrade -y && \
+  apt-get --fix-broken install -y && \
   apt-get install -y $KYTHE_SYSTEM_DEPS && \
   apt-get clean
 fi


### PR DESCRIPTION
This PR adds a new line to `extract.sh` to fix potentially broken packages after `apt upgrade` is run. It also adds a new line to the Dockerfile to block the installation of `usrmerge` and `usr-is-merged` as `usrmerge` cannot run inside a Docker image, `usr-is-merged` will complain that `usrmerge` hasn't been run, and Debian haven't started shipping stable Docker containers that have already been merged.