### PR TITLE
feat: Copy compiler_args to CompilationUnit arguments in Rust extractor

### DIFF
--- a/kythe/go/extractors/cmd/rust/rust_project_to_kzip.go
+++ b/kythe/go/extractors/cmd/rust/rust_project_to_kzip.go
@@ -77,6 +77,7 @@ type crate struct {
 	Target            string   `json:"target"`
 	Source            source   `json:"source,omitempty"`
 	IsWorkspaceMember bool     `json:"is_workspace_member"`
+	CompilerArgs      []string `json:"compiler_args,omitempty"`
 }
 
 type crateId uint32
@@ -505,6 +506,7 @@ func (e *extractor) writeCrate(ctx context.Context, crate crate, transitiveDeps 
 		},
 		RequiredInput: requiredInputs,
 		SourceFile:    crateFiles,
+		Argument:      crate.CompilerArgs,
 	}
 
 	digest, err := e.kzipWriter.AddUnit(compilationUnit, nil)

--- a/kythe/go/extractors/cmd/rust/rust_project_to_kzip_test.go
+++ b/kythe/go/extractors/cmd/rust/rust_project_to_kzip_test.go
@@ -534,25 +534,29 @@ func TestWriteCrate(t *testing.T) {
 			IncludeDirs: []string{"crate0/src"},
 			ExcludeDirs: []string{},
 		},
-		Deps: []dep{{CrateId: 1, Name: "crate1"}},
+		Deps:         []dep{{CrateId: 1, Name: "crate1"}},
+		CompilerArgs: []string{"--sysroot", "/fake/sysroot"},
 	} // crate0 will be modified in the multi-dep test case
 	crate1 := crate{
 		Source: source{
 			IncludeDirs: []string{"vendor/crate1/src", "out/gen"},
 			ExcludeDirs: []string{},
 		},
+		CompilerArgs: []string{"--edition=2018"},
 	}
 	crate2 := crate{
 		Source: source{
 			IncludeDirs: []string{"vendor/crate2"},
 			ExcludeDirs: []string{""},
 		},
+		CompilerArgs: []string{"--cfg=feature=\"test_feature\""},
 	}
 	crate3 := crate{
 		Source: source{
 			IncludeDirs: []string{"vendor/crate3"},
 			ExcludeDirs: []string{"out/gen"}, // the same directory INCLUDED by crate1
 		},
+		CompilerArgs: []string{"-L", "dependency=/some/path"},
 	}
 
 	sourceDirs := map[crateId]source{
@@ -615,7 +619,7 @@ func TestWriteCrate(t *testing.T) {
 				VName:         &spb.VName{Corpus: corpus, Language: "rust"},
 				RequiredInput: append(append(slices.Clone(crate1FileInputs), projectJsonFileInput), crate0FileInputs...), // Clone dep inputs + project.json
 				SourceFile:    []string{"crate0/src/lib.rs", "crate0/src/mod.rs"},                                        // Only crate0 files
-
+				Argument:      crate0.CompilerArgs,
 			},
 			expectWriteCrateErr: false,
 		},
@@ -645,7 +649,8 @@ func TestWriteCrate(t *testing.T) {
 					IncludeDirs: []string{"crate0/src"},
 					ExcludeDirs: []string{},
 				},
-				Deps: []dep{{CrateId: 1, Name: "crate1"}, {CrateId: 2, Name: "crate2"}}, // Depends on 1 and 2
+				Deps:         []dep{{CrateId: 1, Name: "crate1"}, {CrateId: 2, Name: "crate2"}}, // Depends on 1 and 2
+				CompilerArgs: []string{"--crate-type=lib"},
 			},
 			mockCollector: &MockCollectCrateSources{
 				Results: map[string]struct {
@@ -664,6 +669,7 @@ func TestWriteCrate(t *testing.T) {
 				// Required inputs should include both dependencies + project.json
 				RequiredInput: append(append(append(slices.Clone(crate1FileInputs), crate2FileInputs...), crate0FileInputs...), projectJsonFileInput),
 				SourceFile:    []string{"crate0/src/lib.rs", "crate0/src/mod.rs"}, // Only crate0 files
+				Argument:      tt.crateToTest.CompilerArgs,
 			},
 			expectWriteCrateErr: false,
 		},
@@ -677,7 +683,8 @@ func TestWriteCrate(t *testing.T) {
 					IncludeDirs: []string{"crate0/src"},
 					ExcludeDirs: []string{},
 				},
-				Deps: []dep{{CrateId: 1, Name: "crate1"}, {CrateId: 3, Name: "crate3"}},
+				Deps:         []dep{{CrateId: 1, Name: "crate1"}, {CrateId: 3, Name: "crate3"}},
+				CompilerArgs: []string{"--verbose"},
 			},
 			mockCollector: &MockCollectCrateSources{
 				Results: map[string]struct {
@@ -695,6 +702,7 @@ func TestWriteCrate(t *testing.T) {
 				VName:         &spb.VName{Corpus: corpus, Language: "rust"},
 				RequiredInput: append(append(append(slices.Clone(crate1FileInputs), crate3FileInputs...), crate0FileInputs...), projectJsonFileInput),
 				SourceFile:    []string{"crate0/src/lib.rs", "crate0/src/mod.rs"}, // Only crate0 files
+				Argument:      tt.crateToTest.CompilerArgs,
 			},
 			expectWriteCrateErr: false,
 		},
@@ -777,7 +785,10 @@ func TestWriteCrate(t *testing.T) {
 				t.Errorf("writeCrate() produced unexpected RequiredInput diff (-want +got):\n%s", diff)
 			}
 			if diff := cmp.Diff(tt.expectedUnit.SourceFile, mockWriter.AddedUnit.SourceFile, cmp.Comparer(proto.Equal)); diff != "" {
-				t.Errorf("writeCrate() produced unexpected RequiredInput diff (-want +got):\n%s", diff)
+				t.Errorf("writeCrate() produced unexpected SourceFile diff (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tt.expectedUnit.Argument, mockWriter.AddedUnit.Argument, cmp.Comparer(proto.Equal)); diff != "" {
+				t.Errorf("writeCrate() produced unexpected Argument diff (-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
This change modifies the Rust extractor (`kythe/go/extractors/cmd/rust/rust_project_to_kzip.go`) to copy the `compiler_args` field from each crate in the `rust-project.json` input to the `argument` field of the corresponding `CompilationUnit` in the kzip output.

- Added `CompilerArgs []string` to the `crate` struct.
- Updated `writeCrate` to populate `CompilationUnit.Argument` from `crate.CompilerArgs`.
- Updated tests in `rust_project_to_kzip_test.go` to reflect these changes by adding `CompilerArgs` to test data and assertions.