### PR TITLE
chore: apply clang-tidy cleanups under //kythe/cxx/common/

### DIFF
--- a/kythe/cxx/common/BUILD
+++ b/kythe/cxx/common/BUILD
@@ -13,6 +13,7 @@ cc_library(
     hdrs = ["re2_flag.h"],
     deps = [
         "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/strings",
         "@com_googlesource_code_re2//:re2",
     ],
 )
@@ -402,6 +403,7 @@ cc_test(
         "//kythe/testdata/platform:stringset.kzip",
     ],
     deps = [
+        ":index_reader",
         ":kzip_reader",
         ":libzip/error",
         ":testutil",
@@ -412,6 +414,7 @@ cc_test(
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
+        "@org_libzip//:zip",
     ],
 )
 
@@ -498,6 +501,7 @@ cc_test(
         ":kzip_reader",
         ":kzip_writer_c_api",
         ":libzip/error",
+        "//kythe/proto:analysis_cc_proto",
         "//kythe/proto:go_cc_proto",  # Used in stringset.kzip.
         "//third_party:gtest",
         "//third_party:gtest_main",

--- a/kythe/cxx/common/file_utils.cc
+++ b/kythe/cxx/common/file_utils.cc
@@ -16,6 +16,9 @@
 
 #include "file_utils.h"
 
+#include <cstdio>
+#include <string>
+
 #include "absl/log/check.h"
 
 namespace kythe {

--- a/kythe/cxx/common/file_vname_generator.cc
+++ b/kythe/cxx/common/file_vname_generator.cc
@@ -16,14 +16,24 @@
 
 #include "file_vname_generator.h"
 
+#include <algorithm>
+#include <memory>
 #include <optional>
+#include <string>
+#include <utility>
+#include <vector>
 
-#include "absl/log/log.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
 #include "absl/strings/numbers.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_replace.h"
+#include "absl/strings/string_view.h"
+#include "kythe/proto/storage.pb.h"
 #include "rapidjson/document.h"
 #include "rapidjson/error/en.h"
+#include "re2/re2.h"
+#include "re2/stringpiece.h"
 
 namespace kythe {
 namespace {

--- a/kythe/cxx/common/file_vname_generator_test.cc
+++ b/kythe/cxx/common/file_vname_generator_test.cc
@@ -16,8 +16,11 @@
 
 #include "kythe/cxx/common/file_vname_generator.h"
 
+#include <string>
+
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include "kythe/proto/storage.pb.h"
 #include "protobuf-matchers/protocol-buffer-matchers.h"
 
 extern const char kTestFile[];

--- a/kythe/cxx/common/indexing/KytheCachingOutput.cc
+++ b/kythe/cxx/common/indexing/KytheCachingOutput.cc
@@ -16,11 +16,15 @@
 
 #include "kythe/cxx/common/indexing/KytheCachingOutput.h"
 
-#include <algorithm>
-#include <sstream>
+#include <cassert>
+#include <cstddef>
+#include <cstdio>
+#include <string>
 
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
+#include "google/protobuf/io/coded_stream.h"
+#include "kythe/proto/storage.pb.h"
 
 namespace kythe {
 

--- a/kythe/cxx/common/indexing/KytheGraphRecorder.cc
+++ b/kythe/cxx/common/indexing/KytheGraphRecorder.cc
@@ -16,7 +16,13 @@
 
 #include "KytheGraphRecorder.h"
 
-#include "kythe/proto/storage.pb.h"
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "absl/strings/string_view.h"
+#include "kythe/cxx/common/indexing/KytheOutputStream.h"
 
 namespace kythe {
 

--- a/kythe/cxx/common/indexing/MemcachedHashCache.cc
+++ b/kythe/cxx/common/indexing/MemcachedHashCache.cc
@@ -19,6 +19,7 @@
 #include <libmemcached-1.0/memcached.h>
 
 #include <iostream>
+#include <string>
 
 namespace kythe {
 

--- a/kythe/cxx/common/json_proto.cc
+++ b/kythe/cxx/common/json_proto.cc
@@ -16,20 +16,25 @@
 
 #include "json_proto.h"
 
+#include <memory>
+#include <string>
+
 #include "absl/log/check.h"
 #include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
-#include "absl/strings/escaping.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/string_view.h"
+#include "google/protobuf/any.pb.h"
 #include "google/protobuf/io/coded_stream.h"
-#include "google/protobuf/io/zero_copy_stream_impl.h"
 #include "google/protobuf/io/zero_copy_stream_impl_lite.h"
 #include "google/protobuf/message.h"
+#include "google/protobuf/type.pb.h"
 #include "google/protobuf/util/json_util.h"
 #include "google/protobuf/util/type_resolver.h"
 #include "google/protobuf/util/type_resolver_util.h"
 #include "rapidjson/document.h"
-#include "rapidjson/filewritestream.h"
+#include "rapidjson/rapidjson.h"
 #include "rapidjson/stringbuffer.h"
 #include "rapidjson/writer.h"
 

--- a/kythe/cxx/common/json_proto_test.cc
+++ b/kythe/cxx/common/json_proto_test.cc
@@ -16,9 +16,13 @@
 
 #include "json_proto.h"
 
+#include <string>
+
 #include "absl/log/initialize.h"
+#include "google/protobuf/stubs/common.h"
 #include "gtest/gtest.h"
 #include "kythe/proto/analysis.pb.h"
+#include "kythe/proto/storage.pb.h"
 
 namespace kythe {
 namespace {

--- a/kythe/cxx/common/kythe_metadata_file.cc
+++ b/kythe/cxx/common/kythe_metadata_file.cc
@@ -16,10 +16,17 @@
 
 #include "kythe/cxx/common/kythe_metadata_file.h"
 
+#include <cctype>
+#include <cstddef>
+#include <memory>
 #include <optional>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "absl/log/log.h"
 #include "absl/strings/escaping.h"
+#include "absl/strings/string_view.h"
 #include "absl/strings/strip.h"
 #include "google/protobuf/util/json_util.h"
 #include "kythe/cxx/common/json_proto.h"

--- a/kythe/cxx/common/kythe_uri.cc
+++ b/kythe/cxx/common/kythe_uri.cc
@@ -16,10 +16,15 @@
 
 #include "kythe/cxx/common/kythe_uri.h"
 
+#include <cstddef>
+#include <string>
 #include <utility>
 
+#include "absl/strings/match.h"
 #include "absl/strings/str_split.h"
+#include "absl/strings/string_view.h"
 #include "kythe/cxx/common/path_utils.h"
+#include "kythe/proto/storage.pb.h"
 
 namespace kythe {
 namespace {

--- a/kythe/cxx/common/kythe_uri_test.cc
+++ b/kythe/cxx/common/kythe_uri_test.cc
@@ -16,11 +16,13 @@
 
 #include "kythe/cxx/common/kythe_uri.h"
 
+#include <string>
+
 #include "absl/log/initialize.h"
-#include "absl/log/log.h"
 #include "gmock/gmock.h"
+#include "google/protobuf/stubs/common.h"
 #include "gtest/gtest.h"
-#include "kythe/cxx/common/vname_ordering.h"
+#include "kythe/proto/storage.pb.h"
 #include "protobuf-matchers/protocol-buffer-matchers.h"
 
 namespace kythe {
@@ -67,7 +69,7 @@ struct MakeURI {
 
   URI uri() const { return URI(v_name()); }
 
-  operator URI() const { return URI(v_name()); }
+  operator URI() const { return URI(v_name()); }  // NOLINT
 };
 
 TEST(KytheUri, Parse) {

--- a/kythe/cxx/common/kzip_reader.cc
+++ b/kythe/cxx/common/kzip_reader.cc
@@ -16,25 +16,33 @@
 
 #include "kythe/cxx/common/kzip_reader.h"
 
-#include <openssl/sha.h>
+#include <zip.h>
+#include <zipconf.h>
 
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <iterator>
+#include <memory>
 #include <optional>
 #include <set>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "absl/log/check.h"
 #include "absl/log/log.h"
 #include "absl/memory/memory.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
-#include "absl/strings/escaping.h"
-#include "absl/strings/match.h"
 #include "absl/strings/str_cat.h"
-#include "absl/strings/str_split.h"
 #include "absl/strings/string_view.h"
 #include "absl/strings/strip.h"
 #include "google/protobuf/io/zero_copy_stream.h"
-#include "google/protobuf/io/zero_copy_stream_impl.h"
+#include "google/protobuf/io/zero_copy_stream_impl_lite.h"
+#include "kythe/cxx/common/index_reader.h"
 #include "kythe/cxx/common/json_proto.h"
+#include "kythe/cxx/common/kzip_encoding.h"
 #include "kythe/cxx/common/libzip/error.h"
 #include "kythe/proto/analysis.pb.h"
 

--- a/kythe/cxx/common/kzip_reader_test.cc
+++ b/kythe/cxx/common/kzip_reader_test.cc
@@ -16,6 +16,9 @@
 
 #include "kythe/cxx/common/kzip_reader.h"
 
+#include <zip.h>
+#include <zipconf.h>
+
 #include <functional>
 #include <string>
 
@@ -26,6 +29,7 @@
 #include "absl/strings/string_view.h"
 #include "absl/strings/strip.h"
 #include "gtest/gtest.h"
+#include "kythe/cxx/common/index_reader.h"
 #include "kythe/cxx/common/libzip/error.h"
 #include "kythe/cxx/common/testutil.h"
 #include "kythe/proto/go.pb.h"

--- a/kythe/cxx/common/kzip_writer.cc
+++ b/kythe/cxx/common/kzip_writer.cc
@@ -17,10 +17,13 @@
 #include "kythe/cxx/common/kzip_writer.h"
 
 #include <openssl/sha.h>
+#include <zip.h>
 
 #include <array>
+#include <cstdlib>
+#include <ctime>
 #include <string>
-#include <tuple>
+#include <type_traits>
 #include <vector>
 
 #include "absl/log/check.h"
@@ -30,6 +33,9 @@
 #include "absl/status/statusor.h"
 #include "absl/strings/ascii.h"
 #include "absl/strings/escaping.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/string_view.h"
+#include "kythe/cxx/common/index_writer.h"
 #include "kythe/cxx/common/json_proto.h"
 #include "kythe/cxx/common/kzip_encoding.h"
 #include "kythe/cxx/common/libzip/error.h"

--- a/kythe/cxx/common/kzip_writer_c_api.cc
+++ b/kythe/cxx/common/kzip_writer_c_api.cc
@@ -19,12 +19,17 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include <cstring>
+#include <string>
+#include <utility>
+
 #include "absl/log/check.h"
 #include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
 #include "kythe/cxx/common/index_writer.h"
+#include "kythe/cxx/common/kzip_encoding.h"
 #include "kythe/cxx/common/kzip_writer.h"
 #include "kythe/proto/analysis.pb.h"
 

--- a/kythe/cxx/common/kzip_writer_c_api_test.cc
+++ b/kythe/cxx/common/kzip_writer_c_api_test.cc
@@ -18,21 +18,21 @@
 
 #include <zip.h>
 
+#include <cstdint>
 #include <cstdlib>
-#include <unordered_map>
-#include <unordered_set>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
 
-#include "absl/log/log.h"
-#include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_replace.h"
 #include "absl/strings/string_view.h"
 #include "absl/strings/strip.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-#include "kythe/cxx/common/kzip_reader.h"
 #include "kythe/cxx/common/libzip/error.h"
-#include "kythe/proto/go.pb.h"
+#include "kythe/proto/analysis.pb.h"
 
 namespace kythe {
 namespace {

--- a/kythe/cxx/common/libzip/error.cc
+++ b/kythe/cxx/common/libzip/error.cc
@@ -16,6 +16,8 @@
 
 #include "kythe/cxx/common/libzip/error.h"
 
+#include <zip.h>
+
 #include "absl/status/status.h"
 #include "kythe/cxx/common/status.h"
 

--- a/kythe/cxx/common/net_client.cc
+++ b/kythe/cxx/common/net_client.cc
@@ -17,11 +17,19 @@
 #include "kythe/cxx/common/net_client.h"
 
 #include <curl/curl.h>
+#include <curl/easy.h>
+#include <rapidjson/document.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstring>
+#include <string>
 
 #include "absl/log/check.h"
 #include "absl/log/log.h"
 #include "google/protobuf/io/coded_stream.h"
-#include "google/protobuf/io/zero_copy_stream_impl.h"
+#include "google/protobuf/io/zero_copy_stream_impl_lite.h"
+#include "google/protobuf/message.h"
 #include "kythe/cxx/common/json_proto.h"
 #include "rapidjson/error/en.h"
 #include "rapidjson/stringbuffer.h"

--- a/kythe/cxx/common/net_client_test.cc
+++ b/kythe/cxx/common/net_client_test.cc
@@ -23,9 +23,7 @@
 #include "absl/flags/parse.h"
 #include "absl/log/check.h"
 #include "absl/log/initialize.h"
-#include "absl/log/log.h"
-#include "absl/memory/memory.h"
-#include "kythe/cxx/common/json_proto.h"
+#include "google/protobuf/stubs/common.h"
 #include "kythe/proto/common.pb.h"
 #include "kythe/proto/graph.pb.h"
 

--- a/kythe/cxx/common/path_utils_test.cc
+++ b/kythe/cxx/common/path_utils_test.cc
@@ -17,10 +17,14 @@
 #include "kythe/cxx/common/path_utils.h"
 
 #include <stdio.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
+#include <algorithm>
+#include <cerrno>
 #include <string>
 #include <system_error>
+#include <vector>
 
 #include "absl/log/check.h"
 #include "absl/status/status.h"

--- a/kythe/cxx/common/protobuf_metadata_file.cc
+++ b/kythe/cxx/common/protobuf_metadata_file.cc
@@ -16,15 +16,17 @@
 
 #include "kythe/cxx/common/protobuf_metadata_file.h"
 
-#include <sstream>
+#include <memory>
+#include <string>
+#include <vector>
 
 #include "absl/log/log.h"
 #include "absl/strings/match.h"
+#include "absl/strings/string_view.h"
 #include "google/protobuf/descriptor.pb.h"
-#include "google/protobuf/io/zero_copy_stream.h"
-#include "google/protobuf/io/zero_copy_stream_impl.h"
+#include "kythe/cxx/common/kythe_metadata_file.h"
 #include "kythe/cxx/common/schema/edges.h"
-#include "kythe/cxx/common/vname_ordering.h"
+#include "kythe/proto/storage.pb.h"
 
 namespace kythe {
 proto::VName ProtobufMetadataSupport::VNameForAnnotation(

--- a/kythe/cxx/common/re2_flag.cc
+++ b/kythe/cxx/common/re2_flag.cc
@@ -16,6 +16,13 @@
 
 #include "kythe/cxx/common/re2_flag.h"
 
+#include <memory>
+#include <string>
+
+#include "absl/strings/string_view.h"
+#include "re2/re2.h"
+#include "re2/stringpiece.h"
+
 namespace kythe {
 bool AbslParseFlag(absl::string_view text, RE2Flag* value, std::string* error) {
   if (text.empty()) {

--- a/kythe/cxx/common/regex.cc
+++ b/kythe/cxx/common/regex.cc
@@ -17,6 +17,8 @@
 #include "kythe/cxx/common/regex.h"
 
 #include <memory>
+#include <utility>
+#include <vector>
 
 #include "absl/log/check.h"
 #include "absl/log/log.h"

--- a/kythe/cxx/common/regex_test.cc
+++ b/kythe/cxx/common/regex_test.cc
@@ -15,6 +15,8 @@
  */
 #include "kythe/cxx/common/regex.h"
 
+#include <utility>
+
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "re2/re2.h"

--- a/kythe/cxx/common/scope_guard_test.cc
+++ b/kythe/cxx/common/scope_guard_test.cc
@@ -16,6 +16,7 @@
 
 #include "kythe/cxx/common/scope_guard.h"
 
+#include <string>
 #include <vector>
 
 #include "gtest/gtest.h"

--- a/kythe/cxx/common/sha256_hasher.cc
+++ b/kythe/cxx/common/sha256_hasher.cc
@@ -21,10 +21,9 @@
 #include <array>
 #include <cstddef>
 #include <string>
+#include <utility>
 
 #include "absl/strings/escaping.h"
-#include "absl/strings/string_view.h"
-#include "absl/types/span.h"
 
 namespace kythe {
 Sha256Hasher::Sha256Hasher() { ::SHA256_Init(&context_); }

--- a/kythe/cxx/common/status.cc
+++ b/kythe/cxx/common/status.cc
@@ -18,6 +18,8 @@
 
 #include <errno.h>
 
+#include <cstring>
+
 #include "absl/status/status.h"
 
 namespace kythe {

--- a/kythe/cxx/common/testutil.cc
+++ b/kythe/cxx/common/testutil.cc
@@ -15,9 +15,8 @@
  */
 #include "kythe/cxx/common/testutil.h"
 
-#include <unistd.h>
-
 #include <cstdlib>
+#include <string>
 
 #include "absl/log/die_if_null.h"
 #include "absl/strings/str_cat.h"

--- a/kythe/cxx/common/utf8_line_index.cc
+++ b/kythe/cxx/common/utf8_line_index.cc
@@ -16,6 +16,7 @@
 
 #include "kythe/cxx/common/utf8_line_index.h"
 
+#include <cstdint>
 #include <ostream>
 
 #include "absl/algorithm/container.h"
@@ -99,7 +100,7 @@ CharacterPosition UTF8LineIndex::ComputePositionForByteOffset(
     position.character_number =
         line_begin_character_offset + position.column_number;
   } else if (byte_offset == content_.size()) {
-    // TODO: see if we can unify this with the previous case
+    // TODO(unknown): see if we can unify this with the previous case
     // in a less ugly manner.
     position = ComputePositionForByteOffset(byte_offset - 1);
     // For the past-the-end position, we want it to be on the same line as

--- a/kythe/cxx/common/utf8_line_index_test.cc
+++ b/kythe/cxx/common/utf8_line_index_test.cc
@@ -17,9 +17,10 @@
 #include "kythe/cxx/common/utf8_line_index.h"
 
 #include <algorithm>
+#include <cstring>
+#include <string>
 
 #include "absl/log/check.h"
-#include "absl/log/log.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
 #include "gtest/gtest.h"


### PR DESCRIPTION
This cleans up some headers which will make clang-tidy crabby in the future.