### PR TITLE
feat(typescript_indexer): support xrefs in nested object literals

### DIFF
--- a/kythe/typescript/BUILD
+++ b/kythe/typescript/BUILD
@@ -1,6 +1,6 @@
-load("@aspect_rules_ts//ts:defs.bzl", "ts_config", "ts_project")
 load("@aspect_rules_jasmine//jasmine:defs.bzl", "jasmine_test")
 load("@aspect_rules_js//js:defs.bzl", "js_test")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_config", "ts_project")
 
 package(default_visibility = ["//kythe:default_visibility"])
 

--- a/kythe/typescript/testdata/interface.ts
+++ b/kythe/typescript/testdata/interface.ts
@@ -16,21 +16,23 @@ const p: Person = {
   getAge() {}
 };
 
-const p2 = {
-  //- @name ref/id Name
-  name: 'Alice',
+{
+  const p2 = {
+    //- @name ref/id Name
+    name: 'Alice',
+    //- @getAge ref/id GetAge
+    getAge() {}
+  } as Person;
+
+  //- @name ref Name
+  p.name;
+
+  //- @getAge ref GetAge
+  p.getAge();
+
   //- @getAge ref/id GetAge
-  getAge() {}
-} as Person;
-
-//- @name ref Name
-p.name;
-
-//- @getAge ref GetAge
-p.getAge();
-
-//- @getAge ref/id GetAge
-const {getAge} = p;
+  const {getAge} = p;
+}
 
 //- @name ref/id Name
 //- @getAge ref/id GetAge
@@ -57,8 +59,32 @@ function returnPerson(): Person {
 // test property shorthands
 {
   const name = 'Alice';
-  const getAge = () = {};
+  const getAge = () => {};
   //- @name ref/id Name
   //- @getAge ref/id GetAge
   const p3: Person = {name, getAge};
+}
+
+interface Address {
+  person: Person;
+  street: string;
+}
+
+// Test nested objects.
+{
+  const address: Address = {
+    person: {
+      //- @name ref/id Name
+      name: 'Alice',
+      //- @getAge ref/id GetAge
+      getAge() { }
+    },
+    street: '1600 Amphitheater Park',
+  }
+
+  //- @name ref/id Name
+  const {person: {name}} = ({} as Address);
+
+  //- @name ref/id Name
+  function takesAddress({person: {name}}: Address) {}
 }

--- a/kythe/typescript/testdata/interface.ts
+++ b/kythe/typescript/testdata/interface.ts
@@ -66,6 +66,7 @@ function returnPerson(): Person {
 }
 
 interface Address {
+  //- @person defines/binding Person
   person: Person;
   street: string;
 }
@@ -73,6 +74,7 @@ interface Address {
 // Test nested objects.
 {
   const address: Address = {
+    //- @person ref/id Person
     person: {
       //- @name ref/id Name
       name: 'Alice',


### PR DESCRIPTION
Given the following structure:

```typescript
interface Person {
  name: string;
}

interface Address {
  person: Person;
}

const a: Address = {person: {name: 'Alice'}};
```

Previously `name` on the last line was not connected to the `Person.name` property. This PR fixes it. 