### PR TITLE
Update go from 1.23.0 to 1.24.4 in extractor image

### DIFF
--- a/kythe/go/extractors/cmd/gotool/Dockerfile
+++ b/kythe/go/extractors/cmd/gotool/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && \
     apt-get clean
 
 # Get a recent go release, remove the current system one so we don't have multiple version problems, and install the new release.
-RUN curl -LO https://golang.org/dl/go1.24.0.linux-amd64.tar.gz && rm -rf /usr/local/go && tar -C /usr/local -xzf go1.24.0.linux-amd64.tar.gz
+RUN curl -LO https://golang.org/dl/go1.24.4.linux-amd64.tar.gz && rm -rf /usr/local/go && tar -C /usr/local -xzf go1.24.4.linux-amd64.tar.gz
 
 ADD kythe/go/extractors/cmd/gotool/analyze_packages.sh /usr/local/bin/analyze_packages.sh
 ADD kythe/go/extractors/cmd/gotool/gotool /usr/local/bin/extract_go

--- a/kythe/go/extractors/cmd/gotool/Dockerfile
+++ b/kythe/go/extractors/cmd/gotool/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && \
     apt-get clean
 
 # Get a recent go release, remove the current system one so we don't have multiple version problems, and install the new release.
-RUN curl -LO https://golang.org/dl/go1.23.0.linux-amd64.tar.gz && rm -rf /usr/local/go && tar -C /usr/local -xzf go1.23.0.linux-amd64.tar.gz
+RUN curl -LO https://golang.org/dl/go1.24.0.linux-amd64.tar.gz && rm -rf /usr/local/go && tar -C /usr/local -xzf go1.24.0.linux-amd64.tar.gz
 
 ADD kythe/go/extractors/cmd/gotool/analyze_packages.sh /usr/local/bin/analyze_packages.sh
 ADD kythe/go/extractors/cmd/gotool/gotool /usr/local/bin/extract_go


### PR DESCRIPTION
Update go from 1.23.0 to 1.24.4 in extractor image

PR created based on https://github.com/kythe/kythe/pull/6130/files

While https://github.com/kythe/kythe/pull/6187/checks?check_run_id=45100270116 is still in progress, extractor image upgrade does not depend on other changes and hence creating separate PR.