### PR TITLE
indexer/proto: correctly visit oneof

### DIFF
--- a/kythe/cxx/indexer/proto/file_descriptor_walker.cc
+++ b/kythe/cxx/indexer/proto/file_descriptor_walker.cc
@@ -631,7 +631,7 @@ void FileDescriptorWalker::VisitOneofs(const std::string& message_name,
   ScopedLookup nested_type_num(&lookup_path,
                                DescriptorProto::kOneofDeclFieldNumber);
 
-  for (int i = 0; i < dp->oneof_decl_count(); i++) {
+  for (int i = 0; i < dp->real_oneof_decl_count(); i++) {
     ScopedLookup nested_index(&lookup_path, i);
     const OneofDescriptor* oneof = dp->oneof_decl(i);
     std::string vname = absl::StrCat(message_name, ".", oneof->name());


### PR DESCRIPTION
See
https://github.com/protocolbuffers/protobuf/blob/main/docs/implementing_proto3_presence.md#to-iterate-over-all-oneofs
for more info.

This helps silencing some error within simple proto3 files

```
syntax = "proto3";

package moo;

message Foo {
  optional int32 bar = 1;
}
```

which would yield
```
file_descriptor_walker.cc:262] Unexpected location vector [] while walking moo.proto
```

before this change.
