### PR TITLE
Add `load()`s for the Bazel builtin java rules to `.bzl` files

### DIFF
--- a/tools/build_rules/verifier_test/BUILD
+++ b/tools/build_rules/verifier_test/BUILD
@@ -49,7 +49,10 @@ bzl_library(
 bzl_library(
     name = "jvm_verifier_test_bzl",
     srcs = ["jvm_verifier_test.bzl"],
-    deps = [":verifier_test_bzl"],
+    deps = [
+        ":verifier_test_bzl",
+        "@rules_java//java:rules",
+    ],
 )
 
 bzl_library(

--- a/tools/build_rules/verifier_test/java_verifier_test.bzl
+++ b/tools/build_rules/verifier_test/java_verifier_test.bzl
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_java//java:defs.bzl", "java_binary")
 load(
     ":verifier_test.bzl",
     "KytheVerifierSources",
@@ -195,7 +196,7 @@ def java_verifier_test(
     tools = []
     if load_plugin:
         # If loaded plugins have deps, those must be included in the loaded jar
-        native.java_binary(
+        java_binary(
             name = name + "_load_plugin",
             main_class = "not.Used",
             runtime_deps = [load_plugin],


### PR DESCRIPTION
This is in preparation for the rules to be moved out of Bazel and into `@rules_java`