### PR TITLE
chore: excise vestiges of abs nodes from API

### DIFF
--- a/kythe/cxx/indexer/cxx/GoogleFlagsLibrarySupport.cc
+++ b/kythe/cxx/indexer/cxx/GoogleFlagsLibrarySupport.cc
@@ -173,13 +173,9 @@ static GraphObserver::NodeId NodeIdForFlag(GraphObserver& Observer,
 }
 
 void GoogleFlagsLibrarySupport::InspectVariable(
-    IndexerASTVisitor& V, GraphObserver::NodeId& NodeId,
-    GraphObserver::NodeId& DeclBodyNodeId, const clang::VarDecl* Decl,
-    GraphObserver::Completeness Compl, const std::vector<Completion>& Compls) {
-  if (NodeId != DeclBodyNodeId) {
-    // Google flags aren't variable templates, so abort early.
-    return;
-  }
+    IndexerASTVisitor& V, const GraphObserver::NodeId& NodeId,
+    const clang::VarDecl* Decl, GraphObserver::Completeness Compl,
+    const std::vector<Completion>& Compls) {
   GraphObserver& GO = V.getGraphObserver();
   auto Range = GetVarDeclFlagDeclLoc(*GO.getLangOptions(), Decl);
   if (Range.isValid()) {
@@ -216,7 +212,7 @@ void GoogleFlagsLibrarySupport::InspectVariable(
 
 void GoogleFlagsLibrarySupport::InspectDeclRef(
     IndexerASTVisitor& V, clang::SourceLocation DeclRefLocation,
-    const GraphObserver::Range& Ref, GraphObserver::NodeId& RefId,
+    const GraphObserver::Range& Ref, const GraphObserver::NodeId& RefId,
     const clang::NamedDecl* TargetDecl) {
   GraphObserver& GO = V.getGraphObserver();
   const auto* VD = llvm::dyn_cast<const clang::VarDecl>(TargetDecl);

--- a/kythe/cxx/indexer/cxx/GoogleFlagsLibrarySupport.h
+++ b/kythe/cxx/indexer/cxx/GoogleFlagsLibrarySupport.h
@@ -33,8 +33,8 @@ class GoogleFlagsLibrarySupport : public LibrarySupport {
   GoogleFlagsLibrarySupport() {}
 
   /// \brief Emits a google/gflag node if `Decl` is a flag.
-  void InspectVariable(IndexerASTVisitor& V, GraphObserver::NodeId& DeclNodeId,
-                       GraphObserver::NodeId& DeclBodyNodeId,
+  void InspectVariable(IndexerASTVisitor& V,
+                       const GraphObserver::NodeId& DeclNodeId,
                        const clang::VarDecl* Decl,
                        GraphObserver::Completeness Compl,
                        const std::vector<Completion>& Compls) override;
@@ -44,7 +44,7 @@ class GoogleFlagsLibrarySupport : public LibrarySupport {
   void InspectDeclRef(IndexerASTVisitor& V,
                       clang::SourceLocation DeclRefLocation,
                       const GraphObserver::Range& Ref,
-                      GraphObserver::NodeId& RefId,
+                      const GraphObserver::NodeId& RefId,
                       const clang::NamedDecl* TargetDecl) override;
 };
 

--- a/kythe/cxx/indexer/cxx/ImputedConstructorSupport.cc
+++ b/kythe/cxx/indexer/cxx/ImputedConstructorSupport.cc
@@ -151,7 +151,7 @@ ImputedConstructorSupport::ImputedConstructorSupport(
 
 void ImputedConstructorSupport::InspectCallExpr(
     IndexerASTVisitor& visitor, const clang::CallExpr* call_expr,
-    const GraphObserver::Range& range, GraphObserver::NodeId& callee_id) {
+    const GraphObserver::Range& range, const GraphObserver::NodeId& callee_id) {
   const auto* callee = call_expr->getDirectCallee();
   if (callee == nullptr) return;
 

--- a/kythe/cxx/indexer/cxx/ImputedConstructorSupport.h
+++ b/kythe/cxx/indexer/cxx/ImputedConstructorSupport.h
@@ -42,7 +42,7 @@ class ImputedConstructorSupport : public LibrarySupport {
   void InspectCallExpr(IndexerASTVisitor& visitor,
                        const clang::CallExpr* call_expr,
                        const GraphObserver::Range& range,
-                       GraphObserver::NodeId& callee_id) override;
+                       const GraphObserver::NodeId& callee_id) override;
 
  private:
   const std::function<bool(absl::string_view)> allow_constructor_name_;

--- a/kythe/cxx/indexer/cxx/IndexerASTHooks.h
+++ b/kythe/cxx/indexer/cxx/IndexerASTHooks.h
@@ -236,6 +236,7 @@ class IndexerASTVisitor : public RecursiveTypeVisitor<IndexerASTVisitor> {
   bool VisitEnumDecl(const clang::EnumDecl* Decl);
   bool VisitEnumConstantDecl(const clang::EnumConstantDecl* Decl);
   bool VisitFunctionDecl(clang::FunctionDecl* Decl);
+
   bool TraverseDecl(clang::Decl* Decl);
   bool TraverseCXXConstructorDecl(clang::CXXConstructorDecl* CD);
   bool TraverseCXXDefaultInitExpr(const clang::CXXDefaultInitExpr* E);
@@ -855,12 +856,11 @@ class IndexerASTVisitor : public RecursiveTypeVisitor<IndexerASTVisitor> {
   /// Filled on the first call to `getIndexedParents`.
   LazyIndexedParentMap AllParents{[this] { return BuildIndexedParentMap(); }};
 
-  /// Records information about the template `Template` wrapping the node
-  /// `BodyId`, including the edge linking the template and its body. Returns
-  /// the `NodeId` for the dominating template.
+  /// Records information about the template `Template` for the node
+  /// `DeclNode`, including the edges linking the template with its parameters.
   template <typename TemplateDeclish>
-  GraphObserver::NodeId RecordTemplate(
-      const TemplateDeclish* Decl, const GraphObserver::NodeId& BodyDeclNode);
+  void RecordTemplate(const TemplateDeclish* Decl,
+                      const GraphObserver::NodeId& DeclNode);
 
   /// Records information about the generic class by wrapping the node
   /// `BodyId`. Returns the `NodeId` for the dominating generic type.

--- a/kythe/cxx/indexer/cxx/IndexerLibrarySupport.h
+++ b/kythe/cxx/indexer/cxx/IndexerLibrarySupport.h
@@ -42,8 +42,7 @@ class LibrarySupport {
   struct Completion {
     /// The Decl being completed.
     const clang::Decl* Decl;
-    /// The corresponding NodeId. If `Decl` is underneath a template, this will
-    /// point to the `Abs` node of that template.
+    /// The corresponding NodeId.
     GraphObserver::NodeId DeclId;
   };
 
@@ -56,15 +55,12 @@ class LibrarySupport {
   /// meaning.
   ///
   /// \param V The active IndexerASTVisitor.
-  /// \param DeclNodeId If `Decl` is under a template, the `NodeId` of the
-  /// surrounding `Abs`; otherwise, the `NodeId` of the `Decl`.
-  /// \param DeclBodyNodeId The variable's NodeId (not its surrounding Abs)
+  /// \param DeclNodeId The `NodeId` of the `Decl`.
   /// \param Decl The VarDecl in question.
   /// \param Compl Whether the Decl was complete.
   /// \param Compls If the Decl is complete, the decls that it completes.
   virtual void InspectVariable(IndexerASTVisitor& V,
-                               GraphObserver::NodeId& DeclNodeId,
-                               GraphObserver::NodeId& DeclBodyNodeId,
+                               const GraphObserver::NodeId& DeclNodeId,
                                const clang::VarDecl* Decl,
                                GraphObserver::Completeness Compl,
                                const std::vector<Completion>& Compls) {}
@@ -78,7 +74,7 @@ class LibrarySupport {
   virtual void InspectDeclRef(IndexerASTVisitor& V,
                               clang::SourceLocation DeclRefLocation,
                               const GraphObserver::Range& Ref,
-                              GraphObserver::NodeId& RefId,
+                              const GraphObserver::NodeId& RefId,
                               const clang::NamedDecl* TargetDecl) {}
 
   /// \brief Called on any DeclRef. An overload of the above function that
@@ -93,7 +89,7 @@ class LibrarySupport {
   virtual void InspectDeclRef(IndexerASTVisitor& V,
                               clang::SourceLocation DeclRefLocation,
                               const GraphObserver::Range& Ref,
-                              GraphObserver::NodeId& RefId,
+                              const GraphObserver::NodeId& RefId,
                               const clang::NamedDecl* TargetDecl,
                               const clang::Expr* Expr) {
     InspectDeclRef(V, DeclRefLocation, Ref, RefId, TargetDecl);
@@ -107,19 +103,16 @@ class LibrarySupport {
   virtual void InspectCallExpr(IndexerASTVisitor& V,
                                const clang::CallExpr* CallExpr,
                                const GraphObserver::Range& Range,
-                               GraphObserver::NodeId& CalleeId) {}
+                               const GraphObserver::NodeId& CalleeId) {}
 
   /// \brief Called on any FunctionDecl.
   /// \param V The active IndexerASTVisitor.
-  /// \param DeclNodeId If `Decl` is under a template, the `NodeId` of the
-  /// surrounding `Abs`; otherwise, the `NodeId` of the `Decl`.
-  /// \param DeclBodyNodeId The function's NodeId (not its surrounding Abs)
+  /// \param DeclNodeId The `NodeId` of the `Decl`.
   /// \param FunctionDecl The call expr.
   /// \param Compl Whether the Decl was complete.
   /// \param Compls If the Decl is complete, the decls that it completes.
   virtual void InspectFunctionDecl(IndexerASTVisitor& V,
-                                   GraphObserver::NodeId& DeclNodeId,
-                                   GraphObserver::NodeId& DeclBodyNodeId,
+                                   const GraphObserver::NodeId& DeclNodeId,
                                    const clang::FunctionDecl* FunctionDecl,
                                    GraphObserver::Completeness Compl,
                                    const std::vector<Completion>& Compls) {}

--- a/kythe/cxx/indexer/cxx/ProtoLibrarySupport.cc
+++ b/kythe/cxx/indexer/cxx/ProtoLibrarySupport.cc
@@ -336,7 +336,7 @@ bool GoogleProtoLibrarySupport::CompilationUnitHasParseProtoHelperDecl(
 
 void GoogleProtoLibrarySupport::InspectCallExpr(
     IndexerASTVisitor& V, const clang::CallExpr* CallExpr,
-    const GraphObserver::Range& Range, GraphObserver::NodeId& CalleeId) {
+    const GraphObserver::Range& Range, const GraphObserver::NodeId& CalleeId) {
   if (!CompilationUnitHasParseProtoHelperDecl(V.getASTContext(), *CallExpr)) {
     // Return early if there is no ParseProtoHelper in the compilation unit.
     return;

--- a/kythe/cxx/indexer/cxx/ProtoLibrarySupport.h
+++ b/kythe/cxx/indexer/cxx/ProtoLibrarySupport.h
@@ -30,7 +30,7 @@ class GoogleProtoLibrarySupport : public LibrarySupport {
 
   void InspectCallExpr(IndexerASTVisitor& V, const clang::CallExpr* CallExpr,
                        const GraphObserver::Range& Range,
-                       GraphObserver::NodeId& CalleeId) override;
+                       const GraphObserver::NodeId& CalleeId) override;
 
  private:
   // Lazily initializes ParseProtoHelperDecl, and returns true if


### PR DESCRIPTION
Remove some API vestiges from the existence of `abs` nodes.  This will be a breaking change on import for internal users of the plugin API, but should be a straightforward fix. It also corrects some mistakes in the plugin API by passing the NodeId parameters by `const&` instead of non-const.

`abs` delenda est.