### PR TITLE
[extractors] Add an extractor for rust-project.json

### DIFF
--- a/kythe/go/extractors/cmd/rust/BUILD
+++ b/kythe/go/extractors/cmd/rust/BUILD
@@ -1,0 +1,37 @@
+load("//tools:build_rules/shims.bzl", "go_binary", "go_test")
+
+package(default_visibility = ["//kythe:default_visibility"])
+
+go_binary(
+    name = "rust_project_to_kzip",
+    srcs = ["rust_project_to_kzip.go"],
+    deps = [
+        "//kythe/go/platform/kzip",
+        "//kythe/go/platform/vfs",
+        "//kythe/go/util/log",
+        "//kythe/go/util/vnameutil",
+        "//kythe/proto:analysis_go_proto",
+        "//kythe/proto:storage_go_proto",
+    ],
+)
+
+go_test(
+    name = "rust_project_to_kzip_test",
+    size = "small",
+    srcs = [
+        "rust_project_to_kzip.go",
+        "rust_project_to_kzip_test.go",
+    ],
+    visibility = ["//visibility:private"],
+    deps = [
+        "//kythe/go/platform/kzip",
+        "//kythe/go/platform/vfs",
+        "//kythe/go/util/vnameutil",
+        "//kythe/proto:analysis_go_proto",
+        "//kythe/proto:storage_go_proto",
+        "@com_github_google_go_cmp//cmp",
+        "@com_github_google_go_cmp//cmp/cmpopts",
+        "@org_golang_google_protobuf//proto",
+        "@org_golang_google_protobuf//testing/protocmp",
+    ],
+)

