### PR TITLE
fix(cxx_extractor): Correct PathCleaner relativization for non-ancestor paths

### DIFF
--- a/kythe/cxx/common/path_utils.h
+++ b/kythe/cxx/common/path_utils.h
@@ -33,6 +33,11 @@
 
 namespace kythe {
 
+// Computes a relative path from base_path to target_path.
+// Both paths must be absolute and cleaned.
+std::string ComputeRelativePath(absl::string_view target_path,
+                                absl::string_view base_path);
+
 /// \brief PathCleaner relativizes paths against a root using CleanPath.
 class PathCleaner {
  public:


### PR DESCRIPTION
The PathCleaner::Relativize method previously returned an absolute path if the path to be relativized was not a direct descendant of the cleaner's root path.

This change introduces a new helper function, ComputeRelativePath, which correctly calculates relative paths using '../' components when the target path is outside the base path's directory tree.

PathCleaner::Relativize now uses this new function, ensuring that it produces correct relative paths in such scenarios. For example, relativizing /a/b/c/d against /a/b/out/default now correctly yields ../../c/d.

The behavior of PathRealizer::Relativize remains unchanged as it continues to use the original TrimPathPrefix logic, satisfying the constraint that its existing tests should not be affected.

Unit tests for RelativizePath (which uses PathCleaner) have been updated and expanded to cover various new scenarios, including those highlighted in the issue. Tests for PathCanonicalizer that rely on PathRealizer or where PathCleaner's root encompasses the test paths continue to pass without modification.

Before this change, the value of compilation_unit.required_input[].info.path would be an absolute path if the out directory of a corpus didn't have the same path prefix as the source directory. That is, if the out directory was `/a/b/out/default` and the source directory was `/a/b/src`, we'd see `/a/b/src/foo.cc`, and not `../../src/foo.cc`. The Kythe spec demands that the path to a required_input's path is relative to the build directory, so the previous behavior was not compliant.