### PR TITLE
[fix] Correct source_file inclusion in rust extractor

### DIFF
--- a/kythe/go/extractors/cmd/rust/rust_project_to_kzip.go
+++ b/kythe/go/extractors/cmd/rust/rust_project_to_kzip.go
@@ -338,6 +338,7 @@ func collectCrateSourcesImpl(ctx context.Context, e *extractor, sourceDirs sourc
 			continue
 		}
 
+		dirSourceFiles := []string{}
 		dirRequiredInputs := []*apb.CompilationUnit_FileInput{}
 		err := vfs.Walk(ctx, abspath, func(path string, info os.FileInfo, err error) error {
 			if err != nil {
@@ -375,7 +376,7 @@ func collectCrateSourcesImpl(ctx context.Context, e *extractor, sourceDirs sourc
 				vname.Corpus = e.corpus
 			}
 
-			sourceFiles = append(sourceFiles, relativePath)
+			dirSourceFiles = append(dirSourceFiles, relativePath)
 			dirRequiredInputs = append(dirRequiredInputs, &apb.CompilationUnit_FileInput{
 				VName: vname,
 				Info: &apb.FileInfo{
@@ -393,10 +394,11 @@ func collectCrateSourcesImpl(ctx context.Context, e *extractor, sourceDirs sourc
 		}
 
 		requiredInputs = append(requiredInputs, dirRequiredInputs...)
+		sourceFiles = append(sourceFiles, dirSourceFiles...)
 
 		e.requiredInputsCache.cache[mapKey] = &requiredInputValue{
 			requiredInputs: dirRequiredInputs,
-			sourceFiles:    sourceFiles,
+			sourceFiles:    dirSourceFiles,
 		}
 	}
 


### PR DESCRIPTION
Previously, source file entries were polluted in the cache that speeds up directory traversal. Instead of putting only a single directory's source files in the cache, we were entering the source files for (potentially) the entire crate.

Fix: only store source files for the current directory, not the whole crate.

Test: proved that Fuchsia's corpus has no more errors like "source_file does not have a required_input entry"