### PR TITLE
fix(cxx_indexer): properly handle dependent using decl names 

### DIFF
--- a/kythe/cxx/indexer/cxx/decl_printer.cc
+++ b/kythe/cxx/indexer/cxx/decl_printer.cc
@@ -192,7 +192,9 @@ bool DeclPrinter::PrintDeclarationName(const clang::DeclarationName& name,
       [[fallthrough]];
     case DeclarationName::CXXConstructorName:
       if (const auto type = name.getCXXNameType(); !type.isNull()) {
-        return PrintNamedDecl(*type->getAsCXXRecordDecl(), out);
+        // UnresolvedUsingValueDecl (and potentially others) result in a
+        // non-null QualType, but a null CXXRecordDecl.
+        return PrintName(type->getAsCXXRecordDecl(), out);
       }
       break;
     // These will be given parent-relative identifiers.

--- a/kythe/cxx/indexer/cxx/decl_printer_test.cc
+++ b/kythe/cxx/indexer/cxx/decl_printer_test.cc
@@ -291,5 +291,25 @@ TEST(DeclPrinterTest, AnonymousNamespace) {
   EXPECT_THAT(decl, Pointee(HasQualifiedId(printer, "foo:@#anon")));
 }
 
+TEST(DeclPrinterTest, UnresolvedUsingValueDecl) {
+  using ::clang::ast_matchers::unresolvedUsingValueDecl;
+  constexpr std::string_view code = R"c++(
+    template <typename>
+    struct Base {};
+    template <typename T>
+    struct Child : Base<T> {
+      using Base<T>::Base;
+    };
+  )c++";
+
+  ParsedUnit unit(buildASTFromCode(code, "input.cc"));
+  DeclPrinter printer = unit.CreateDeclPrinter();
+  const auto* decl = FindSingleDeclOrDie<clang::UnresolvedUsingValueDecl>(
+      unresolvedUsingValueDecl(), unit.ast_context());
+
+  EXPECT_THAT(decl,
+              Pointee(HasQualifiedId(printer, MatchesRegex(R"(\d:Child)"))));
+}
+
 }  // namespace
 }  // namespace kythe

--- a/kythe/cxx/indexer/cxx/decl_printer_test.cc
+++ b/kythe/cxx/indexer/cxx/decl_printer_test.cc
@@ -308,7 +308,7 @@ TEST(DeclPrinterTest, UnresolvedUsingValueDecl) {
       unresolvedUsingValueDecl(), unit.ast_context());
 
   EXPECT_THAT(decl,
-              Pointee(HasQualifiedId(printer, MatchesRegex(R"(\d:Child)"))));
+              Pointee(HasQualifiedId(printer, MatchesRegex(R"([0-9]:Child)"))));
 }
 
 }  // namespace


### PR DESCRIPTION
They tell me binding a reference to a null pointer is bad.