### PR TITLE
chore(bazel_go_extractor): statically-link binary

### DIFF
--- a/kythe/go/extractors/cmd/bazel/bazel_go_extractor/BUILD
+++ b/kythe/go/extractors/cmd/bazel/bazel_go_extractor/BUILD
@@ -5,6 +5,7 @@ package(default_visibility = ["//kythe:default_visibility"])
 go_binary(
     name = "bazel_go_extractor",
     srcs = ["bazel_go_extractor.go"],
+    static = "on",
     deps = [
         "//kythe/go/extractors/bazel",
         "//kythe/go/extractors/govname",


### PR DESCRIPTION
A user of this binary has had issues with glibc versioning (ours being newer than their host system's). Linking statically should resolve this.