### PR TITLE
Update "Extracting projects built with `make`" in examples.md

### DIFF
--- a/kythe/web/site/examples.md
+++ b/kythe/web/site/examples.md
@@ -262,8 +262,9 @@ bin: main.cc
 # cxx_wrapper.sh
 #!/bin/bash -e
 
-$KYTHE_RELEASE_DIR/extractors/cxx_extractor "$@" &
+$KYTHE_RELEASE_DIR/extractors/cxx_extractor "$@" & pid=$!
 /usr/bin/c++ "$@"
+wait "$pid"
 ```
 
 Extraction is done by setting the `CXX` make variable as well as some environment variables that configure `cxx_extractor`.


### PR DESCRIPTION
We need to wait for cxx_extractor's completion before returning from cxx_wrapper. This ensures the kzip is fully written before returning. Otherwise we cannot guarantee that all kzip files are ready when `make` completes. This risks losing the last few kzip files when cxx_extractor races with steps called after `make`.