### PR TITLE
Update documentation for macOS, remove references to Sample Web UI that no longer exists

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -26,7 +26,7 @@ module.exports = {
                    [
                      'api',        // user-facing API (e.g. XRefService)
                      'dev',        // developer tooling/scripting (e.g. linting)
-                     'example',    // example tools or docs (e.g. sample web ui)
+                     'example',    // example tools or docs (e.g. sample proto indexer)
                      'extraction', // compilation extraction
                      'indexing',   // semantic analysis over compilations
                      'post_processing', // serving data construction

--- a/README.adoc
+++ b/README.adoc
@@ -27,7 +27,7 @@ image:https://img.shields.io/github/license/kythe/kythe.svg[link=https://github.
 * Indexer implementations for C++, Go, and Java
 * Compilation extractors for javac, Maven, cmake, Go, and link:http://bazel.io/[Bazel]
 * Generic verifier for indexers
-* Sample cross-reference service and accompanying web UI
+* Sample cross-reference service
 * Many useful utility commands to work with Kythe artifacts
 
 == Getting Started

--- a/kythe/docs/kythes-command-line-tool.txt
+++ b/kythe/docs/kythes-command-line-tool.txt
@@ -19,7 +19,7 @@ Every good interface deserves a good command-line tool.
 
 NOTE: This post has been edited 2015/05/19 to reflect changes in the way to build Kythe.
 
-Along with the sample cross-reference service, Kythe also provides a basic command-line 
+Along with the sample cross-reference service, Kythe also provides a basic command-line
 tool for the xrefs, filetree, and search interfaces.  The Kythe tool can use serving
 tables directly or communicate with a remote API service.
 

--- a/kythe/docs/kythes-command-line-tool.txt
+++ b/kythe/docs/kythes-command-line-tool.txt
@@ -19,18 +19,9 @@ Every good interface deserves a good command-line tool.
 
 NOTE: This post has been edited 2015/05/19 to reflect changes in the way to build Kythe.
 
-Along with the sample web UI, Kythe also provides a basic command-line tool for
-the xrefs, filetree, and search interfaces.  The Kythe tool can use serving
-tables directly or communicate with a remote API service.  By default, it talks
-to the API at https://xrefs-dot-kythe-repo.appspot.com/ which serves a
-recent index of Kythe's own sources. (The serving data for the sample web UI is
-currently updated manually which can lead to stale data over time.)
-
-All of the information surfaced by the sample web UI, and *more*, can be
-retrieved with the Kythe command-line tool.  It's simply a wrapper around the
-protobuf service APIs that exist in
-https://kythe.io/repo/kythe/go/services/[kythe/go/services] with some extra
-usability features.
+Along with the sample cross-reference service, Kythe also provides a basic command-line 
+tool for the xrefs, filetree, and search interfaces.  The Kythe tool can use serving
+tables directly or communicate with a remote API service.
 
 So, what _exactly_ can the tool do?  Let's build it and then check its `help`
 command.

--- a/kythe/web/site/contributing.md
+++ b/kythe/web/site/contributing.md
@@ -94,8 +94,4 @@ can index.
 ### User Interfaces
 
 Kythe emits a lot of data and there are *many* ways to interpret/display it all.
-Kythe has provided a
-[sample UI]({{site.baseuri}}/examples#visualizing-cross-references), but it
-currently only scratches the surface of Kythe's data.  Other ideas for
-visualizers include an interactive graph, a documentation browser and a source file
-hierarchical overview.
+Ideas for visualizers include an interactive graph, a documentation browser and a source file hierarchical overview.

--- a/kythe/web/site/examples.md
+++ b/kythe/web/site/examples.md
@@ -364,13 +364,10 @@ cayley repl --dbpath kythe.nq.gz # or cayley http --dbpath kythe.nq.gz
     // Get the file(s) defining a particular node
     cayley> g.V("node_ticket").In("/kythe/edge/defines").Out("/kythe/edge/childof").Has("/kythe/node/kind", "file").All()
 
-## Visualizing Cross-References
+## Serving data over HTTP
 
-As part of Kythe's first release, a sample UI has been made to show Kythe's
-basic cross-reference capabilities.  The following command can be run over the
-serving table created with the `write_tables` binary (see above).
-
-Note: Version v0.0.30 is the latest version that includes the web UI. If you want a newer Kythe than this, you'll need to build from source.
+The `http_server` tool can be run over the serving table created with the 
+`write_tables` binary (see above).
 
 {% highlight bash %}
 # --listen localhost:8080 allows access from only this machine; change to

--- a/kythe/web/site/examples.md
+++ b/kythe/web/site/examples.md
@@ -366,7 +366,7 @@ cayley repl --dbpath kythe.nq.gz # or cayley http --dbpath kythe.nq.gz
 
 ## Serving data over HTTP
 
-The `http_server` tool can be run over the serving table created with the 
+The `http_server` tool can be run over the serving table created with the
 `write_tables` binary (see above).
 
 {% highlight bash %}

--- a/kythe/web/site/getting-started-macos.md
+++ b/kythe/web/site/getting-started-macos.md
@@ -59,15 +59,19 @@ rest of these instructions assume you have it.
 To install most of the [external dependencies][ext], run
 
 {% highlight bash %}
-for pkg in asciidoc bison brotli flex go graphviz leveldb node openjdk parallel source-highlight wget ; do
+for pkg in asciidoc bison brotli flex gnu-sed go graphviz leveldb node openjdk parallel source-highlight wget ; do
    brew install $pkg
 done
 
 # Bison and Flex. The stock versions are too old, but these tools are keg-only
 # and Bazel uses a restricted PATH, so we need to tell Bazel where to find
 # them (see #3514, #4455).
-export BISON=/usr/local/opt/bison/bin/bison
-export FLEX=/usr/local/opt/flex/bin/flex
+export BISON=$(brew --prefix --installed bison)/bin/bison
+export FLEX=$(brew --prefix --installed flex)/bin/flex
+
+# GNU sed. The stock version is too old.
+export PATH="$(brew --prefix --installed gnu-sed)/libexec/gnubin:$PATH"
+
 
 # Java (OpenJDK). By default macOS does not have a JDK installed, so we use the
 # openjdk package from Homebrew.  We need to set JAVA_HOME so the command-line

--- a/kythe/web/site/index.html
+++ b/kythe/web/site/index.html
@@ -19,7 +19,7 @@ layout: default
       <li>Indexer implementations for C++ and Java</li>
       <li>Compilation extractors for javac, Maven, cmake, Go, and <a href="http://bazel.io/">Bazel</a></li>
       <li>Generic <a href="{{site.baseurl}}/docs/kythe-verifier.html">verifier</a> for indexers</li>
-      <li>Sample cross-reference service and accompanying <a href="{{site.baseurl}}/examples/#visualizing-cross-references">web UI</a></li>
+      <li>Sample <a href="{{site.baseurl}}/examples/#serving-data-over-http">cross-reference service</a></li>
       <li>Many useful utility commands to work with Kythe artifacts</li>
     </ul>
   </p>


### PR DESCRIPTION
I'm new to Kythe and got tripped up a bit by the documentation being a bit out of date.