### PR TITLE
fix(cxx_extractor): fix cc proto_lang_toolchain

### DIFF
--- a/kythe/extractors/BUILD
+++ b/kythe/extractors/BUILD
@@ -37,23 +37,9 @@ java_library(
 # --proto_toolchain_for_cc=@io_kythe//kythe/extractors:cc_proto_toolchain
 proto_lang_toolchain(
     name = "cc_proto_toolchain",
-    blacklisted_protos = [
-        "@com_google_protobuf//:any_proto",
-        "@com_google_protobuf//:api_proto",
-        "@com_google_protobuf//:compiler_plugin_proto",
-        "@com_google_protobuf//:descriptor_proto",
-        "@com_google_protobuf//:duration_proto",
-        "@com_google_protobuf//:empty_proto",
-        "@com_google_protobuf//:field_mask_proto",
-        "@com_google_protobuf//:source_context_proto",
-        "@com_google_protobuf//:struct_proto",
-        "@com_google_protobuf//:timestamp_proto",
-        "@com_google_protobuf//:type_proto",
-        "@com_google_protobuf//:wrappers_proto",
-    ],
     command_line = "--PLUGIN_C++_out=:$(OUT)",
     plugin = "//kythe/cxx/tools:proto_metadata_plugin",
-    runtime = "@com_google_protobuf//:protobuf",
+    runtime = "@com_google_protobuf//:protobuf_nowkt",
 )
 
 # Alternatively, if the plugin doesn't work you can use the default code generator
@@ -64,22 +50,8 @@ proto_lang_toolchain(
 #   --cc_proto_library_header_suffixes=.pb.h,.pb.h.meta
 proto_lang_toolchain(
     name = "cc_native_proto_toolchain",
-    blacklisted_protos = [
-        "@com_google_protobuf//:any_proto",
-        "@com_google_protobuf//:api_proto",
-        "@com_google_protobuf//:compiler_plugin_proto",
-        "@com_google_protobuf//:descriptor_proto",
-        "@com_google_protobuf//:duration_proto",
-        "@com_google_protobuf//:empty_proto",
-        "@com_google_protobuf//:field_mask_proto",
-        "@com_google_protobuf//:source_context_proto",
-        "@com_google_protobuf//:struct_proto",
-        "@com_google_protobuf//:timestamp_proto",
-        "@com_google_protobuf//:type_proto",
-        "@com_google_protobuf//:wrappers_proto",
-    ],
     command_line = "--cpp_out=annotate_headers,annotation_pragma_name=kythe_metadata,annotation_guard_name=KYTHE_IS_RUNNING:$(OUT)",
-    runtime = "@com_google_protobuf//:protobuf",
+    runtime = "@com_google_protobuf//:protobuf_nowkt",
 )
 
 extractor_action(

--- a/kythe/release/release.BUILD
+++ b/kythe/release/release.BUILD
@@ -64,20 +64,6 @@ java_library(
 # cross-language metadata file generation.
 proto_lang_toolchain(
     name = "cc_proto_toolchain",
-    blacklisted_protos = [
-        "@com_google_protobuf//:any_proto",
-        "@com_google_protobuf//:api_proto",
-        "@com_google_protobuf//:compiler_plugin_proto",
-        "@com_google_protobuf//:descriptor_proto",
-        "@com_google_protobuf//:duration_proto",
-        "@com_google_protobuf//:empty_proto",
-        "@com_google_protobuf//:field_mask_proto",
-        "@com_google_protobuf//:source_context_proto",
-        "@com_google_protobuf//:struct_proto",
-        "@com_google_protobuf//:timestamp_proto",
-        "@com_google_protobuf//:type_proto",
-        "@com_google_protobuf//:wrappers_proto",
-    ],
     command_line = "--$(PLUGIN_OUT)=:$(OUT)",
     plugin = ":cc_proto_metadata_plugin",
     runtime = "@com_google_protobuf//:protobuf",
@@ -91,20 +77,6 @@ proto_lang_toolchain(
 #   --cc_proto_library_header_suffixes=.pb.h,.pb.h.meta
 proto_lang_toolchain(
     name = "cc_native_proto_toolchain",
-    blacklisted_protos = [
-        "@com_google_protobuf//:any_proto",
-        "@com_google_protobuf//:api_proto",
-        "@com_google_protobuf//:compiler_plugin_proto",
-        "@com_google_protobuf//:descriptor_proto",
-        "@com_google_protobuf//:duration_proto",
-        "@com_google_protobuf//:empty_proto",
-        "@com_google_protobuf//:field_mask_proto",
-        "@com_google_protobuf//:source_context_proto",
-        "@com_google_protobuf//:struct_proto",
-        "@com_google_protobuf//:timestamp_proto",
-        "@com_google_protobuf//:type_proto",
-        "@com_google_protobuf//:wrappers_proto",
-    ],
     command_line = "--cpp_out=annotate_headers,annotation_pragma_name=kythe_metadata,annotation_guard_name=KYTHE_IS_RUNNING:$(OUT)",
     runtime = "@com_google_protobuf//:protobuf",
 )

--- a/setup.bzl
+++ b/setup.bzl
@@ -200,6 +200,9 @@ def kythe_rule_repositories():
             # Use the rules_rust provided proto plugin, rather than the native one
             # which hijacks the --rust_out command line and is incompatible.
             "//third_party:protobuf-no-rust.patch",
+            # Patch https://github.com/protocolbuffers/protobuf/commit/5b6c2459b57c23669d6efc5a14a874c693004eec
+            # until it gets included in a release.
+            "//third_party:protobuf-nowkt.patch",
         ],
         patch_args = [
             "-p1",

--- a/third_party/protobuf-nowkt.patch
+++ b/third_party/protobuf-nowkt.patch
@@ -1,0 +1,31 @@
+From 5b6c2459b57c23669d6efc5a14a874c693004eec Mon Sep 17 00:00:00 2001
+From: Protobuf Team Bot <protobuf-github-bot@google.com>
+Date: Thu, 14 Sep 2023 12:04:25 -0700
+Subject: [PATCH] Expose alias to protobuf_nowkt runtime
+
+This will allow users such as Kythe to use the same runtime as the default toolchain in their own proto_lang_toolchain definitions.
+
+PiperOrigin-RevId: 565438071
+---
+ BUILD.bazel | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/BUILD.bazel b/BUILD.bazel
+index 88a19996826..492b750c8a3 100644
+--- a/BUILD.bazel
++++ b/BUILD.bazel
+@@ -198,6 +198,14 @@ cc_binary(
+ # C++ runtime
+ ################################################################################
+
++# Expose the runtime for the proto_lang_toolchain so that it can also be used in
++# a user-defined proto_lang_toolchain.
++alias(
++  name = "protobuf_nowkt",
++  actual = "//src/google/protobuf:protobuf_nowkt",
++  visibility = ["//visibility:public"],
++)
++
+ # The "lite" runtime works for .proto files that specify the option:
+ #     optimize_for = LITE_RUNTIME;
+ #


### PR DESCRIPTION
This PR adds a patch for the protobuf repository that includes the changes from https://github.com/protocolbuffers/protobuf/commit/5b6c2459b57c23669d6efc5a14a874c693004eec to expose `protobuf_nowkt` and updates the `proto_lang_toolchain` for the C++ protobuf toolchain to work with newer versions of protobuf. This will fix issues with extracting the Kythe GitHub repo once a new version of the bazel-extractor Docker container is built with this change included.