### PR TITLE
chore(cxx_common): update LLVM w/ concomitant FileEntryRef migration

### DIFF
--- a/kythe/cxx/extractor/cxx_extractor.cc
+++ b/kythe/cxx/extractor/cxx_extractor.cc
@@ -399,7 +399,7 @@ class ExtractorPPCallbacks : public clang::PPCallbacks {
 
   /// \brief Records the content of `file` (with spelled path `path`)
   /// if it has not already been recorded.
-  std::string AddFile(const clang::FileEntry* file, llvm::StringRef path);
+  std::string AddFile(clang::FileEntryRef file, llvm::StringRef path);
 
   /// \brief Records the content of `file` if it has not already been recorded.
   std::string AddFile(clang::FileEntryRef file, llvm::StringRef file_name,
@@ -509,7 +509,7 @@ class ExtractorPPCallbacks : public clang::PPCallbacks {
 
  private:
   /// \brief Returns the main file for this compile action.
-  const clang::FileEntry* GetMainFile();
+  clang::OptionalFileEntryRef GetMainFile();
 
   /// \brief Return the active `RunningHash` for preprocessor events.
   RunningHash* history();
@@ -525,7 +525,7 @@ class ExtractorPPCallbacks : public clang::PPCallbacks {
   /// \param file The file entry of the main source file.
   /// \param path The path as known to Clang.
   /// \return The path that should be used to generate VNames.
-  std::string FixStdinPath(const clang::FileEntry* file, llvm::StringRef path);
+  std::string FixStdinPath(clang::FileEntryRef file, llvm::StringRef path);
 
   /// The `SourceManager` used for the compilation.
   clang::SourceManager* source_manager_;
@@ -601,7 +601,7 @@ void ExtractorPPCallbacks::FileChanged(
     clang::SrcMgr::CharacteristicKind /*FileType*/, clang::FileID /*PrevFID*/) {
   if (Reason == EnterFile) {
     if (last_inclusion_directive_path_.empty()) {
-      if (auto* mfile = GetMainFile()) {
+      if (clang::OptionalFileEntryRef mfile = GetMainFile()) {
         current_files_.push(FileState{NormalizePath(mfile->getName()),
                                       ClaimDirective::AlwaysClaim});
       } else {
@@ -670,13 +670,13 @@ PreprocessorTranscript ExtractorPPCallbacks::PopFile() {
 }
 
 void ExtractorPPCallbacks::EndOfMainFile() {
-  if (auto* mfile = GetMainFile()) {
-    *main_source_file_ = AddFile(mfile, mfile->getName());
+  if (clang::OptionalFileEntryRef mfile = GetMainFile()) {
+    *main_source_file_ = AddFile(*mfile, mfile->getName());
     *main_source_file_transcript_ = PopFile();
   }
 }
 
-std::string ExtractorPPCallbacks::FixStdinPath(const clang::FileEntry* file,
+std::string ExtractorPPCallbacks::FixStdinPath(clang::FileEntryRef file,
                                                llvm::StringRef path) {
   if (IsStdinPath(path)) {
     if (main_source_file_stdin_alternate_->empty()) {
@@ -691,7 +691,7 @@ std::string ExtractorPPCallbacks::FixStdinPath(const clang::FileEntry* file,
   return std::string(path);
 }
 
-std::string ExtractorPPCallbacks::AddFile(const clang::FileEntry* file,
+std::string ExtractorPPCallbacks::AddFile(clang::FileEntryRef file,
                                           llvm::StringRef path) {
   auto [iter, inserted] =
       source_files_->insert({NormalizePath(path), SourceFile{""}});
@@ -762,11 +762,11 @@ void ExtractorPPCallbacks::RecordSpecificLocation(clang::SourceLocation loc) {
       source_manager_->getFileID(loc) != preprocessor_->getPredefinesFileID()) {
     history()->Update(source_manager_->getFileOffset(loc));
     const auto filename_ref = source_manager_->getFilename(loc);
-    const auto* file_ref =
-        source_manager_->getFileEntryForID(source_manager_->getFileID(loc));
+    const clang::OptionalFileEntryRef file_ref =
+        source_manager_->getFileEntryRefForID(source_manager_->getFileID(loc));
     if (file_ref) {
       auto vname =
-          index_writer_->VNameForPath(FixStdinPath(file_ref, filename_ref));
+          index_writer_->VNameForPath(FixStdinPath(*file_ref, filename_ref));
       history()->Update(vname.signature());
       history()->Update(vname.corpus());
       history()->Update(vname.root());
@@ -968,8 +968,9 @@ std::string ExtractorPPCallbacks::AddFile(clang::FileEntryRef file,
   return AddFile(file, out_name);
 }
 
-const clang::FileEntry* ExtractorPPCallbacks::GetMainFile() {
-  return source_manager_->getFileEntryForID(source_manager_->getMainFileID());
+clang::OptionalFileEntryRef ExtractorPPCallbacks::GetMainFile() {
+  return source_manager_->getFileEntryRefForID(
+      source_manager_->getMainFileID());
 }
 
 RunningHash* ExtractorPPCallbacks::history() {

--- a/kythe/cxx/extractor/path_utils.cc
+++ b/kythe/cxx/extractor/path_utils.cc
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-#include "path_utils.h"
+#include "kythe/cxx/extractor/path_utils.h"
 
 #include <cstdio>
+#include <optional>
 
 #include "absl/strings/str_format.h"
 #include "clang/Basic/FileEntry.h"
@@ -31,17 +32,17 @@
 namespace kythe {
 namespace cxx_extractor {
 
-const clang::FileEntry* LookupFileForIncludePragma(
+clang::OptionalFileEntryRef LookupFileForIncludePragma(
     clang::Preprocessor* preprocessor, llvm::SmallVectorImpl<char>* search_path,
     llvm::SmallVectorImpl<char>* relative_path,
     llvm::SmallVectorImpl<char>* result_filename) {
   clang::Token filename_token;
   if (preprocessor->LexHeaderName(filename_token)) {
-    return nullptr;
+    return std::nullopt;
   }
   if (!filename_token.isOneOf(clang::tok::header_name,
                               clang::tok::string_literal)) {
-    return nullptr;
+    return std::nullopt;
   }
   llvm::SmallString<128> filename_buffer;
   llvm::StringRef filename =
@@ -50,7 +51,7 @@ const clang::FileEntry* LookupFileForIncludePragma(
       filename_token.getLocation(), filename);
   if (filename.empty()) {
     preprocessor->DiscardUntilEndOfDirective();
-    return nullptr;
+    return std::nullopt;
   }
   preprocessor->CheckEndOfDirective("pragma", true);
   if (preprocessor->getHeaderSearchInfo().HasIncludeAliasMap()) {
@@ -80,9 +81,8 @@ const clang::FileEntry* LookupFileForIncludePragma(
       nullptr /* IsFrameworkFound */, false /* SkipCache */);
   if (!file) {
     absl::FPrintF(stderr, "Missing required file %s.\n", filename.str());
-    return nullptr;
   }
-  return &file->getFileEntry();
+  return file;
 }
 
 }  // namespace cxx_extractor

--- a/kythe/cxx/extractor/path_utils.h
+++ b/kythe/cxx/extractor/path_utils.h
@@ -19,6 +19,7 @@
 
 #include <string>
 
+#include "clang/Basic/FileEntry.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringRef.h"
 
@@ -36,7 +37,7 @@ namespace cxx_extractor {
 /// \param relative_path The path to the file, relative to search_path.
 /// \param filename The filename used to consult the filesystem.
 /// \return The FileEntry we found or null if we didn't find one.
-const clang::FileEntry* LookupFileForIncludePragma(
+clang::OptionalFileEntryRef LookupFileForIncludePragma(
     clang::Preprocessor* preprocessor, llvm::SmallVectorImpl<char>* search_path,
     llvm::SmallVectorImpl<char>* relative_path,
     llvm::SmallVectorImpl<char>* filename);

--- a/kythe/cxx/indexer/cxx/GraphObserver.h
+++ b/kythe/cxx/indexer/cxx/GraphObserver.h
@@ -333,9 +333,9 @@ class GraphObserver {
   /// \param SearchString if non-empty, is used to locate a C-style comment
   /// inside `FE` that contains metadata.
   /// \param TargetFile the file to which the metadata is being applied.
-  virtual void applyMetadataFile(clang::FileID ID, const clang::FileEntry* FE,
+  virtual void applyMetadataFile(clang::FileID ID, clang::FileEntryRef FE,
                                  const std::string& SearchString,
-                                 const clang::FileEntry* TargetFile) {}
+                                 clang::FileEntryRef TargetFile) {}
 
   /// \param LO the language options in use.
   virtual void setLangOptions(const clang::LangOptions* LO) {
@@ -948,7 +948,7 @@ class GraphObserver {
   /// \param SourceRange The `Range` covering the text causing the inclusion.
   /// \param File The resource being included.
   virtual void recordIncludesRange(const Range& SourceRange,
-                                   const clang::FileEntry* File) {}
+                                   clang::FileEntryRef File) {}
 
   /// \brief Records that the specified variable is static.
   /// \param VarNodeId The `NodeId` of the static variable.

--- a/kythe/cxx/indexer/cxx/KytheGraphObserver.h
+++ b/kythe/cxx/indexer/cxx/KytheGraphObserver.h
@@ -188,9 +188,9 @@ class KytheGraphObserver : public GraphObserver {
     return &vname_token_;
   }
 
-  void applyMetadataFile(clang::FileID ID, const clang::FileEntry* file,
+  void applyMetadataFile(clang::FileID ID, clang::FileEntryRef file,
                          const std::string& search_string,
-                         const clang::FileEntry* target_file) override;
+                         clang::FileEntryRef target_file) override;
   void StopDeferringNodes() { deferring_nodes_ = false; }
   void DropRedundantWraiths() { drop_redundant_wraiths_ = true; }
   void Delimit() override { recorder_->PushEntryGroup(); }
@@ -371,7 +371,7 @@ class KytheGraphObserver : public GraphObserver {
                             const NodeId& macro_id) override;
 
   void recordIncludesRange(const Range& source_range,
-                           const clang::FileEntry* file) override;
+                           clang::FileEntryRef file) override;
 
   void recordBoundQueryRange(const Range& source_range,
                              const NodeId& macro_id) override;
@@ -506,8 +506,7 @@ class KytheGraphObserver : public GraphObserver {
                                          llvm::raw_ostream& Ostream) const;
 
   VNameRef VNameRefFromNodeId(const GraphObserver::NodeId& node_id) const;
-  kythe::proto::VName VNameFromFileEntry(
-      const clang::FileEntry* file_entry) const;
+  kythe::proto::VName VNameFromFileEntry(clang::FileEntryRef file_entry) const;
   kythe::proto::VName ClaimableVNameFromFileID(const clang::FileID& file_id);
   kythe::proto::VName VNameFromRange(const GraphObserver::Range& range);
   kythe::proto::VName StampedVNameFromRange(const GraphObserver::Range& range,

--- a/kythe/cxx/indexer/cxx/KytheIndexerUnitTest.cc
+++ b/kythe/cxx/indexer/cxx/KytheIndexerUnitTest.cc
@@ -409,8 +409,8 @@ class PushPopLintingGraphObserver : public NullGraphObserver {
     if (File.isInvalid()) {
       FileNames.push("invalid-file");
     }
-    if (const clang::FileEntry* file_entry =
-            SourceManager->getFileEntryForID(File)) {
+    if (const clang::OptionalFileEntryRef file_entry =
+            SourceManager->getFileEntryRefForID(File)) {
       FileNames.push(std::string(file_entry->getName()));
     } else {
       FileNames.push("null-file");

--- a/kythe/cxx/indexer/cxx/KytheVFS.cc
+++ b/kythe/cxx/indexer/cxx/KytheVFS.cc
@@ -143,9 +143,8 @@ void IndexVFS::SetVName(const std::string& path, const proto::VName& vname) {
   }
 }
 
-bool IndexVFS::get_vname(const clang::FileEntry* entry,
-                         proto::VName* merge_with) {
-  auto record = uid_to_record_map_.find(PairFromUid(entry->getUniqueID()));
+bool IndexVFS::get_vname(clang::FileEntryRef entry, proto::VName* merge_with) {
+  auto record = uid_to_record_map_.find(PairFromUid(entry.getUniqueID()));
   if (record != uid_to_record_map_.end()) {
     if (record->second->status.getType() ==
             llvm::sys::fs::file_type::regular_file &&

--- a/kythe/cxx/indexer/cxx/KytheVFS.h
+++ b/kythe/cxx/indexer/cxx/KytheVFS.h
@@ -70,7 +70,7 @@ class IndexVFS : public llvm::vfs::FileSystem {
   /// \param entry The `FileEntry` to look up.
   /// \param merge_with The `VName` to copy the vname onto.
   /// \return true if a match was found; false otherwise.
-  bool get_vname(const clang::FileEntry* entry, proto::VName* merge_with);
+  bool get_vname(clang::FileEntryRef entry, proto::VName* merge_with);
   /// \brief Returns the vname associated with some `path`.
   /// \param path The path to look up.
   /// \param merge_with The `VName` to copy the vname onto.

--- a/kythe/cxx/tools/fyi/fyi.cc
+++ b/kythe/cxx/tools/fyi/fyi.cc
@@ -471,16 +471,16 @@ void PreprocessorHooks::FileChanged(clang::SourceLocation loc,
     clang::SourceManager* source_manager =
         &enclosing_pass_->getCompilerInstance().getSourceManager();
     clang::FileID loc_id = source_manager->getFileID(loc);
-    if (const clang::FileEntry* file_entry =
-            source_manager->getFileEntryForID(loc_id)) {
+    if (const clang::OptionalFileEntryRef file_entry =
+            source_manager->getFileEntryRefForID(loc_id)) {
       if (file_entry->getName() == enclosing_pass_->tracker()->filename()) {
         enclosing_pass_->tracker()->set_file_begin(loc);
         const auto buffer =
-            source_manager->getMemoryBufferForFileOrNone(file_entry);
+            source_manager->getMemoryBufferForFileOrNone(*file_entry);
         if (buffer) {
           enclosing_pass_->tracker()->SetInitialContent(buffer->getBuffer());
         }
-        tracked_file_ = file_entry;
+        tracked_file_ = &file_entry->getFileEntry();
       }
     }
   }

--- a/setup.bzl
+++ b/setup.bzl
@@ -169,8 +169,8 @@ def kythe_rule_repositories():
     maybe(
         github_archive,
         repo_name = "llvm/llvm-project",
-        commit = "4706251a3186c34da0ee8fd894f7e6b095da8fdc",
-        sha256 = "125cb3648b3c2a06e1a789ddd768a1af356fbad8a1c9d39c14d88e39c62a94c1",
+        commit = "3661a48a84731ab5086bf1fca8f7e6b9f294225a",
+        sha256 = "33ac9070619a7ebb02321814e06ba819f9ce6219dd202e1c87f46792d3bb74b2",
         name = "llvm-raw",
         build_file_content = "#empty",
         patch_args = ["-p1"],


### PR DESCRIPTION
While I'm sure there exist more places which can/should be migrated to `FileEntryRef`, this at least hits all the blockers.