### PR TITLE
fix(cxx_extractor): remove inapplicable CUDA driver and LLVM flags

### DIFF
--- a/kythe/cxx/extractor/CommandLineUtils.cc
+++ b/kythe/cxx/extractor/CommandLineUtils.cc
@@ -296,6 +296,7 @@ std::vector<std::string> AdjustClangArgsForSyntaxOnly(
       "|-W[al],.*"
       "|-Xlinker=.*"
       "|--for-linker=.*"
+      "|--llvm=.*"
       "|-f(no-)?data-sections"
       "|-f(no-)?function-sections"
       "|-f(no-)?omit-frame-pointer"
@@ -313,7 +314,9 @@ std::vector<std::string> AdjustClangArgsForSyntaxOnly(
       "-M[FTQ]"
       "|-Xlinker"
       "|--for-linker"
-      "|-Xassembler");
+      "|-Xassembler"
+      "|-Xarch_.*"
+      "|-mllvm");
   // Arguments which may match one of the above lists which we want to keep
   // regardless.
   const FullMatchRegex keep_args("-X(clang|preprocessor).*");

--- a/kythe/cxx/extractor/CommandLineUtils.cc
+++ b/kythe/cxx/extractor/CommandLineUtils.cc
@@ -296,7 +296,7 @@ std::vector<std::string> AdjustClangArgsForSyntaxOnly(
       "|-W[al],.*"
       "|-Xlinker=.*"
       "|--for-linker=.*"
-      "|--llvm=.*"
+      "|--mllvm=.*"
       "|-f(no-)?data-sections"
       "|-f(no-)?function-sections"
       "|-f(no-)?omit-frame-pointer"


### PR DESCRIPTION
Remove flags aimed at the LLVM and CUDA driver when removing incompatible flags.