### PR TITLE
fix(cxx_extractor): preserve upward relative paths in args

### DIFF
--- a/kythe/cxx/extractor/cxx_extractor.h
+++ b/kythe/cxx/extractor/cxx_extractor.h
@@ -365,7 +365,6 @@ class ExtractorConfiguration {
   /// If nonempty, the name of the build config targeted by this compilation.
   std::string build_config_;
 };
-
 }  // namespace kythe
 
 #endif


### PR DESCRIPTION
For projects which use upward relative paths (`../<path>`), the existing PathCleaner logic was insufficient. Particularly, it would output absolute paths for inputs which were specified as ../<path>, which meant that later indexing would fail, as the `arguments` field likely referred to those inputs by their relative paths.

We address this with two fixes:

1. PathCleaner now preserves (does not modify) a relative path if it starts with ../
2. FindStableRoot now outputs the current working directory if any arguments start with ../

Many thanks to @shahms for his advice on this set of changes.

Test: Added unit tests, also verified manually that this gets the Fuchsia indexing pipeline working again
Fixes #6181