### PR TITLE
fix(go_indexer): emit nodes for anonymous interface params

### DIFF
--- a/kythe/go/indexer/indexer.go
+++ b/kythe/go/indexer/indexer.go
@@ -135,7 +135,7 @@ type PackageInfo struct {
 
 type funcInfo struct {
 	vname    *spb.VName
-	numAnons int // number of anonymous functions defined inside this one
+	numAnons int // number of anonymous params/functions defined inside this one
 }
 
 // packageImporter implements the types.Importer interface by fetching files

--- a/kythe/go/indexer/testdata/code/rendered.go
+++ b/kythe/go/indexer/testdata/code/rendered.go
@@ -69,3 +69,11 @@ func Str[T fmt.Stringer](t T) string { return t.String() }
 // - VA.code/rendered/callsite_signature "VA(args)"
 // - VA.code/rendered/signature "func VA(args ...any)"
 func VA(args ...any) {}
+
+// - @I defines/binding I
+// - I.code/rendered/signature "type I"
+type I interface {
+	// - @M defines/binding IM
+	// - IM.code/rendered/signature "func (I) M(int) bool"
+	M(int) bool
+}


### PR DESCRIPTION
This fixes the rendering of all interface methods since they all have at least an anonymous receiver (the interface itself).