### PR TITLE
Add `load()`s for the Bazel builtin java top-level symbols

### DIFF
--- a/kythe/java/com/google/devtools/kythe/extractors/java/bazel/BUILD
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/bazel/BUILD
@@ -33,5 +33,8 @@ java_binary(
 bzl_library(
     name = "aspect_bzl",
     srcs = ["aspect.bzl"],
-    deps = ["@rules_java//java:utils"],
+    deps = [
+        "@rules_java//java:rules",
+        "@rules_java//java:utils",
+    ],
 )

--- a/kythe/java/com/google/devtools/kythe/extractors/java/bazel/aspect.bzl
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/bazel/aspect.bzl
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+load("@rules_java//java:defs.bzl", "JavaInfo", "java_common")
 load("@rules_java//java:java_utils.bzl", _java_utils = "utils")
 
 _mnemonic = "Javac"

--- a/kythe/java/com/google/devtools/kythe/extractors/java/standalone/BUILD
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/standalone/BUILD
@@ -176,5 +176,8 @@ java_library(
 bzl_library(
     name = "aspect_bzl",
     srcs = ["aspect.bzl"],
-    deps = ["@rules_java//java:utils"],
+    deps = [
+        "@rules_java//java:rules",
+        "@rules_java//java:utils",
+    ],
 )

--- a/kythe/java/com/google/devtools/kythe/extractors/java/standalone/aspect.bzl
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/standalone/aspect.bzl
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 load("//tools/build_rules/verifier_test:verifier_test.bzl", "extract")
+load("@rules_java//java:defs.bzl", "JavaInfo")
 load("@rules_java//java:java_utils.bzl", _java_utils = "utils")
 
 def _extract_java_aspect(target, ctx):

--- a/tools/build_rules/verifier_test/BUILD
+++ b/tools/build_rules/verifier_test/BUILD
@@ -28,7 +28,10 @@ bzl_library(
 bzl_library(
     name = "java_verifier_test_bzl",
     srcs = ["java_verifier_test.bzl"],
-    deps = [":verifier_test_bzl"],
+    deps = [
+        ":verifier_test_bzl",
+        "@rules_java//java:rules",
+    ],
 )
 
 bzl_library(

--- a/tools/build_rules/verifier_test/java_verifier_test.bzl
+++ b/tools/build_rules/verifier_test/java_verifier_test.bzl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@rules_java//java:defs.bzl", "java_binary")
+load("@rules_java//java:defs.bzl", "JavaInfo", "java_binary", "java_common")
 load(
     ":verifier_test.bzl",
     "KytheVerifierSources",

--- a/tools/build_rules/verifier_test/jvm_verifier_test.bzl
+++ b/tools/build_rules/verifier_test/jvm_verifier_test.bzl
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_java//java:defs.bzl", "JavaInfo")
 load(
     ":verifier_test.bzl",
     "KytheVerifierSources",


### PR DESCRIPTION
This is in preparation for the symbols to be moved out of Bazel and into `@rules_java`