### PR TITLE
chore(go): update go from 1.21 to 1.23 in extractor image

### DIFF
--- a/kythe/go/extractors/cmd/gotool/Dockerfile
+++ b/kythe/go/extractors/cmd/gotool/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && \
     apt-get clean
 
 # Get a recent go release, remove the current system one so we don't have multiple version problems, and install the new release.
-RUN curl -LO https://golang.org/dl/go1.21.6.linux-amd64.tar.gz && rm -rf /usr/local/go && tar -C /usr/local -xzf go1.21.6.linux-amd64.tar.gz
+RUN curl -LO https://golang.org/dl/go1.23.0.linux-amd64.tar.gz && rm -rf /usr/local/go && tar -C /usr/local -xzf go1.23.0.linux-amd64.tar.gz
 
 ADD kythe/go/extractors/cmd/gotool/analyze_packages.sh /usr/local/bin/analyze_packages.sh
 ADD kythe/go/extractors/cmd/gotool/gotool /usr/local/bin/extract_go


### PR DESCRIPTION
Go itself requires at least 1.22.6 for bootstrapping as of https://go.dev/cl/606156. Thus it is no longer possible to use the extractor image on the Go repo.

Update to 1.23.0, as that is the latest release.

As an aside, it is unclear to me why there is a mismatch in the base image (1.20) and the installed version (1.21). gcr.io/cloud-builders/go doesn't seem to have a 1.23 tag yet.