### PR TITLE
Do not use `bind` with a `maybe` macro

### DIFF
--- a/external.bzl
+++ b/external.bzl
@@ -1774,45 +1774,38 @@ def _go_dependencies():
     )
 
 def _bindings():
-    maybe(
-        native.bind,
+    native.bind(
         name = "vnames_config",
         actual = "@io_kythe//kythe/data:vnames_config",
     )
 
-    maybe(
-        native.bind,
+    native.bind(
         name = "libuuid",
         actual = "@io_kythe//third_party:libuuid",
     )
 
-    maybe(
-        native.bind,
+    native.bind(
         name = "libmemcached",
         actual = "@org_libmemcached_libmemcached//:libmemcached",
     )
 
-    maybe(
-        native.bind,
+    native.bind(
         name = "guava",  # required by @com_google_protobuf
         actual = "@io_kythe//third_party/guava",
     )
 
-    maybe(
-        native.bind,
+    native.bind(
         name = "gson",  # required by @com_google_protobuf
         actual = "@maven//:com_google_code_gson_gson",
     )
 
-    maybe(
-        native.bind,
+    native.bind(
         name = "zlib",  # required by @com_google_protobuf
         actual = "@net_zlib//:zlib",
     )
 
     # This binding is needed for protobuf. See https://github.com/protocolbuffers/protobuf/pull/5811
-    maybe(
-        native.bind,
+    native.bind(
         name = "error_prone_annotations",
         actual = "@maven//:com_google_errorprone_error_prone_annotations",
     )


### PR DESCRIPTION
After https://github.com/bazelbuild/bazel/commit/c7e391cc422d9069e6cbf24a09807638d352c4b0, Bazel interprets the `actual` parameter of a `bind` call in the context of the repo where it happens.

Unfortunately, this means that wrapping `native.bind` in a `maybe` macro loaded from `@bazel_tools` causes the `actual` parameter to be interpreted in `@bazel_tools`'s context, which is obviously wrong.

This is amazingly hard to fix at the root and is more evidence that `bind` needs to go.

Fixes https://github.com/kythe/kythe/issues/5921.