### PR TITLE
Replace instances of to_proto() method with proto.encode_text(..)

### DIFF
--- a/kythe/java/com/google/devtools/kythe/extractors/java/bazel/aspect.bzl
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/bazel/aspect.bzl
@@ -74,7 +74,7 @@ def _extract_java(target, ctx):
     text_xa = ctx.actions.declare_file(ctx.label.name + ".xa.textproto")
     ctx.actions.write(
         output = text_xa,
-        content = xa.to_proto(),
+        content = proto.encode_text(xa),
     )
 
     xa = ctx.actions.declare_file(ctx.label.name + ".xa")


### PR DESCRIPTION
The to_proto and to_proto methods on struct are deprecated and will be
removed. The "json" and "proto" builtin modules should be used instead.

This replaces instances of `foo.to_proto()` with `proto.encode_text(foo)`.