### PR TITLE
fix(bazel): remove cyclic dependency by removing usage of assign_external_projects_to_separate_corpora config_setting flag

### DIFF
--- a/kythe/release/release.BUILD
+++ b/kythe/release/release.BUILD
@@ -17,7 +17,6 @@ construct_vnames_config(
             "vnames.cxx.json",
             "vnames.go.json",
             "vnames.java.json",
-            "vnames.proto.json",
             "vnames.json",
         ],
 )

--- a/kythe/release/release.BUILD
+++ b/kythe/release/release.BUILD
@@ -11,28 +11,15 @@ exports_files(glob([
     "tools/*",
 ]))
 
-config_setting(
-    name = "assign_external_projects_to_separate_corpora",
-    values = {
-        "define": "kythe_assign_external_projects_to_separate_corpora=true",
-    },
-)
-
 construct_vnames_config(
     name = "vnames_config",
-    srcs = select({
-        "//conditions:default": [
-            # by default, the simple vname rules are used, which map everything
-            # to the corpus set via `--define kythe_corpus=<my corpus>`.
-            "simple_vnames.json",
-        ],
-        ":assign_external_projects_to_separate_corpora": [
+    srcs = [
             "vnames.cxx.json",
             "vnames.go.json",
             "vnames.java.json",
+            "vnames.proto.json",
             "vnames.json",
         ],
-    }),
 )
 
 # Clone of default Java proto toolchain with "annotate_code" enabled for


### PR DESCRIPTION
Usage of `assign_external_projects_to_separate_corpora` along with `select` statement is causing a cyclic dependency for Bazel 8. Also not usage of flag  `assign_external_projects_to_separate_corpora` was found hence deprecating the flag. The flag was initially introduced for backward compatibility in https://source.corp.google.com/h/github/kythe/kythe/+/3966e3f7aa790a61645e6babf511f7ae21b78011.

Tested by executing bazelisk --bazelrc=$KYTHE_RELEASE_DIR/extractors.bazelrc build //src:bazel which succeeded.