### PR TITLE
docs: describe CU VFS inode semantics

### DIFF
--- a/kythe/proto/analysis.proto
+++ b/kythe/proto/analysis.proto
@@ -117,6 +117,10 @@ message CompilationUnit {
   // All files that might be touched in the course of this compilation.
   // Consumers of the CompilationUnit may not assume anything about the order
   // of the elements of this field.
+  //
+  // This specifies a virtual file system to be exposed to the compiler.
+  // FileInputs with equal digests are the same file, with e.g. the same inode.
+  // (This can affect the behavior of `#pragma once` in C, among other things).
   repeated FileInput required_input = 3;
 
   // Set by the extractor to indicate that the original input had compile


### PR DESCRIPTION
CompilationUnit does not directly represent soft/hardlink information for its inputs. Currently a reasonable assumption is that files under different paths are unrelated, even if their content is the same.

For most languages this doesn't matter, but for the C preprocessor it does:
- the common `#pragma once` extension will allow both files to be parsed
- obscure cases of current-file-relative `#include` resolution

The "obvious" interpretation gives incorrect behavior in practice, and the C++ indexer treats same-content FileInputs as the same file to avoid this (see IndexVFS::IndexVFS in kythe/cxx/indexer/cxx/KytheVFS.cc).

This patch codifies this interpretation. I don't expect any indexers to actually change, as most languages don't care and C++ already does the right thing. But this provides important guidance to non-Kythe consumers of Kythe data.