### PR TITLE
Fix build with Clang 19

### DIFF
--- a/external.bzl
+++ b/external.bzl
@@ -129,6 +129,7 @@ def _cc_dependencies():
         patches = [
             "@io_kythe//third_party:souffle_remove_config.patch",
             "@io_kythe//third_party:souffle_filesystem.patch",
+            "@io_kythe//third_party:souffle_atomic.patch",
         ],
     )
 

--- a/external.bzl
+++ b/external.bzl
@@ -14,8 +14,8 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_depe
 load("@io_kythe//:setup.bzl", "github_archive")
 load("@io_kythe//kythe/cxx/extractor:toolchain.bzl", cxx_extractor_register_toolchains = "register_toolchains")
 load("@io_kythe//third_party/bazel:bazel_repository_files.bzl", "bazel_repository_files")
-load("@io_kythe//tools/build_rules/lexyacc:lexyacc.bzl", "lexyacc_configure")
 load("@io_kythe//tools:build_rules/shims.bzl", "go_repository")
+load("@io_kythe//tools/build_rules/lexyacc:lexyacc.bzl", "lexyacc_configure")
 load("@llvm-raw//utils/bazel:configure.bzl", "llvm_configure")
 load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
 load(
@@ -181,6 +181,9 @@ def _cc_dependencies():
         urls = [
             "https://mirror.bazel.build/github.com/Tencent/rapidjson/archive/v1.1.0.zip",
             "https://github.com/Tencent/rapidjson/archive/v1.1.0.zip",
+        ],
+        patches = [
+            "@io_kythe//third_party:rapidjson_assignment.patch",
         ],
     )
 

--- a/third_party/rapidjson_assignment.patch
+++ b/third_party/rapidjson_assignment.patch
@@ -1,0 +1,11 @@
+--- include/rapidjson/document.h
++++ include/rapidjson/document.h
+@@ -316,8 +316,6 @@ struct GenericStringRef {
+ 
+     GenericStringRef(const GenericStringRef& rhs) : s(rhs.s), length(rhs.length) {}
+ 
+-    GenericStringRef& operator=(const GenericStringRef& rhs) { s = rhs.s; length = rhs.length; }
+-
+     //! implicit conversion to plain CharType pointer
+     operator const Ch *() const { return s; }
+ 

--- a/third_party/souffle_atomic.patch
+++ b/third_party/souffle_atomic.patch
@@ -1,0 +1,11 @@
+--- src/interpreter/Index.h     
++++ src/interpreter/Index.h
+@@ -414,7 +414,7 @@
+     }
+ 
+     void insert(const Index& src) {
+-        data = src.data;
++        data = true;
+     }
+ 
+     bool contains(const Tuple& /* t */) const {


### PR DESCRIPTION
See #6171 

I wonder if I missed a doc somewhere that should have told me to use an earlier version of clang, but it seems we should be able to build with the latest release of clang available. 

So... fix the build with Clang 19.