### PR TITLE
chore: allow running clang-tidy via an aspect

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -119,16 +119,27 @@ build:prepush --verbose_failures --noshow_loading_progress --noshow_progress
 test:prepush --test_summary=terse --test_output=errors
 test:prepush --test_tag_filters=-manual,-broken,-arc-ignore,-docker
 
-# For clang tidy and related builds, include additional flags for use in compile_commands.json
-build:clang-tidy --features=-layering_check --copt=-Wno-everything --copt=-Wno-error
-build:clang-tidy --copt=-Wdeprecated-declarations --copt=-D_LIBCPP_DISABLE_DEPRECATION_WARNINGS
-build:clang-tidy --copt=-Wdeprecated-register --copt=-Wexpansion-to-defined
-build:clang-tidy --copt=-Wignored-attributes --copt=-Wnon-pod-varargs --copt=-Wshadow-field
-build:clang-tidy --copt=-Wshift-sign-overflow --copt=-Wtautological-undefined-compare
-build:clang-tidy --copt=-Wthread-safety-analysis --copt=-Wthread-safety-beta --copt=-Wthread-safety-reference
-build:clang-tidy --copt=-Wundefined-bool-conversion --copt=-Wunreachable-code --copt=-Wunused-const-variable
-build:clang-tidy --copt=-Wunused-function --copt=-Wunused-lambda-capture --copt=-Wunused-local-typedef
-build:clang-tidy --copt=-Wunused-private-field --copt=-Wuser-defined-warnings
+# Include additional flags for use in compile_commands.json
+build:compile-commands --features=-layering_check --copt=-Wno-everything --copt=-Wno-error
+build:compile-commands --copt=-Wdeprecated-declarations --copt=-D_LIBCPP_DISABLE_DEPRECATION_WARNINGS
+build:compile-commands --copt=-Wdeprecated-register --copt=-Wexpansion-to-defined
+build:compile-commands --copt=-Wignored-attributes --copt=-Wnon-pod-varargs --copt=-Wshadow-field
+build:compile-commands --copt=-Wshift-sign-overflow --copt=-Wtautological-undefined-compare
+build:compile-commands --copt=-Wthread-safety-analysis --copt=-Wthread-safety-beta --copt=-Wthread-safety-reference
+build:compile-commands --copt=-Wundefined-bool-conversion --copt=-Wunreachable-code --copt=-Wunused-const-variable
+build:compile-commands --copt=-Wunused-function --copt=-Wunused-lambda-capture --copt=-Wunused-local-typedef
+build:compile-commands --copt=-Wunused-private-field --copt=-Wuser-defined-warnings
+
+# Applies clang-tidy to targets without building them.
+build:clang-tidy --config=compile-commands
+build:clang-tidy --output_groups=report
+build:clang-tidy --aspects=@bazel_clang_tidy//clang_tidy:clang_tidy.bzl%clang_tidy_aspect
+build:clang-tidy --@bazel_clang_tidy//:clang_tidy_config=//:clang_tidy_config
+
+# Compiles and runs the in-tree clang-tidy over targets.
+build:clang-tidy-from-source --config=clang-tidy
+build:clang-tidy-from-source --noincompatible_disallow_empty_glob
+build:clang-tidy-from-source --@bazel_clang_tidy//:clang_tidy_executable=@llvm-project//clang-tools-extra/clang-tidy
 
 # Support user-provided user.bazelrc
 try-import %workspace%/user.bazelrc

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -69,6 +69,7 @@ Checks: >
   google-runtime-int,
   google-runtime-memset,
   google-runtime-operator,
+  misc-include-cleaner,
   misc-definitions-in-headers,
   misc-static-assert,
   misc-unconventional-assign-operator,
@@ -106,7 +107,6 @@ Checks: >
 
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
-AnalyzeTemporaryDtors: false
 FormatStyle:     file
 CheckOptions:
   - key:             llvm-else-after-return.WarnOnConditionVariables

