### PR TITLE
fix(typescript): Update getPropertyNameStr to always return a value

### DIFF
--- a/kythe/typescript/indexer.ts
+++ b/kythe/typescript/indexer.ts
@@ -2037,6 +2037,7 @@ class Visitor {
         // case" is good enough for now.
         return name !== '__computed' ? name : undefined;
     }
+    return undefined;
   }
 
   /**


### PR DESCRIPTION
Resolves the error:

```
TS7030: Not all code paths return a value.
```

I'm assuming that the tsconfig tsc flags are not causing this error to trigger.

Compiling this code in our usage at Google results in the above errors for TS 5.6