--- a/kythe/go/extractors/cmd/rust/rust_project_to_kzip.go
+++ b/kythe/go/extractors/cmd/rust/rust_project_to_kzip.go
@@ -1,0 +1,603 @@
+/*
+ * Copyright 2025 The Kythe Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"kythe.io/kythe/go/platform/kzip"
+	"kythe.io/kythe/go/platform/vfs"
+	"kythe.io/kythe/go/util/vnameutil"
+	apb "kythe.io/kythe/proto/analysis_go_proto"
+	spb "kythe.io/kythe/proto/storage_go_proto"
+)
+
+// the central state for the rust-project extractor
+type extractor struct {
+	project             rustProject
+	projectRoot         string
+	corpus              string
+	rules               vnameutil.Rules
+	kzipWriter          kzipWriterInterface
+	requiredInputsCache *requiredInputsCache
+}
+
+// kzipWriterInterface defines the methods needed from a kzip writer.
+type kzipWriterInterface interface {
+	AddUnit(cu *apb.CompilationUnit, index *apb.IndexedCompilation_Index) (string, error)
+	AddFile(r io.Reader) (string, error)
+	Close() error // Add if Close is needed by the caller of writeCrate, though not writeCrate itself
+}
+
+// source is the set of directories which may have source files for this crate,
+// as well as directories which are explicitly excluded from containing necessary source files.
+type source struct {
+	IncludeDirs []string `json:"include_dirs"`
+	ExcludeDirs []string `json:"exclude_dirs"`
+}
+
+// dep is a dependency of a Crate
+type dep struct {
+	CrateId crateId `json:"crate"`
+	Name    string  `json:"name"`
+}
+
+type crate struct {
+	DisplayName       string   `json:"display_name,omitempty"`
+	RootModule        string   `json:"root_module"`
+	Edition           string   `json:"edition"`
+	Deps              []dep    `json:"deps"`
+	Cfg               []string `json:"cfg"`
+	CrateId           crateId  `json:"-"` // do not output
+	Label             string   `json:"label"`
+	Target            string   `json:"target"`
+	Source            source   `json:"source,omitempty"`
+	IsWorkspaceMember bool     `json:"is_workspace_member"`
+}
+
+type crateId uint32
+
+// A representation of rust-project.json.
+// Note: doesn't include all fields which exist in rust-project.json, only the ones we need to convert to a kzip.
+type rustProject struct {
+	Crates []crate `json:"crates"`
+}
+
+// Go doesn't let you use a struct with a slice member as a key to a map
+// So, define a struct which is of the type we want for a key, then give it a method to get a
+// valid key to a map out of it.
+type requiredInputMapKey string
+type requiredInputCacheKey struct {
+	includeDir   string
+	exclude_dirs []string
+}
+
+func (k *requiredInputCacheKey) mapKey() requiredInputMapKey {
+	sort.Slice(k.exclude_dirs, func(i, j int) bool {
+		return k.exclude_dirs[i] < k.exclude_dirs[j]
+	})
+	return requiredInputMapKey(strings.Join(append([]string{k.includeDir}, k.exclude_dirs...), "|"))
+}
+
+type requiredInputValue struct {
+	requiredInputs []*apb.CompilationUnit_FileInput
+	sourceFiles    []string
+}
+
+// requiredInputsCache stores the results of file discovery operations to avoid
+// redundant filesystem walks and kzip additions. It maps include directory paths
+// (relative to the project root) to the files found within them. This is
+// particularly useful when multiple crates share common dependency source directories.
+type requiredInputsCache struct {
+	cache map[requiredInputMapKey]*requiredInputValue
+}
+
+func newRequiredInputsCache() requiredInputsCache {
+	return requiredInputsCache{
+		cache: make(map[requiredInputMapKey]*requiredInputValue),
+	}
+}
+
+// Check that the project root exists and is valid.
+func ensureProjectRoot(projectRoot string) {
+	if info, err := os.Stat(projectRoot); os.IsNotExist(err) {
+		log.Fatalf("Project root does not exist: %s\n", projectRoot)
+	} else if err == nil && !info.IsDir() {
+		log.Fatalf("Project root is not a directory: %s\n", projectRoot)
+	} else if err != nil {
+		log.Fatalf("Error checking project root: %v\n", err)
+	}
+}
+
+// Parse a RustProject from a path on the disk, then make all paths within that RustProject relative to a projectRoot.
+func getProjectJSON(projectJSONPath string) rustProject {
+	projectJsonFile, err := os.Open(projectJSONPath)
+	if err != nil {
+		log.Fatalf("Error opening rust-project.json: %v\n", err)
+	}
+	defer projectJsonFile.Close()
+
+	var projectJson rustProject
+	decoder := json.NewDecoder(projectJsonFile)
+	err = decoder.Decode(&projectJson)
+	if err != nil {
+		log.Fatalf("Error decoding rust-project.json: %v\n", err)
+	}
+
+	return projectJson
+}
+
+// Make all paths in includeDirs, excludeDirs, and rootModule relative to the project root
+func (project *rustProject) relativizeProjectJson(projectRoot string) {
+	for i, crate := range project.Crates {
+		for j, includeDir := range crate.Source.IncludeDirs {
+			relativized, err := removeProjectRoot(includeDir, projectRoot)
+			if err != nil {
+				log.Printf("Error getting relative path between %s and %s, not relativizing:%v\n", includeDir, projectRoot, err)
+				continue
+			}
+
+			project.Crates[i].Source.IncludeDirs[j] = relativized
+		}
+
+		for j, excludeDir := range crate.Source.ExcludeDirs {
+			relativized, err := removeProjectRoot(excludeDir, projectRoot)
+			if err != nil {
+				log.Printf("Error getting relative path between %s and %s, not relativizing:%v\n", excludeDir, projectRoot, err)
+				continue
+			}
+			project.Crates[i].Source.ExcludeDirs[j] = relativized
+		}
+
+		relativized, err := removeProjectRoot(crate.RootModule, projectRoot)
+		if err != nil {
+			log.Printf("Error getting relative path between %s and %s, not relativizing:%v\n", crate.RootModule, projectRoot, err)
+			continue
+		}
+		project.Crates[i].RootModule = relativized
+
+	}
+}
+
+// Remove the project root from a path, returning the relative path.
+func removeProjectRoot(path string, projectRoot string) (string, error) {
+	newPath, err := filepath.Rel(projectRoot, path)
+	if err != nil {
+		log.Printf("Error getting relative path between %s and %s, not relativizing:%v\n", path, projectRoot, err)
+		return "", err
+	}
+	return newPath, nil
+}
+
+// Create a new kzip writer.
+func newKzipWriter(ctx context.Context, outputZipPath string) *kzip.Writer {
+	// Delete output zip if it already exists
+	_ = os.RemoveAll(outputZipPath)
+
+	out, err := vfs.Create(ctx, outputZipPath)
+	if err != nil {
+		log.Fatalf("Error creating output zip: %v\n", err)
+	}
+
+	kzipWriter, err := kzip.NewWriteCloser(out)
+	if err != nil {
+		log.Fatalf("Error creating kzip writer: %v\n", err)
+	}
+	return kzipWriter
+}
+
+// transitiveDepsForCrate performs a breadth-first search on the crate dependency graph
+// starting from the given `crate`. It uses the direct dependency relationships defined
+// in `crateDeps` to find all reachable crates.
+func transitiveDepsForCrate(crate crate, crateDeps map[crateId][]crateId) []crateId {
+	queue := []crateId{crate.CrateId}
+	visited := make(map[crateId]bool)
+	for len(queue) > 0 {
+		currentCrateId := queue[0]
+		queue = queue[1:] // Dequeue
+
+		// Iterate over the direct dependencies of the current crate
+		for _, dep := range crateDeps[currentCrateId] {
+			// If the dependency hasn't been visited, add it to the queue and mark it as visited
+			if _, ok := visited[dep]; !ok {
+				queue = append(queue, dep)
+				visited[dep] = true
+			}
+		}
+	}
+	transitiveDeps := make([]crateId, 0)
+	for k := range visited {
+		transitiveDeps = append(transitiveDeps, k)
+	}
+	sort.Slice(transitiveDeps, func(i, j int) bool {
+		return transitiveDeps[i] < transitiveDeps[j]
+	})
+
+	return transitiveDeps
+}
+
+// getTransitiveDeps returns a map of all crate IDs to transitive crate dependencies, including itself
+func getTransitiveDeps(crates []crate) [][]crateId {
+	crateDeps := make(map[crateId][]crateId)
+	for _, crate := range crates {
+		// Add direct dependencies
+		for _, dep := range crate.Deps {
+			crateDeps[crate.CrateId] = append(crateDeps[crate.CrateId], dep.CrateId)
+		}
+
+		// Add the crate itself as its own dependency
+		crateDeps[crate.CrateId] = append(crateDeps[crate.CrateId], crate.CrateId)
+	}
+
+	// get the transitive dependencies of each crate
+	transitiveDeps := make([][]crateId, len(crates))
+	for _, crate := range crates {
+		transitiveDepsForCrate := transitiveDepsForCrate(crate, crateDeps)
+		transitiveDeps[crate.CrateId] = transitiveDepsForCrate
+	}
+	return transitiveDeps
+}
+
+// getSourceDirs returns the set of included and excluded directories for all crates
+// Additionally, we add the directory of the root module to the set of included directories.
+// It returns a data structure containing the source directories and dependent directories, paired by include and exclude.
+// Note: the returned source directories are NOT transitive
+func getSourceDirs(crates []crate) map[crateId]source {
+	perCrateSourceDirs := make(map[crateId]source)
+	for _, crate := range crates {
+		currentSourceDirs := source{
+			IncludeDirs: []string{},
+			ExcludeDirs: []string{},
+		}
+		currentSourceDirs.IncludeDirs = append(currentSourceDirs.IncludeDirs, crate.Source.IncludeDirs...)
+		currentSourceDirs.ExcludeDirs = append(currentSourceDirs.ExcludeDirs, crate.Source.ExcludeDirs...)
+
+		if len(crate.Source.IncludeDirs) == 0 {
+			// Add the dir of the root module for the crate, which is implicitly included
+			currentSourceDirs.IncludeDirs = append(currentSourceDirs.IncludeDirs, filepath.Dir(crate.RootModule))
+		}
+
+		perCrateSourceDirs[crate.CrateId] = currentSourceDirs
+	}
+
+	return perCrateSourceDirs
+}
+
+// whether we should include this file in the Compilation Unit based on the inclusions/exclusions in `sourceDirs`
+func shouldIncludeFile(info os.FileInfo, path string, excludeDirs []string, projectRoot string) (bool, error) {
+	if info.IsDir() {
+		// check that this file isn't one of the dirs excluded by this crate
+		for _, excludeDir := range excludeDirs {
+			if filepath.Dir(path) == filepath.Join(projectRoot, excludeDir) {
+				return false, filepath.SkipDir
+			}
+		}
+		return false, nil
+	}
+
+	// only index .rs files for now. It's possible that some rust files depend on non rust files, like if they use include_bytes,
+	// TODO(wittrock): figure out a better scheme for including all actually depended-on files and still exclude files like .deps and .rmeta
+	if filepath.Ext(path) != ".rs" {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+type collectCrateSourcesFunc func(ctx context.Context, e *extractor, sourceDirs source) ([]string, []*apb.CompilationUnit_FileInput, error)
+
+// collectCrateSourcesImpl walks the file system based on the provided sourceDirs,
+// identifies relevant source files (currently only .rs files), adds them to the
+// kzip archive, and returns lists of their relative paths and FileInput protos.
+func collectCrateSourcesImpl(ctx context.Context, e *extractor, sourceDirs source) ([]string, []*apb.CompilationUnit_FileInput, error) {
+	var sourceFiles []string
+	var requiredInputs []*apb.CompilationUnit_FileInput
+
+	// cache required inputs for each include_dir
+	for _, includeDir := range sourceDirs.IncludeDirs {
+
+		abspath := filepath.Join(e.projectRoot, includeDir)
+
+		cacheKey := requiredInputCacheKey{
+			includeDir:   abspath,
+			exclude_dirs: sourceDirs.ExcludeDirs,
+		}
+
+		mapKey := cacheKey.mapKey()
+
+		cacheVal := e.requiredInputsCache.cache[mapKey]
+		if cacheVal != nil {
+			requiredInputs = append(requiredInputs, cacheVal.requiredInputs...)
+			sourceFiles = append(sourceFiles, cacheVal.sourceFiles...)
+
+			// we don't need to add sources in this directory, because they've already been written if they're in the cache.
+			continue
+		}
+
+		dirRequiredInputs := []*apb.CompilationUnit_FileInput{}
+		err := vfs.Walk(ctx, abspath, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+
+			shouldInclude, err := shouldIncludeFile(info, path, sourceDirs.ExcludeDirs, e.projectRoot)
+			if err != nil || !shouldInclude {
+				return err
+			}
+
+			relativePath, err := removeProjectRoot(path, e.projectRoot)
+			if err != nil {
+				log.Fatalf("couldn't relativize %s to project root %s: %v", path, e.projectRoot, err)
+			}
+
+			input, err := vfs.Open(ctx, path)
+			if err != nil {
+				return err
+			}
+			defer input.Close()
+
+			digest, err := e.kzipWriter.AddFile(input)
+			if err != nil {
+				return err
+			}
+
+			vname := &spb.VName{
+				Corpus: e.corpus,
+				Path:   relativePath,
+			}
+
+			if inferredVname, ok := e.rules.Apply(relativePath); ok {
+				vname = inferredVname
+				vname.Corpus = e.corpus
+			}
+
+			sourceFiles = append(sourceFiles, relativePath)
+			dirRequiredInputs = append(dirRequiredInputs, &apb.CompilationUnit_FileInput{
+				VName: vname,
+				Info: &apb.FileInfo{
+					Path:   relativePath,
+					Digest: digest,
+				},
+			})
+			return nil
+		})
+
+		// Some crates have include_dirs that don't actually exist on disk
+		if err != nil && !os.IsNotExist(err) && err != filepath.SkipDir {
+			log.Printf("not including %s: %v\n", abspath, err)
+			continue
+		}
+
+		requiredInputs = append(requiredInputs, dirRequiredInputs...)
+
+		e.requiredInputsCache.cache[mapKey] = &requiredInputValue{
+			requiredInputs: dirRequiredInputs,
+			sourceFiles:    sourceFiles,
+		}
+	}
+
+	return sourceFiles, requiredInputs, nil
+}
+
+// Copies a crate, but does not clone strings
+func deepCopyCrate(crate crate) crate {
+	newCrate := crate
+	newCrate.Deps = make([]dep, len(crate.Deps))
+	copy(newCrate.Deps, crate.Deps)
+	return newCrate
+}
+
+// synthesizeProjectJson creates a RustProject from a given crate and its transitive dependencies
+func synthesizeProjectJson(id crateId, crates []crate, transitiveDeps [][]crateId) rustProject {
+	project := rustProject{
+		Crates: []crate{},
+	}
+
+	// Map of old crate ID -> new crate ID for all crates in this project
+	newCrateIds := make(map[crateId]crateId)
+
+	for _, dep := range transitiveDeps[id] {
+		crate := deepCopyCrate(crates[dep])
+		crate.IsWorkspaceMember = true
+		newCrateIds[crate.CrateId] = crateId(len(project.Crates))
+		project.Crates = append(project.Crates, crate)
+	}
+
+	// fix up crate deps - deps are defined by an index into the crates array,
+	// but the new crates array no longer has the same crate ID space
+	for i, crate := range project.Crates {
+		for j, dep := range crate.Deps {
+			project.Crates[i].Deps[j].CrateId = newCrateIds[dep.CrateId]
+		}
+	}
+
+	return project
+}
+
+// return a rustProject as its JSON-encoded bytes
+func getProjectBytes(project rustProject) *bytes.Reader {
+	var buf bytes.Buffer
+	err := json.NewEncoder(&buf).Encode(project)
+	if err != nil {
+		log.Fatalf("Error encoding project JSON: %v\n", err)
+	}
+
+	return bytes.NewReader(buf.Bytes())
+}
+
+// writeCrate processes a single Rust crate, determines its source files and all
+// required inputs (including transitive dependencies), constructs a Kythe
+// CompilationUnit protobuf, and adds the unit and its required files to the
+// kzip archive. It utilizes a cache (`requiredInputsBuilder`) to efficiently find
+// necessary files. The `rust-project.json` file is synthesized and added as a required
+// input to every unit.
+func (e *extractor) writeCrate(ctx context.Context, crate crate, transitiveDeps [][]crateId, sourceDirs map[crateId]source, collectCrateSources collectCrateSourcesFunc) error {
+	// We need to write two sets of files to the kzip:
+	// 1. the set of files in this crate, as Source files
+	// 2. the other required inputs for this crate which aren't in the set of source files for this crate (dependencies)
+	// We can use collectCrateSources for both, with a different argument of source dirs
+	var crateFiles []string
+	var err error
+	if crateFiles, _, err = collectCrateSources(ctx, e, sourceDirs[crate.CrateId]); err != nil {
+		log.Printf("Error getting source files for crate %s: %v\n", crate.Label, err)
+		return err
+	}
+
+	// Get the set of depended-on files for the entire crate, not just direct source files
+	var requiredInputs []*apb.CompilationUnit_FileInput = make([]*apb.CompilationUnit_FileInput, 0)
+	for _, dep := range transitiveDeps[crate.CrateId] {
+		_, depRequiredInputs, err := collectCrateSources(ctx, e, sourceDirs[dep])
+		if err != nil {
+			log.Printf("Error getting source files for crate %s: %v\n", crate.Label, err)
+			return err
+		}
+		requiredInputs = append(requiredInputs, depRequiredInputs...)
+	}
+
+	// Synthesize a rust-project.json for this crate and add it to the CU
+	projectJsonDigest, err := e.kzipWriter.AddFile(getProjectBytes(synthesizeProjectJson(crate.CrateId, e.project.Crates, transitiveDeps)))
+	if err != nil {
+		log.Printf("Error adding project json to kzip: %v\n", err)
+		return err
+	}
+	projectJsonVname := &spb.VName{
+		Corpus: e.corpus,
+		Path:   "rust-project.json",
+	}
+	requiredInputs = append(requiredInputs, &apb.CompilationUnit_FileInput{
+		VName: projectJsonVname,
+		Info: &apb.FileInfo{
+			Path:   "rust-project.json",
+			Digest: projectJsonDigest,
+		},
+	})
+
+	compilationUnit := &apb.CompilationUnit{
+		VName: &spb.VName{
+			Corpus:   e.corpus,
+			Language: "rust",
+		},
+		RequiredInput: requiredInputs,
+		SourceFile:    crateFiles,
+	}
+
+	digest, err := e.kzipWriter.AddUnit(compilationUnit, nil)
+	if err != nil {
+		log.Printf("Error adding compilation unit to kzip: %v, crate %s, digest: %s\n", err, crate.Label, digest)
+		return err
+	}
+
+	return nil
+}
+
+func main() {
+	projectJSONPath := flag.String("project_json", "", "Path to the rust-project.json file (required)")
+	outputZipPath := flag.String("output", "", "Path for the output kzip file (required)")
+	projectRoot := flag.String("root", "", "Directory to which all paths to source files are relative; the root directory to all possible source files. (required)")
+	corpus := flag.String("corpus", "", "Corpus name for VNames (required)")
+	vnamesJsonPath := flag.String("vnames_json_path", "", "Path to vnames.json (required)")
+	crateFilter := flag.String("crate_filter", "", "optional, the module path for a specific crate to extract and output. All other crates will be ignored")
+
+	flag.Parse()
+
+	if *projectJSONPath == "" || *outputZipPath == "" || *projectRoot == "" || *corpus == "" || *vnamesJsonPath == "" {
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	ctx := context.Background()
+
+	ensureProjectRoot(*projectRoot)
+
+	rules, err := vnameutil.LoadRules(*vnamesJsonPath)
+	if err != nil {
+		log.Fatalf("Error loading vname rules: %v", err)
+	}
+
+	projectJson := getProjectJSON(*projectJSONPath)
+	projectJson.relativizeProjectJson(*projectRoot)
+
+	// Assign crate IDs (dense)
+	for id := range projectJson.Crates {
+		projectJson.Crates[id].CrateId = crateId(id)
+	}
+
+	crates := projectJson.Crates
+
+	// Many crates have the same source dirs they depend on.
+	// Caching the map of crate -> files speeds this program up by ~two orders of magnitude for the Fuchsia corpus.
+	requiredInputsCache := newRequiredInputsCache()
+
+	// rust-project.json's deps aren't transitive, but Compilation Units deps are.
+	// Get the set of source dirs we'll need files from, transitively.
+	transitiveDeps := getTransitiveDeps(crates)
+	sourceDirsPerCrate := getSourceDirs(crates)
+
+	kzipWriter := newKzipWriter(ctx, *outputZipPath)
+
+	extractor := extractor{
+		project:             projectJson,
+		projectRoot:         *projectRoot,
+		corpus:              *corpus,
+		rules:               rules,
+		kzipWriter:          kzipWriter,
+		requiredInputsCache: &requiredInputsCache,
+	}
+
+	cratesWritten := 0
+	for _, crate := range crates {
+		if *crateFilter != "" && *crateFilter != crate.RootModule {
+			continue
+		}
+
+		if !crate.IsWorkspaceMember {
+			// rust-project.json allows crates to be included in the file which aren't part of the workspace.
+			// For completeness we choose to index them anyway.
+			log.Printf("crate %s isn't a workspace member, but indexing anyway\n", crate.Label)
+		}
+
+		// If the root module for this crate doesn't exist on disk, skip the crate
+		if _, err := os.Stat(filepath.Join(*projectRoot, crate.RootModule)); os.IsNotExist(err) {
+			log.Printf("Root module does not exist: %s\n", crate.RootModule)
+			continue
+		}
+
+		log.Printf("Adding crate %s...", crate.Label)
+		err := extractor.writeCrate(ctx, crate, transitiveDeps, sourceDirsPerCrate, collectCrateSourcesImpl)
+		fmt.Println(" done.")
+		if err != nil {
+			log.Printf("Error writing crate %s: %v\n", crate.Label, err)
+			continue
+		}
+		cratesWritten++
+	}
+
+	log.Printf("Processed %d crates\n", len(crates))
+	log.Printf("Wrote %d units\n", cratesWritten)
+	kzipWriter.Close()
+	log.Printf("Wrote zip to %s\n", *outputZipPath)
+}

--- a/kythe/go/extractors/cmd/rust/rust_project_to_kzip_test.go
+++ b/kythe/go/extractors/cmd/rust/rust_project_to_kzip_test.go
@@ -1,0 +1,1005 @@
+/*
+ * Copyright 2025 The Kythe Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"slices"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/testing/protocmp"
+	apb "kythe.io/kythe/proto/analysis_go_proto"
+	spb "kythe.io/kythe/proto/storage_go_proto"
+)
+
+func TestGetTransitiveDependencies(t *testing.T) {
+	// Helper to create a simple Crate for testing
+	makeCrate := func(id crateId) crate {
+		return crate{CrateId: id}
+	}
+
+	tests := []struct {
+		name       string
+		startCrate crate
+		crateDeps  map[crateId][]crateId
+		want       []crateId
+	}{{
+		name:       "No dependencies",
+		startCrate: makeCrate(1),
+		crateDeps: map[crateId][]crateId{
+			1: {},
+		},
+		want: []crateId{},
+	},
+		{
+			name:       "Simple direct dependencies",
+			startCrate: makeCrate(1),
+			crateDeps: map[crateId][]crateId{
+				1: {2, 3},
+				2: {},
+				3: {},
+			},
+			want: []crateId{2, 3},
+		},
+		{
+			name:       "Simple transitive dependencies (A -> B -> C)",
+			startCrate: makeCrate(1),
+			crateDeps: map[crateId][]crateId{
+				1: {2},
+				2: {3},
+				3: {},
+			},
+			want: []crateId{2, 3},
+		},
+		{
+			name:       "Multiple paths to same dependency (A -> B, A -> C, B -> C)",
+			startCrate: makeCrate(1),
+			crateDeps: map[crateId][]crateId{
+				1: {2, 3},
+				2: {3},
+				3: {},
+			},
+			want: []crateId{2, 3},
+		},
+		{
+			name:       "Diamond dependency (A -> B, A -> C, B -> D, C -> D)",
+			startCrate: makeCrate(1),
+			crateDeps: map[crateId][]crateId{
+				1: {2, 3},
+				2: {4},
+				3: {4},
+				4: {},
+			},
+			want: []crateId{2, 3, 4},
+		},
+		{
+			name:       "Cyclic dependency (A -> B -> C -> A)",
+			startCrate: makeCrate(1),
+			crateDeps: map[crateId][]crateId{
+				1: {2},
+				2: {3},
+				3: {1}, // Cycle back to A
+			},
+			want: []crateId{1, 2, 3},
+		},
+		{
+			name:       "Deeper cycle (A -> B -> C -> D -> B)",
+			startCrate: makeCrate(1),
+			crateDeps: map[crateId][]crateId{
+				1: {2},
+				2: {3},
+				3: {4},
+				4: {2}, // Cycle back to B
+			},
+			want: []crateId{2, 3, 4},
+		},
+		{
+			name:       "Disconnected graph (A -> B, C -> D)",
+			startCrate: makeCrate(1),
+			crateDeps: map[crateId][]crateId{
+				1: {2},
+				2: {},
+				3: {4},
+				4: {},
+			},
+			want: []crateId{2}, // Only B is reachable from A
+		},
+		{
+			name:       "Empty dependency graph",
+			startCrate: makeCrate(1),
+			crateDeps:  map[crateId][]crateId{},
+			want:       []crateId{},
+		},
+		{
+			name:       "Start crate not in graph keys",
+			startCrate: makeCrate(5), // Crate 5 is not a key in crateDeps
+			crateDeps: map[crateId][]crateId{
+				1: {2},
+				2: {3},
+			},
+			want: []crateId{},
+		},
+		{
+			name:       "Dependencies not defined elsewhere",
+			startCrate: makeCrate(1),
+			crateDeps: map[crateId][]crateId{
+				1: {2, 3}, // Crate 2 and 3 don't have entries in the map
+			},
+			want: []crateId{2, 3},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := transitiveDepsForCrate(tt.startCrate, tt.crateDeps)
+			// Sort the expected slice just in case (though they should be defined sorted)
+			sort.Slice(tt.want, func(i, j int) bool { return tt.want[i] < tt.want[j] })
+
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("getTransitiveDependencies() diff: %v", diff)
+			}
+		})
+	}
+}
+
+// Test specifically for sorting output
+func TestGetTransitiveDependencies_Sorting(t *testing.T) {
+	makeCrate := func(id crateId) crate {
+		return crate{CrateId: id}
+	}
+	crateDeps := map[crateId][]crateId{
+		1: {5, 2, 4, 3}, // Unsorted direct dependencies
+		2: {6},
+		3: {},
+		4: {},
+		5: {},
+		6: {},
+	} // Unsorted direct dependencies
+	startCrate := makeCrate(1)
+	want := []crateId{2, 3, 4, 5, 6} // Expected sorted output
+
+	got := transitiveDepsForCrate(startCrate, crateDeps)
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("getTransitiveDependencies() sorting failed = %v, want %v", got, want)
+	}
+}
+
+func TestRelativizeProjectJson(t *testing.T) {
+	projectRoot := "/home/user/myproject"
+	projectRootWithSlash := projectRoot + "/"
+
+	join := func(elem ...string) string {
+		// Filter out empty strings which Join usually ignores
+		nonEmpty := []string{}
+		for _, e := range elem {
+			if e != "" {
+				nonEmpty = append(nonEmpty, e)
+			}
+		}
+		if len(nonEmpty) == 0 {
+			return ""
+		}
+		// Use filepath.Clean to handle separators and relative elements correctly
+		return filepath.Clean(strings.Join(nonEmpty, "/"))
+	}
+
+	tests := []struct {
+		name        string
+		projectRoot string
+		input       rustProject
+		want        rustProject
+	}{
+		{
+			name:        "Empty project",
+			projectRoot: projectRoot,
+			input:       rustProject{Crates: []crate{}},
+			want:        rustProject{Crates: []crate{}},
+		},
+		{
+			name:        "Single crate with absolute paths inside root",
+			projectRoot: projectRoot,
+			input: rustProject{
+				Crates: []crate{
+					{
+						CrateId:    0,
+						RootModule: join(projectRoot, "src", "main.rs"),
+						Source: source{
+							IncludeDirs: []string{join(projectRoot, "src"), join(projectRoot, "vendor", "dep1")},
+							ExcludeDirs: []string{join(projectRoot, "target"), join(projectRoot, "src", "tests")},
+						},
+					},
+				},
+			},
+			want: rustProject{
+				Crates: []crate{
+					{
+						CrateId:    0,
+						RootModule: join("src", "main.rs"),
+						Source: source{
+							IncludeDirs: []string{join("src"), join("vendor", "dep1")},
+							ExcludeDirs: []string{join("target"), join("src", "tests")},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "Single crate with trailing slash in root",
+			projectRoot: projectRootWithSlash, // Use root with trailing slash
+			input: rustProject{
+				Crates: []crate{
+					{
+						CrateId:    0,
+						RootModule: join(projectRoot, "src", "main.rs"),
+						Source: source{
+							IncludeDirs: []string{join(projectRoot, "src")},
+							ExcludeDirs: []string{join(projectRoot, "target")},
+						},
+					},
+				},
+			},
+			want: rustProject{
+				Crates: []crate{
+					{
+						CrateId:    0,
+						RootModule: join("src", "main.rs"),
+						Source: source{
+							IncludeDirs: []string{join("src")},
+							ExcludeDirs: []string{join("target")},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "Multiple crates",
+			projectRoot: projectRoot,
+			input: rustProject{
+				Crates: []crate{
+					{
+						CrateId:    0,
+						RootModule: join(projectRoot, "crate0", "lib.rs"),
+						Source: source{
+							IncludeDirs: []string{join(projectRoot, "crate0")},
+							ExcludeDirs: []string{},
+						},
+					},
+					{
+						CrateId:    1,
+						RootModule: join(projectRoot, "crate1", "main.rs"),
+						Source: source{
+							IncludeDirs: []string{join(projectRoot, "crate1", "src")},
+							ExcludeDirs: []string{join(projectRoot, "crate1", "target")},
+						},
+					},
+				},
+			},
+			want: rustProject{
+				Crates: []crate{
+					{
+						CrateId:    0,
+						RootModule: join("crate0", "lib.rs"),
+						Source: source{
+							IncludeDirs: []string{join("crate0")},
+							ExcludeDirs: []string{},
+						},
+					},
+					{
+						CrateId:    1,
+						RootModule: join("crate1", "main.rs"),
+						Source: source{
+							IncludeDirs: []string{join("crate1", "src")},
+							ExcludeDirs: []string{join("crate1", "target")},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "Paths already relative",
+			projectRoot: projectRoot,
+			input: rustProject{
+				Crates: []crate{
+					{
+						CrateId:    0,
+						RootModule: join("src", "main.rs"), // Already relative
+						Source: source{
+							IncludeDirs: []string{join("src")},
+							ExcludeDirs: []string{join("target")},
+						},
+					},
+				},
+			},
+			want: rustProject{ // Expect no change
+				Crates: []crate{
+					{
+						CrateId:    0,
+						RootModule: join("src", "main.rs"),
+						Source: source{
+							IncludeDirs: []string{join("src")},
+							ExcludeDirs: []string{join("target")},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "Paths outside project root (should become relative with ..)",
+			projectRoot: projectRoot,
+			input: rustProject{
+				Crates: []crate{
+					{
+						CrateId:    0,
+						RootModule: join(filepath.Dir(projectRoot), "other_project", "main.rs"),
+						Source: source{
+							IncludeDirs: []string{join(filepath.Dir(projectRoot), "shared_lib")},
+							ExcludeDirs: []string{join(projectRoot, "target")},
+						},
+					},
+				},
+			},
+			want: rustProject{
+				Crates: []crate{
+					{
+						CrateId:    0,
+						RootModule: join("..", "other_project", "main.rs"),
+						Source: source{
+							IncludeDirs: []string{join("..", "shared_lib")},
+							ExcludeDirs: []string{join("target")},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "Empty paths",
+			projectRoot: projectRoot,
+			input: rustProject{
+				Crates: []crate{
+					{
+						CrateId:    0,
+						RootModule: "", // Empty
+						Source: source{
+							IncludeDirs: []string{""}, // Empty
+							ExcludeDirs: []string{""}, // Empty
+						},
+					},
+				},
+			},
+			want: rustProject{
+				Crates: []crate{
+					{
+						CrateId:    0,
+						RootModule: "",
+						Source: source{
+							IncludeDirs: []string{""},
+							ExcludeDirs: []string{""},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "Nil/Empty slices for dirs",
+			projectRoot: projectRoot,
+			input: rustProject{
+				Crates: []crate{
+					{
+						CrateId:    0,
+						RootModule: join(projectRoot, "main.rs"),
+						Source: source{
+							IncludeDirs: nil,        // Nil slice
+							ExcludeDirs: []string{}, // Empty slice
+						},
+					},
+				},
+			},
+			want: rustProject{
+				Crates: []crate{
+					{
+						CrateId:    0,
+						RootModule: "main.rs",
+						Source: source{
+							IncludeDirs: nil,        // Should remain nil
+							ExcludeDirs: []string{}, // Should remain empty
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			input := tt.input
+			// Execute the method
+			input.relativizeProjectJson(tt.projectRoot)
+
+			// Assert
+			if diff := cmp.Diff(input, tt.want); diff != "" {
+				t.Errorf("relativizeProjectJson() (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// MockKzipWriter satisfies the parts of kzip.Writer used by writeCrate
+type MockKzipWriter struct {
+	AddUnitFunc func(*apb.CompilationUnit, *apb.IndexedCompilation_Index) (string, error)
+	// AddFile is needed by the mock getSourceFiles, not directly by writeCrate
+	AddFileFunc func(r io.Reader) (string, error)
+	AddedUnit   *apb.CompilationUnit // Stores the unit passed to AddUnit
+}
+
+func (m *MockKzipWriter) AddUnit(unit *apb.CompilationUnit, index *apb.IndexedCompilation_Index) (string, error) {
+	m.AddedUnit = unit
+	if m.AddUnitFunc != nil {
+		return m.AddUnitFunc(unit, index)
+	}
+	return "mockDigest", nil
+}
+
+func (m *MockKzipWriter) AddFile(r io.Reader) (string, error) {
+	if m.AddFileFunc != nil {
+		return m.AddFileFunc(r)
+	}
+	return "mockFileDigest", nil
+}
+
+func (m *MockKzipWriter) Close() error {
+	return nil
+}
+
+// MockCollectCrateSources provides a mock implementation for collectCrateSourcesFunc.
+type MockCollectCrateSources struct {
+	Results map[string]struct { // Keyed by a representative string (e.g., first include dir)
+		Files  []string
+		Inputs []*apb.CompilationUnit_FileInput
+		Err    error
+	}
+	Calls []struct {
+		SourceDirs  source
+		ProjectRoot string
+		Corpus      string
+	}
+}
+
+// collectCrateSources is the method implementing the collectCrateSourcesFunc signature.
+func (m *MockCollectCrateSources) collectCrateSources(ctx context.Context, e *extractor, sourceDirs source) ([]string, []*apb.CompilationUnit_FileInput, error) {
+	m.Calls = append(m.Calls, struct {
+		SourceDirs  source
+		ProjectRoot string
+		Corpus      string
+	}{SourceDirs: sourceDirs, ProjectRoot: e.projectRoot, Corpus: e.corpus})
+
+	// Use the first include dir as a simple key for the mock results.
+	// This requires test setup to ensure this key is unique enough.
+	key := ""
+	if len(sourceDirs.IncludeDirs) > 0 {
+		key = sourceDirs.IncludeDirs[0]
+	}
+
+	if res, ok := m.Results[key]; ok {
+		// Simulate adding files to kzip if not erroring
+		if res.Err == nil && e.kzipWriter != nil {
+			for _, f := range res.Files {
+				// We don't need the actual content for this mock
+				_, _ = e.kzipWriter.AddFile(strings.NewReader("mock content for " + f))
+			}
+		}
+		return res.Files, res.Inputs, res.Err
+	}
+	return nil, nil, fmt.Errorf("mock collectCrateSources not configured for key: %q", key)
+}
+
+func TestWriteCrate(t *testing.T) {
+	ctx := context.Background()
+	projectRoot := "/test/root"
+	corpus := "testcorpus"
+
+	// --- Test Data ---
+	crate0 := crate{
+		CrateId:    0,
+		Label:      "crate0",
+		RootModule: "crate0/src/lib.rs",
+		Source: source{
+			IncludeDirs: []string{"crate0/src"},
+			ExcludeDirs: []string{},
+		},
+		Deps: []dep{{CrateId: 1, Name: "crate1"}},
+	} // crate0 will be modified in the multi-dep test case
+	crate1 := crate{
+		Source: source{
+			IncludeDirs: []string{"vendor/crate1/src", "out/gen"},
+			ExcludeDirs: []string{},
+		},
+	}
+	crate2 := crate{
+		Source: source{
+			IncludeDirs: []string{"vendor/crate2"},
+			ExcludeDirs: []string{""},
+		},
+	}
+	crate3 := crate{
+		Source: source{
+			IncludeDirs: []string{"vendor/crate3"},
+			ExcludeDirs: []string{"out/gen"}, // the same directory INCLUDED by crate1
+		},
+	}
+
+	sourceDirs := map[crateId]source{
+		0: crate0.Source,
+		1: crate1.Source,
+		2: crate2.Source,
+		3: crate3.Source,
+	}
+	baseTransitiveDeps := [][]crateId{
+		0: {0, 1},
+		1: {1},
+		2: {2},
+		3: {3},
+	}
+
+	// Expected FileInputs
+	crate0FileInputs := []*apb.CompilationUnit_FileInput{
+		{VName: &spb.VName{Corpus: corpus, Path: "crate0/src/lib.rs"}, Info: &apb.FileInfo{Path: "crate0/src/lib.rs", Digest: "digest-lib0"}},
+		{VName: &spb.VName{Corpus: corpus, Path: "crate0/src/mod.rs"}, Info: &apb.FileInfo{Path: "crate0/src/mod.rs", Digest: "digest-mod0"}},
+	}
+	crate1FileInputs := []*apb.CompilationUnit_FileInput{
+		{VName: &spb.VName{Corpus: corpus, Path: "vendor/crate1/src/lib.rs"}, Info: &apb.FileInfo{Path: "vendor/crate1/src/lib.rs", Digest: "digest-lib1"}},
+		{VName: &spb.VName{Corpus: corpus, Path: "out/gen/lib.rs"}, Info: &apb.FileInfo{Path: "out/gen/lib.rs", Digest: "digest-lib1"}},
+	}
+	crate2FileInputs := []*apb.CompilationUnit_FileInput{
+		{VName: &spb.VName{Corpus: corpus, Path: "vendor/crate2/lib.rs"}, Info: &apb.FileInfo{Path: "vendor/crate2/lib.rs", Digest: "digest-lib2"}},
+	}
+	crate3FileInputs := []*apb.CompilationUnit_FileInput{
+		{VName: &spb.VName{Corpus: corpus, Path: "vendor/crate3/lib.rs"}, Info: &apb.FileInfo{Path: "vendor/crate3/lib.rs", Digest: "digest-lib3"}},
+	}
+
+	projectJsonFileInput := &apb.CompilationUnit_FileInput{
+		VName: &spb.VName{Corpus: corpus, Path: "rust-project.json"},
+		Info:  &apb.FileInfo{Path: "rust-project.json", Digest: "mockFileDigest"},
+	}
+
+	tests := []struct {
+		name                string
+		crateToTest         crate
+		mockCollector       *MockCollectCrateSources
+		mockKzipWriter      *MockKzipWriter
+		expectedUnit        *apb.CompilationUnit
+		expectWriteCrateErr bool
+	}{
+		{
+			name:        "Basic crate with dependency",
+			crateToTest: crate0,
+			mockCollector: &MockCollectCrateSources{
+				Results: map[string]struct {
+					Files  []string
+					Inputs []*apb.CompilationUnit_FileInput
+					Err    error
+				}{
+					"crate0/src":        {Files: []string{"crate0/src/lib.rs", "crate0/src/mod.rs"}, Inputs: crate0FileInputs, Err: nil},
+					"vendor/crate1/src": {Files: []string{"vendor/crate1/src/lib.rs"}, Inputs: crate1FileInputs, Err: nil},
+				},
+			},
+			mockKzipWriter: &MockKzipWriter{},
+			expectedUnit: &apb.CompilationUnit{
+				VName:         &spb.VName{Corpus: corpus, Language: "rust"},
+				RequiredInput: append(append(slices.Clone(crate1FileInputs), projectJsonFileInput), crate0FileInputs...), // Clone dep inputs + project.json
+				SourceFile:    []string{"crate0/src/lib.rs", "crate0/src/mod.rs"},                                        // Only crate0 files
+
+			},
+			expectWriteCrateErr: false,
+		},
+		{
+			name:        "Error collecting crate sources",
+			crateToTest: crate0,
+			mockCollector: &MockCollectCrateSources{
+				Results: map[string]struct {
+					Files  []string
+					Inputs []*apb.CompilationUnit_FileInput
+					Err    error
+				}{
+					"crate0/src": {Err: errors.New("failed to collect crate0")},
+					// No need to configure crate1 as it won't be reached
+				},
+			},
+			mockKzipWriter:      &MockKzipWriter{},
+			expectWriteCrateErr: true, // Expect error from writeCrate itself
+		},
+		{
+			name: "Crate with multiple dependencies",
+			crateToTest: crate{ // Modify crate0 for this test
+				CrateId:    0,
+				Label:      "crate0_multi",
+				RootModule: "crate0/src/lib.rs",
+				Source: source{
+					IncludeDirs: []string{"crate0/src"},
+					ExcludeDirs: []string{},
+				},
+				Deps: []dep{{CrateId: 1, Name: "crate1"}, {CrateId: 2, Name: "crate2"}}, // Depends on 1 and 2
+			},
+			mockCollector: &MockCollectCrateSources{
+				Results: map[string]struct {
+					Files  []string
+					Inputs []*apb.CompilationUnit_FileInput
+					Err    error
+				}{
+					"crate0/src":        {Files: []string{"crate0/src/lib.rs", "crate0/src/mod.rs"}, Inputs: crate0FileInputs, Err: nil},
+					"vendor/crate1/src": {Files: []string{"vendor/crate1/src/lib.rs"}, Inputs: crate1FileInputs, Err: nil},
+					"vendor/crate2":     {Files: []string{"vendor/crate2/lib.rs"}, Inputs: crate2FileInputs, Err: nil}, // Add result for crate2
+				},
+			},
+			mockKzipWriter: &MockKzipWriter{},
+			expectedUnit: &apb.CompilationUnit{
+				VName: &spb.VName{Corpus: corpus, Language: "rust"},
+				// Required inputs should include both dependencies + project.json
+				RequiredInput: append(append(append(slices.Clone(crate1FileInputs), crate2FileInputs...), crate0FileInputs...), projectJsonFileInput),
+				SourceFile:    []string{"crate0/src/lib.rs", "crate0/src/mod.rs"}, // Only crate0 files
+			},
+			expectWriteCrateErr: false,
+		},
+		{
+			name: "Conflicting include/exclude in dependencies",
+			crateToTest: crate{ // crate0 depends on crate1 (includes shared) and crate2 (excludes shared)
+				CrateId:    0,
+				Label:      "crate0_conflict",
+				RootModule: "crate0/src/lib.rs",
+				Source: source{
+					IncludeDirs: []string{"crate0/src"},
+					ExcludeDirs: []string{},
+				},
+				Deps: []dep{{CrateId: 1, Name: "crate1"}, {CrateId: 3, Name: "crate3"}},
+			},
+			mockCollector: &MockCollectCrateSources{
+				Results: map[string]struct {
+					Files  []string
+					Inputs []*apb.CompilationUnit_FileInput
+					Err    error
+				}{
+					"crate0/src":        {Files: []string{"crate0/src/lib.rs", "crate0/src/mod.rs"}, Inputs: crate0FileInputs, Err: nil},
+					"vendor/crate1/src": {Files: []string{"crate1/src/lib.rs", "out/gen/lib.rs"}, Inputs: crate1FileInputs, Err: nil}, // this includes a directory explicitly excluded by crate3.
+					"vendor/crate3":     {Files: []string{"crate3/src/lib.rs"}, Inputs: crate3FileInputs, Err: nil},
+				},
+			},
+			mockKzipWriter: &MockKzipWriter{},
+			expectedUnit: &apb.CompilationUnit{
+				VName:         &spb.VName{Corpus: corpus, Language: "rust"},
+				RequiredInput: append(append(append(slices.Clone(crate1FileInputs), crate3FileInputs...), crate0FileInputs...), projectJsonFileInput),
+				SourceFile:    []string{"crate0/src/lib.rs", "crate0/src/mod.rs"}, // Only crate0 files
+			},
+			expectWriteCrateErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cache := newRequiredInputsCache()
+
+			mockWriter := tt.mockKzipWriter
+
+			// Adjust transitiveDeps specifically for the multi-dep test case
+			currentTransitiveDeps := baseTransitiveDeps
+			switch tt.name {
+			case "Crate with multiple dependencies":
+				currentTransitiveDeps = [][]crateId{
+					0: {0, 1, 2}, // Crate 0 depends on 1 and 2
+					1: {1},
+					2: {2},
+					3: {3},
+				}
+			case "Conflicting include/exclude in dependencies":
+				// Simulate: 0 -> 1, 0 -> 2. Crate 1 needs shared/src, Crate 2 does not.
+				// For simplicity, let's assume crate1 depends on crate3 (shared), and crate2 does not.
+				currentTransitiveDeps = [][]crateId{
+					0: {0, 1, 3},
+					1: {1},
+					2: {2},
+					3: {3},
+				}
+			}
+
+			extractor := extractor{
+				project: rustProject{
+					Crates: []crate{crate0, crate1, crate2, crate3},
+				},
+				projectRoot:         projectRoot,
+				corpus:              corpus,
+				rules:               nil,
+				requiredInputsCache: &cache,
+				kzipWriter:          mockWriter,
+			}
+
+			// Pass the mock collector's method as the function argument
+			err := extractor.writeCrate(ctx, tt.crateToTest, currentTransitiveDeps, sourceDirs, tt.mockCollector.collectCrateSources)
+
+			if tt.expectWriteCrateErr {
+				if err == nil {
+					t.Errorf("writeCrate() expected an error, but got nil")
+				}
+				// Don't check unit if an error was expected during collection/writing
+				return
+			}
+			if err != nil {
+				t.Fatalf("writeCrate() unexpected error: %v", err)
+			}
+
+			// Verify the CompilationUnit passed to AddUnit
+			if mockWriter.AddedUnit == nil {
+				t.Fatalf("mockKzipWriter.AddUnit was not called")
+			}
+
+			fmt.Printf("added unit: %v\n", mockWriter.AddedUnit)
+
+			// Sort slices for consistent comparison
+			sort.Strings(mockWriter.AddedUnit.SourceFile)
+			sort.Strings(tt.expectedUnit.SourceFile)
+			sort.Slice(mockWriter.AddedUnit.RequiredInput, func(i, j int) bool {
+				pathI := mockWriter.AddedUnit.RequiredInput[i].Info.Path
+				pathJ := mockWriter.AddedUnit.RequiredInput[j].Info.Path
+				return pathI < pathJ
+			})
+			sort.Slice(tt.expectedUnit.RequiredInput, func(i, j int) bool {
+				pathI := tt.expectedUnit.RequiredInput[i].Info.Path
+				pathJ := tt.expectedUnit.RequiredInput[j].Info.Path
+				return pathI < pathJ
+			})
+
+			if diff := cmp.Diff(tt.expectedUnit.RequiredInput, mockWriter.AddedUnit.RequiredInput, cmp.Comparer(proto.Equal)); diff != "" {
+				t.Errorf("writeCrate() produced unexpected RequiredInput diff (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tt.expectedUnit.SourceFile, mockWriter.AddedUnit.SourceFile, cmp.Comparer(proto.Equal)); diff != "" {
+				t.Errorf("writeCrate() produced unexpected RequiredInput diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// MockFileInfo implements os.FileInfo for testing.
+type MockFileInfo struct {
+	FName    string
+	FIsDir   bool
+	FMode    os.FileMode
+	FSize    int64
+	FModTime time.Time
+	FSys     any
+}
+
+func (fi *MockFileInfo) Name() string       { return fi.FName }
+func (fi *MockFileInfo) IsDir() bool        { return fi.FIsDir }
+func (fi *MockFileInfo) Mode() os.FileMode  { return fi.FMode }
+func (fi *MockFileInfo) Size() int64        { return fi.FSize }
+func (fi *MockFileInfo) ModTime() time.Time { return fi.FModTime }
+func (fi *MockFileInfo) Sys() any           { return fi.FSys }
+
+func TestShouldIncludeFile(t *testing.T) {
+	projectRoot := "/project"
+	tests := []struct {
+		name        string
+		info        os.FileInfo
+		path        string // Absolute path
+		sourceDirs  source
+		projectRoot string
+		wantInclude bool
+		wantErr     error
+	}{
+		{
+			name:        "Include .rs file in include dir",
+			info:        &MockFileInfo{FName: "main.rs", FIsDir: false},
+			path:        filepath.Join(projectRoot, "src/main.rs"),
+			sourceDirs:  source{IncludeDirs: []string{"src"}, ExcludeDirs: []string{}},
+			projectRoot: projectRoot,
+			wantInclude: true,
+			wantErr:     nil,
+		},
+		{
+			name:        "Exclude non-.rs file",
+			info:        &MockFileInfo{FName: "README.md", FIsDir: false},
+			path:        filepath.Join(projectRoot, "src/README.md"),
+			sourceDirs:  source{IncludeDirs: []string{"src"}, ExcludeDirs: []string{}},
+			projectRoot: projectRoot,
+			wantInclude: false,
+			wantErr:     nil,
+		},
+		{
+			name:        "Exclude excluded dir",
+			info:        &MockFileInfo{FName: "test.rs", FIsDir: false},
+			path:        filepath.Join(projectRoot, "src/tests/"),
+			sourceDirs:  source{IncludeDirs: []string{"src"}, ExcludeDirs: []string{"src/tests"}},
+			projectRoot: projectRoot,
+			wantInclude: false,
+			wantErr:     nil,
+		},
+		{
+			name:        "Handle directory not in exclude list",
+			info:        &MockFileInfo{FName: "subdir", FIsDir: true},
+			path:        filepath.Join(projectRoot, "src/subdir"),
+			sourceDirs:  source{IncludeDirs: []string{"src"}, ExcludeDirs: []string{"target"}},
+			projectRoot: projectRoot,
+			wantInclude: false,
+			wantErr:     nil,
+		},
+		{
+			name:        "File without extension",
+			info:        &MockFileInfo{FName: "config", FIsDir: false},
+			path:        filepath.Join(projectRoot, "config"),
+			sourceDirs:  source{IncludeDirs: []string{"."}, ExcludeDirs: []string{}},
+			projectRoot: projectRoot,
+			wantInclude: false,
+			wantErr:     nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotInclude, gotErr := shouldIncludeFile(tt.info, tt.path, tt.sourceDirs.ExcludeDirs, tt.projectRoot)
+			if gotInclude != tt.wantInclude || !errors.Is(gotErr, tt.wantErr) {
+				t.Errorf("shouldIncludeFile(%q) = (%v, %v), want (%v, %v)", tt.path, gotInclude, gotErr, tt.wantInclude, tt.wantErr)
+			}
+		})
+	}
+}
+
+func makeTestCrate(id crateId, label string, deps []dep, isMember bool) crate {
+	return crate{
+		CrateId:           id,
+		Label:             label,
+		RootModule:        fmt.Sprintf("src/%s/lib.rs", label),
+		Deps:              deps,
+		IsWorkspaceMember: isMember,
+	}
+}
+
+func TestSynthesizeProjectJson(t *testing.T) {
+	crate0 := makeTestCrate(0, "crate0", []dep{{CrateId: 1, Name: "crate1"}, {CrateId: 2, Name: "crate2"}}, true)
+	crate1 := makeTestCrate(1, "crate1", []dep{{CrateId: 3, Name: "crate3"}}, false) // Initially not a member
+	crate2 := makeTestCrate(2, "crate2", []dep{{CrateId: 3, Name: "crate3"}}, true)
+	crate3 := makeTestCrate(3, "crate3", []dep{}, false) // Initially not a member
+	crate4 := makeTestCrate(4, "crate4", []dep{}, true)  // Standalone
+
+	allCratesBase := []crate{crate0, crate1, crate2, crate3, crate4}
+
+	tests := []struct {
+		name           string
+		targetId       crateId
+		allCrates      []crate
+		transitiveDeps [][]crateId
+		wantProject    rustProject
+	}{
+		{
+			name:      "No dependencies",
+			targetId:  4,
+			allCrates: allCratesBase,
+			transitiveDeps: [][]crateId{
+				0: {0, 1, 2, 3},
+				1: {3, 1},
+				2: {3, 2},
+				3: {3},
+				4: {4}, // Crate 4 has no deps
+			},
+			wantProject: rustProject{
+				Crates: []crate{
+					// Only crate 4, IsWorkspaceMember forced to true
+					makeTestCrate(4, "crate4", []dep{}, true),
+				},
+			},
+		},
+		{
+			name:      "Simple direct dependency",
+			targetId:  1, // Target crate 1 depends on 3
+			allCrates: allCratesBase,
+			transitiveDeps: [][]crateId{
+				0: {0, 1, 2, 3},
+				1: {1, 3}, // Crate 1 depends on 3
+				2: {2, 3},
+				3: {3},
+				4: {4},
+			},
+			wantProject: rustProject{
+				Crates: []crate{
+					// Crate 1 (index 0), depends on crate 3 (new index 1)
+					makeTestCrate(1, "crate1", []dep{{CrateId: 1, Name: "crate3"}}, true), // Dep ID updated to 1
+					// Crate 3 (index 1)
+					makeTestCrate(3, "crate3", []dep{}, true),
+				},
+			},
+		},
+		{
+			name:      "Multiple direct dependencies and transitive",
+			targetId:  0, // Target crate 0 depends on 1, 2; 1->3, 2->3
+			allCrates: allCratesBase,
+			transitiveDeps: [][]crateId{
+				0: {0, 1, 2, 3}, // Transitive deps of 0 are 1, 2, 3
+				1: {1, 3},
+				2: {2, 3},
+				3: {3},
+				4: {4},
+			},
+			wantProject: rustProject{
+				// Crates sorted by original ID: 0, 1, 2, 3
+				Crates: []crate{
+					// Crate 0 (index 0), depends on 1 (new index 1), 2 (new index 2)
+					makeTestCrate(0, "crate0", []dep{{CrateId: 1, Name: "crate1"}, {CrateId: 2, Name: "crate2"}}, true),
+					// Crate 1 (index 1), depends on 3 (new index 3)
+					makeTestCrate(1, "crate1", []dep{{CrateId: 3, Name: "crate3"}}, true),
+					// Crate 2 (index 2), depends on 3 (new index 3)
+					makeTestCrate(2, "crate2", []dep{{CrateId: 3, Name: "crate3"}}, true),
+					// Crate 3 (index 3)
+					makeTestCrate(3, "crate3", []dep{}, true),
+				},
+			},
+		},
+		{
+			name:     "Dependency ID remapping with different order",
+			targetId: 0,
+			allCrates: []crate{
+				makeTestCrate(0, "crate0", []dep{{CrateId: 2, Name: "crate2"}}, true),
+				makeTestCrate(1, "crate1", []dep{}, false),
+				makeTestCrate(2, "crate2", []dep{}, false),
+			},
+			transitiveDeps: [][]crateId{
+				0: {0, 2}, // Depends on 1 and 2
+				1: {1},
+				2: {2},
+			},
+			wantProject: rustProject{
+				Crates: []crate{
+					// crate0 depends on crate2, which is now the 1st crate in the array (0-indexed)
+					makeTestCrate(0, "crate0", []dep{{CrateId: 1, Name: "crate2"}}, true),
+					// Crate 2
+					makeTestCrate(1, "crate2", []dep{}, true),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Need a deep copy of allCrates to avoid modification across tests
+			cratesCopy := make([]crate, len(tt.allCrates))
+			for i := range tt.allCrates {
+				cratesCopy[i] = deepCopyCrate(tt.allCrates[i])
+			}
+
+			gotProject := synthesizeProjectJson(tt.targetId, cratesCopy, tt.transitiveDeps)
+
+			opts := []cmp.Option{
+				// ignore crateID because we're going to drop it when writing the json anyway.
+				cmpopts.IgnoreFields(crate{}, "CrateId"),
+				protocmp.Transform(),
+			}
+
+			if diff := cmp.Diff(tt.wantProject, gotProject, opts...); diff != "" {
+				t.Errorf("synthesizeProjectJson(%d) mismatch (-want +got):\n%s", tt.targetId, diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Many projects using Rust with complicated build systems use rust-project.json to tell rust-analyzer about their source files. We can transform rust-project.json into a .kzip pretty trivially, without needing build system integration. This is simpler than integrating an extractor into every possible build system which large Rust projects use.

Add an extractor called rust_project_to_kzip which takes in a rust-project.json and outputs a .kzip. This kzip will have one CompilationUnit per Rust crate, and each CompilationUnit will include a copy of rust-project.json for the Kythe Rust indexer.

This extractor doesn't yet extract non-.rs files or the stdlib.

Test: added unit tests
Fixes #6167