### PR TITLE
chore(cxx_common): add and use a vnames_config.proto for vname rules

### DIFF
--- a/kythe/cxx/common/BUILD
+++ b/kythe/cxx/common/BUILD
@@ -159,7 +159,6 @@ cc_library(
         "//kythe/proto:analysis_cc_proto",
         "//kythe/proto:metadata_cc_proto",
         "//kythe/proto:storage_cc_proto",
-        "@com_github_tencent_rapidjson//:rapidjson",
         "@com_google_absl//absl/base",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/memory",

--- a/kythe/cxx/common/BUILD
+++ b/kythe/cxx/common/BUILD
@@ -207,12 +207,14 @@ cc_library(
     srcs = ["file_vname_generator.cc"],
     hdrs = ["file_vname_generator.h"],
     deps = [
+        ":json_proto",
         "//kythe/proto:storage_cc_proto",
-        "@com_github_tencent_rapidjson//:rapidjson",
+        "//kythe/proto:vnames_config_cc_proto",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
+        "@com_google_protobuf//src/google/protobuf/io",
         "@com_googlesource_code_re2//:re2",
     ],
 )

--- a/kythe/cxx/common/file_vname_generator.h
+++ b/kythe/cxx/common/file_vname_generator.h
@@ -24,6 +24,7 @@
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
+#include "google/protobuf/io/zero_copy_stream.h"
 #include "kythe/proto/storage.pb.h"
 #include "re2/re2.h"
 
@@ -41,6 +42,11 @@ class FileVNameGenerator {
   bool LoadJsonString(absl::string_view data, std::string* error_text);
   absl::Status LoadJsonString(absl::string_view data);
 
+  /// \brief Adds configuration entries from the JSON-encoded list of entries.
+  /// \param input The input stream containing the JSON entries.
+  /// \return Non-OK status if the input was invalid.
+  absl::Status LoadJsonStream(google::protobuf::io::ZeroCopyInputStream& input);
+
   /// \brief Returns a base VName for a given file path (or an empty VName if
   /// no configuration rule matches the path).
   kythe::proto::VName LookupBaseVName(absl::string_view path) const;
@@ -57,7 +63,7 @@ class FileVNameGenerator {
   /// \brief A rule to apply to certain paths.
   struct VNameRule {
     /// The pattern used to match against a path.
-    std::shared_ptr<re2::RE2> pattern;
+    std::shared_ptr<const re2::RE2> pattern;
     /// Substitution pattern used to construct the corpus.
     std::string corpus;
     /// Substitution pattern used to construct the root.

--- a/kythe/proto/BUILD
+++ b/kythe/proto/BUILD
@@ -857,6 +857,17 @@ cc_proto_library(
     ],
 )
 
+proto_library(
+    name = "vnames_config_proto",
+    srcs = ["vnames_config.proto"],
+    deps = [":storage_proto"],
+)
+
+cc_proto_library(
+    name = "vnames_config_cc_proto",
+    deps = [":vnames_config_proto"],
+)
+
 # Uses native.existing_rules() to find rules to update; must come last.
 update_generated_protos(
     name = "update",

--- a/kythe/proto/vnames_config.proto
+++ b/kythe/proto/vnames_config.proto
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 The Kythe Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+
+package kythe.proto;
+
+import "kythe/proto/storage.proto";
+
+option go_package = "kythe.io/kythe/proto/vnames_config_go_proto";
+option java_package = "com.google.devtools.kythe.proto";
+option cc_enable_arenas = true;
+
+// Top-level configuration for vnames.json file.
+message VNamesConfiguration {
+  // An individual pattern -> VName entry.
+  message Rule {
+    // The RE2-compatible pattern against which to match the build path.
+    // The match will be "unanchored" or "partial".
+    string pattern = 1;
+    // The VName substitution template to use. Capture groups can be
+    // referenced via @n@ where n is the number.
+    // Only corpus, root and path are relevant.
+    VName vname = 2;
+  }
+  repeated Rule rules = 1;
+}


### PR DESCRIPTION
This reifies the ad-hoc format used for vnames.json files into a Real Proto and uses that to parse the configuration in C++.