### PR TITLE
Set safe.directory='*' on `git` call

### DIFF
--- a/kythe/go/extractors/cmd/gotool/analyze_packages.sh
+++ b/kythe/go/extractors/cmd/gotool/analyze_packages.sh
@@ -92,7 +92,7 @@ fi
 # cd into the top-level git directory of our package and query git for the
 # commit timestamp.
 pushd "$(go env GOPATH)/src/${PACKAGE}"
-TIMESTAMP="$(git log --pretty='%ad' -n 1 HEAD)"
+TIMESTAMP="$(git -c safe.directory='*' log --pretty='%ad' -n 1 HEAD)"
 popd
 
 # Record the timestamp of the git commit in a metadata kzip.


### PR DESCRIPTION
This avoids the error:

```
fatal: detected dubious ownership in repository at '/tmp/workspace/gopath/src/golang.org/x/tools'
To add an exception for this directory, call:

	git config --global --add safe.directory /tmp/workspace/gopath/src/golang.org/x/tools
```