### PR TITLE
feat(typescript_indexer): support private fields 

### DIFF
--- a/kythe/typescript/indexer.ts
+++ b/kythe/typescript/indexer.ts
@@ -373,6 +373,7 @@ class StandardIndexerContext implements IndexerHost {
           if (decl.name) {
             switch (decl.name.kind) {
               case ts.SyntaxKind.Identifier:
+              case ts.SyntaxKind.PrivateIdentifier:
               case ts.SyntaxKind.StringLiteral:
               case ts.SyntaxKind.NumericLiteral:
               case ts.SyntaxKind.ComputedPropertyName:
@@ -1598,6 +1599,7 @@ class Visitor {
     let vname: VName|undefined;
     switch (decl.name.kind) {
       case ts.SyntaxKind.Identifier:
+      case ts.SyntaxKind.PrivateIdentifier:
       case ts.SyntaxKind.StringLiteral:
       case ts.SyntaxKind.NumericLiteral:
         const sym = this.host.getSymbolAtLocation(decl.name);
@@ -2651,6 +2653,7 @@ class Visitor {
         this.visitVariableDeclaration(node as ts.JsxAttribute);
         return;
       case ts.SyntaxKind.Identifier:
+      case ts.SyntaxKind.PrivateIdentifier:
       case ts.SyntaxKind.StringLiteral:
       case ts.SyntaxKind.NumericLiteral:
         // Assume that this identifer is occurring as part of an

--- a/kythe/typescript/testdata/class.ts
+++ b/kythe/typescript/testdata/class.ts
@@ -43,6 +43,12 @@ class Class implements IFace {
     //- StaticMember childof Class
     static member: number;
 
+    //- @"#privateMember" defines/binding PrivateMember
+    //- PrivateMember.node/kind variable
+    //- PrivateMember.subkind field
+    //- PrivateMember childof Class
+    #privateMember: number;
+
     // This ctor declares a new member var named 'otherMember', and also
     // declares an ordinary parameter named 'member' (to ensure we don't get
     // confused about params to the ctor vs true member variables).
@@ -67,9 +73,21 @@ class Class implements IFace {
         //- @this ref Class
         //- @member ref Member
         this.member;
+
         //- @this ref Class
         //- @method ref Method
         this.method();
+    }
+
+    //- @"#privateMethod" defines/binding PrivateMethod
+    //- PrivateMethod.node/kind function
+    //- PrivateMethod childof Class
+    #privateMethod() {
+        //- @"#privateMember" ref PrivateMember
+        this.#privateMember;
+
+        //- @"#privateMethod" ref PrivateMethod
+        this.#privateMethod();
     }
 
     //- @ifaceMethod defines/binding ClassIFaceMethod


### PR DESCRIPTION
Adds support for private `#foo` properties: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_properties