### PR TITLE
fix(extraction): add proto rule to simple vnames config

### DIFF
--- a/kythe/data/simple_vnames.json
+++ b/kythe/data/simple_vnames.json
@@ -1,5 +1,13 @@
 [
   {
+    "pattern": "bazel-out/[^/]+/bin/.*/_virtual_imports/[^/]+/(.*)",
+    "vname": {
+      "corpus": "CORPUS",
+      "root": "bazel-out/bin",
+      "path": "@1@"
+    }
+  },
+  {
     "pattern": "bazel-out/[^/]+/([^/]+/external/[^/]+)/(.*)\\.[xa]$",
     "vname": {
       "corpus": "CORPUS",


### PR DESCRIPTION
I copied this entry from vnames.json.

Before this change, extracting the kythe repo using the bazel-extractor image results in this entry in required_inputs for protos that depend on descriptor.proto:

```
      "v_name": {
        "corpus": "CORPUS",
        "root": "bazel-out/bin/external/com_google_protobuf",
        "path": "src/google/protobuf/_virtual_imports/descriptor_proto/google/protobuf/descriptor.proto"
      },
```

After this change, we get:

```
      "v_name": {
        "corpus": "CORPUS",
        "root": "bazel-out/bin",
        "path": "google/protobuf/descriptor.proto"
      },
```


This extraction change should fix errors we've been seeing where the indexer is unable to find descriptor.proto (or other external protos) and fails.