### PR TITLE
chore(cxx_indexer): cleanup decl/defn mismatch and enable warning

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -21,10 +21,10 @@ common --workspace_status_command tools/buildstamp/get_workspace_status
 common --client_env=CC=clang
 # We require C++17, but bazel defaults to C++0x (pre-C++11).
 common --cxxopt=-std=c++17 --host_cxxopt=-std=c++17 --client_env=BAZEL_CXXOPTS=-std=c++17
-# Don't warn on deprecations when compiling protobufs.
-# This generates a lot of spurious warnings when compiling the definitions of proto fields
-# which are marked deprecated.
-common --per_file_copt=.*\.pb\.cc@-Wno-deprecated-declarations
+# Enable -Wmissing-prototypes for Kythe code, but not external repositories.
+common --per_file_copt=//...@-Wmissing-prototypes
+# Disable diagnostics when compiling protobufs.
+common --per_file_copt=.*\.pb\.cc@-w
 # Disable diagnostics on external repositories as we don't control them.
 common --per_file_copt=external/.*@-w
 # Disable diagnostics in host mode. There is no host_per_file_copt and

--- a/kythe/cxx/extractor/cxx_extractor.cc
+++ b/kythe/cxx/extractor/cxx_extractor.cc
@@ -1378,6 +1378,7 @@ std::unique_ptr<clang::FrontendAction> NewExtractor(
   return std::make_unique<ExtractorAction>(index_writer, std::move(callback));
 }
 
+namespace {
 llvm::IntrusiveRefCntPtr<llvm::vfs::InMemoryFileSystem> MapCompilerResources(
     llvm::StringRef map_directory) {
   llvm::IntrusiveRefCntPtr<llvm::vfs::InMemoryFileSystem> memory_fs(
@@ -1410,13 +1411,6 @@ llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> GetRootFileSystem(
   return llvm::vfs::getRealFileSystem();
 }
 
-void ExtractorConfiguration::SetVNameConfig(const std::string& path) {
-  if (!index_writer_.SetVNameConfiguration(LoadFileOrDie(path))) {
-    absl::FPrintF(stderr, "Couldn't configure vnames from %s\n", path);
-    exit(1);
-  }
-}
-
 bool IsCuda(const std::vector<std::string>& args) {
   for (int i = 0; i < args.size() - 1; i++) {
     if (args[i] == "-x" && args[i + 1] == "cuda") {
@@ -1424,6 +1418,15 @@ bool IsCuda(const std::vector<std::string>& args) {
     }
   }
   return false;
+}
+
+}  // namespace
+
+void ExtractorConfiguration::SetVNameConfig(const std::string& path) {
+  if (!index_writer_.SetVNameConfiguration(LoadFileOrDie(path))) {
+    absl::FPrintF(stderr, "Couldn't configure vnames from %s\n", path);
+    exit(1);
+  }
 }
 
 void ExtractorConfiguration::SetArgs(const std::vector<std::string>& args) {

--- a/kythe/cxx/extractor/testdata/BUILD
+++ b/kythe/cxx/extractor/testdata/BUILD
@@ -372,6 +372,7 @@ objc_bazel_extractor_test(
 cc_library(
     name = "cc_lib",
     srcs = ["cc_lib.cc"],
+    copts = ["-Wno-missing-prototypes"],
 )
 
 # Test that we can use the bazel extractor to extract a .xa file, index the

--- a/kythe/cxx/indexer/cxx/BUILD
+++ b/kythe/cxx/indexer/cxx/BUILD
@@ -101,12 +101,8 @@ cc_library(
         "-Wno-implicit-fallthrough",
     ],
     deps = [
-        ":indexed_parent_map",
         "//third_party/llvm/src:clang_builtin_headers",
-        "@com_google_absl//absl/log",
         "@llvm-project//clang:ast",
-        "@llvm-project//clang:basic",
-        "@llvm-project//clang:lex",
         "@llvm-project//llvm:Support",
     ],
 )

--- a/kythe/cxx/indexer/cxx/KytheIndexerMain.cc
+++ b/kythe/cxx/indexer/cxx/KytheIndexerMain.cc
@@ -72,6 +72,7 @@ ABSL_FLAG(bool, experimental_set_aliases_as_writes, false,
           "Set protobuf aliases as writes.");
 
 namespace kythe {
+namespace {
 
 int main(int argc, char* argv[]) {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
@@ -156,6 +157,7 @@ int main(int argc, char* argv[]) {
   return (had_errors ? 1 : 0);
 }
 
+}  // namespace
 }  // namespace kythe
 
 int main(int argc, char* argv[]) { return kythe::main(argc, argv); }

--- a/kythe/cxx/indexer/cxx/clang_utils.cc
+++ b/kythe/cxx/indexer/cxx/clang_utils.cc
@@ -16,11 +16,8 @@
 
 #include "kythe/cxx/indexer/cxx/clang_utils.h"
 
-#include "absl/log/log.h"
 #include "clang/AST/DeclTemplate.h"
 #include "clang/AST/DeclVisitor.h"
-#include "clang/Basic/CharInfo.h"
-#include "clang/Lex/Lexer.h"
 
 namespace kythe {
 bool isObjCSelector(const clang::DeclarationName& DN) {
@@ -32,18 +29,6 @@ bool isObjCSelector(const clang::DeclarationName& DN) {
     default:
       return false;
   }
-}
-
-clang::SourceLocation GetLocForEndOfToken(
-    const clang::SourceManager& source_manager,
-    const clang::LangOptions& lang_options,
-    clang::SourceLocation start_location) {
-  if (start_location.isMacroID()) {
-    start_location = source_manager.getExpansionLoc(start_location);
-  }
-  return clang::Lexer::getLocForEndOfToken(start_location,
-                                           0 /* offset from end of token */,
-                                           source_manager, lang_options);
 }
 
 namespace {

--- a/kythe/cxx/indexer/cxx/clang_utils.h
+++ b/kythe/cxx/indexer/cxx/clang_utils.h
@@ -20,9 +20,6 @@
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclCXX.h"
 #include "clang/AST/DeclarationName.h"
-#include "clang/Basic/LangOptions.h"
-#include "clang/Basic/SourceManager.h"
-#include "kythe/cxx/indexer/cxx/indexed_parent_map.h"
 
 namespace kythe {
 /// \return true if `DN` is an Objective-C selector.
@@ -40,10 +37,7 @@ const clang::Decl* FindSpecializedTemplate(const clang::Decl* decl);
 
 /// \brief Finds the root member template starting at `decl` (which can be
 /// any decl; if it's not a member template, returns `decl`).
-/// \param use_mts If false, always return `decl`. (This parameter is temporary
-/// and is used for the abs deprecation.)
-const clang::Decl* DereferenceMemberTemplates(const clang::Decl* decl,
-                                              bool use_mts);
+const clang::Decl* DereferenceMemberTemplates(const clang::Decl* decl);
 
 /// \return true if a reference to `decl` should be given blame context.
 bool ShouldHaveBlameContext(const clang::Decl* decl);


### PR DESCRIPTION
The final removal of `abs` nodes updated the function definition, but not the declaration.

Update the declaration, add `-Wmissing-prototypes` for Kythe targets and cleanup the remaining violations.