### PR TITLE
Update xrefs for record accessor methods to their corresponding fields in Record Class.

### DIFF
--- a/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
@@ -730,7 +730,7 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
     if (isRecordField(varDef, owner)) {
       emitRecordComponentAliasEdge(ctx, varDef, varNode);
     }
-  
+
     boolean documented = visitDocComment(varNode, varDef.getModifiers());
     emitDefinesBindingAnchorEdge(ctx, varDef.name, varDef.getPreferredPosition(), varNode);
     emitAnchor(ctx, EdgeKind.DEFINES, varNode);

--- a/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
@@ -730,7 +730,7 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
     if (isRecordField(varDef, owner)) {
       emitRecordComponentAliasEdge(ctx, varDef, varNode);
     }
-    
+  
     boolean documented = visitDocComment(varNode, varDef.getModifiers());
     emitDefinesBindingAnchorEdge(ctx, varDef.name, varDef.getPreferredPosition(), varNode);
     emitAnchor(ctx, EdgeKind.DEFINES, varNode);

--- a/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
@@ -17,7 +17,6 @@
 package com.google.devtools.kythe.analyzers.java;
 
 import static com.google.common.collect.MoreCollectors.onlyElement;
-import static com.google.errorprone.util.ASTHelpers.isStatic;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.base.Ascii;
@@ -800,7 +799,6 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
     emitAnchor(ctx, EdgeKind.DEFINES, recordComponent);
     entrySets.emitEdge(recordComponent, EdgeKind.ALIASES, varNode);
   }
-
 
   @Override
   public JavaNode visitTypeApply(JCTypeApply tApply, TreeContext owner) {

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Classes.java
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Classes.java
@@ -98,6 +98,64 @@ public class Classes {
     // - LCISI childof ClassInit
     class LocalClassInStaticInitializer {}
   }
+
+  // - @TestRecord defines/binding TR
+  private static record TestRecord(
+      // - @name defines/binding TRCName
+      // - TRMName aliases TRCName
+      String name,
+      // - @value defines/binding TRCValue
+      // - TRMValue aliases TRCValue
+      int value) {}
+
+  // - @TestRecordOverridenConstructor defines/binding TROC
+  private static record TestRecordOverridenConstructor(
+      // - @name defines/binding TROCCName
+      // - TROCMName aliases TROCCName
+      String name,
+      // - @value defines/binding TROCCValue
+      // - TROCMValue aliases TROCCValue
+      int value) {
+    TestRecordOverridenConstructor(String name, int value) {
+      this.name = name;
+      this.value = value;
+    }
+  }
+
+  // - @TestRecordCompactConstructor defines/binding TRCC
+  private static record TestRecordCompactConstructor(
+      // - @name defines/binding TRCCCName
+      // - TRCCMName aliases TRCCCName
+      String name,
+      // - @value defines/binding TRCCCValue
+      // - TRCCMValue aliases TRCCCValue
+      int value) {
+    TestRecordCompactConstructor {}
+  }
+
+  private void testMethod() {
+    // - @tr defines/binding TRInstance
+    // - TRInstance typed TR
+    TestRecord tr = new TestRecord("test", 123);
+    // - @name ref TRMName
+    tr.name();
+    // - @value ref TRMValue
+    tr.value();
+    // - @troc defines/binding TROCInstance
+    // - TROCInstance typed TROC
+    TestRecordOverridenConstructor troc = new TestRecordOverridenConstructor("test", 123);
+    // - @name ref TROCMName
+    troc.name();
+    // - @value ref TROCMValue
+    troc.value();
+    // - @trcc defines/binding TRCCInstance
+    // - TRCCInstance typed TRCC
+    TestRecordCompactConstructor trcc = new TestRecordCompactConstructor("test", 123);
+    // - @name ref TRCCMName
+    trcc.name();
+    // - @value ref TRCCMValue
+    trcc.value();
+  }
 }
 
 // - SubclassOne.tag/static _


### PR DESCRIPTION
Record fields are not present in record symbols if they belong to separate CU hence emit an anchor for record component and alias from record component anchor to record field when we encounter the CU defining the record. This way the record field accessors will redirect correctly to the record fields. 