### PR TITLE
fix(java_indexer): use extant JDK21 shim in one more place

### DIFF
--- a/kythe/java/com/google/devtools/kythe/platform/java/helpers/JCTreeScanner.java
+++ b/kythe/java/com/google/devtools/kythe/platform/java/helpers/JCTreeScanner.java
@@ -223,7 +223,7 @@ public class JCTreeScanner<R, P> extends SimpleTreeVisitor<R, P> {
   }
 
   public R visitImport(JCImport tree, P p) {
-    return scan(tree.qualid, p);
+    return scan(shims.getQualifiedIdentifier(tree), p);
   }
 
   @Override

--- a/setup.bzl
+++ b/setup.bzl
@@ -321,8 +321,8 @@ def remote_jdk21_repos():
         name = "remotejdk21_linux",
         os = "linux",
         cpu = "x86_64",
-        version = "21.28.85-ca-jre21.0.0",
-        sha256 = "283ed539e0fb8ae9b53de3e949e7d7e29100c05d1128a5b280b10aef44591430",
+        version = "21.28.85-ca-jdk21.0.0",
+        sha256 = "0c0eadfbdc47a7ca64aeab51b9c061f71b6e4d25d2d87674512e9b6387e9e3a6",
     )
 
     maybe(
@@ -330,7 +330,7 @@ def remote_jdk21_repos():
         name = "remotejdk21_macos",
         os = "macos",
         cpu = "x86_64",
-        version = "21.28.85-ca-jre21.0.0",
+        version = "21.28.85-ca-jdk21.0.0",
     )
 
     maybe(
@@ -338,7 +338,7 @@ def remote_jdk21_repos():
         name = "remotejdk21_macos_aarch64",
         os = "macos",
         cpu = "aarch64",
-        version = "21.28.85-ca-jre21.0.0",
+        version = "21.28.85-ca-jdk21.0.0",
     )
 
     maybe(
@@ -346,5 +346,5 @@ def remote_jdk21_repos():
         name = "remotejdk21_win",
         os = "windows",
         cpu = "x86_64",
-        version = "21.28.85-ca-jre21.0.0",
+        version = "21.28.85-ca-jdk21.0.0",
     )


### PR DESCRIPTION
Note: I can't actually test this with JDK21 as Turbine still barfs (https://github.com/bazelbuild/bazel/issues/18743)

It's possible we "just" need to update rules_java, but I'm running into issues with ErrorProne in attempting that 🤷, so will do so in a future PR.