### PR TITLE
chore(go): update go from 1.24.4 to 1.24.6

### DIFF
--- a/kythe/go/extractors/cmd/gotool/Dockerfile
+++ b/kythe/go/extractors/cmd/gotool/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && \
     apt-get clean
 
 # Get a recent go release, remove the current system one so we don't have multiple version problems, and install the new release.
-RUN curl -LO https://golang.org/dl/go1.24.4.linux-amd64.tar.gz && rm -rf /usr/local/go && tar -C /usr/local -xzf go1.24.4.linux-amd64.tar.gz
+RUN curl -LO https://golang.org/dl/go1.24.6.linux-amd64.tar.gz && rm -rf /usr/local/go && tar -C /usr/local -xzf go1.24.6.linux-amd64.tar.gz
 
 ADD kythe/go/extractors/cmd/gotool/analyze_packages.sh /usr/local/bin/analyze_packages.sh
 ADD kythe/go/extractors/cmd/gotool/gotool /usr/local/bin/extract_go


### PR DESCRIPTION
As of https://go.dev/cl/694535, Go itself requires 1.24.6 for bootstrapping the toolchain. Upgrade so we can run the extractor on the Go repository itself.