### PR TITLE
fix(typescript_indexer): Fully log errors from plugins.

### DIFF
--- a/kythe/typescript/indexer.ts
+++ b/kythe/typescript/indexer.ts
@@ -2755,7 +2755,7 @@ export function index(compilationUnit: CompilationUnit, options: IndexingOptions
     try {
       plugin.index(indexingContext);
     } catch (err) {
-      console.error(`Plugin ${plugin.name} errored: ${err}`);
+      console.error(`Plugin ${plugin.name} errored:`, err);
     }
   }
 


### PR DESCRIPTION
Currently only error name is logged without stacktrace. That makes it hard to debug. 

Before:
```
Plugin GeneratedCodePlugin errored: TypeError: Cannot read properties of undefined (reading 'getPath')
```

After:
```
Plugin GeneratedCodePlugin errored: TypeError: Cannot read properties of undefined (reading 'getPath')
    at GeneratedCodePlugin.emitMappingEdge (.../generated_code_plugin/indexer.ts:332:36)
    at GeneratedCodePlugin.emitEdges (.../generated_code_plugin/indexer.ts:170:14)
    at GeneratedCodePlugin.index (.../generated_code_plugin/indexer.ts:156:14)
   ...
```