--- a/BUILD
+++ b/BUILD
@@ -13,6 +13,12 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
+filegroup(
+    name = "clang_tidy_config",
+    srcs = [".clang-tidy"],
+    visibility = ["//visibility:public"],
+)
+
 sh_test(
     name = "check_bazel_versions",
     srcs = ["//tools:check_bazel_versions.sh"],
@@ -93,7 +99,7 @@ refresh_compile_commands(
     # If clangd is complaining about missing headers (and all that goes along with it),
     # and you're using remote builds, rebuild with --remote_download_outputs=all
     # With layering_check enabled, clangd warns about missing dependencies on standard library headers.
-    targets = {"//kythe/cxx/...": "--config=clang-tidy"},
+    targets = {"//kythe/cxx/...": "--config=compile-commands"},
 )
 
 load("@npm//:defs.bzl", "npm_link_all_packages")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -128,3 +128,15 @@ http_archive(
 load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies")
 
 aspect_bazel_lib_dependencies()
+
+# clang-tidy aspect wrapper
+load(
+    "@bazel_tools//tools/build_defs/repo:git.bzl",
+    "git_repository",
+)
+
+git_repository(
+    name = "bazel_clang_tidy",
+    commit = "133d89a6069ce253a92d32a93fdb7db9ef100e9d",
+    remote = "https://github.com/erenon/bazel_clang_tidy.git",
+)

--- a/kythe/cxx/indexer/cxx/decl_printer.cc
+++ b/kythe/cxx/indexer/cxx/decl_printer.cc
@@ -16,7 +16,7 @@
 
 #include "kythe/cxx/indexer/cxx/decl_printer.h"
 
-#include <cstdint>
+#include <cstddef>
 #include <optional>
 #include <string>
 
@@ -72,12 +72,12 @@ void DeclPrinter::PrintQualifiedId(const RootTraversal& path,
                                    llvm::raw_ostream& out) const {
   bool missing_separator = false;
   for (const auto& context : path) {
-    if (clang::isa_and_present<clang::LinkageSpecDecl>(context.decl)) {
+    if (llvm::isa_and_present<clang::LinkageSpecDecl>(context.decl)) {
       // Ignore linkage specification blocks to support C headers that wrap
       // extern "C" in #ifdef __cplusplus.
       continue;
     } else if (missing_separator &&
-               clang::isa_and_present<clang::TemplateDecl>(context.decl)) {
+               llvm::isa_and_present<clang::TemplateDecl>(context.decl)) {
       // We would rather name 'template <etc> class C' as C, not C:C, but
       // we also want to be able to give useful names to templates when they're
       // explicitly requested. Therefore:
@@ -92,7 +92,7 @@ void DeclPrinter::PrintQualifiedId(const RootTraversal& path,
     const std::optional<size_t> index = context.parent_index();
     if (!index.has_value()) {
       if (const auto* named =
-              clang::dyn_cast_or_null<clang::NamedDecl>(context.decl);
+              llvm::dyn_cast_or_null<clang::NamedDecl>(context.decl);
           // Make sure that we don't miss out on implicit nodes.
           named != nullptr && named->isImplicit()) {
         if (!PrintNamedDecl(*named, out)) {
@@ -101,7 +101,7 @@ void DeclPrinter::PrintQualifiedId(const RootTraversal& path,
           // in anonymous parameter declarations that belong to function
           // prototypes.
           const auto* parent =
-              clang::dyn_cast<clang::FunctionDecl>(named->getDeclContext());
+              llvm::dyn_cast<clang::FunctionDecl>(named->getDeclContext());
           if (parent != nullptr) {
             out << FindParameterParentIndex(*parent, *named) << ":";
             // Resume printing parent context from our DeclContext rather than
@@ -135,7 +135,7 @@ void DeclPrinter::PrintQualifiedId(const RootTraversal& path,
 
 bool DeclPrinter::PrintName(const clang::Decl* decl,
                             llvm::raw_ostream& out) const {
-  if (const auto* named = clang::dyn_cast_or_null<clang::NamedDecl>(decl)) {
+  if (const auto* named = llvm::dyn_cast_or_null<clang::NamedDecl>(decl)) {
     return PrintNamedDecl(*named, out);
   }
   return false;
@@ -148,7 +148,7 @@ bool DeclPrinter::PrintNamedDecl(const clang::NamedDecl& decl,
   }
 
   // NamedDecls with empty names, e.g. unnamed namespaces, enums, structs, etc.
-  if (clang::isa<clang::NamespaceDecl>(decl)) {
+  if (llvm::isa<clang::NamespaceDecl>(decl)) {
     // This is an anonymous namespace. We have two cases:
     // If there is any file that is not a textual include (.inc,
     //     or explicitly marked as such in a module) between the declaration
@@ -161,10 +161,10 @@ bool DeclPrinter::PrintNamedDecl(const clang::NamedDecl& decl,
     }
     out << "@#anon";
     return true;
-  } else if (const auto* recdecl = clang::dyn_cast<clang::RecordDecl>(&decl)) {
+  } else if (const auto* recdecl = llvm::dyn_cast<clang::RecordDecl>(&decl)) {
     out << HashToString(hasher().Hash(recdecl));
     return true;
-  } else if (const auto* enumdecl = clang::dyn_cast<clang::EnumDecl>(&decl)) {
+  } else if (const auto* enumdecl = llvm::dyn_cast<clang::EnumDecl>(&decl)) {
     out << HashToString(hasher().Hash(enumdecl));
     return true;
   }

--- a/kythe/cxx/indexer/cxx/decl_printer_test.cc
+++ b/kythe/cxx/indexer/cxx/decl_printer_test.cc
@@ -27,7 +27,6 @@
 #include "clang/AST/DeclCXX.h"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 #include "clang/ASTMatchers/ASTMatchers.h"
-#include "clang/Basic/LangOptions.h"
 #include "clang/Frontend/ASTUnit.h"
 #include "clang/Tooling/Tooling.h"
 #include "gmock/gmock.h"


### PR DESCRIPTION
And then use it to fix the warnings which triggered on the previous import via:
```
bazel build --config=clang-tidy-from-source //kythe/cxx/indexer/cxx:decl_printer{,_test}
```

`--config=clang-tidy` will run the system clang-tidy, so does not work with `--config=remote` (as the build worker lacks a clang-tidy binary).  `--config=clang-tidy-from-source` compiles and runs the copy of clang-tidy which resides in the llvm repository. It's slow, but can be run remotely and will pick up newer checks.