### PR TITLE
feat(typescript_indexer): add flag to fail analysis on plugin error

### DIFF
--- a/kythe/typescript/indexer.ts
+++ b/kythe/typescript/indexer.ts
@@ -2755,6 +2755,9 @@ export function index(compilationUnit: CompilationUnit, options: IndexingOptions
     try {
       plugin.index(indexingContext);
     } catch (err) {
+      if (indexingContext.options.failAnalysisOnPluginError) {
+        throw err;
+      }
       console.error(`Plugin ${plugin.name} errored:`, err);
     }
   }

--- a/kythe/typescript/plugin_api.ts
+++ b/kythe/typescript/plugin_api.ts
@@ -82,17 +82,16 @@ export interface IndexingOptions {
   readFile?: (path: string) => Buffer;
 
   /**
-   * When enabled emits 0-0 spans at the beginning of each file that represent
-   * current module. By default 0-1 spans are emitted. Also this flag changes it
-   * to emit `defines/implicit` edges instead of `defines/binding`.
-   */
-  emitZeroWidthSpansForModuleNodes?: boolean;
-
-  /**
    * When enabled, ref/call source anchors span identifiers instead of full
    * call expressions when possible.
    */
   emitRefCallOverIdentifier?: boolean;
+
+  /**
+   * When enabled any error thrown from any plugin gets propagated to the caller.
+   * Currently errors from plugins are logged without interrupting analysis.
+   */
+  failAnalysisOnPluginError?: boolean;
 }
 
 


### PR DESCRIPTION
Instead of log-and-continue behavior on plugin error it will fail analysis. This way errors can be reported as analysis failures and become more visible during pipeline run. Additionally it will help testing where analysis will be flagged as failed earlier.