### PR TITLE
chore: convert re2::StringPiece to absl::string_view

### DIFF
--- a/kythe/cxx/common/file_vname_generator.cc
+++ b/kythe/cxx/common/file_vname_generator.cc
@@ -33,7 +33,6 @@
 #include "rapidjson/document.h"
 #include "rapidjson/error/en.h"
 #include "re2/re2.h"
-#include "re2/stringpiece.h"
 
 namespace kythe {
 namespace {
@@ -46,9 +45,9 @@ std::string EscapeBackslashes(absl::string_view value) {
 
 std::optional<absl::string_view> FindMatch(absl::string_view text,
                                            const RE2& pattern) {
-  re2::StringPiece match;
+  absl::string_view match;
   if (pattern.Match(text, 0, text.size(), RE2::UNANCHORED, &match, 1)) {
-    return absl::string_view(match.data(), match.size());
+    return match;
   }
   return std::nullopt;
 }
@@ -102,7 +101,7 @@ absl::StatusOr<std::string> ParseTemplateMember(const RE2& pattern,
 kythe::proto::VName FileVNameGenerator::LookupBaseVName(
     absl::string_view path) const {
   for (const auto& rule : rules_) {
-    std::vector<re2::StringPiece> captures(
+    std::vector<absl::string_view> captures(
         1 +
         std::max({RE2::MaxSubmatch(rule.corpus), RE2::MaxSubmatch(rule.root),
                   RE2::MaxSubmatch(rule.path)}));
@@ -131,7 +130,7 @@ kythe::proto::VName FileVNameGenerator::LookupVName(
     absl::string_view path) const {
   kythe::proto::VName vname = LookupBaseVName(path);
   if (vname.path().empty()) {
-    vname.set_path(path.data(), path.size());
+    vname.set_path(path);
   }
   return vname;
 }

--- a/kythe/cxx/common/re2_flag.cc
+++ b/kythe/cxx/common/re2_flag.cc
@@ -21,7 +21,6 @@
 
 #include "absl/strings/string_view.h"
 #include "re2/re2.h"
-#include "re2/stringpiece.h"
 
 namespace kythe {
 bool AbslParseFlag(absl::string_view text, RE2Flag* value, std::string* error) {
@@ -30,8 +29,7 @@ bool AbslParseFlag(absl::string_view text, RE2Flag* value, std::string* error) {
   }
   re2::RE2::Options options;
   options.set_never_capture(true);
-  *value = {std::make_shared<re2::RE2>(
-      re2::StringPiece{text.data(), text.size()}, options)};
+  *value = {std::make_shared<re2::RE2>(text, options)};
   if (!value->value->ok()) {
     *error = value->value->error();
   }

--- a/kythe/cxx/verifier/assertions.cc
+++ b/kythe/cxx/verifier/assertions.cc
@@ -16,9 +16,8 @@
 
 #include "assertions.h"
 
-#include <sstream>
-
 #include "absl/strings/str_cat.h"
+#include "absl/strings/string_view.h"
 #include "kythe/cxx/common/file_utils.h"
 #include "verifier.h"
 
@@ -518,10 +517,10 @@ void AssertionParser::ScanBeginString(const RE2& goal_comment_regex,
   std::string yy_buf;
   size_t next_line_begin = 0;
   auto append_line = [&](size_t line_end) {
-    re2::StringPiece match_region;
+    absl::string_view match_region;
     size_t line_length = line_end - next_line_begin;
     auto is_goal = RE2::FullMatch(
-        re2::StringPiece(data.data() + next_line_begin, line_length),
+        absl::string_view(data.data() + next_line_begin, line_length),
         goal_comment_regex, &match_region);
     if (is_goal == 1) {
       yy_buf.push_back('-');


### PR DESCRIPTION
`re2::StringPiece` is just an alias for `absl::string_view` these days.