### PR TITLE
Add rust extractor to release, cut a new release

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,7 @@
 # Release Notes
 
+## [v0.0.70] - 2025-05-08
+
 ## [v0.0.69] - 2025-05-08
 
 ## [v0.0.68] - 2025-01-06
@@ -1795,7 +1797,8 @@ https://github.com/kythe/kythe/compare/v0.0.26...v0.0.27
 
 Initial release
 
-[Unreleased] https://github.com/kythe/kythe/compare/v0.0.69...HEAD
+[Unreleased] https://github.com/kythe/kythe/compare/v0.0.70...HEAD
+[v0.0.70] https://github.com/kythe/kythe/compare/v0.0.69...v0.0.70
 [v0.0.69] https://github.com/kythe/kythe/compare/v0.0.68...v0.0.69
 [v0.0.68] https://github.com/kythe/kythe/compare/v0.0.67...v0.0.68
 [v0.0.67] https://github.com/kythe/kythe/compare/v0.0.66...v0.0.67

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,7 @@
 # Release Notes
 
+## [v0.0.69] - 2025-05-08
+
 ## [v0.0.68] - 2025-01-06
 #### Bug Fixes
 * **go_indexer:**
@@ -1793,7 +1795,8 @@ https://github.com/kythe/kythe/compare/v0.0.26...v0.0.27
 
 Initial release
 
-[Unreleased] https://github.com/kythe/kythe/compare/v0.0.68...HEAD
+[Unreleased] https://github.com/kythe/kythe/compare/v0.0.69...HEAD
+[v0.0.69] https://github.com/kythe/kythe/compare/v0.0.68...v0.0.69
 [v0.0.68] https://github.com/kythe/kythe/compare/v0.0.67...v0.0.68
 [v0.0.67] https://github.com/kythe/kythe/compare/v0.0.66...v0.0.67
 [v0.0.66] https://github.com/kythe/kythe/compare/v0.0.65...v0.0.66

--- a/kythe/release/BUILD
+++ b/kythe/release/BUILD
@@ -22,7 +22,7 @@ docker_build(
     deps = ["//kythe/release/base"],
 )
 
-release_version = "v0.0.69"
+release_version = "v0.0.70"
 
 genrule(
     name = "release",

--- a/kythe/release/BUILD
+++ b/kythe/release/BUILD
@@ -22,7 +22,7 @@ docker_build(
     deps = ["//kythe/release/base"],
 )
 
-release_version = "v0.0.68"
+release_version = "v0.0.69"
 
 genrule(
     name = "release",
@@ -46,6 +46,7 @@ genrule(
         ":cxx_indexer",
         ":go_indexer",
         ":proto_extractor",
+        ":rustproject_extractor",
         "@maven//:org_apache_tomcat_tomcat_annotations_api",
         ":proto_indexer",
         ":textproto_extractor",
@@ -87,6 +88,7 @@ genrule(
         "--cp $(location @maven//:org_apache_tomcat_tomcat_annotations_api) jsr250-api-1.0.jar",
         "--cp $(location cxx_extractor) extractors/cxx_extractor",
         "--cp $(location go_extractor) extractors/go_extractor",
+        "--cp $(location rustproject_extractor) extractors/rustproject_extractor",
         "--cp $(location proto_extractor) extractors/proto_extractor",
         "--cp $(location textproto_extractor) extractors/textproto_extractor",
         "--cp $(location cc_proto_metadata_plugin) tools/cc_proto_metadata_plugin",
@@ -210,6 +212,11 @@ filegroup(
 filegroup(
     name = "go_indexer",
     srcs = ["//kythe/go/indexer/cmd/go_indexer"],
+)
+
+filegroup(
+    name = "rustproject_extractor",
+    srcs = ["//kythe/go/extractors/cmd/rust:rust_project_to_kzip"],
 )
 
 filegroup(

--- a/kythe/release/release.MODULE.bazel
+++ b/kythe/release/release.MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "kythe",
-    version = "0.0.68",
+    version = "v0.0.69",
     repo_name = "io_kythe",
 )
 

--- a/kythe/release/release.MODULE.bazel
+++ b/kythe/release/release.MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "kythe",
-    version = "v0.0.69",
+    version = "v0.0.70",
     repo_name = "io_kythe",
 )
 


### PR DESCRIPTION
I (frustratingly) forgot to add the actual built artifact of my new extractor to the release artifacts. So, do that now, and update releases.