### PR TITLE
fix(cxx_extractor): allow empty PathEntry flag values

### DIFF
--- a/kythe/cxx/common/path_utils.cc
+++ b/kythe/cxx/common/path_utils.cc
@@ -314,6 +314,9 @@ std::string JoinPath(absl::string_view a, absl::string_view b) {
 
 bool AbslParseFlag(absl::string_view text, PathCanonicalizer::PathEntry* entry,
                    std::string* error) {
+  if (text.empty()) {
+    return true;
+  }
   size_t pos = text.find('@');
   if (pos == text.npos) {
     *error = "missing @ delimiter between path and policy";


### PR DESCRIPTION
Without this change, leaving the `--per_file_canonicalization_policy` flag unset results in `[external/com_google_absl/absl/flags/internal/flag.cc : 598] RAW: Flag per_file_canonicalization_policy (from kythe/cxx/extractor/cxx_extractor_bazel_main.cc): string form of default value '' could not be parsed; error=missing @ delimiter between path and policy`