### PR TITLE
fix(typescript_indexer): emit correct vnames for static methods

### DIFF
--- a/kythe/typescript/indexer.ts
+++ b/kythe/typescript/indexer.ts
@@ -71,7 +71,7 @@ function hasExpressionInitializer(node: ts.Node):
  * Determines if a node is a static member of a class.
  */
 function isStaticMember(node: ts.Node, klass: ts.Declaration): boolean {
-  return ts.isPropertyDeclaration(node) && node.parent === klass &&
+  return (ts.isPropertyDeclaration(node) || ts.isMethodDeclaration(node)) && node.parent === klass &&
       ((ts.getCombinedModifierFlags(node) & ts.ModifierFlags.Static) > 0);
 }
 
@@ -1655,11 +1655,8 @@ class Visitor {
       todo(this.sourceRoot, decl, 'Emit variable delaration code');
     }
 
-    if (ts.isPropertyDeclaration(decl)) {
-      const declNode = decl as ts.PropertyDeclaration;
-      if (isStaticMember(declNode, declNode.parent)) {
-        this.emitFact(vname, FactName.TAG_STATIC, '');
-      }
+    if (ts.isPropertyDeclaration(decl) && isStaticMember(decl, decl.parent)) {
+      this.emitFact(vname, FactName.TAG_STATIC, '');
     }
     if (ts.isPropertySignature(decl) ||
         ts.isPropertyDeclaration(decl) ||
@@ -2157,6 +2154,9 @@ class Visitor {
       this.emitFact(vname, FactName.COMPLETE, 'incomplete');
     }
     this.emitMarkedSourceForFunction(decl, vname);
+    if (ts.isMethodDeclaration(decl) && isStaticMember(decl, decl.parent)) {
+      this.emitFact(vname, FactName.TAG_STATIC, '');
+    }
   }
 
   /**

--- a/kythe/typescript/testdata/class.ts
+++ b/kythe/typescript/testdata/class.ts
@@ -79,6 +79,13 @@ class Class implements IFace {
         this.method();
     }
 
+    //- @method defines/binding StaticMethod
+    //- StaticMethod.tag/static _
+    //- !{ @method defines/binding Method }
+    //- StaticMethod.node/kind function
+    //- StaticMethod childof Class
+    static method() {}
+
     //- @"#privateMethod" defines/binding PrivateMethod
     //- PrivateMethod.node/kind function
     //- PrivateMethod childof Class


### PR DESCRIPTION
According to https://github.com/kythe/kythe/blob/master/kythe/typescript/SCHEMA.md#class-declaration static methods should get different vnames from instance methods. But currently static methods are treated as instance methods and vnames overlap. This PR fixes that.

Note that static properties already work correctly.