### PR TITLE
C++ indexer: Also read proto metadata from files ending in .pbobjc.h.meta

### DIFF
--- a/kythe/cxx/common/protobuf_metadata_file.cc
+++ b/kythe/cxx/common/protobuf_metadata_file.cc
@@ -51,7 +51,8 @@ std::unique_ptr<kythe::MetadataFile> ProtobufMetadataSupport::ParseFile(
         absl::EndsWith(filename, ".pb.h") ||
         absl::EndsWith(filename, ".proto.h.meta") ||
         absl::EndsWith(filename, ".proto.h") ||
-        absl::EndsWith(filename, ".stubby.h"))) {
+        absl::EndsWith(filename, ".stubby.h") ||
+        absl::EndsWith(filename, ".pbobjc.h.meta"))) {
     return nullptr;
   }
   proto::VName context_vname;


### PR DESCRIPTION
`.pbobjc.h` is the extension used by the Objc generated code (which is also indexed by the C++ indexer). `.pbobjc.h.meta` will be the extension used to provide cross-references in the objc code generator.