### PR TITLE
chore: move the NullGraphObserver token inline and use non-pointer opaque type

### DIFF
--- a/kythe/cxx/indexer/cxx/GraphObserver.h
+++ b/kythe/cxx/indexer/cxx/GraphObserver.h
@@ -111,7 +111,7 @@ class GraphObserver {
     /// token.
     virtual std::string StampIdentity(const std::string& Identity) const = 0;
     /// \brief Returns a value unique to each implementation of `ClaimToken`.
-    virtual void* GetClass() const = 0;
+    virtual uintptr_t GetClass() const = 0;
     /// \brief Checks for equality.
     ///
     /// `ClaimTokens` are only equal if they have the same value for `GetClass`.
@@ -1150,7 +1150,7 @@ class NullGraphObserver : public GraphObserver {
     std::string StampIdentity(const std::string& Identity) const override {
       return Identity;
     }
-    void* GetClass() const override { return &NullClaimTokenClass; }
+    uintptr_t GetClass() const override { return kNullClaimTokenClass; }
     bool operator==(const ClaimToken& RHS) const override {
       return RHS.GetClass() == GetClass();
     }
@@ -1159,7 +1159,8 @@ class NullGraphObserver : public GraphObserver {
     }
 
    private:
-    static void* NullClaimTokenClass;
+    static inline const uintptr_t kNullClaimTokenClass =
+        reinterpret_cast<uintptr_t>(&kNullClaimTokenClass);
   };
 
   NodeId getNodeIdForBuiltinType(llvm::StringRef Spelling) const override {

--- a/kythe/cxx/indexer/cxx/IndexerASTHooks.cc
+++ b/kythe/cxx/indexer/cxx/IndexerASTHooks.cc
@@ -66,6 +66,7 @@ ABSL_FLAG(bool, emit_anchors_on_builtins, true,
           "Emit anchors on builtin types like int and float.");
 
 namespace kythe {
+namespace {
 
 using ::clang::dyn_cast;
 using ::clang::dyn_cast_or_null;
@@ -77,9 +78,6 @@ using ::clang::SourceRange;
 using Claimability = GraphObserver::Claimability;
 using NodeId = GraphObserver::NodeId;
 
-void* NullGraphObserver::NullClaimToken::NullClaimTokenClass = nullptr;
-
-namespace {
 /// Decides whether `Tok` can be used to quote an identifier.
 bool TokenQuotesIdentifier(const clang::SourceManager& SM,
                            const clang::Token& Tok) {

--- a/kythe/cxx/indexer/cxx/KytheGraphObserver.cc
+++ b/kythe/cxx/indexer/cxx/KytheGraphObserver.cc
@@ -1738,7 +1738,4 @@ void KytheGraphObserver::EmitMetaNodes() {
   tapp_body->set_post_text(">");
   EmitNode("tapp", tapp_signature);
 }
-
-void* KytheClaimToken::clazz_ = nullptr;
-
 }  // namespace kythe

--- a/kythe/cxx/indexer/cxx/KytheGraphObserver.h
+++ b/kythe/cxx/indexer/cxx/KytheGraphObserver.h
@@ -64,9 +64,11 @@ class KytheClaimToken : public GraphObserver::ClaimToken {
     return stamped;
   }
 
-  void* GetClass() const override { return &clazz_; }
+  uintptr_t GetClass() const final { return kTokenClass; }
 
-  static bool classof(const ClaimToken* t) { return t->GetClass() == &clazz_; }
+  static bool classof(const ClaimToken* t) {
+    return t->GetClass() == kTokenClass;
+  }
 
   /// \brief Marks a VNameRef as belonging to this token.
   /// This token must outlive the VNameRef.
@@ -125,7 +127,9 @@ class KytheClaimToken : public GraphObserver::ClaimToken {
   }
 
  private:
-  static void* clazz_;
+  static inline const uintptr_t kTokenClass =
+      reinterpret_cast<uintptr_t>(&kTokenClass);
+
   /// The prototypical VName to use for claimed objects.
   kythe::proto::VName vname_;
   bool rough_claimed_ = true;

--- a/kythe/cxx/indexer/cxx/KytheIndexerUnitTest.cc
+++ b/kythe/cxx/indexer/cxx/KytheIndexerUnitTest.cc
@@ -51,7 +51,7 @@ class AnchorMarkTest : public ::testing::Test {
   class EmptyToken : public GraphObserver::ClaimToken {
    public:
     std::string StampIdentity(const std::string&) const override { return ""; }
-    void* GetClass() const override { return nullptr; }
+    uintptr_t GetClass() const override { return 0; }
     bool operator==(const ClaimToken&) const override { return false; }
     bool operator!=(const ClaimToken&) const override { return true; }
   };


### PR DESCRIPTION
Class members should not have their definitions provided by unrelated source files, so move NullGraphObserver::kTokenClaimClass out of IndexerASTHooks.cc and into an inline constant in the class itself.

Change the opaque identifier from being a `void*` (which comes with the usual issues around `const` safety) and use the more suitable `uintptr_t` type.  While these *could* be pointers, they are more reasonably just an opaque nonce.

Finally, move the nonce definition from being the address of the nonce at point-of-use, to doing the same within the definition of the nonce directly to avoid potential mistakes.