### PR TITLE
fix(build): disable layering check so textproto indexer compiles

### DIFF
--- a/kythe/cxx/indexer/textproto/BUILD
+++ b/kythe/cxx/indexer/textproto/BUILD
@@ -94,6 +94,9 @@ cc_library(
     name = "recordio_textparser",
     srcs = ["recordio_textparser.cc"],
     hdrs = ["recordio_textparser.h"],
+    features = [
+        "-layering_check",  # TODO: protocolbuffers/protobuf#10889
+    ],
     deps = [
         "@com_google_absl//absl/flags:flag",
         "@com_google_absl//absl/functional:function_ref",


### PR DESCRIPTION
Without this, my local build fails with:

```

ERROR: /usr/local/google/home/justinbuchanan/src/github/kythe/kythe/cxx/indexer/textproto/BUILD:93:11: Compiling kythe/cxx/indexer/textproto/recordio_textparser.cc failed: (Exit 1): clang failed: error executing command (from target //kythe/cxx/indexer/textproto:recordio_textparser) /usr/lib/llvm-16/bin/clang -U_FORTIFY_SOURCE -fstack-protector -Wall -Wthread-safety -Wself-assign -Wunused-but-set-parameter -Wno-free-nonheap-object -fcolor-diagnostics -fno-omit-frame-pointer ... (remaining 100 arguments skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
In file included from kythe/cxx/indexer/textproto/recordio_textparser.cc:17:
./kythe/cxx/indexer/textproto/recordio_textparser.h:24:10: error: module //kythe/cxx/indexer/textproto:recordio_textparser does not depend on a module exporting 'google/protobuf/descriptor.h'
#include "google/protobuf/descriptor.h"
         ^
./kythe/cxx/indexer/textproto/recordio_textparser.h:25:10: error: module //kythe/cxx/indexer/textproto:recordio_textparser does not depend on a module exporting 'google/protobuf/dynamic_message.h'
#include "google/protobuf/dynamic_message.h"
         ^
./kythe/cxx/indexer/textproto/recordio_textparser.h:26:10: error: module //kythe/cxx/indexer/textproto:recordio_textparser does not depend on a module exporting 'google/protobuf/text_format.h'
#include "google/protobuf/text_format.h"
         ^
3 errors generated.

```