### PR TITLE
Add support for Bzlmod

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
             ^(AUTHORS|CONTRIBUTORS|WORKSPACE|LICENSE)$
             |(^|/)BUILD([^*/]*\.bazel)?$
             |(^|/)requirements\.[^.]+$
-            |\.(pb\.go|md|yaml|yml|json|html|bzl|lock|patch|BUILD|WORKSPACE|kzip|tex|tac|bazelproject)$
+            |\.(pb\.go|md|yaml|yml|json|html|bzl|lock|patch|BUILD|WORKSPACE|MODULE.bazel|kzip|tex|tac|bazelproject)$
             |(^|/)(\.[^/]*|go\.mod|go\.sum)$
             |^tools/|^third_party/|^kythe/web/site/
             |worker/info/(admin|host)$

--- a/kythe/release/BUILD
+++ b/kythe/release/BUILD
@@ -28,6 +28,7 @@ genrule(
     name = "release",
     srcs = [
         "release.BUILD",
+        "release.MODULE.bazel",
         "release.WORKSPACE",
         ":bazel_cxx_extractor",
         ":bazel_extract_kzip",
@@ -68,6 +69,7 @@ genrule(
         "$(locations misc)",
         "--cp $(location release.BUILD) BUILD",
         "--cp $(location release.WORKSPACE) WORKSPACE",
+        "--cp $(location release.MODULE.bazel) MODULE.bazel",
         "--cp $(location java_indexer) indexers/java_indexer.jar",
         "--cp $(location jvm_indexer) indexers/jvm_indexer.jar",
         "--cp $(location cxx_indexer) indexers/cxx_indexer",

--- a/kythe/release/release.MODULE.bazel
+++ b/kythe/release/release.MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "kythe",
+    version = "0.0.68",
+    repo_name = "io_kythe",
+)
+
+bazel_dep(name = "protobuf", version = "3.19.6", repo_name = "com_google_protobuf")

--- a/kythe/release/setup_release.sh
+++ b/kythe/release/setup_release.sh
@@ -92,8 +92,9 @@ EOF
 } > RELEASES.md.new
 mv -f RELEASES.md.new RELEASES.md
 
-# Update release_version stamp for binaries
+# Update release_version stamp for binaries and BCR releases
 sed -ri "s/^release_version = .+/release_version = \"$version\"/" kythe/release/BUILD
+sed -ri "s/^    version = .+/    version = \"$version\",/" kythe/release/release.MODULE.bazel
 
 if ! diff -q <(git diff --name-only) <(echo RELEASES.md; echo kythe/release/BUILD) >/dev/null; then
   if [[ -z "$(git diff --name-only -- RELEASES.md)" ]]; then


### PR DESCRIPTION
The extracted Kythe release archive can now be added as a `bazel_dep` via `local_path_override`. Upon the next release, it could also be added to the Bazel Central Registry.